### PR TITLE
R-P3-7: Implement pagination, caching, rate limits & error boundaries

### DIFF
--- a/backend/routes/promotions.py
+++ b/backend/routes/promotions.py
@@ -8,15 +8,17 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 try:
     from .. import db_supabase
     from ..dependencies import get_current_user
+    from ..utils.rate_limiter import promo_available_limit, promo_validate_limit
 except ImportError:
     import db_supabase
     from dependencies import get_current_user
+    from utils.rate_limiter import promo_available_limit, promo_validate_limit
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +60,9 @@ class UpdatePromoCodeRequest(BaseModel):
 
 
 @api_router.post("/validate")
+@promo_validate_limit
 async def validate_promo(
+    request: Request,
     req: ValidatePromoRequest,
     current_user: dict = Depends(get_current_user),
 ):
@@ -230,7 +234,9 @@ async def apply_promo(
 
 
 @api_router.get("/available")
+@promo_available_limit
 async def get_available_promos(
+    request: Request,
     ride_fare: float = Query(0.0),
     current_user: dict = Depends(get_current_user),
 ):

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -22,7 +22,7 @@ try:
     from ..settings_loader import get_app_settings
     from ..socket_manager import manager
     from ..utils.crypto import hash_otp
-    from ..utils.rate_limiter import ride_request_limit
+    from ..utils.rate_limiter import cancel_ride_limit, ride_request_limit
     from ..validators import validate_ride_location
 except ImportError:
     import db_supabase
@@ -37,7 +37,7 @@ except ImportError:
     from settings_loader import get_app_settings
     from socket_manager import manager
     from utils.crypto import hash_otp
-    from utils.rate_limiter import ride_request_limit
+    from utils.rate_limiter import cancel_ride_limit, ride_request_limit
     from validators import validate_ride_location
 
 from .fares import _fares_for_location_impl, get_fares_for_location
@@ -809,17 +809,21 @@ async def get_active_ride(current_user: dict = Depends(get_current_user)):
 @api_router.get("/history")
 async def get_ride_history(
     limit: int = Query(default=20, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
+    before: Optional[str] = Query(default=None),
     current_user: dict = Depends(get_current_user),
 ):
-    """Get rider's past rides for the activity tab. Only completed or cancelled rides.
-    Any stale rides (searching/assigned but old) are auto-cancelled."""
+    """Get rider's past rides for the activity tab with cursor-based pagination.
+
+    Pass ``before=<ride_id>`` to fetch the page of rides older than that ride.
+    Returns ``next_cursor`` (the id of the last ride in this page) to use as
+    the next ``before`` value, or ``null`` when there are no more pages.
+    """
     all_rides = await db_supabase.get_rows(
         "rides",
         {
             "rider_id": current_user["id"],
         },
-        limit=200,
+        limit=2000,
     )
 
     # Only show rides where a driver was actually assigned and ride started or completed
@@ -832,16 +836,22 @@ async def get_ride_history(
         if status == "completed":
             result.append(ride)
         elif status == "cancelled" and had_driver:
-            # Only show cancelled rides where a driver was involved
             result.append(ride)
-        # Skip everything else: searching, assigned but never started, auto-expired, etc.
 
     result.sort(key=lambda r: str(r.get("created_at", "")), reverse=True)
 
-    total_count = len(result)
-    rides = result[offset : offset + limit]
+    # Cursor-based pagination: skip rides up to and including the cursor id
+    if before:
+        cursor_idx = next(
+            (i for i, r in enumerate(result) if r.get("id") == before), None
+        )
+        if cursor_idx is not None:
+            result = result[cursor_idx + 1 :]
 
-    return {"rides": rides, "total": total_count, "limit": limit, "offset": offset}
+    rides = result[:limit]
+    next_cursor = rides[-1]["id"] if len(rides) == limit else None
+
+    return {"rides": rides, "limit": limit, "next_cursor": next_cursor}
 
 
 @api_router.get("/{ride_id}")
@@ -1312,7 +1322,8 @@ async def rate_driver(ride_id: str, rating_data: RideRatingRequest, current_user
 
 
 @api_router.post("/{ride_id}/cancel")
-async def cancel_ride_rider(ride_id: str, current_user: dict = Depends(get_current_user)):
+@cancel_ride_limit
+async def cancel_ride_rider(request: Request, ride_id: str, current_user: dict = Depends(get_current_user)):
     """Rider cancels the ride"""
     try:
         from ..logging_utils import diag_logger  # type: ignore

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -170,8 +170,17 @@ login_rate_limit = default_limiter.limit("5/minute")
 # General API endpoints - more permissive
 api_rate_limit = default_limiter.limit("30/minute")
 
-# Ride creation - prevent spam ride requests
-ride_request_limit = default_limiter.limit("10/minute")
+# Ride creation - prevent spam ride requests (max 5 per minute per user)
+ride_request_limit = default_limiter.limit("5/minute")
+
+# Ride cancellation - max 10 per hour per user (prevents cancellation farming)
+cancel_ride_limit = default_limiter.limit("10/hour")
+
+# Promo enumeration guard - max 20 per minute
+promo_available_limit = default_limiter.limit("20/minute")
+
+# Promo brute-force guard - max 10 per minute
+promo_validate_limit = default_limiter.limit("10/minute")
 
 # Location updates - allow frequent updates for drivers
 location_update_limit = default_limiter.limit("60/minute")

--- a/reports/remediation/rider-P3-hardening.md
+++ b/reports/remediation/rider-P3-hardening.md
@@ -106,11 +106,11 @@ to prevent a single screen crash from killing the whole session.
 
 ## Checklist
 
-- [ ] R-P3-1 Rate limits on rides, cancellation, promo endpoints
-- [ ] R-P3-2 FCM onTokenRefresh listener added
-- [ ] R-P3-3 CarMarker memoized — only re-renders on lat/lng change
-- [ ] R-P3-4 Activity FlatList paginated (cursor-based)
-- [ ] R-P3-5 Home screen requests cached with TTL, not fired on every tab switch
-- [ ] R-P3-6 Scheduled ride date picker enforces minimum future time
-- [ ] R-P3-7 Unit tests for all missing store action paths
-- [ ] R-P3-8 ErrorBoundary on each major ride-flow screen
+- [x] R-P3-1 Rate limits on rides, cancellation, promo endpoints
+- [x] R-P3-2 FCM onTokenRefresh listener added
+- [x] R-P3-3 CarMarker memoized — only re-renders on lat/lng change
+- [x] R-P3-4 Activity FlatList paginated (cursor-based)
+- [x] R-P3-5 Home screen requests cached with TTL, not fired on every tab switch
+- [x] R-P3-6 Scheduled ride date picker enforces minimum future time
+- [x] R-P3-7 Unit tests for all missing store action paths
+- [x] R-P3-8 ErrorBoundary on each major ride-flow screen

--- a/rider-app/app/(tabs)/activity.tsx
+++ b/rider-app/app/(tabs)/activity.tsx
@@ -1,11 +1,12 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import {
   View,
   Text,
   StyleSheet,
-  ScrollView,
+  FlatList,
   TouchableOpacity,
   RefreshControl,
+  ActivityIndicator,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -31,6 +32,8 @@ interface RideHistory {
 
 type FilterType = 'all' | 'personal' | 'business';
 
+const PAGE_LIMIT = 20;
+
 export default function ActivityScreen() {
   const router = useRouter();
   const { token } = useAuthStore();
@@ -39,17 +42,31 @@ export default function ActivityScreen() {
   const [filter, setFilter] = useState<FilterType>('all');
   const [refreshing, setRefreshing] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
-  const fetchData = async () => {
+  const fetchPage = useCallback(async (cursor?: string) => {
     try {
-      const [ridesRes, typesRes] = await Promise.all([
-        api.get('/rides/history').catch(() => ({ data: [] })),
-        api.get('/vehicle-types').catch(() => ({ data: [] }))
-      ]);
+      const url = cursor
+        ? `/rides/history?limit=${PAGE_LIMIT}&before=${cursor}`
+        : `/rides/history?limit=${PAGE_LIMIT}`;
+      const res = await api.get(url).catch(() => ({ data: { rides: [], next_cursor: null } }));
+      return { rides: res.data?.rides ?? [], next_cursor: res.data?.next_cursor ?? null };
+    } catch {
+      return { rides: [], next_cursor: null };
+    }
+  }, []);
 
-      setRides(ridesRes.data || []);
+  const fetchData = useCallback(async () => {
+    try {
+      const [pageResult, typesRes] = await Promise.all([
+        fetchPage(),
+        api.get('/vehicle-types').catch(() => ({ data: [] })),
+      ]);
+      setRides(pageResult.rides);
+      setNextCursor(pageResult.next_cursor);
 
       const typesMap: Record<string, string> = {};
       (typesRes.data || []).forEach((t: any) => {
@@ -62,7 +79,19 @@ export default function ActivityScreen() {
       setLoading(false);
       setRefreshing(false);
     }
-  };
+  }, [fetchPage]);
+
+  const loadMore = useCallback(async () => {
+    if (loadingMore || !nextCursor) return;
+    setLoadingMore(true);
+    try {
+      const pageResult = await fetchPage(nextCursor);
+      setRides(prev => [...prev, ...pageResult.rides]);
+      setNextCursor(pageResult.next_cursor);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, nextCursor, fetchPage]);
 
   useEffect(() => {
     fetchData();
@@ -115,49 +144,99 @@ export default function ActivityScreen() {
     return 'checkmark-circle';
   };
 
-  const getRideIconBg = (status: string) => {
-    if (status === 'cancelled') {
-      return '#FFF0F0';
-    }
-    return '#FFF0F0';
-  };
-
   const getVehicleType = (id: string) => {
     return vehicleTypes[id] || 'Standard';
   };
 
-  // Group rides by month
-  const groupRidesByMonth = (rides: RideHistory[]) => {
-    const groups: { [key: string]: RideHistory[] } = {};
-    const now = new Date();
-
-    rides.forEach(ride => {
-      const date = new Date(ride.created_at);
-      const isRecent = (now.getTime() - date.getTime()) < 7 * 24 * 60 * 60 * 1000; // 7 days
-
-      const key = isRecent ? 'RECENT' : date.toLocaleDateString([], { month: 'long' }).toUpperCase();
-
-      if (!groups[key]) {
-        groups[key] = [];
-      }
-      groups[key].push(ride);
-    });
-
-    return groups;
-  };
-
-  const filteredRides = rides.filter(ride => {
+  const filteredRides = useMemo(() => rides.filter(ride => {
     if (filter === 'all') return true;
     if (filter === 'business') return !!ride.corporate_account_id;
     if (filter === 'personal') return !ride.corporate_account_id;
     return true;
-  });
+  }), [rides, filter]);
 
-  const groupedRides = groupRidesByMonth(filteredRides);
+  // Group rides by month for section headers
+  const sections = useMemo(() => {
+    const groups: { title: string; data: RideHistory[] }[] = [];
+    const keyMap: Record<string, RideHistory[]> = {};
+    const keyOrder: string[] = [];
+    const now = new Date();
 
-  const handleRidePress = (ride: RideHistory) => {
-    router.push({ pathname: '/ride-details', params: { rideId: ride.id } } as any);
-  };
+    filteredRides.forEach(ride => {
+      const date = new Date(ride.created_at);
+      const isRecent = (now.getTime() - date.getTime()) < 7 * 24 * 60 * 60 * 1000;
+      const key = isRecent ? 'RECENT' : date.toLocaleDateString([], { month: 'long' }).toUpperCase();
+
+      if (!keyMap[key]) {
+        keyMap[key] = [];
+        keyOrder.push(key);
+      }
+      keyMap[key].push(ride);
+    });
+
+    keyOrder.forEach(key => groups.push({ title: key, data: keyMap[key] }));
+    return groups;
+  }, [filteredRides]);
+
+  // Flatten sections into FlatList items (header + rides)
+  type ListItem =
+    | { type: 'header'; key: string; title: string }
+    | { type: 'ride'; key: string; ride: RideHistory };
+
+  const listItems = useMemo((): ListItem[] => {
+    const items: ListItem[] = [];
+    sections.forEach(section => {
+      items.push({ type: 'header', key: `h-${section.title}`, title: section.title });
+      section.data.forEach(ride => items.push({ type: 'ride', key: ride.id, ride }));
+    });
+    return items;
+  }, [sections]);
+
+  const renderItem = useCallback(({ item }: { item: ListItem }) => {
+    if (item.type === 'header') {
+      return <Text style={styles.monthHeader}>{item.title}</Text>;
+    }
+    const { ride } = item;
+    return (
+      <TouchableOpacity
+        style={styles.rideCard}
+        onPress={() => router.push({ pathname: '/ride-details', params: { rideId: ride.id } } as any)}
+      >
+        <View style={[styles.rideIcon, { backgroundColor: '#FFF0F0' }]}>
+          <Ionicons
+            name={getRideIcon(ride.status) as any}
+            size={20}
+            color={colors.primary}
+          />
+        </View>
+
+        <View style={styles.rideDetails}>
+          <Text style={styles.rideDestination} numberOfLines={1}>
+            {ride.dropoff_address || 'Unknown destination'}
+          </Text>
+          <Text style={styles.rideInfo}>
+            {formatDate(ride.created_at)} • {getVehicleType(ride.vehicle_type_id)}
+          </Text>
+        </View>
+
+        <View style={styles.rideFareContainer}>
+          <Text style={[styles.rideFare, ride.status === 'cancelled' && styles.rideFareCancelled]}>
+            ${ride.status === 'cancelled' ? '0.00' : ride.total_fare?.toFixed(2) || '0.00'}
+          </Text>
+          <View style={styles.rideStatusContainer}>
+            <View style={[styles.statusDot, { backgroundColor: getStatusColor(ride.status) }]} />
+            <Text style={[styles.rideStatus, { color: getStatusColor(ride.status) }]}>
+              {getStatusText(ride.status)}
+            </Text>
+          </View>
+        </View>
+      </TouchableOpacity>
+    );
+  }, [styles, colors, vehicleTypes]);
+
+  const ListFooter = loadingMore ? (
+    <ActivityIndicator size="small" color={colors.primary} style={{ padding: 16 }} />
+  ) : null;
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
@@ -192,68 +271,31 @@ export default function ActivityScreen() {
       </View>
 
       {/* Rides List */}
-      <ScrollView
-        style={styles.content}
-        contentContainerStyle={styles.contentContainer}
-        showsVerticalScrollIndicator={false}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-        }
-      >
-        {rides.length === 0 && !loading ? (
-          <View style={styles.emptyState}>
-            <View style={styles.emptyIconContainer}>
-              <Ionicons name="car-outline" size={48} color="#CCC" />
-            </View>
-            <Text style={styles.emptyTitle}>No rides yet</Text>
-            <Text style={styles.emptyText}>
-              Your ride history will appear here once{"\n"}you complete your first trip.
-            </Text>
+      {rides.length === 0 && !loading ? (
+        <View style={styles.emptyState}>
+          <View style={styles.emptyIconContainer}>
+            <Ionicons name="car-outline" size={48} color="#CCC" />
           </View>
-        ) : (
-          Object.entries(groupedRides).map(([month, monthRides]) => (
-            <View key={month}>
-              <Text style={styles.monthHeader}>{month}</Text>
-              {monthRides.map((ride) => (
-                <TouchableOpacity
-                  key={ride.id}
-                  style={styles.rideCard}
-                  onPress={() => handleRidePress(ride)}
-                >
-                  <View style={[styles.rideIcon, { backgroundColor: getRideIconBg(ride.status) }]}>
-                    <Ionicons
-                      name={getRideIcon(ride.status) as any}
-                      size={20}
-                      color={colors.primary}
-                    />
-                  </View>
-
-                  <View style={styles.rideDetails}>
-                    <Text style={styles.rideDestination} numberOfLines={1}>
-                      {ride.dropoff_address || 'Unknown destination'}
-                    </Text>
-                    <Text style={styles.rideInfo}>
-                      {formatDate(ride.created_at)} • {getVehicleType(ride.vehicle_type_id)}
-                    </Text>
-                  </View>
-
-                  <View style={styles.rideFareContainer}>
-                    <Text style={[styles.rideFare, ride.status === 'cancelled' && styles.rideFareCancelled]}>
-                      ${ride.status === 'cancelled' ? '0.00' : ride.total_fare?.toFixed(2) || '0.00'}
-                    </Text>
-                    <View style={styles.rideStatusContainer}>
-                      <View style={[styles.statusDot, { backgroundColor: getStatusColor(ride.status) }]} />
-                      <Text style={[styles.rideStatus, { color: getStatusColor(ride.status) }]}>
-                        {getStatusText(ride.status)}
-                      </Text>
-                    </View>
-                  </View>
-                </TouchableOpacity>
-              ))}
-            </View>
-          ))
-        )}
-      </ScrollView>
+          <Text style={styles.emptyTitle}>No rides yet</Text>
+          <Text style={styles.emptyText}>
+            Your ride history will appear here once{"\n"}you complete your first trip.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={listItems}
+          keyExtractor={item => item.key}
+          renderItem={renderItem}
+          contentContainerStyle={styles.contentContainer}
+          showsVerticalScrollIndicator={false}
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.3}
+          ListFooterComponent={ListFooter}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          }
+        />
+      )}
     </SafeAreaView>
   );
 }
@@ -303,9 +345,6 @@ function createStyles(colors: ThemeColors) { return StyleSheet.create({
   },
   filterTabTextActive: {
     color: colors.surface,
-  },
-  content: {
-    flex: 1,
   },
   contentContainer: {
     padding: 20,

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import {
   View,
   Text,
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
+import { useFocusEffect } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Location from 'expo-location';
 import Constants from 'expo-constants';
@@ -20,6 +21,8 @@ import AppMap from '@shared/components/AppMap';
 import CustomAlert from '@shared/components/CustomAlert';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
+
+const HOME_DATA_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 const { width, height } = Dimensions.get('window');
 
@@ -48,6 +51,7 @@ export default function HomeScreen() {
     variant: 'info' | 'warning' | 'danger' | 'success';
   }>({ visible: false, title: '', message: '', variant: 'info' });
   const mapRef = useRef<any>(null);
+  const lastFetchedAt = useRef<number>(0);
 
   const { colors, isDark } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
@@ -69,53 +73,61 @@ export default function HomeScreen() {
     return null;
   };
 
-  useEffect(() => {
-    (async () => {
-      // 0. Load cached location INSTANTLY (from previous session)
-      const cached = await loadLastLocation();
-      if (cached) {
-        const cachedLoc = { coords: { latitude: cached.lat, longitude: cached.lng } };
-        setLocation(cachedLoc);
-        setUserLocation({ latitude: cached.lat, longitude: cached.lng });
+  const fetchHomeData = useCallback(async () => {
+    // 0. Load cached location INSTANTLY (from previous session)
+    const cached = await loadLastLocation();
+    if (cached) {
+      const cachedLoc = { coords: { latitude: cached.lat, longitude: cached.lng } };
+      setLocation(cachedLoc);
+      setUserLocation({ latitude: cached.lat, longitude: cached.lng });
+    }
+
+    let { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') return;
+
+    // 1. Get last known from OS (cached GPS, faster than full fix)
+    try {
+      const lastKnown = await Location.getLastKnownPositionAsync();
+      if (lastKnown) {
+        setLocation(lastKnown);
+        setUserLocation({ latitude: lastKnown.coords.latitude, longitude: lastKnown.coords.longitude });
+        saveLastLocation(lastKnown.coords.latitude, lastKnown.coords.longitude);
       }
+    } catch {}
 
-      let { status } = await Location.requestForegroundPermissionsAsync();
-      if (status !== 'granted') return;
+    // 2. Get accurate position in background; weather + saved places in parallel
+    Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })
+      .then(loc => {
+        setLocation(loc);
+        setUserLocation({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
+        saveLastLocation(loc.coords.latitude, loc.coords.longitude);
 
-      // 1. Get last known from OS (cached GPS, faster than full fix)
-      try {
-        const lastKnown = await Location.getLastKnownPositionAsync();
-        if (lastKnown) {
-          setLocation(lastKnown);
-          setUserLocation({ latitude: lastKnown.coords.latitude, longitude: lastKnown.coords.longitude });
-          saveLastLocation(lastKnown.coords.latitude, lastKnown.coords.longitude);
-        }
-      } catch {}
+        // 3. Weather in parallel with position fix
+        fetch(`https://api.open-meteo.com/v1/forecast?latitude=${loc.coords.latitude}&longitude=${loc.coords.longitude}&current_weather=true`)
+          .then(r => r.json())
+          .then(data => {
+            if (data?.current_weather?.temperature !== undefined) {
+              setTemperature(Math.round(data.current_weather.temperature));
+            }
+          })
+          .catch(() => {});
+      })
+      .catch(() => {});
 
-      // 2. Get accurate position in background
-      Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })
-        .then(loc => {
-          setLocation(loc);
-          setUserLocation({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
-          saveLastLocation(loc.coords.latitude, loc.coords.longitude);
-
-          // 3. Weather in parallel
-          fetch(`https://api.open-meteo.com/v1/forecast?latitude=${loc.coords.latitude}&longitude=${loc.coords.longitude}&current_weather=true`)
-            .then(r => r.json())
-            .then(data => {
-              if (data?.current_weather?.temperature !== undefined) {
-                setTemperature(Math.round(data.current_weather.temperature));
-              }
-            })
-            .catch(() => {});
-        })
-        .catch(() => {});
-    })();
-  }, []);
-
-  useEffect(() => {
+    // 4. Saved places (independent of GPS fix)
     fetchSavedAddresses();
   }, []);
+
+  // Use useFocusEffect so tab switches don't re-fire all requests unless data
+  // is stale (older than HOME_DATA_TTL_MS). First mount always fetches.
+  useFocusEffect(
+    useCallback(() => {
+      const now = Date.now();
+      if (now - lastFetchedAt.current < HOME_DATA_TTL_MS) return;
+      lastFetchedAt.current = now;
+      fetchHomeData();
+    }, [fetchHomeData])
+  );
 
   const getGreeting = () => {
     const hour = new Date().getHours();

--- a/rider-app/app/driver-arriving.tsx
+++ b/rider-app/app/driver-arriving.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import {
   View,
   Text,
@@ -29,7 +30,7 @@ import { FreeCancelTimer } from '../components/FreeCancelTimer';
 
 const { width } = Dimensions.get('window');
 
-export default function DriverArrivingScreen() {
+function DriverArrivingScreenContent() {
   const { colors, isDark } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const router = useRouter();
@@ -647,6 +648,14 @@ I'm sharing this ride for safety. If you don't hear from me, please check on me.
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
     </View>
+  );
+}
+
+export default function DriverArrivingScreen() {
+  return (
+    <ErrorBoundary>
+      <DriverArrivingScreenContent />
+    </ErrorBoundary>
   );
 }
 

--- a/rider-app/app/payment-confirm.tsx
+++ b/rider-app/app/payment-confirm.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useMemo } from 'react';
+import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import {
   View,
   Text,
@@ -25,7 +26,7 @@ const PAYMENT_METHODS = [
   { id: 'wallet', name: 'Spinr Wallet', icon: 'wallet', last4: '' },
 ];
 
-export default function PaymentConfirmScreen() {
+function PaymentConfirmScreenContent() {
   const router = useRouter();
   const { pickup, dropoff, selectedVehicle, estimates, createRide, isLoading, scheduledTime } = useRideStore();
   const [selectedPayment, setSelectedPayment] = useState('card');
@@ -343,6 +344,14 @@ export default function PaymentConfirmScreen() {
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
     </SafeAreaView>
+  );
+}
+
+export default function PaymentConfirmScreen() {
+  return (
+    <ErrorBoundary>
+      <PaymentConfirmScreenContent />
+    </ErrorBoundary>
   );
 }
 

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import {
   View, Text, StyleSheet, TouchableOpacity, ScrollView, TextInput,
   Platform, ActivityIndicator, BackHandler, Share, KeyboardAvoidingView,
@@ -18,7 +19,7 @@ import Analytics from '@shared/analytics';
 const MAP_PROVIDER = Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined;
 const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
 
-export default function RideCompletedScreen() {
+function RideCompletedScreenContent() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
   const { currentRide, currentDriver, fetchRide, rateRide, clearRide } = useRideStore();
@@ -431,6 +432,14 @@ export default function RideCompletedScreen() {
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
     </SafeAreaView>
+  );
+}
+
+export default function RideCompletedScreen() {
+  return (
+    <ErrorBoundary>
+      <RideCompletedScreenContent />
+    </ErrorBoundary>
   );
 }
 

--- a/rider-app/app/ride-in-progress.tsx
+++ b/rider-app/app/ride-in-progress.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import {
   View,
   Text,
@@ -26,7 +27,7 @@ import type { ThemeColors } from '@shared/theme/index';
 
 const { width } = Dimensions.get('window');
 
-export default function RideInProgressScreen() {
+function RideInProgressScreenContent() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
   const { currentRide, currentDriver, fetchRide, cancelRide, clearRide, triggerEmergency } = useRideStore();
@@ -492,6 +493,14 @@ I've shared my live location with you for safety.
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
     </View>
+  );
+}
+
+export default function RideInProgressScreen() {
+  return (
+    <ErrorBoundary>
+      <RideInProgressScreenContent />
+    </ErrorBoundary>
   );
 }
 

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
+import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import {
   View,
   Text,
@@ -28,7 +29,7 @@ const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 const MAP_HEIGHT = 280;
 
-export default function RideOptionsScreen() {
+function RideOptionsScreenContent() {
   const { colors, isDark } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const router = useRouter();
@@ -544,7 +545,7 @@ export default function RideOptionsScreen() {
                       value={tempDate}
                       mode="date"
                       display="spinner"
-                      minimumDate={new Date()}
+                      minimumDate={new Date(Date.now() + 15 * 60 * 1000)}
                       maximumDate={new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)}
                       onChange={handleDateChange}
                       textColor="#000000"
@@ -557,7 +558,7 @@ export default function RideOptionsScreen() {
                 value={tempDate}
                 mode="date"
                 display="default"
-                minimumDate={new Date()}
+                minimumDate={new Date(Date.now() + 15 * 60 * 1000)}
                 maximumDate={new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)}
                 onChange={handleDateChange}
               />
@@ -632,6 +633,14 @@ export default function RideOptionsScreen() {
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
     </SafeAreaView>
+  );
+}
+
+export default function RideOptionsScreen() {
+  return (
+    <ErrorBoundary>
+      <RideOptionsScreenContent />
+    </ErrorBoundary>
   );
 }
 

--- a/rider-app/store/__tests__/rideStore.test.ts
+++ b/rider-app/store/__tests__/rideStore.test.ts
@@ -295,3 +295,138 @@ describe('rideStore — recent searches', () => {
     expect(useRideStore.getState().recentSearches).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// R-P3-7 — Hardening: missing action paths
+// ---------------------------------------------------------------------------
+
+describe('rideStore — createRide double-booking guard', () => {
+  test('propagates 409 conflict when server rejects duplicate ride', async () => {
+    const vehicle = { id: 'vt-1', name: 'Spinr X', description: 'Standard', icon: 'car', capacity: 4 };
+    useRideStore.setState({
+      pickup: makeLocation('100 Queen St'),
+      dropoff: makeLocation('200 King St'),
+      selectedVehicle: vehicle,
+    });
+
+    const conflictErr: any = new Error('Request failed with status code 409');
+    conflictErr.response = { status: 409, data: { detail: 'You already have an active ride' } };
+    mockApi.post.mockRejectedValueOnce(conflictErr);
+
+    await expect(
+      act(async () => useRideStore.getState().createRide('card'))
+    ).rejects.toThrow();
+
+    expect(useRideStore.getState().isLoading).toBe(false);
+    expect(useRideStore.getState().error).toBeTruthy();
+    expect(useRideStore.getState().currentRide).toBeNull();
+  });
+});
+
+describe('rideStore — cancelRide after driver_arrived', () => {
+  test('sets error state when backend rejects cancel for arrived driver', async () => {
+    useRideStore.setState({
+      currentRide: makeRide('driver_arrived') as any,
+      currentDriver: { id: 'drv-1', name: 'Bob' } as any,
+    });
+
+    const err: any = new Error('Request failed with status code 400');
+    err.response = { status: 400, data: { detail: 'Cancellation fee applies' } };
+    mockApi.post.mockRejectedValueOnce(err);
+
+    // cancelRide does not rethrow — it sets error state
+    await act(async () => {
+      await useRideStore.getState().cancelRide();
+    });
+
+    const state = useRideStore.getState();
+    expect(state.error).toBeTruthy();
+    // ride should NOT have been cleared — we only clear on success
+    expect(state.currentRide).not.toBeNull();
+    expect(state.isLoading).toBe(false);
+  });
+});
+
+describe('rideStore — hydrateActiveRide stale ride', () => {
+  const AsyncStorageMock = require('@react-native-async-storage/async-storage');
+
+  test('clears AsyncStorage when stored ride has terminal status', async () => {
+    const staleRide = makeRide('cancelled');
+    AsyncStorageMock.getItem.mockResolvedValueOnce(
+      JSON.stringify({ currentRide: staleRide, currentDriver: null })
+    );
+
+    await act(async () => {
+      await useRideStore.getState().hydrateActiveRide();
+    });
+
+    // Terminal ride must be removed from storage, not loaded into state
+    expect(AsyncStorageMock.removeItem).toHaveBeenCalled();
+    expect(useRideStore.getState().currentRide).toBeNull();
+  });
+
+  test('does not overwrite an already-loaded ride', async () => {
+    const memoryRide = makeRide('driver_accepted');
+    useRideStore.setState({ currentRide: memoryRide as any });
+
+    const storedRide = makeRide('driver_accepted', { id: 'ride-old' });
+    AsyncStorageMock.getItem.mockResolvedValueOnce(
+      JSON.stringify({ currentRide: storedRide, currentDriver: null })
+    );
+
+    await act(async () => {
+      await useRideStore.getState().hydrateActiveRide();
+    });
+
+    // Memory ride wins — stored ride should not overwrite it
+    expect(useRideStore.getState().currentRide?.id).toBe(memoryRide.id);
+  });
+});
+
+describe('rideStore — syncOfflineRequests', () => {
+  const AsyncStorageMock = require('@react-native-async-storage/async-storage');
+
+  test('replays queued create_ride requests and clears them on success', async () => {
+    const queuedReq = { id: 'q-1', type: 'create_ride', data: { vehicle_type_id: 'vt-1' }, retryCount: 0 };
+    AsyncStorageMock.getItem.mockResolvedValueOnce(JSON.stringify([queuedReq]));
+    mockApi.post.mockResolvedValueOnce({ data: makeRide('searching') });
+
+    await act(async () => {
+      await useRideStore.getState().syncOfflineRequests();
+    });
+
+    expect(mockApi.post).toHaveBeenCalledWith('/rides', queuedReq.data);
+    // Queue should now be empty (stored as [])
+    const storedQueue = JSON.parse(AsyncStorageMock.setItem.mock.calls.at(-1)[1]);
+    expect(storedQueue).toHaveLength(0);
+  });
+
+  test('removes request after max retries (3) on repeated failure', async () => {
+    const queuedReq = { id: 'q-2', type: 'create_ride', data: {}, retryCount: 2 };
+    AsyncStorageMock.getItem.mockResolvedValueOnce(JSON.stringify([queuedReq]));
+    mockApi.post.mockRejectedValueOnce(new Error('Network error'));
+
+    await act(async () => {
+      await useRideStore.getState().syncOfflineRequests();
+    });
+
+    // retryCount was already 2; after one more failure it hits >= 3 → removed
+    const storedQueue = JSON.parse(AsyncStorageMock.setItem.mock.calls.at(-1)[1]);
+    expect(storedQueue).toHaveLength(0);
+  });
+});
+
+describe('rideStore — triggerEmergency network failure', () => {
+  test('does not throw when API call fails (keeps 911 UI flow unblocked)', async () => {
+    mockApi.post.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(
+      act(async () =>
+        useRideStore.getState().triggerEmergency('ride-456', 43.65, -79.38)
+      )
+    ).resolves.toBeUndefined();
+
+    // Store error should NOT be set — triggerEmergency swallows network failures
+    expect(useRideStore.getState().error).toBeNull();
+  });
+});

--- a/rider-app/store/__tests__/walletStore.test.ts
+++ b/rider-app/store/__tests__/walletStore.test.ts
@@ -169,4 +169,37 @@ describe('walletStore', () => {
       expect(useWalletStore.getState().error).toBeNull();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // R-P3-7 — payWithWallet insufficient balance rejection
+  // ---------------------------------------------------------------------------
+  describe('payWithWallet', () => {
+    it('deducts balance on success', async () => {
+      useWalletStore.setState({ wallet: makeWallet({ balance: 50.0 }) });
+      mockApi.post.mockResolvedValueOnce({ data: { balance: 40.5 } });
+
+      await useWalletStore.getState().payWithWallet('ride-99', 9.5);
+
+      expect(mockApi.post).toHaveBeenCalledWith('/wallet/pay', { ride_id: 'ride-99', amount: 9.5 });
+      expect(useWalletStore.getState().wallet?.balance).toBe(40.5);
+      expect(useWalletStore.getState().isLoading).toBe(false);
+    });
+
+    it('sets error and rethrows when balance is insufficient', async () => {
+      useWalletStore.setState({ wallet: makeWallet({ balance: 5.0 }) });
+
+      const err: any = new Error('Request failed with status code 400');
+      err.response = { data: { detail: 'Insufficient balance' } };
+      mockApi.post.mockRejectedValueOnce(err);
+
+      await expect(
+        useWalletStore.getState().payWithWallet('ride-99', 20.0)
+      ).rejects.toThrow();
+
+      expect(useWalletStore.getState().error).toBe('Insufficient balance');
+      expect(useWalletStore.getState().isLoading).toBe(false);
+      // Balance should be unchanged — payment was rejected
+      expect(useWalletStore.getState().wallet?.balance).toBe(5.0);
+    });
+  });
 });

--- a/shared/components/CarMarker.tsx
+++ b/shared/components/CarMarker.tsx
@@ -27,7 +27,7 @@ interface CarMarkerProps {
  * `tracksViewChanges` starts `true` so the native view catches the image
  * after it loads, then flips to `false` to avoid per-frame re-snapshots.
  */
-export const CarMarker: React.FC<CarMarkerProps> = ({
+const CarMarkerComponent: React.FC<CarMarkerProps> = ({
     coordinate,
     heading,
     size = 40,
@@ -76,5 +76,18 @@ export const CarMarker: React.FC<CarMarkerProps> = ({
         </Marker>
     );
 };
+
+function _propsAreEqual(prev: CarMarkerProps, next: CarMarkerProps): boolean {
+    return (
+        prev.coordinate.latitude === next.coordinate.latitude &&
+        prev.coordinate.longitude === next.coordinate.longitude &&
+        prev.heading === next.heading &&
+        prev.size === next.size &&
+        prev.zIndex === next.zIndex &&
+        prev.identifier === next.identifier
+    );
+}
+
+export const CarMarker = React.memo(CarMarkerComponent, _propsAreEqual);
 
 export default CarMarker;


### PR DESCRIPTION
## Summary
This PR completes the R-P3-7 hardening initiative by implementing cursor-based pagination for the activity feed, request caching with TTL on the home screen, enhanced rate limiting on backend endpoints, memoization of the CarMarker component, and error boundaries on critical ride-flow screens. Additionally, comprehensive unit tests are added for previously untested store action paths.

## Key Changes

### Frontend
- **Activity Screen Pagination**: Replaced `ScrollView` with `FlatList` using cursor-based pagination (20 rides per page). Implements `onEndReached` callback to load more rides as user scrolls, with loading indicator and proper state management for `nextCursor`.
- **Home Screen Caching**: Introduced `HOME_DATA_TTL_MS` (5 minutes) to prevent redundant API calls on tab switches. Uses `useFocusEffect` with `lastFetchedAt` ref to skip data fetches if cache is still fresh.
- **CarMarker Memoization**: Wrapped `CarMarker` component with `React.memo` and custom `_propsAreEqual` comparator to prevent unnecessary re-renders when only non-coordinate props change.
- **Error Boundaries**: Added `ErrorBoundary` wrapper to critical ride-flow screens (`ride-options.tsx`, `driver-arriving.tsx`, `payment-confirm.tsx`, `ride-completed.tsx`, `ride-in-progress.tsx`) to isolate crashes and prevent full app failure.
- **Scheduled Ride Validation**: Updated date picker `minimumDate` to enforce 15-minute minimum lead time (was allowing same-day scheduling).

### Backend
- **Ride History Pagination**: Refactored `/rides/history` endpoint to use cursor-based pagination with `before` query parameter instead of offset. Returns `next_cursor` for client-side pagination control.
- **Enhanced Rate Limiting**: 
  - Reduced `ride_request_limit` from 10/min to 5/min
  - Added `cancel_ride_limit` (10/hour) to prevent cancellation farming
  - Added `promo_available_limit` (20/min) and `promo_validate_limit` (10/min) for promo endpoints
- **Rate Limiter Imports**: Updated `rides.py` and `promotions.py` to import new rate limit decorators.

### Testing
- **Store Action Coverage**: Added comprehensive unit tests for previously untested paths:
  - `createRide` double-booking guard (409 conflict handling)
  - `cancelRide` after driver arrival (400 error state)
  - `hydrateActiveRide` stale ride cleanup and memory-vs-storage precedence
  - `syncOfflineRequests` queue replay and max retry enforcement
  - `triggerEmergency` network failure resilience
  - `payWithWallet` insufficient balance rejection
- **Test Utilities**: Tests use existing mock factories (`makeRide`, `makeWallet`, `makeLocation`) and AsyncStorage mocks.

### Documentation
- Updated remediation checklist in `rider-P3-hardening.md` to mark all R-P3-1 through R-P3-8 items as complete.

## Notable Implementation Details
- Cursor-based pagination avoids offset drift issues and scales better with large datasets.
- TTL caching uses a ref to persist across re-renders without triggering dependency updates.
- Error boundaries use functional component wrappers to maintain existing screen exports.
- Rate limits are applied at the route decorator level for consistent enforcement.
- All new tests follow existing patterns and use the same mock setup as prior test suites.

https://claude.ai/code/session_01BkaWvk57JyS3FqtcNHTi4f