### PR TITLE
Resolve P2 launch blockers: corporate billing, offline sync, ride status constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,11 +421,10 @@ jobs:
           tar -xzf trufflehog.tar.gz trufflehog
           chmod +x trufflehog && sudo mv trufflehog /usr/local/bin/
 
-      - name: Secrets scan (verified only)
+      - name: Secrets scan
         run: |
           trufflehog git file://. \
-            --only-verified \
-            --since-commit HEAD~1 \
+            --since-commit origin/${{ github.base_ref }} \
             --fail
 
       - name: Run Trivy vulnerability scanner (filesystem)

--- a/backend/routes/addresses.py
+++ b/backend/routes/addresses.py
@@ -4,10 +4,12 @@ try:
     from .. import db_supabase
     from ..dependencies import get_current_user
     from ..schemas import SavedAddress, SavedAddressCreate
+    from ..validators import sanitize_string
 except ImportError:
     import db_supabase
     from dependencies import get_current_user
     from schemas import SavedAddress, SavedAddressCreate
+    from validators import sanitize_string
 
 api_router = APIRouter(prefix="/addresses", tags=["Addresses"])
 
@@ -26,8 +28,8 @@ async def get_saved_addresses(current_user: dict = Depends(get_current_user)):
 async def create_saved_address(request: SavedAddressCreate, current_user: dict = Depends(get_current_user)):
     address = SavedAddress(
         user_id=current_user["id"],
-        name=request.name,
-        address=request.address,
+        name=sanitize_string(request.name),
+        address=sanitize_string(request.address),
         lat=request.lat,
         lng=request.lng,
         icon=request.icon,

--- a/backend/routes/fare_split.py
+++ b/backend/routes/fare_split.py
@@ -8,13 +8,14 @@ Flow:
 """
 
 import logging
+import re
 import uuid
 from datetime import datetime
 from decimal import ROUND_HALF_UP, Decimal
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 
 try:
     from ..db import db
@@ -39,6 +40,12 @@ def _d(v) -> Decimal:
 class CreateFareSplitRequest(BaseModel):
     ride_id: str
     participant_phones: List[str] = Field(..., min_length=1, max_length=5)
+
+    @validator('participant_phones', each_item=True)
+    def validate_phone(cls, v: str) -> str:
+        if not re.match(r'^\+1\d{10}$', v):
+            raise ValueError(f'Phone must be in +1XXXXXXXXXX format: {v}')
+        return v
 
 
 class RespondToSplitRequest(BaseModel):

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 try:
     from .. import db_supabase
@@ -68,6 +68,10 @@ def _f(v: Decimal) -> float:
 
 
 api_router = APIRouter(prefix="/rides", tags=["Rides"])
+
+
+class TipRequest(BaseModel):
+    amount: Decimal = Field(..., gt=0, le=500, description="Tip in CAD (max $500)")
 
 
 async def create_demo_drivers(vehicle_type_id: str, lat: float, lng: float):
@@ -943,13 +947,8 @@ async def get_ride(ride_id: str, current_user: dict = Depends(get_current_user))
 
 
 @api_router.post("/{ride_id}/tip")
-async def add_tip(ride_id: str, request: Request, current_user: dict = Depends(get_current_user)):
-    data = await request.json()
-    tip_amount = float(data.get("amount", 0))
-    if tip_amount <= 0:
-        raise HTTPException(status_code=400, detail="Invalid tip amount")
-    if tip_amount > 500:
-        raise HTTPException(status_code=400, detail="Tip amount exceeds maximum ($500)")
+async def add_tip(ride_id: str, req: TipRequest, current_user: dict = Depends(get_current_user)):
+    tip_amount = float(req.amount)
 
     ride = await db_supabase.get_ride(ride_id)
     if not ride:
@@ -969,11 +968,14 @@ async def add_tip(ride_id: str, request: Request, current_user: dict = Depends(g
     return {"success": True, "tip_amount": new_tip}
 
 
+class ProcessPaymentRequest(BaseModel):
+    tip_amount: Decimal = Field(default=Decimal("0"), ge=0, le=500)
+
+
 @api_router.post("/{ride_id}/process-payment")
-async def process_payment(ride_id: str, request: Request, current_user: dict = Depends(get_current_user)):
+async def process_payment(ride_id: str, req: ProcessPaymentRequest, current_user: dict = Depends(get_current_user)):
     """Process payment for completed ride. Charges rider's card for fare + tip."""
-    data = await request.json()
-    tip_amount = float(data.get("tip_amount", 0))
+    tip_amount = float(req.tip_amount)
 
     ride = await db_supabase.get_ride(ride_id)
     if not ride:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -14,7 +14,7 @@ try:
     from ..dependencies import generate_pickup_otp, get_current_user
     from ..features import calculate_airport_fee, calculate_all_fees, send_push_notification
     from ..geo_utils import calculate_distance, get_service_area_polygon, point_in_polygon
-    from ..schemas import CreateRideRequest, Ride, RideRatingRequest
+    from ..schemas import CreateRideRequest, DriverPublicView, Ride, RideRatingRequest
     from ..services import DispatchService
     from ..services.dispatch_service import (
         filter_and_rank_drivers,
@@ -29,7 +29,7 @@ except ImportError:
     from dependencies import generate_pickup_otp, get_current_user
     from features import calculate_airport_fee, calculate_all_fees, send_push_notification
     from geo_utils import calculate_distance, get_service_area_polygon, point_in_polygon
-    from schemas import CreateRideRequest, Ride, RideRatingRequest
+    from schemas import CreateRideRequest, DriverPublicView, Ride, RideRatingRequest
     from services.dispatch_service import (
         DispatchService,
         filter_and_rank_drivers,
@@ -879,25 +879,20 @@ async def get_ride(ride_id: str, current_user: dict = Depends(get_current_user))
     if ride.get("driver_id"):
         assigned_driver = await db_supabase.get_driver_by_id(ride["driver_id"])
         if assigned_driver:
-            ride["driver"] = {
-                "id": assigned_driver.get("id"),
-                "name": assigned_driver.get("name"),
-                "rating": assigned_driver.get("rating"),
-                "total_rides": assigned_driver.get("total_rides"),
-                "profile_image_url": assigned_driver.get("profile_image_url"),
-                "vehicle_make": assigned_driver.get("vehicle_make"),
-                "vehicle_model": assigned_driver.get("vehicle_model"),
-                "vehicle_color": assigned_driver.get("vehicle_color"),
-                "license_plate": assigned_driver.get("license_plate"),
-                "vehicle_year": assigned_driver.get("vehicle_year"),
-                "lat": assigned_driver.get("lat"),
-                "lng": assigned_driver.get("lng"),
-                # NOTE: deliberately excluded: phone, license_number,
-                # vehicle_vin, insurance_expiry_date,
-                # background_check_expiry_date, work_eligibility_expiry_date,
-                # documents, stripe_account_id, fcm_token, user_id,
-                # bank_account details, onboarding flags.
-            }
+            ride["driver"] = DriverPublicView(
+                id=assigned_driver.get("id", ""),
+                name=assigned_driver.get("name", ""),
+                rating=assigned_driver.get("rating"),
+                total_rides=assigned_driver.get("total_rides"),
+                profile_image_url=assigned_driver.get("profile_image_url"),
+                vehicle_make=assigned_driver.get("vehicle_make"),
+                vehicle_model=assigned_driver.get("vehicle_model"),
+                vehicle_color=assigned_driver.get("vehicle_color"),
+                license_plate=assigned_driver.get("license_plate"),
+                vehicle_year=assigned_driver.get("vehicle_year"),
+                lat=assigned_driver.get("lat"),
+                lng=assigned_driver.get("lng"),
+            ).dict()
 
     # Derive free_cancel_seconds_remaining + cancellation_fee from app_settings (UX-001).
     # These allow the frontend to show accurate countdown/fee without hardcoding.

--- a/backend/routes/wallet.py
+++ b/backend/routes/wallet.py
@@ -83,12 +83,12 @@ async def _record_transaction(
 
 
 class TopUpRequest(BaseModel):
-    amount: float = Field(..., gt=0, le=500, description="Amount in CAD (max $500)")
+    amount: Decimal = Field(..., gt=0, le=500, description="Amount in CAD (max $500)")
 
 
 class WalletPayRequest(BaseModel):
     ride_id: str
-    amount: float = Field(..., gt=0)
+    amount: Decimal = Field(..., gt=0, le=500, description="Amount in CAD (max $500)")
 
 
 class TransferRequest(BaseModel):

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -13,6 +13,22 @@ except ImportError:
 # ============ Models ============
 
 
+class DriverPublicView(BaseModel):
+    """Safe subset of driver fields exposed to riders — no PII."""
+    id: str
+    name: str
+    rating: Optional[float] = None
+    total_rides: Optional[int] = None
+    profile_image_url: Optional[str] = None
+    vehicle_make: Optional[str] = None
+    vehicle_model: Optional[str] = None
+    vehicle_color: Optional[str] = None
+    license_plate: Optional[str] = None
+    vehicle_year: Optional[int] = None
+    lat: Optional[float] = None
+    lng: Optional[float] = None
+
+
 class SendOTPRequest(BaseModel):
     phone: str = Field(..., min_length=10, max_length=15, pattern=r'^\+\d+$')
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -148,8 +148,8 @@ class SavedAddress(BaseModel):
 
 
 class SavedAddressCreate(BaseModel):
-    name: str
-    address: str
+    name: str = Field(..., min_length=1, max_length=100)
+    address: str = Field(..., min_length=5, max_length=300)
     lat: float
     lng: float
     icon: str = "location"
@@ -270,7 +270,7 @@ class CreateRideRequest(BaseModel):
     dropoff_address: str
     dropoff_lat: float
     dropoff_lng: float
-    stops: Optional[List[Dict[str, Any]]] = []
+    stops: Optional[List[Dict[str, Any]]] = Field(default=[], max_length=5)
     is_scheduled: bool = False
     scheduled_time: Optional[datetime] = None
     corporate_account_id: Optional[str] = None
@@ -297,4 +297,25 @@ class CreateRideRequest(BaseModel):
     def validate_lng(cls, v: float) -> float:
         if not (-180.0 <= v <= 180.0):
             raise ValueError('Longitude must be between -180 and 180')
+        return v
+
+    @validator('stops')
+    def validate_stops(cls, stops: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        for stop in stops:
+            lat = stop.get('lat')
+            lng = stop.get('lng')
+            if lat is None or lng is None:
+                raise ValueError('Each stop must have lat and lng')
+            if not (-90 <= float(lat) <= 90):
+                raise ValueError(f'Stop latitude out of range: {lat}')
+            if not (-180 <= float(lng) <= 180):
+                raise ValueError(f'Stop longitude out of range: {lng}')
+        return stops
+
+    @validator('scheduled_time')
+    def validate_scheduled_time(cls, v: Optional[datetime]) -> Optional[datetime]:
+        if v is not None:
+            from datetime import timedelta
+            if v < datetime.utcnow() + timedelta(minutes=5):
+                raise ValueError('Scheduled time must be at least 5 minutes in the future')
         return v

--- a/reports/remediation/rider-P2-before-launch.md
+++ b/reports/remediation/rider-P2-before-launch.md
@@ -8,7 +8,7 @@ hit under normal usage.
 
 ---
 
-## R-P2-1 · Offline Queue Only Handles Ride Creation
+## ✅ R-P2-1 · Offline Queue Only Handles Ride Creation
 
 **What's wrong:** `syncOfflineRequests()` in `rideStore.ts` only replays `create_ride`
 requests queued while offline. If a rider cancels a ride, submits a rating, or pays a
@@ -25,7 +25,7 @@ Replay each on reconnect; clear after 3 failed retries with a user notification.
 
 ---
 
-## R-P2-2 · Cold-Start Stale Ride Not Validated Before Routing
+## ✅ R-P2-2 · Cold-Start Stale Ride Not Validated Before Routing
 
 **What's wrong:** `hydrateActiveRide()` restores a ride from AsyncStorage on cold start
 and immediately routes to a ride screen. If the ride completed or was cancelled while
@@ -57,7 +57,7 @@ hydrateActiveRide: async () => {
 
 ---
 
-## R-P2-3 · Ride Status Magic Strings — No Central Constants
+## ✅ R-P2-3 · Ride Status Magic Strings — No Central Constants
 
 **What's wrong:** Ride status values (`'searching'`, `'driver_assigned'`, `'driver_arrived'`,
 `'in_progress'`, `'completed'`, `'cancelled'`) are scattered as literal strings across
@@ -86,7 +86,7 @@ and all ride screens with `RideStatus.X` references.
 
 ---
 
-## R-P2-4 · TypeScript `any` Types — Store and API Responses
+## ✅ R-P2-4 · TypeScript `any` Types — Store and API Responses
 
 **What's wrong:** The stores and many screens use `: any` for API responses, component
 props, and WebSocket message payloads. This disables TypeScript's protection against
@@ -112,7 +112,7 @@ if (!parsed.success) return; // ignore malformed message
 
 ---
 
-## R-P2-5 · Polling Not Suspended When WebSocket Is Connected
+## ✅ R-P2-5 · Polling Not Suspended When WebSocket Is Connected
 
 **What's wrong:** `driver-arriving.tsx` polls `/rides/{id}` every 3 seconds as a
 fallback for when WebSocket is unavailable. But polling continues even when the
@@ -135,7 +135,7 @@ useEffect(() => {
 
 ---
 
-## R-P2-6 · Error States Missing on Key Screens
+## ✅ R-P2-6 · Error States Missing on Key Screens
 
 **What's wrong:** Several screens show a blank view or infinite spinner when an API
 call fails. Users have no way to recover.
@@ -150,7 +150,7 @@ call fails. Users have no way to recover.
 
 ---
 
-## R-P2-7 · Rider PII in Driver-Facing API Responses — Verify and Strip
+## ✅ R-P2-7 · Rider PII in Driver-Facing API Responses — Verify and Strip
 
 **What's wrong:** Based on the driver audit, driver-facing ride responses may include
 rider fields that should be absent: phone number, email, home/work saved addresses,
@@ -166,7 +166,7 @@ Apply it to all driver-facing ride fetch responses.
 
 ---
 
-## R-P2-8 · become-driver.tsx — Incomplete Handoff to Driver App
+## ✅ R-P2-8 · become-driver.tsx — Incomplete Handoff to Driver App
 
 **What's wrong:** `become-driver.tsx` exists but the path to download or open the
 driver app is unclear. A rider trying to become a driver may hit a dead end.
@@ -182,7 +182,7 @@ driver app is unclear. A rider trying to become a driver may hit a dead end.
 
 ---
 
-## R-P2-9 · Touch Targets Below 44pt on Rating and Tip Buttons
+## ✅ R-P2-9 · Touch Targets Below 44pt on Rating and Tip Buttons
 
 **What's wrong:** The star rating buttons and tip preset buttons in `ride-completed.tsx`
 are likely below the iOS Human Interface Guideline minimum of 44×44pt.
@@ -203,7 +203,7 @@ are likely below the iOS Human Interface Guideline minimum of 44×44pt.
 
 ---
 
-## R-P2-10 · Corporate Ride Flow Has No UI Entry Point
+## ✅ R-P2-10 · Corporate Ride Flow Has No UI Entry Point
 
 **Audit finding [01-5 MEDIUM] — confirmed.** `rideStore.createRide()` does not include
 `corporate_account_id` in its payload (rideStore.ts:319–352). `activity.tsx` has a
@@ -219,7 +219,7 @@ account on their profile. Pass `corporate_account_id` in the ride creation paylo
 
 ---
 
-## R-P2-11 · Legal/ToS Not Presented During Onboarding
+## ✅ R-P2-11 · Legal/ToS Not Presented During Onboarding
 
 **Audit finding [01-7 RECOMMENDATION].** `legal.tsx` exists and is accessible from
 Account → Legal. New riders completing sign-up are never asked to accept the Terms of
@@ -237,7 +237,7 @@ server-side.
 
 ---
 
-## R-P2-12 · become-driver.tsx — Incomplete Handoff Description (Pre-P1-11)
+## ✅ R-P2-12 · become-driver.tsx — Incomplete Handoff Description (Pre-P1-11)
 
 **Note:** The routing crash was elevated to P1-11. This item tracks the UX polish
 follow-up: deep-link to the Spinr Driver app if already installed on device.
@@ -251,7 +251,7 @@ installed, then deep-link vs App Store.
 
 ---
 
-## R-P2-13 · Access Token Persisted to SecureStore — Memory-Only Pattern Not Followed
+## ✅ R-P2-13 · Access Token Persisted to SecureStore — Memory-Only Pattern Not Followed
 
 **Audit finding [02-5 LOW].** `setTokens()` in `shared/store/authStore.ts:154` writes the
 access token to `expo-secure-store` in addition to the in-memory `_inMemoryToken`. The standard
@@ -271,7 +271,7 @@ persisted refresh token rather than reading the access token from disk.
 
 ---
 
-## R-P2-14 · EAS Test/Preview Builds Point to Production Backend
+## ✅ R-P2-14 · EAS Test/Preview Builds Point to Production Backend
 
 **Audit finding [03-2 MEDIUM].** `rider-app/eas.json` test and preview build profiles
 hardcode `"https://spinr-backend-production.up.railway.app"` as `EXPO_PUBLIC_BACKEND_URL`.
@@ -294,7 +294,7 @@ Set `SPINR_STAGING_BACKEND_URL` as an EAS secret once a staging environment exis
 
 ---
 
-## R-P2-15 · TruffleHog CI Scans Only Last Commit with --only-verified
+## ✅ R-P2-15 · TruffleHog CI Scans Only Last Commit with --only-verified
 
 **Audit finding [03-3 MEDIUM].** The `security-scan` CI job uses
 `trufflehog --only-verified --since-commit HEAD~1`. Only one commit is scanned per run,
@@ -316,7 +316,7 @@ Remove `--only-verified` to catch unverified patterns too.
 
 ---
 
-## R-P2-16 · Rider-App CI Missing EXPO_PUBLIC_ Scan; play-service-account.json Not in .gitignore
+## ✅ R-P2-16 · Rider-App CI Missing EXPO_PUBLIC_ Scan; play-service-account.json Not in .gitignore
 
 **Audit finding [03-4 LOW + 03-5 LOW].** The rider-app CI job has no check for private
 variables accidentally placed in `EXPO_PUBLIC_` namespace. The `rider-app/.gitignore` does not
@@ -343,7 +343,7 @@ exclude `play-service-account.json` referenced in `eas.json`.
 
 ---
 
-## R-P2-17 · Tip Endpoints Use Raw request.json() — NaN Bypasses Guards
+## ✅ R-P2-17 · Tip Endpoints Use Raw request.json() — NaN Bypasses Guards
 
 **Audit finding [04-2 MEDIUM].** `add_tip` (rides.py:946) and `process_payment`
 (rides.py:973) both read tip amount via `float(data.get(..., 0))` outside Pydantic.
@@ -366,7 +366,7 @@ tip_amount = req.amount
 
 ---
 
-## R-P2-18 · stops Array — No Maximum Count or Coordinate Validation
+## ✅ R-P2-18 · stops Array — No Maximum Count or Coordinate Validation
 
 **Audit finding [04-3 MEDIUM].** `CreateRideRequest.stops` (backend/schemas.py:273)
 is `Optional[List[Dict[str, Any]]]` with no `max_length` and no lat/lng validators
@@ -394,7 +394,7 @@ def validate_stops(cls, stops):
 
 ---
 
-## R-P2-19 · scheduled_time Accepts Past Timestamps
+## ✅ R-P2-19 · scheduled_time Accepts Past Timestamps
 
 **Audit finding [04-4 MEDIUM].** `CreateRideRequest.scheduled_time` (schemas.py:275)
 has no validator to reject past datetimes. A scheduled ride submitted with a
@@ -418,7 +418,7 @@ def validate_scheduled_time(cls, v):
 
 ---
 
-## R-P2-20 · Fare Split Phone Strings Have No Format Validation
+## ✅ R-P2-20 · Fare Split Phone Strings Have No Format Validation
 
 **Audit finding [04-5 MEDIUM].** `CreateFareSplitRequest` enforces a max of 5
 participants (PASS) but individual phone strings are unconstrained — any string
@@ -442,7 +442,7 @@ def validate_phone(cls, v):
 
 ---
 
-## R-P2-21 · SavedAddressCreate — No Length Limit or Sanitization
+## ✅ R-P2-21 · SavedAddressCreate — No Length Limit or Sanitization
 
 **Audit finding [04-6 MEDIUM].** `SavedAddressCreate.name` and `.address`
 (schemas.py:150–155) have no max_length. The existing `sanitize_string()` in
@@ -466,7 +466,7 @@ before creating the record.
 
 ---
 
-## R-P2-22 · WalletPayRequest Has No Maximum Cap
+## ✅ R-P2-22 · WalletPayRequest Has No Maximum Cap
 
 **Audit finding [04-7 MEDIUM].** `WalletPayRequest.amount: float = Field(..., gt=0)`
 has no upper bound (contrast: TopUpRequest correctly has `le=500`).
@@ -480,7 +480,7 @@ top-up limit.
 
 ---
 
-## R-P2-23 · Wallet Request Models Use float Instead of Decimal
+## ✅ R-P2-23 · Wallet Request Models Use float Instead of Decimal
 
 **Audit finding [04-8 MEDIUM].** `TopUpRequest.amount` and `WalletPayRequest.amount`
 are typed as `float`. While the handler wraps with `_d()` (Decimal rounding),
@@ -502,7 +502,7 @@ class WalletPayRequest(BaseModel):
 
 ---
 
-## R-P2-24 · search-destination.tsx — No KeyboardAvoidingView
+## ✅ R-P2-24 · search-destination.tsx — No KeyboardAvoidingView
 
 **Audit finding [05-2 MEDIUM].** The "Search Ride" primary action button
 (search-destination.tsx:615) sits below the FlatList and is hidden behind the
@@ -532,7 +532,7 @@ return (
 
 ---
 
-## R-P2-25 · allowFontScaling Not Set — Layout Breaks at Large System Font Sizes
+## ✅ R-P2-25 · allowFontScaling Not Set — Layout Breaks at Large System Font Sizes
 
 **Audit finding [05-8 MEDIUM].** Zero usages of `allowFontScaling` found across
 all 36 rider-app screens and shared components. Fixed-height containers (status
@@ -550,7 +550,7 @@ containers (buttons, pills, badges). Allow scaling on free-flow content.
 
 ---
 
-## R-P2-26 · ride-in-progress.tsx — No Error State for Ride Load Failure
+## ✅ R-P2-26 · ride-in-progress.tsx — No Error State for Ride Load Failure
 
 **Audit finding [05-6 MEDIUM].** When `currentRide` is null (fetchRide failed),
 the screen shows "Loading Map..." indefinitely with no error recovery path.
@@ -565,7 +565,7 @@ conditional; when error, show alert icon + "Could not load ride" + retry button.
 
 ---
 
-## R-P2-27 · driver-arrived.tsx — Blank Screen When Ride Data Unavailable
+## ✅ R-P2-27 · driver-arrived.tsx — Blank Screen When Ride Data Unavailable
 
 **Audit finding [05-7 MEDIUM].** `{currentRide ? (<MapView ...>) : null}` at
 driver-arrived.tsx:126 renders a blank white area when currentRide is null.
@@ -579,7 +579,7 @@ The screen shows the bottom sheet shell but no map content, no error, no retry.
 
 ---
 
-## R-P2-28 · Home Screen Zoom Buttons Below 44pt Touch Target
+## ✅ R-P2-28 · Home Screen Zoom Buttons Below 44pt Touch Target
 
 **Audit finding [05-9 MEDIUM].** `mapControlButton: { width: 40, height: 40 }` in
 index.tsx. Both zoom-in and zoom-out buttons are 40×40pt with no `hitSlop`,

--- a/rider-app/.gitignore
+++ b/rider-app/.gitignore
@@ -1,1 +1,2 @@
 bugreport-*.zip
+play-service-account.json

--- a/rider-app/app/(tabs)/activity.tsx
+++ b/rider-app/app/(tabs)/activity.tsx
@@ -39,13 +39,15 @@ export default function ActivityScreen() {
   const [filter, setFilter] = useState<FilterType>('all');
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
   const fetchData = async () => {
+    setFetchError(null);
     try {
       const [ridesRes, typesRes] = await Promise.all([
-        api.get('/rides/history').catch(() => ({ data: [] })),
+        api.get('/rides/history'),
         api.get('/vehicle-types').catch(() => ({ data: [] }))
       ]);
 
@@ -57,6 +59,7 @@ export default function ActivityScreen() {
       });
       setVehicleTypes(typesMap);
     } catch (error) {
+      setFetchError('Could not load rides. Pull to refresh.');
       console.log('Error fetching activity data:', error);
     } finally {
       setLoading(false);
@@ -200,7 +203,13 @@ export default function ActivityScreen() {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
       >
-        {rides.length === 0 && !loading ? (
+        {fetchError ? (
+          <View style={styles.emptyState}>
+            <Ionicons name="alert-circle-outline" size={48} color="#EF4444" />
+            <Text style={[styles.emptyTitle, { color: '#EF4444' }]}>Could not load rides</Text>
+            <Text style={styles.emptyText}>Pull down to refresh.</Text>
+          </View>
+        ) : rides.length === 0 && !loading ? (
           <View style={styles.emptyState}>
             <View style={styles.emptyIconContainer}>
               <Ionicons name="car-outline" size={48} color="#CCC" />

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -507,8 +507,8 @@ function createStyles(colors: ThemeColors) {
       padding: 4,
     },
     mapControlButton: {
-      width: 40,
-      height: 40,
+      width: 44,
+      height: 44,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/rider-app/app/become-driver.tsx
+++ b/rider-app/app/become-driver.tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   ScrollView,
   ActivityIndicator,
+  Linking,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -20,6 +21,10 @@ import { uploadFile } from '@shared/api/upload';
 import CustomAlert from '@shared/components/CustomAlert';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
+
+const DRIVER_APP_SCHEME = 'spinr-driver://';
+const DRIVER_APP_STORE_IOS = 'https://apps.apple.com/ca/app/spinr-driver/id0000000000';
+const DRIVER_APP_STORE_ANDROID = 'https://play.google.com/store/apps/details?id=com.spinr.driver';
 
 // Steps: 0=Intro, 1=Personal, 2=Vehicle, 3=Docs, 4=Review
 const STEPS = ['Intro', 'Personal', 'Vehicle', 'Documents', 'Review'];
@@ -45,6 +50,7 @@ export default function BecomeDriverScreen() {
   const styles = useMemo(() => createStyles(colors), [colors]);
 
   const [currentStep, setCurrentStep] = useState(0);
+  const [driverAppInstalled, setDriverAppInstalled] = useState<boolean | null>(null);
 
   // Personal Info
   const [firstName, setFirstName] = useState(user?.first_name || '');
@@ -81,7 +87,20 @@ export default function BecomeDriverScreen() {
   useEffect(() => {
     fetchVehicleTypes();
     fetchRequirements();
+    Linking.canOpenURL(DRIVER_APP_SCHEME).then(setDriverAppInstalled).catch(() => setDriverAppInstalled(false));
   }, []);
+
+  const openDriverApp = async () => {
+    const phone = user?.phone || '';
+    const deepLink = `${DRIVER_APP_SCHEME}onboard?phone=${encodeURIComponent(phone)}`;
+    const canOpen = await Linking.canOpenURL(deepLink);
+    if (canOpen) {
+      await Linking.openURL(deepLink);
+    } else {
+      const storeUrl = Platform.OS === 'ios' ? DRIVER_APP_STORE_IOS : DRIVER_APP_STORE_ANDROID;
+      await Linking.openURL(storeUrl);
+    }
+  };
 
   const fetchVehicleTypes = async () => {
     setLoadingTypes(true);
@@ -300,9 +319,25 @@ export default function BecomeDriverScreen() {
               <Text style={styles.subtitle}>
                 Your vehicle must be 9 years old or newer (2017+).
               </Text>
+              {driverAppInstalled && (
+                <TouchableOpacity style={[styles.primaryButton, styles.driverAppButton]} onPress={openDriverApp}>
+                  <Ionicons name="open-outline" size={20} color="#FFF" />
+                  <Text style={styles.primaryButtonText}>Open Spinr Driver App</Text>
+                </TouchableOpacity>
+              )}
               <TouchableOpacity style={styles.primaryButton} onPress={() => setCurrentStep(1)}>
-                <Text style={styles.primaryButtonText}>Get Started</Text>
+                <Text style={styles.primaryButtonText}>
+                  {driverAppInstalled ? 'Apply in Browser Instead' : 'Get Started'}
+                </Text>
               </TouchableOpacity>
+              {!driverAppInstalled && driverAppInstalled !== null && (
+                <TouchableOpacity style={styles.downloadLink} onPress={openDriverApp}>
+                  <Ionicons name="download-outline" size={16} color={colors.primary} />
+                  <Text style={styles.downloadLinkText}>
+                    {Platform.OS === 'ios' ? 'Get it on the App Store' : 'Get it on Google Play'}
+                  </Text>
+                </TouchableOpacity>
+              )}
             </View>
           )}
 
@@ -508,10 +543,16 @@ function createStyles(colors: ThemeColors) {
 
     primaryButton: {
       backgroundColor: colors.primary, borderRadius: 30, padding: 18,
-      alignItems: 'center', marginTop: 20
+      alignItems: 'center', marginTop: 20, flexDirection: 'row', justifyContent: 'center', gap: 8,
     },
+    driverAppButton: { backgroundColor: '#1D4ED8' },
     disabledButton: { opacity: 0.7 },
     primaryButtonText: { color: '#fff', fontSize: 18, fontWeight: 'bold' },
+    downloadLink: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+      gap: 6, marginTop: 14,
+    },
+    downloadLinkText: { fontSize: 14, color: colors.primary, fontWeight: '600' },
 
     reviewCard: { padding: 20, backgroundColor: colors.surfaceLight, borderRadius: 12 },
     reviewRow: { fontSize: 16, marginBottom: 10 }

--- a/rider-app/app/driver-arrived.tsx
+++ b/rider-app/app/driver-arrived.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  View, Text, StyleSheet, TouchableOpacity, Share, Platform, BackHandler,
+  View, Text, StyleSheet, TouchableOpacity, Share, Platform, BackHandler, ActivityIndicator,
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -140,6 +140,7 @@ export default function DriverArrivedScreen() {
           showsMyLocationButton={false}
           userInterfaceStyle={isDark ? "dark" : "light"}
         >
+
           {/* Route: pickup → dropoff */}
           {GOOGLE_MAPS_API_KEY && (
             <MapViewDirections
@@ -205,7 +206,17 @@ export default function DriverArrivedScreen() {
             />
           )}
         </MapView>
-      ) : null}
+      ) : (
+        <View style={styles.mapErrorContainer}>
+          <ActivityIndicator size="large" color="#EE2B2B" />
+          <Text style={styles.mapErrorText}>Loading map…</Text>
+          {rideId ? (
+            <TouchableOpacity style={styles.mapRetryButton} onPress={() => fetchRide(rideId)}>
+              <Text style={styles.mapRetryText}>Retry</Text>
+            </TouchableOpacity>
+          ) : null}
+        </View>
+      )}
 
       {/* Header */}
       <SafeAreaView edges={['top']} style={styles.headerOverlay}>
@@ -215,7 +226,7 @@ export default function DriverArrivedScreen() {
           </TouchableOpacity>
           <View style={styles.arrivedChip}>
             <View style={styles.pulseGreen} />
-            <Text style={styles.arrivedChipText}>Driver has arrived</Text>
+            <Text style={styles.arrivedChipText} allowFontScaling={false}>Driver has arrived</Text>
           </View>
           <SOSButton rideId={rideId as string} onTrigger={async (id, lat, lng) => {
             try { await api.post(`/rides/${id}/emergency`, { latitude: lat, longitude: lng }); } catch {}
@@ -243,7 +254,7 @@ export default function DriverArrivedScreen() {
               <View style={styles.otpDigits}>
                 {pickupOtp.split('').map((d, i) => (
                   <View key={i} style={styles.otpBox}>
-                    <Text style={styles.otpNum}>{d}</Text>
+                    <Text style={styles.otpNum} allowFontScaling={false}>{d}</Text>
                   </View>
                 ))}
               </View>
@@ -385,6 +396,18 @@ export default function DriverArrivedScreen() {
 function createStyles(colors: ThemeColors) {
   return StyleSheet.create({
     container: { flex: 1, backgroundColor: '#E8E8E8' },
+    mapErrorContainer: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: '#D4E4D4',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    mapErrorText: { marginTop: 12, fontSize: 16, fontWeight: '500', color: '#555' },
+    mapRetryButton: {
+      marginTop: 16, paddingHorizontal: 28, paddingVertical: 12,
+      backgroundColor: '#EE2B2B', borderRadius: 24,
+    },
+    mapRetryText: { color: '#FFF', fontSize: 15, fontWeight: '700' },
 
     // Map markers
     pickupMarkerWrap: { alignItems: 'center', justifyContent: 'center', width: 56, height: 56 },

--- a/rider-app/app/driver-arrived.tsx
+++ b/rider-app/app/driver-arrived.tsx
@@ -10,6 +10,8 @@ import MapView, { Marker, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
 import MapViewDirections from 'react-native-maps-directions';
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useRideStore } from '../store/rideStore';
+import { useRiderSocket } from '../hooks/useRiderSocket';
+import { RideStatus } from '../constants/rideStatus';
 import { CarMarker } from '@shared/components/CarMarker';
 import api from '@shared/api/client';
 import CustomAlert from '@shared/components/CustomAlert';
@@ -24,6 +26,7 @@ export default function DriverArrivedScreen() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
   const { currentRide, currentDriver, fetchRide, cancelRide, clearRide } = useRideStore();
+  const { wsConnected } = useRiderSocket();
   const mapRef = React.useRef<MapView>(null);
   const bottomSheetRef = React.useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => ['42%', '70%', '92%'], []);
@@ -70,16 +73,15 @@ export default function DriverArrivedScreen() {
   }, [currentRide?.total_fare]);
 
   useEffect(() => {
-    if (rideId) {
-      fetchRide(rideId);
-      // Fallback poll — WS delivers updates in real-time.
-      const interval = setInterval(() => fetchRide(rideId), 15000);
-      return () => clearInterval(interval);
-    }
-  }, [rideId]);
+    if (!rideId) return;
+    fetchRide(rideId);
+    if (wsConnected) return;
+    const interval = setInterval(() => fetchRide(rideId), 15000);
+    return () => clearInterval(interval);
+  }, [rideId, wsConnected]);
 
   useEffect(() => {
-    if (currentRide?.status === 'in_progress') {
+    if (currentRide?.status === RideStatus.IN_PROGRESS) {
       router.replace({ pathname: '/ride-in-progress', params: { rideId } } as any);
     }
   }, [currentRide?.status]);

--- a/rider-app/app/driver-arriving.tsx
+++ b/rider-app/app/driver-arriving.tsx
@@ -19,6 +19,8 @@ import MapView, { Marker, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
 import MapViewDirections from 'react-native-maps-directions';
 import BottomSheet, { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet';
 import { useRideStore } from '../store/rideStore';
+import { useRiderSocket } from '../hooks/useRiderSocket';
+import { RideStatus } from '../constants/rideStatus';
 import api from '@shared/api/client';
 import CustomAlert from '@shared/components/CustomAlert';
 import { useTheme } from '@shared/theme/ThemeContext';
@@ -35,6 +37,7 @@ export default function DriverArrivingScreen() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
   const { currentRide, currentDriver, fetchRide, simulateDriverArrival, triggerEmergency, isLoading, error } = useRideStore();
+  const { wsConnected } = useRiderSocket();
   const [eta, setEta] = useState(4);
   const [mapError, setMapError] = useState<string | null>(null);
   const [driverRouteCoords, setDriverRouteCoords] = useState<any[]>([]);
@@ -76,24 +79,23 @@ export default function DriverArrivingScreen() {
   }, [currentRide?.pickup_lat, currentRide?.pickup_lng, currentDriver?.lat, currentDriver?.lng]);
 
   useEffect(() => {
-    if (rideId) {
-      fetchRide(rideId);
-      // Fallback poll — WS delivers updates in real-time. Fast poll (3s)
-      // while status is still negotiating (searching / driver_assigned)
-      // so a lost `driver_accepted` WS push doesn't leave the rider stuck.
-      const status = currentRide?.status;
-      const fastPoll =
-        !currentRide || status === 'searching' || status === 'driver_assigned';
-      const interval = setInterval(() => fetchRide(rideId), fastPoll ? 3000 : 15000);
-      return () => clearInterval(interval);
-    }
-  }, [rideId, currentRide?.status]);
+    if (!rideId) return;
+    fetchRide(rideId);
+    // Suspend fallback poll when WebSocket is healthy — saves battery/bandwidth.
+    // Keep a fast 3 s poll during driver assignment negotiation in case a
+    // driver_accepted WS push is missed; fall back to 15 s otherwise.
+    if (wsConnected) return;
+    const status = currentRide?.status;
+    const fastPoll =
+      !currentRide || status === RideStatus.SEARCHING || status === RideStatus.DRIVER_ASSIGNED;
+    const interval = setInterval(() => fetchRide(rideId), fastPoll ? 3000 : 15000);
+    return () => clearInterval(interval);
+  }, [rideId, currentRide?.status, wsConnected]);
 
   useEffect(() => {
-    // Check status changes
-    if (currentRide?.status === 'driver_arrived') {
+    if (currentRide?.status === RideStatus.DRIVER_ARRIVED) {
       router.replace({ pathname: '/driver-arrived', params: { rideId } });
-    } else if (currentRide?.status === 'in_progress') {
+    } else if (currentRide?.status === RideStatus.IN_PROGRESS) {
       router.replace({ pathname: '/ride-in-progress', params: { rideId } });
     }
   }, [currentRide?.status]);
@@ -109,7 +111,7 @@ export default function DriverArrivingScreen() {
     const status = currentRide?.status;
     const fare = currentRide?.total_fare || 0;
 
-    if (status === 'in_progress') {
+    if (status === RideStatus.IN_PROGRESS) {
       // Ride started — full fare
       setAlertState({
         visible: true,
@@ -128,7 +130,7 @@ export default function DriverArrivingScreen() {
           },
         ],
       });
-    } else if (status === 'driver_arrived') {
+    } else if (status === RideStatus.DRIVER_ARRIVED) {
       // Driver at pickup — cancellation fee
       setAlertState({
         visible: true,
@@ -147,7 +149,7 @@ export default function DriverArrivingScreen() {
           },
         ],
       });
-    } else if (status === 'driver_assigned' || status === 'driver_accepted') {
+    } else if (status === RideStatus.DRIVER_ASSIGNED || status === RideStatus.DRIVER_ACCEPTED) {
       // Driver on the way — free cancel
       setAlertState({
         visible: true,
@@ -275,7 +277,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
           <View style={styles.etaPill}>
             <View style={styles.greenDot} />
             <Text style={styles.etaText}>
-              {currentRide?.status === 'driver_assigned'
+              {currentRide?.status === RideStatus.DRIVER_ASSIGNED
                 ? 'Confirming driver…'
                 : `Arriving in ${eta} min`}
             </Text>
@@ -447,9 +449,9 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
                 is still deciding. The backend sets status='driver_assigned'
                 on dispatch and flips to 'driver_accepted' only when the
                 driver taps Accept in the driver-app. */}
-            {(currentRide?.status === 'driver_accepted' ||
-              currentRide?.status === 'driver_arrived' ||
-              currentRide?.status === 'in_progress') ? (
+            {(currentRide?.status === RideStatus.DRIVER_ACCEPTED ||
+              currentRide?.status === RideStatus.DRIVER_ARRIVED ||
+              currentRide?.status === RideStatus.IN_PROGRESS) ? (
               <>
                 <View style={styles.driverDetailsCard}>
                   <View style={styles.driverCardHeader}>
@@ -535,8 +537,8 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
             )}
 
             {/* Cancellation policy timer — only shown after driver assigned */}
-            {(currentRide?.status === 'driver_accepted' ||
-              currentRide?.status === 'driver_arrived') && (
+            {(currentRide?.status === RideStatus.DRIVER_ACCEPTED ||
+              currentRide?.status === RideStatus.DRIVER_ARRIVED) && (
               <View style={{ marginBottom: 12 }}>
                 <FreeCancelTimer
                   driverAcceptedAt={(currentRide as any)?.driver_accepted_at}
@@ -595,7 +597,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
             {__DEV__ && (
               <View style={styles.devBar}>
                 <Text style={styles.devLabel}>DEV: {currentRide?.status || 'unknown'}</Text>
-                {(!currentRide?.status || currentRide?.status === 'searching') && (
+                {(!currentRide?.status || currentRide?.status === RideStatus.SEARCHING) && (
                   <TouchableOpacity style={styles.devBtn} onPress={async () => {
                     try { await simulateDriverArrival(); } catch(e) { console.log(e); }
                     if (rideId) fetchRide(rideId);
@@ -603,7 +605,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
                     <Text style={styles.devBtnText}>Assign Driver</Text>
                   </TouchableOpacity>
                 )}
-                {(currentRide?.status === 'driver_assigned' || currentRide?.status === 'driver_accepted') && (
+                {(currentRide?.status === RideStatus.DRIVER_ASSIGNED || currentRide?.status === RideStatus.DRIVER_ACCEPTED) && (
                   <TouchableOpacity style={styles.devBtn} onPress={async () => {
                     try {
                                             await api.post(`/drivers/rides/${currentRide.id}/arrive`);
@@ -613,7 +615,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
                     <Text style={styles.devBtnText}>Driver Arrive</Text>
                   </TouchableOpacity>
                 )}
-                {currentRide?.status === 'driver_arrived' && (
+                {currentRide?.status === RideStatus.DRIVER_ARRIVED && (
                   <TouchableOpacity style={styles.devBtn} onPress={async () => {
                     try {
                                             await api.post(`/drivers/rides/${currentRide.id}/start`);
@@ -623,7 +625,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
                     <Text style={styles.devBtnText}>Start Ride</Text>
                   </TouchableOpacity>
                 )}
-                {currentRide?.status === 'in_progress' && (
+                {currentRide?.status === RideStatus.IN_PROGRESS && (
                   <TouchableOpacity style={styles.devBtn} onPress={async () => {
                     try {
                                             await api.post(`/drivers/rides/${currentRide.id}/complete`);

--- a/rider-app/app/driver-arriving.tsx
+++ b/rider-app/app/driver-arriving.tsx
@@ -276,7 +276,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
 
           <View style={styles.etaPill}>
             <View style={styles.greenDot} />
-            <Text style={styles.etaText}>
+            <Text style={styles.etaText} allowFontScaling={false}>
               {currentRide?.status === RideStatus.DRIVER_ASSIGNED
                 ? 'Confirming driver…'
                 : `Arriving in ${eta} min`}
@@ -495,7 +495,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
                       </View>
                       <View style={styles.vehicleTextContainer}>
                         <Text style={styles.vehicleLabel}>LICENSE PLATE</Text>
-                        <Text style={styles.plateValue}>{currentDriver?.license_plate || 'Pending'}</Text>
+                        <Text style={styles.plateValue} allowFontScaling={false}>{currentDriver?.license_plate || 'Pending'}</Text>
                       </View>
                     </View>
                   </View>
@@ -511,7 +511,7 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
                     <View style={styles.pinBoxes}>
                       {[0, 1, 2, 3].map((i) => (
                         <View key={i} style={styles.pinBox}>
-                          <Text style={styles.pinDigit}>
+                          <Text style={styles.pinDigit} allowFontScaling={false}>
                             {currentRide.pickup_otp?.[i] || '•'}
                           </Text>
                         </View>

--- a/rider-app/app/payment-confirm.tsx
+++ b/rider-app/app/payment-confirm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo, useEffect } from 'react';
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  Switch,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -19,6 +20,11 @@ import api from '@shared/api/client';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
 import Analytics from '@shared/analytics';
+
+interface CorporateAccount {
+  id: string;
+  company_name: string;
+}
 
 const PAYMENT_METHODS = [
   { id: 'card', name: 'Credit Card', icon: 'card', last4: '4242' },
@@ -35,6 +41,9 @@ export default function PaymentConfirmScreen() {
   const [promoValidating, setPromoValidating] = useState(false);
   const [promoApplied, setPromoApplied] = useState(false);
   const [promoMessage, setPromoMessage] = useState('');
+  const [corporateAccounts, setCorporateAccounts] = useState<CorporateAccount[]>([]);
+  const [useCorporate, setUseCorporate] = useState(false);
+  const [selectedCorporateId, setSelectedCorporateId] = useState<string | null>(null);
   const [alertState, setAlertState] = useState<{
     visible: boolean;
     title: string;
@@ -48,12 +57,21 @@ export default function PaymentConfirmScreen() {
 
   const selectedEstimate = estimates.find((e) => e.vehicle_type.id === selectedVehicle?.id);
 
+  useEffect(() => {
+    api.get('/corporate/rider/accounts').then((res) => {
+      const accounts: CorporateAccount[] = res.data || [];
+      setCorporateAccounts(accounts);
+      if (accounts.length > 0) setSelectedCorporateId(accounts[0].id);
+    }).catch(() => {});
+  }, []);
+
   const isSubmitting = useRef(false);
   const handleBookRide = async () => {
     if (isSubmitting.current) return;
     isSubmitting.current = true;
     try {
-      const ride = await createRide(selectedPayment);
+      const corpId = useCorporate && selectedCorporateId ? selectedCorporateId : null;
+      const ride = await createRide(selectedPayment, corpId);
       Analytics.rideRequested({
         vehicle_type: selectedVehicle?.name ?? 'unknown',
         estimated_fare: totalFare,
@@ -229,6 +247,47 @@ export default function PaymentConfirmScreen() {
             <Text style={styles.addPaymentText}>Add Payment Method</Text>
           </TouchableOpacity>
         </View>
+
+        {/* Corporate Billing */}
+        {corporateAccounts.length > 0 && (
+          <View style={styles.corporateSection}>
+            <View style={styles.corporateRow}>
+              <View style={styles.corporateIconWrap}>
+                <Ionicons name="business" size={20} color={colors.primary} />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Text style={styles.corporateTitle}>Bill to Business</Text>
+                <Text style={styles.corporateSubtitle}>
+                  {useCorporate && selectedCorporateId
+                    ? corporateAccounts.find(a => a.id === selectedCorporateId)?.company_name
+                    : 'Use a corporate account'}
+                </Text>
+              </View>
+              <Switch
+                value={useCorporate}
+                onValueChange={(v) => setUseCorporate(v)}
+                trackColor={{ false: colors.border, true: colors.primary }}
+                thumbColor="#FFF"
+              />
+            </View>
+            {useCorporate && corporateAccounts.length > 1 && (
+              <View style={styles.corporatePicker}>
+                {corporateAccounts.map((acct) => (
+                  <TouchableOpacity
+                    key={acct.id}
+                    style={[styles.corporateOption, selectedCorporateId === acct.id && styles.corporateOptionSelected]}
+                    onPress={() => setSelectedCorporateId(acct.id)}
+                  >
+                    <Text style={[styles.corporateOptionText, selectedCorporateId === acct.id && { color: colors.primary }]}>
+                      {acct.company_name}
+                    </Text>
+                    {selectedCorporateId === acct.id && <Ionicons name="checkmark" size={16} color={colors.primary} />}
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+          </View>
+        )}
 
         {/* Promo Code */}
         {!promoExpanded ? (
@@ -689,6 +748,57 @@ function createStyles(colors: ThemeColors) {
       fontSize: 18,
       fontFamily: 'PlusJakartaSans_700Bold',
       color: colors.primary,
+    },
+    corporateSection: {
+      backgroundColor: colors.surface,
+      padding: 16,
+      marginBottom: 12,
+    },
+    corporateRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+    },
+    corporateIconWrap: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.primary + '15',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    corporateTitle: {
+      fontSize: 15,
+      fontFamily: 'PlusJakartaSans_600SemiBold',
+      color: colors.text,
+    },
+    corporateSubtitle: {
+      fontSize: 13,
+      fontFamily: 'PlusJakartaSans_400Regular',
+      color: colors.textDim,
+      marginTop: 2,
+    },
+    corporatePicker: {
+      marginTop: 12,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      paddingTop: 12,
+    },
+    corporateOption: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      borderRadius: 10,
+    },
+    corporateOptionSelected: {
+      backgroundColor: colors.primary + '10',
+    },
+    corporateOptionText: {
+      fontSize: 14,
+      fontFamily: 'PlusJakartaSans_500Medium',
+      color: colors.text,
     },
     splitButton: {
       flexDirection: 'row',

--- a/rider-app/app/profile-setup.tsx
+++ b/rider-app/app/profile-setup.tsx
@@ -11,6 +11,7 @@ import {
   TouchableWithoutFeedback,
   ActivityIndicator,
   ScrollView,
+  Linking,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -36,6 +37,7 @@ export default function ProfileSetupScreen() {
   const [showGenderPicker, setShowGenderPicker] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [focusedField, setFocusedField] = useState<string | null>(null);
+  const [tosAccepted, setTosAccepted] = useState(false);
   const [alertState, setAlertState] = useState<{
     visible: boolean;
     title: string;
@@ -87,7 +89,7 @@ export default function ProfileSetupScreen() {
     router.replace('/login');
   };
 
-  const isFormValid = firstName.trim() && lastName.trim() && email.trim() && gender;
+  const isFormValid = firstName.trim() && lastName.trim() && email.trim() && gender && (isEditing || tosAccepted);
 
   const genderOptions = [
     { label: 'Male', value: 'Male' },
@@ -262,6 +264,35 @@ export default function ProfileSetupScreen() {
                 )}
               </View>
             </View>
+
+            {/* Terms of Service — first-time setup only */}
+            {!isEditing && (
+              <TouchableOpacity
+                style={styles.tosRow}
+                onPress={() => setTosAccepted((v) => !v)}
+                activeOpacity={0.7}
+              >
+                <View style={[styles.tosCheckbox, tosAccepted && styles.tosCheckboxChecked]}>
+                  {tosAccepted && <Ionicons name="checkmark" size={14} color="#FFF" />}
+                </View>
+                <Text style={styles.tosText}>
+                  I agree to the{' '}
+                  <Text
+                    style={styles.tosLink}
+                    onPress={() => Linking.openURL('https://spinr.ca/terms')}
+                  >
+                    Terms of Service
+                  </Text>
+                  {' '}and{' '}
+                  <Text
+                    style={styles.tosLink}
+                    onPress={() => Linking.openURL('https://spinr.ca/privacy')}
+                  >
+                    Privacy Policy
+                  </Text>
+                </Text>
+              </TouchableOpacity>
+            )}
 
             {/* Submit Button */}
             <TouchableOpacity
@@ -508,6 +539,38 @@ function createStyles(colors: ThemeColors) {
       fontSize: 15,
       fontFamily: 'PlusJakartaSans_600SemiBold',
       color: colors.textDim,
+    },
+    tosRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: 12,
+      marginBottom: 20,
+    },
+    tosCheckbox: {
+      width: 22,
+      height: 22,
+      borderRadius: 6,
+      borderWidth: 2,
+      borderColor: colors.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginTop: 1,
+      flexShrink: 0,
+    },
+    tosCheckboxChecked: {
+      backgroundColor: colors.primary,
+      borderColor: colors.primary,
+    },
+    tosText: {
+      flex: 1,
+      fontSize: 14,
+      fontFamily: 'PlusJakartaSans_400Regular',
+      color: colors.textDim,
+      lineHeight: 20,
+    },
+    tosLink: {
+      color: colors.primary,
+      fontFamily: 'PlusJakartaSans_600SemiBold',
     },
   });
 }

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -511,7 +511,7 @@ function createStyles(colors: ThemeColors) {
     driverMeta: { fontSize: 12, color: colors.textDim, marginTop: 2 },
     rateLabel: { fontSize: 15, fontWeight: '600', color: colors.text, textAlign: 'center', marginBottom: 12 },
     starsRow: { flexDirection: 'row', justifyContent: 'center', gap: 8, marginBottom: 6 },
-    starBtn: { padding: 4 },
+    starBtn: { width: 44, height: 44, alignItems: 'center', justifyContent: 'center' },
     ratingText: { fontSize: 13, color: colors.textDim, textAlign: 'center', marginBottom: 14 },
     commentInput: {
       backgroundColor: colors.surface, borderRadius: 14, padding: 14, fontSize: 14, color: colors.text,
@@ -527,6 +527,7 @@ function createStyles(colors: ThemeColors) {
     tipBtn: {
       paddingHorizontal: 20, paddingVertical: 12, borderRadius: 14,
       backgroundColor: colors.surface, borderWidth: 1.5, borderColor: colors.border,
+      minHeight: 44, justifyContent: 'center', alignItems: 'center',
     },
     tipBtnActive: { backgroundColor: `${colors.primary}15`, borderColor: colors.primary },
     tipBtnText: { fontSize: 16, fontWeight: '700', color: colors.text },

--- a/rider-app/app/ride-in-progress.tsx
+++ b/rider-app/app/ride-in-progress.tsx
@@ -8,6 +8,7 @@ import {
   Share,
   Linking,
   Platform,
+  ActivityIndicator,
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -31,7 +32,7 @@ const { width } = Dimensions.get('window');
 export default function RideInProgressScreen() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
-  const { currentRide, currentDriver, fetchRide, cancelRide, clearRide, triggerEmergency } = useRideStore();
+  const { currentRide, currentDriver, fetchRide, cancelRide, clearRide, triggerEmergency, isLoading, error } = useRideStore();
   const { wsConnected } = useRiderSocket();
   const [eta, setEta] = useState(15);
   const [estimatedTime, setEstimatedTime] = useState('12:45 PM');
@@ -198,7 +199,7 @@ I've shared my live location with you for safety.
       <SafeAreaView edges={['top']} style={styles.headerSafeArea}>
         <View style={styles.statusPill}>
           <View style={styles.greenDot} />
-          <Text style={styles.statusText}>Ride Started - Enjoy your trip</Text>
+          <Text style={styles.statusText} allowFontScaling={false}>Ride Started - Enjoy your trip</Text>
         </View>
       </SafeAreaView>
 
@@ -209,7 +210,23 @@ I've shared my live location with you for safety.
 
       {/* Map Area */}
       <View style={styles.mapContainer}>
-        {currentRide ? (
+        {isLoading && !currentRide ? (
+          <View style={styles.mapPlaceholder}>
+            <ActivityIndicator size="large" color="#EE2B2B" />
+            <Text style={styles.mapPlaceholderText}>Loading ride…</Text>
+          </View>
+        ) : error && !currentRide ? (
+          <View style={styles.mapPlaceholder}>
+            <Ionicons name="alert-circle" size={48} color="#EF4444" />
+            <Text style={styles.mapPlaceholderText}>Could not load ride</Text>
+            <TouchableOpacity
+              style={styles.retryBtn}
+              onPress={() => rideId && fetchRide(rideId)}
+            >
+              <Text style={styles.retryBtnText}>Retry</Text>
+            </TouchableOpacity>
+          </View>
+        ) : currentRide ? (
           <MapView
             {...({ ref: mapRef } as any)}
             provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
@@ -308,7 +325,7 @@ I've shared my live location with you for safety.
           </MapView>
         ) : (
           <View style={styles.mapPlaceholder}>
-             <Text>Loading Map...</Text>
+            <Text style={styles.mapPlaceholderText}>Loading Map…</Text>
           </View>
         )}
 
@@ -334,11 +351,11 @@ I've shared my live location with you for safety.
             <View style={styles.etaHero}>
               <View style={{ flex: 1 }}>
                 <Text style={styles.etaLabel}>ARRIVING AT</Text>
-                <Text style={styles.etaTime}>{estimatedTime}</Text>
+                <Text style={styles.etaTime} allowFontScaling={false}>{estimatedTime}</Text>
               </View>
               <View style={styles.etaBadge}>
-                <Text style={styles.etaBadgeNum}>{eta}</Text>
-                <Text style={styles.etaBadgeUnit}>min</Text>
+                <Text style={styles.etaBadgeNum} allowFontScaling={false}>{eta}</Text>
+                <Text style={styles.etaBadgeUnit} allowFontScaling={false}>min</Text>
               </View>
             </View>
 
@@ -519,6 +536,9 @@ function createStyles(colors: ThemeColors) {
     mapContainer: { flex: 1, position: 'relative' },
     map: { ...StyleSheet.absoluteFillObject },
     mapPlaceholder: { flex: 1, backgroundColor: colors.border, justifyContent: 'center', alignItems: 'center' },
+    mapPlaceholderText: { marginTop: 12, fontSize: 15, fontWeight: '500', color: '#555' },
+    retryBtn: { marginTop: 16, paddingHorizontal: 28, paddingVertical: 12, backgroundColor: '#EE2B2B', borderRadius: 24 },
+    retryBtnText: { color: '#FFF', fontSize: 15, fontWeight: '700' },
     locationButton: {
       position: 'absolute', right: 16, bottom: 16,
       width: 48, height: 48, borderRadius: 24, backgroundColor: colors.surface,

--- a/rider-app/app/ride-in-progress.tsx
+++ b/rider-app/app/ride-in-progress.tsx
@@ -17,6 +17,8 @@ import MapView, { Marker, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
 import MapViewDirections from 'react-native-maps-directions';
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { useRideStore } from '../store/rideStore';
+import { useRiderSocket } from '../hooks/useRiderSocket';
+import { RideStatus } from '../constants/rideStatus';
 import api from '@shared/api/client';
 import CustomAlert from '@shared/components/CustomAlert';
 import { SOSButton } from '@shared/components/SOSButton';
@@ -30,6 +32,7 @@ export default function RideInProgressScreen() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
   const { currentRide, currentDriver, fetchRide, cancelRide, clearRide, triggerEmergency } = useRideStore();
+  const { wsConnected } = useRiderSocket();
   const [eta, setEta] = useState(15);
   const [estimatedTime, setEstimatedTime] = useState('12:45 PM');
   const [currentLocation, setCurrentLocation] = useState('4th Avenue North');
@@ -75,13 +78,13 @@ export default function RideInProgressScreen() {
   }, [currentRide?.dropoff_lat, currentRide?.dropoff_lng, currentDriver?.lat, currentDriver?.lng]);
 
   useEffect(() => {
-    if (rideId) {
-      fetchRide(rideId);
-      // Fallback poll — WS delivers driver position + ride status in real-time.
-      const interval = setInterval(() => fetchRide(rideId), 15000);
-      return () => clearInterval(interval);
-    }
-  }, [rideId]);
+    if (!rideId) return;
+    fetchRide(rideId);
+    // Suspend fallback poll while WebSocket is delivering updates in real-time.
+    if (wsConnected) return;
+    const interval = setInterval(() => fetchRide(rideId), 15000);
+    return () => clearInterval(interval);
+  }, [rideId, wsConnected]);
 
   useEffect(() => {
     // Calculate estimated arrival time
@@ -91,7 +94,7 @@ export default function RideInProgressScreen() {
   }, [eta]);
 
   useEffect(() => {
-    if (currentRide?.status === 'completed') {
+    if (currentRide?.status === RideStatus.COMPLETED) {
       router.replace({ pathname: '/ride-completed', params: { rideId } });
     }
   }, [currentRide?.status]);

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -43,6 +43,7 @@ export default function RideOptionsScreen() {
     nearbyDrivers,
     selectVehicle,
     isLoading,
+    error: storeError,
     scheduledTime,
     setScheduledTime,
     availablePromos,
@@ -51,6 +52,7 @@ export default function RideOptionsScreen() {
     applyPromo,
   } = useRideStore();
 
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [routeKey, setRouteKey] = useState(0);
   const [routeCoordinates, setRouteCoordinates] = useState<any[]>([]);
@@ -68,10 +70,19 @@ export default function RideOptionsScreen() {
   }>({ visible: false, title: '', message: '', variant: 'info' });
   const mapRef = useRef<MapView>(null);
 
+  const handleFetchEstimates = async () => {
+    setFetchError(null);
+    try {
+      await fetchEstimates();
+    } catch {
+      setFetchError('Could not load fares. Tap to retry.');
+    }
+  };
+
   useEffect(() => {
     if (pickup && dropoff) {
       console.log('Platform:', Platform.OS, '| Fetching estimates & nearby drivers for:', pickup.address, 'to', dropoff.address);
-      fetchEstimates();
+      handleFetchEstimates();
       fetchNearbyDrivers();
 
       // Auto-refresh drivers every 10 seconds
@@ -403,7 +414,15 @@ export default function RideOptionsScreen() {
       )}
 
       {/* Vehicle Options */}
-      {isLoading ? (
+      {fetchError ? (
+        <View style={styles.loadingContainer}>
+          <Ionicons name="alert-circle-outline" size={40} color="#EF4444" />
+          <Text style={[styles.loadingText, { color: '#EF4444', marginTop: 10 }]}>{fetchError}</Text>
+          <TouchableOpacity style={styles.retryButton} onPress={handleFetchEstimates}>
+            <Text style={styles.retryButtonText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
+      ) : isLoading ? (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
           <Text style={styles.loadingText}>Finding best rides...</Text>
@@ -733,6 +752,18 @@ function createStyles(colors: ThemeColors) {
     fontSize: 14,
     fontFamily: 'PlusJakartaSans_400Regular',
     color: colors.textDim,
+  },
+  retryButton: {
+    marginTop: 16,
+    paddingHorizontal: 28,
+    paddingVertical: 12,
+    backgroundColor: colors.primary,
+    borderRadius: 24,
+  },
+  retryButtonText: {
+    color: '#FFF',
+    fontSize: 15,
+    fontFamily: 'PlusJakartaSans_600SemiBold',
   },
   optionsList: {
     flex: 1,

--- a/rider-app/app/search-destination.tsx
+++ b/rider-app/app/search-destination.tsx
@@ -8,6 +8,8 @@ import {
   FlatList,
   Keyboard,
   ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, useLocalSearchParams } from 'expo-router';
@@ -316,6 +318,10 @@ export default function SearchDestinationScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
       {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
@@ -632,6 +638,7 @@ export default function SearchDestinationScreen() {
         buttons={alertState.buttons || [{ text: 'OK', style: 'default' }]}
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }

--- a/rider-app/app/wallet.tsx
+++ b/rider-app/app/wallet.tsx
@@ -47,6 +47,7 @@ export default function WalletScreen() {
     fetchWallet, topUp, fetchTransactions, clearError,
   } = useWalletStore();
 
+  const [walletError, setWalletError] = useState<string | null>(null);
   const [showTopUp, setShowTopUp] = useState(false);
   const [customAmount, setCustomAmount] = useState('');
   const [topUpLoading, setTopUpLoading] = useState(false);
@@ -56,8 +57,10 @@ export default function WalletScreen() {
   }>({ visible: false, title: '', message: '', variant: 'info' });
 
   useEffect(() => {
-    fetchWallet();
-    fetchTransactions(30);
+    setWalletError(null);
+    Promise.all([fetchWallet(), fetchTransactions(30)]).catch(() => {
+      setWalletError('Balance unavailable');
+    });
   }, []);
 
   const handleTopUp = async (amount: number) => {
@@ -118,9 +121,13 @@ export default function WalletScreen() {
       {/* Balance Card */}
       <View style={styles.balanceCard}>
         <Text style={styles.balanceLabel}>Available Balance</Text>
-        <Text style={styles.balanceAmount}>
-          ${(wallet?.balance ?? 0).toFixed(2)}
-        </Text>
+        {walletError ? (
+          <Text style={[styles.balanceAmount, { fontSize: 20 }]}>Balance unavailable</Text>
+        ) : (
+          <Text style={styles.balanceAmount}>
+            ${(wallet?.balance ?? 0).toFixed(2)}
+          </Text>
+        )}
         <Text style={styles.balanceCurrency}>{wallet?.currency || 'CAD'}</Text>
 
         <View style={styles.balanceActions}>

--- a/rider-app/constants/rideStatus.ts
+++ b/rider-app/constants/rideStatus.ts
@@ -1,0 +1,12 @@
+export const RideStatus = {
+  SEARCHING: 'searching',
+  DRIVER_ASSIGNED: 'driver_assigned',
+  DRIVER_ACCEPTED: 'driver_accepted',
+  DRIVER_ARRIVED: 'driver_arrived',
+  IN_PROGRESS: 'in_progress',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
+  FAILED: 'failed',
+} as const;
+
+export type RideStatusType = typeof RideStatus[keyof typeof RideStatus];

--- a/rider-app/eas.json
+++ b/rider-app/eas.json
@@ -19,7 +19,7 @@
         "buildType": "apk"
       },
       "env": {
-        "EXPO_PUBLIC_BACKEND_URL": "https://spinr-backend-production.up.railway.app"
+        "EXPO_PUBLIC_BACKEND_URL": "$SPINR_STAGING_BACKEND_URL"
       }
     },
     "preview": {
@@ -28,7 +28,7 @@
         "buildType": "apk"
       },
       "env": {
-        "EXPO_PUBLIC_BACKEND_URL": "https://spinr-backend-production.up.railway.app"
+        "EXPO_PUBLIC_BACKEND_URL": "$SPINR_STAGING_BACKEND_URL"
       }
     },
     "production": {

--- a/rider-app/hooks/useRiderSocket.ts
+++ b/rider-app/hooks/useRiderSocket.ts
@@ -4,6 +4,7 @@ import { useRouter } from 'expo-router';
 import { useAuthStore } from '@shared/store/authStore';
 import { useRideStore } from '../store/rideStore';
 import { API_URL } from '@shared/config';
+import { RideStatus } from '../constants/rideStatus';
 
 /**
  * Real-time WebSocket client for the rider app.
@@ -93,7 +94,7 @@ export function useRiderSocket() {
 
       case 'ride_completed':
         if (rideId) {
-          applyRideStatusFromWS(rideId, 'completed', {
+          applyRideStatusFromWS(rideId, RideStatus.COMPLETED, {
             total_fare: data.total_fare,
           });
           fetchRide(rideId);
@@ -252,7 +253,8 @@ export function useRiderSocket() {
     }
   }, []);
 
-  return { connectionState, sendMessage };
+  const wsConnected = connectionState === 'connected';
+  return { connectionState, wsConnected, sendMessage };
 }
 
 export default useRiderSocket;

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -2,9 +2,11 @@ import { create } from 'zustand';
 import api from '@shared/api/client';
 import { useAuthStore } from '@shared/store/authStore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Alert } from 'react-native';
+import { RideStatus } from '../constants/rideStatus';
 
 const ACTIVE_RIDE_KEY = '@spinr:active_ride';
-const TERMINAL_STATUSES = new Set(['completed', 'cancelled', 'failed']);
+const TERMINAL_STATUSES = new Set([RideStatus.COMPLETED, RideStatus.CANCELLED, RideStatus.FAILED]);
 
 // Write currentRide + currentDriver to AsyncStorage. Clears key when ride is
 // terminal so stale data never survives across sessions.
@@ -213,8 +215,13 @@ export const useRideStore = create<RideState>((set, get) => ({
         _persistRide(ride, driver);
         return response.data;
       }
+      // No active ride on server — clear any stale local state
+      get().clearRide();
       return null;
-    } catch {
+    } catch (err: any) {
+      if (err?.response?.status === 404) {
+        get().clearRide();
+      }
       return null;
     }
   },
@@ -276,40 +283,67 @@ export const useRideStore = create<RideState>((set, get) => ({
 
   applyPromo: (promo) => set({ appliedPromo: promo }),
 
-  // Sync offline queued requests when back online
+  // Sync offline queued requests when back online.
+  // Queue entry shape: { id, type, rideId, payload, retries, timestamp }
+  // Supported types: create_ride | cancel_ride | rate_ride | tip | emergency
   syncOfflineRequests: async () => {
     try {
       const queueStr = await AsyncStorage.getItem('offline_queue');
       if (!queueStr) return;
 
-      const queue = JSON.parse(queueStr);
+      const queue: Array<{
+        id: string;
+        type: 'create_ride' | 'cancel_ride' | 'rate_ride' | 'tip' | 'emergency';
+        rideId?: string;
+        payload?: any;
+        retries?: number;
+        timestamp?: number;
+      }> = JSON.parse(queueStr);
       if (queue.length === 0) return;
 
       const successfulSyncs: string[] = [];
+      const failedPermanently: string[] = [];
 
       for (const request of queue) {
         try {
-          if (request.type === 'create_ride') {
-            await api.post('/rides', request.data);
-            successfulSyncs.push(request.id);
+          switch (request.type) {
+            case 'create_ride':
+              await api.post('/rides', request.payload);
+              break;
+            case 'cancel_ride':
+              if (request.rideId) await api.post(`/rides/${request.rideId}/cancel`);
+              break;
+            case 'rate_ride':
+              if (request.rideId) await api.post(`/rides/${request.rideId}/rate`, request.payload);
+              break;
+            case 'tip':
+              if (request.rideId) await api.post(`/rides/${request.rideId}/tip`, request.payload);
+              break;
+            case 'emergency':
+              if (request.rideId) await api.post(`/rides/${request.rideId}/emergency`, request.payload);
+              break;
           }
-          // Add other request types here as needed
-        } catch (error) {
-          // Increment retry count, remove after max retries
-          request.retryCount = (request.retryCount || 0) + 1;
-          if (request.retryCount >= 3) {
-            successfulSyncs.push(request.id); // Remove failed requests
+          successfulSyncs.push(request.id);
+        } catch {
+          request.retries = (request.retries || 0) + 1;
+          if (request.retries >= 3) {
+            failedPermanently.push(request.id);
           }
         }
       }
 
-      // Remove successfully synced requests
-      const updatedQueue = queue.filter(req => !successfulSyncs.includes(req.id));
+      const idsToRemove = new Set([...successfulSyncs, ...failedPermanently]);
+      const updatedQueue = queue.filter(req => !idsToRemove.has(req.id));
       await AsyncStorage.setItem('offline_queue', JSON.stringify(updatedQueue));
 
+      if (failedPermanently.length > 0) {
+        Alert.alert(
+          'Sync Failed',
+          `${failedPermanently.length} offline action(s) could not be synced and were dropped.`,
+        );
+      }
       if (successfulSyncs.length > 0) {
-        // Could emit an event or show notification that offline requests were synced
-        console.log(`Synced ${successfulSyncs.length} offline requests`);
+        console.log(`[Offline] Synced ${successfulSyncs.length} requests`);
       }
     } catch (error) {
       console.error('Failed to sync offline requests:', error);
@@ -391,7 +425,7 @@ export const useRideStore = create<RideState>((set, get) => ({
     try {
       const response = await api.post(`/rides/${currentRide.id}/simulate-arrival`);
       set({
-        currentRide: { ...currentRide, status: 'driver_arrived', pickup_otp: response.data.pickup_otp },
+        currentRide: { ...currentRide, status: RideStatus.DRIVER_ARRIVED, pickup_otp: response.data.pickup_otp },
       });
     } catch (error: any) {
       set({ error: error.message });
@@ -405,7 +439,7 @@ export const useRideStore = create<RideState>((set, get) => ({
     try {
       await api.post(`/rides/${currentRide.id}/start`);
       set({
-        currentRide: { ...currentRide, status: 'in_progress' },
+        currentRide: { ...currentRide, status: RideStatus.IN_PROGRESS },
       });
     } catch (error: any) {
       set({ error: error.message });
@@ -585,18 +619,32 @@ export const useRideStore = create<RideState>((set, get) => ({
     try {
       const raw = await AsyncStorage.getItem(ACTIVE_RIDE_KEY);
       if (!raw) return;
-      const { currentRide, currentDriver } = JSON.parse(raw);
-      if (!currentRide || TERMINAL_STATUSES.has(currentRide.status)) {
+      const { currentRide: stored, currentDriver } = JSON.parse(raw);
+      if (!stored || TERMINAL_STATUSES.has(stored.status)) {
         await AsyncStorage.removeItem(ACTIVE_RIDE_KEY);
         return;
       }
-      // Only restore if there's no ride already in memory (e.g. from a
-      // previous mount in the same session).
-      if (!get().currentRide) {
-        set({ currentRide, currentDriver: currentDriver || null });
+      // Validate against backend — if the ride completed or was cancelled
+      // while the app was closed the stored data would be stale.
+      try {
+        const live = await api.get('/rides/active');
+        if (!live.data?.active || live.data.ride?.id !== stored.id) {
+          await AsyncStorage.removeItem(ACTIVE_RIDE_KEY);
+          return; // stale — do not route
+        }
+        const liveRide = live.data.ride;
+        const liveDriver = liveRide.driver || currentDriver || null;
+        if (!get().currentRide) {
+          set({ currentRide: liveRide, currentDriver: liveDriver });
+        }
+      } catch {
+        // Offline or server error — restore from cache optimistically but
+        // fetchActiveRide on mount will correct any stale state.
+        if (!get().currentRide) {
+          set({ currentRide: stored, currentDriver: currentDriver || null });
+        }
       }
     } catch {
-      // Corrupt data — clear and let the API fetch handle it
       AsyncStorage.removeItem(ACTIVE_RIDE_KEY).catch(() => {});
     }
   },

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -138,7 +138,7 @@ interface RideState {
   fetchEstimates: () => Promise<void>;
   fetchNearbyDrivers: () => Promise<void>;
   selectVehicle: (vehicle: VehicleType) => void;
-  createRide: (paymentMethod: string) => Promise<Ride>;
+  createRide: (paymentMethod: string, corporateAccountId?: string | null) => Promise<Ride>;
   fetchRide: (rideId: string) => Promise<void>;
   cancelRide: () => Promise<void>;
   simulateDriverArrival: () => Promise<void>;
@@ -350,7 +350,7 @@ export const useRideStore = create<RideState>((set, get) => ({
     }
   },
 
-  createRide: async (paymentMethod) => {
+  createRide: async (paymentMethod, corporateAccountId) => {
     const { pickup, dropoff, selectedVehicle, stops, scheduledTime } = get();
     if (!pickup || !dropoff || !selectedVehicle) {
       throw new Error('Missing ride details');
@@ -368,6 +368,7 @@ export const useRideStore = create<RideState>((set, get) => ({
         dropoff_lng: dropoff.lng,
         stops: stops,
         payment_method: paymentMethod,
+        corporate_account_id: corporateAccountId || null,
         created_at: new Date().toISOString(),
       };
 

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -150,10 +150,13 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
 
   setTokens: async (token: string, refreshToken: string, expiresIn: number) => {
     const expiresAt = Date.now() + expiresIn * 1000;
+    // Access token is memory-only (wiped on restart, stays within JWT TTL).
+    // Only the refresh token is persisted to hardware-backed secure storage.
     setInMemoryToken(token);
-    await storage.setItem('auth_token', token);
     await storage.setItem('refresh_token', refreshToken);
     await storage.setItem('token_expires_at', String(expiresAt));
+    // Remove any previously-persisted access token from older app versions.
+    await storage.deleteItem('auth_token');
     set({ token, refreshToken, tokenExpiresAt: expiresAt });
   },
 


### PR DESCRIPTION
## Summary
This PR addresses six critical P2 launch blockers identified in the remediation report:
- Corporate account billing support for riders
- Comprehensive offline request queue handling (not just ride creation)
- Centralized ride status constants to eliminate magic strings
- WebSocket-aware polling to reduce battery/bandwidth usage
- Terms of Service acceptance on signup
- Enhanced error handling and validation across multiple screens

## Key Changes

### Corporate Billing (R-P2-10)
- Added `CorporateAccount` interface and corporate accounts UI in `payment-confirm.tsx`
- Fetch rider's corporate accounts on mount via `/corporate/rider/accounts`
- Toggle switch to bill ride to corporate account with account selection dropdown
- Pass `corporate_account_id` to `createRide()` API call
- Added corresponding styles for corporate section UI

### Offline Queue Expansion (R-P2-1)
- Extended `syncOfflineRequests()` in `rideStore.ts` to handle: `create_ride`, `cancel_ride`, `rate_ride`, `tip`, `emergency`
- Improved queue entry typing with explicit `type` discriminator
- Retry logic: increment on failure, remove after 3 failed attempts
- User alert when requests fail permanently after max retries
- Separate tracking of successful vs. permanently failed syncs

### Ride Status Constants (R-P2-3)
- Created `rider-app/constants/rideStatus.ts` with centralized `RideStatus` enum
- Replaced all magic string literals (`'searching'`, `'driver_arrived'`, etc.) with `RideStatus.X` references
- Updated: `rideStore.ts`, `driver-arriving.tsx`, `driver-arrived.tsx`, `ride-in-progress.tsx`, `useRiderSocket.ts`
- Added TypeScript type export `RideStatusType` for type safety

### WebSocket-Aware Polling (R-P2-5)
- Modified polling logic in `driver-arriving.tsx`, `driver-arrived.tsx`, `ride-in-progress.tsx`
- Suspend fallback polling when `wsConnected` is true (from `useRiderSocket` hook)
- Maintain fast 3s poll during driver assignment negotiation only when WS unavailable
- Fall back to 15s poll otherwise
- Reduces unnecessary API calls and battery drain when WebSocket is healthy

### Cold-Start Stale Ride Validation (R-P2-2)
- Enhanced `fetchRide()` in `rideStore.ts` to detect 404 responses
- Call `clearRide()` when ride not found on server (completed/cancelled while offline)
- Prevents routing to stale ride screens on cold start

### Terms of Service (Profile Setup)
- Added `tosAccepted` state and checkbox UI in `profile-setup.tsx`
- TOS acceptance required only for new signups (not profile edits)
- Links to `https://spinr.ca/terms` and `https://spinr.ca/privacy`
- Form validation blocks submission until TOS is accepted

### Error Handling & Validation
- Added error states to `ride-options.tsx`: fetch error with retry button
- Added loading state to `driver-arrived.tsx` and `ride-in-progress.tsx` when ride data missing
- Enhanced `wallet.tsx` error handling with `setWalletError` state
- Improved `activity.tsx` error handling for ride history fetch
- Added `ActivityIndicator` loading indicators on key screens

### Backend Improvements
- Created `DriverPublicView` schema in `schemas.py` to safely expose driver fields to riders (no PII)
- Applied schema to `/rides/{id}` GET response to strip sensitive driver data
- Added `TipRequest` model with validation (amount: $0.01–$500)
- Enhanced `CreateRideRequest` validation: stops max 5 items, scheduled time min 5 min future
- Added `@validator` for stops (lat/lng bounds) and scheduled_time
- Improved `SavedAddressCreate` field constraints (name, address length limits)
- Fixed `TopUpRequest` to use `Decimal` instead of `float` for monetary values

### Become Driver Flow
- Added

https://claude.ai/code/session_01KjE9j7bopVFYP7wRSipP3B