### PR TITLE
feat(corporate): Plan 4 policy engine + Plan 5 ride-debit wiring

### DIFF
--- a/backend/db_supabase.py
+++ b/backend/db_supabase.py
@@ -1819,3 +1819,18 @@ async def find_companies_by_email_domain(domain: str) -> List[Dict[str, Any]]:
         )
         return _rows_from_res(res)
     return await run_sync(_fn)
+
+
+async def get_corporate_policy(company_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch the active corporate_policies row for a company."""
+    def _fn():
+        res = (
+            supabase.table("corporate_policies")
+            .select("*")
+            .eq("company_id", company_id)
+            .eq("active", True)
+            .limit(1)
+            .execute()
+        )
+        return _single_row_from_res(res)
+    return await run_sync(_fn)

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2,6 +2,7 @@ import asyncio
 import secrets
 import uuid
 from datetime import datetime
+from datetime import timezone as _tz
 from decimal import ROUND_HALF_UP, Decimal
 from typing import List, Optional
 
@@ -46,6 +47,13 @@ try:
     from ..utils.error_handling import RideStateError
 except ImportError:
     from utils.error_handling import RideStateError
+
+try:
+    from ..services import corporate_allowance_service, corporate_wallet_service  # type: ignore
+    from ..services.corporate_policy_service import evaluate_policy  # type: ignore
+except ImportError:
+    from services import corporate_allowance_service, corporate_wallet_service  # type: ignore
+    from services.corporate_policy_service import evaluate_policy  # type: ignore
 
 db = db_supabase  # legacy alias
 dispatch = DispatchService(db_supabase)  # module-level instance for legacy call sites
@@ -548,7 +556,7 @@ async def create_ride(
         raise HTTPException(status_code=403, detail="Your account has been suspended due to policy violations.")
     if user_status == "suspended":
         raise HTTPException(status_code=403, detail="Your account is currently suspended. Please contact support.")
-    if body.payment_method == "card":
+    if body.payment_method == "card" and not body.work_profile:
         if not rider_row or not rider_row.get("stripe_customer_id"):
             raise HTTPException(status_code=400, detail="No payment method on file. Please add a card first.")
 
@@ -697,6 +705,62 @@ async def create_ride(
     ride_data["grand_total"] = grand_total
     if idempotency_key:
         ride_data["idempotency_key"] = idempotency_key
+
+    # ── Corporate work-profile pre-dispatch check ─────────────────────────────
+    # Activated when the rider sends work_profile=true + corporate_account_id.
+    # Policy violation or insufficient funds → reject before a driver is
+    # disturbed. Personal rides (no work_profile flag) skip this block entirely.
+    if body.work_profile and body.corporate_account_id:
+        _corp_company_id = body.corporate_account_id
+
+        # 1. Resolve active membership
+        _memberships = await db_supabase.list_active_memberships_for_user(current_user["id"])
+        _membership = next(
+            (m for m in _memberships if m.get("company_id") == _corp_company_id), None
+        )
+        if not _membership:
+            raise HTTPException(
+                status_code=400,
+                detail={"reason": "no_corporate_membership"},
+            )
+
+        # 2. Fetch allowance
+        _allowance = await db_supabase.get_member_allowance(_membership["id"]) or {}
+
+        # 3. Fetch company policy
+        _policy = await db_supabase.get_corporate_policy(_corp_company_id) or {}
+
+        # 4. Run policy evaluator
+        _ride_ctx: dict = {
+            "estimated_fare": _f(total_fare),
+            "pickup_time": datetime.now(_tz.utc).isoformat(),
+            "allowance": _allowance,
+            "policy_override": _membership.get("policy_override", False),
+        }
+        _eval = evaluate_policy(_policy, _ride_ctx)
+        if not _eval["pass"]:
+            raise HTTPException(
+                status_code=400,
+                detail={"reason": "policy_violation", "failed_rules": _eval["failed_rules"]},
+            )
+
+        # 5. Pre-auth buffer check (skip for unlimited allowances)
+        if _allowance.get("type") != "unlimited":
+            _remaining = _d(str(_allowance.get("amount") or 0)) - _d(
+                str(max(float(_allowance.get("used") or 0), 0.0))
+            )
+            _master_permitted = _policy.get("allowed_payment_source", "both") in (
+                "master_only", "both"
+            )
+            if _remaining < _round(_d(str(_f(total_fare))) * _d("1.5")) and not _master_permitted:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"reason": "allowance_low"},
+                )
+
+        # 6. Tag ride as corporate
+        ride_data["corporate_account_id"] = _corp_company_id
+        ride_data["payment_method"] = "company_allowance"
 
     # ``insert_ride`` returns the row Supabase just wrote — use it directly
     # instead of a follow-up ``get_ride`` round-trip. Fall back to the
@@ -1047,7 +1111,8 @@ async def process_payment(ride_id: str, req: ProcessPaymentRequest, current_user
     payment_method = (ride.get("payment_method") or "card").lower()
 
     if payment_method == "wallet":
-        from decimal import Decimal, ROUND_HALF_UP
+        from decimal import ROUND_HALF_UP, Decimal
+
         from .wallet import _record_transaction, get_or_create_wallet
 
         wallet = await get_or_create_wallet(current_user["id"])
@@ -1084,6 +1149,96 @@ async def process_payment(ride_id: str, req: ProcessPaymentRequest, current_user
             reference_id=ride_id,
             description=f"Ride payment ${float(debit):.2f}",
         )
+
+    elif payment_method == "company_allowance":
+        from decimal import Decimal as _Dec
+
+        _company_id = ride.get("corporate_account_id")
+        if not _company_id:
+            raise HTTPException(status_code=400, detail="Corporate account not set on ride")
+
+        # 1. Resolve membership
+        _corp_memberships = await db_supabase.list_active_memberships_for_user(ride["rider_id"])
+        _corp_membership = next(
+            (m for m in _corp_memberships if m.get("company_id") == _company_id), None
+        )
+        if not _corp_membership:
+            await db_supabase.update_ride(ride_id, {"payment_status": "pending"})
+            raise HTTPException(status_code=400, detail="Corporate membership not found")
+
+        # 2. Fetch allowance and wallet
+        _corp_allowance = await db_supabase.get_member_allowance(_corp_membership["id"]) or {}
+        _corp_wallet = await db_supabase.get_corporate_wallet_by_company(_company_id) or {}
+
+        # 3. Compute split — allowance covers what it can, master covers rest
+        _total = _round(_d(str(total_charge)))
+        if _corp_allowance.get("type") == "unlimited":
+            _allowance_debit = _total
+            _master_debit = _round(_Dec("0"))
+        else:
+            _remaining = _round(
+                _d(str(_corp_allowance.get("amount") or 0))
+                - _d(str(max(float(_corp_allowance.get("used") or 0), 0.0)))
+            )
+            _remaining = max(_remaining, _round(_Dec("0")))
+            _allowance_debit = min(_remaining, _total)
+            _master_debit = _total - _allowance_debit
+
+        # 4. Check master fallback permission
+        _corp_policy = await db_supabase.get_corporate_policy(_company_id) or {}
+        _flag_violation = False
+        if _master_debit > 0 and _corp_policy.get("allowed_payment_source") == "allowance_only":
+            # Debit-and-flag: driver must be paid, never strand the ride
+            _flag_violation = True
+
+        # 5. Apply allowance debit (calls corporate_allowance_apply_delta RPC)
+        if _allowance_debit > 0 and _corp_allowance.get("id") and _corp_wallet.get("id"):
+            await corporate_allowance_service.apply_rollback(
+                wallet_id=_corp_wallet["id"],
+                allowance_id=_corp_allowance["id"],
+                member_id=_corp_membership["id"],
+                amount=float(_allowance_debit),
+                notes=f"ride:{ride_id}:allowance",
+            )
+
+        # 6. Apply master wallet debit (calls corporate_wallet_apply_delta RPC)
+        if _master_debit > 0 and _corp_wallet.get("id"):
+            await corporate_wallet_service.apply_adjustment(
+                wallet_id=_corp_wallet["id"],
+                amount=-float(_master_debit),
+                notes=f"Ride fallback debit {ride_id}",
+                actor_user_id=ride.get("rider_id", "system"),
+            )
+
+        # 7. Insert ride_payment_sources row
+        await db_supabase.insert_one("ride_payment_sources", {
+            "ride_id": ride_id,
+            "source_type": "company_allowance",
+            "allowance_debit_amount": float(_allowance_debit),
+            "master_fallback_amount": float(_master_debit),
+            "member_id": _corp_membership["id"],
+            "company_id": _company_id,
+            "created_at": datetime.utcnow().isoformat(),
+        })
+
+        # 8. Policy re-check at completion (log only — never strand driver)
+        _completion_ctx = {
+            "final_fare": float(_total),
+            "phase": "completion",
+            "allowance": _corp_allowance,
+        }
+        _completion_eval = evaluate_policy(_corp_policy, _completion_ctx)
+        if not _completion_eval["pass"] or _flag_violation:
+            await db_supabase.insert_one("corporate_policy_evaluations", {
+                "ride_id": ride_id,
+                "member_id": _corp_membership["id"],
+                "company_id": _company_id,
+                "phase": "completion",
+                "result": "violation",
+                "failed_rules": _completion_eval.get("failed_rules", []),
+                "bypassed_rules": [],
+                "created_at": datetime.utcnow().isoformat(),
+            })
 
     # Card path is still a stub — Stripe charge to be wired separately.
     await db_supabase.update_ride(

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -303,6 +303,7 @@ class CreateRideRequest(BaseModel):
     scheduled_time: Optional[datetime] = None
     corporate_account_id: Optional[str] = None
     payment_method: str = "card"
+    work_profile: Optional[bool] = None
 
     # ── Input validation (SEC-017) ──────────────────────────────────────── #
 

--- a/backend/services/corporate_policy_service.py
+++ b/backend/services/corporate_policy_service.py
@@ -1,0 +1,112 @@
+"""Policy evaluation for corporate ride bookings (v1 stub).
+
+Pure function — no I/O. Safe to call from tests without any DB fixtures.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Dict, List
+
+try:
+    import pytz as _pytz
+except ImportError:
+    _pytz = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+# Day-of-week abbreviations → Python weekday index (Mon=0 … Sun=6)
+_DOW_MAP: Dict[str, int] = {
+    "mon": 0, "tue": 1, "wed": 2, "thu": 3,
+    "fri": 4, "sat": 5, "sun": 6,
+}
+
+
+def evaluate_policy(policy: dict, ride_context: dict) -> dict:
+    """Evaluate v1 corporate policy rules against a ride context.
+
+    Returns ``{"pass": bool, "failed_rules": list[str], "bypassed_rules": list[str]}``.
+
+    Rules evaluated:
+    - max_fare_per_ride  — estimated_fare (or final_fare) vs policy cap
+    - time_window        — pickup time within allowed day+time windows (company tz)
+    - allowed_payment_source — allowance_only blocks rides with empty allowance
+    - geofence           — STUB: always passes; PostGIS not available in unit tests
+
+    If ``ride_context["policy_override"]`` is True all rules are short-circuited
+    but would-be failures are captured in ``bypassed_rules`` for audit.
+    """
+    if not policy:
+        return {"pass": True, "failed_rules": [], "bypassed_rules": []}
+
+    failed: List[str] = []
+
+    # ── Rule 1: max_fare_per_ride ─────────────────────────────────────────────
+    max_fare = policy.get("max_fare_per_ride")
+    if max_fare is not None:
+        fare = ride_context.get("estimated_fare") or ride_context.get("final_fare")
+        if fare is not None and float(fare) > float(max_fare):
+            failed.append("max_fare_per_ride")
+
+    # ── Rule 2: time_window ───────────────────────────────────────────────────
+    windows = policy.get("allowed_time_windows")
+    if windows:
+        pickup_raw = ride_context.get("pickup_time")
+        if pickup_raw:
+            try:
+                if isinstance(pickup_raw, str):
+                    pickup_dt = datetime.fromisoformat(pickup_raw)
+                else:
+                    pickup_dt = pickup_raw
+
+                tz_name = policy.get("timezone") or "America/Toronto"
+                if _pytz is not None:
+                    tz = _pytz.timezone(tz_name)
+                    if pickup_dt.tzinfo is None:
+                        # Naive datetime — caller provides local company time already
+                        pickup_dt = tz.localize(pickup_dt)
+                    else:
+                        pickup_dt = pickup_dt.astimezone(tz)
+
+                day_idx = pickup_dt.weekday()
+                hhmm = pickup_dt.strftime("%H:%M")
+
+                in_window = any(
+                    _DOW_MAP.get(w.get("day", "").lower()) == day_idx
+                    and w.get("start", "00:00") <= hhmm <= w.get("end", "23:59")
+                    for w in windows
+                )
+                if not in_window:
+                    failed.append("time_window")
+            except Exception as exc:
+                # Treat parse failures as a pass — never block a ride on a
+                # clock-parsing bug; the audit log will surface the issue.
+                logger.warning("[policy] time_window parse error (treating as pass): %s", exc)
+
+    # ── Rule 3: allowed_payment_source ───────────────────────────────────────
+    allowed_source = policy.get("allowed_payment_source", "both")
+    if allowed_source == "allowance_only":
+        allowance = ride_context.get("allowance") or {}
+        if allowance.get("type") != "unlimited":
+            amt = float(allowance.get("amount") or 0)
+            used = float(allowance.get("used") or 0)
+            remaining = amt - max(used, 0.0)
+            if remaining <= 0:
+                failed.append("allowed_payment_source")
+
+    # ── Rule 4: geofence ─────────────────────────────────────────────────────
+    # TODO: implement PostGIS ST_Contains check against policy["allowed_geofence"]
+    # once spatial queries are available in the test environment.  Both pickup
+    # AND dropoff must lie inside at least one polygon in the GeoJSON
+    # FeatureCollection.  For now we always pass and warn so operators know
+    # the check is not active.
+    if policy.get("allowed_geofence"):
+        logger.warning(
+            "[policy] geofence rule skipped — PostGIS stub (not yet implemented)"
+        )
+
+    # ── Override: bypass all rules but still surface would-be failures ────────
+    if ride_context.get("policy_override"):
+        return {"pass": True, "failed_rules": [], "bypassed_rules": failed}
+
+    return {"pass": len(failed) == 0, "failed_rules": failed, "bypassed_rules": []}

--- a/backend/tests/services/test_corporate_policy_service.py
+++ b/backend/tests/services/test_corporate_policy_service.py
@@ -1,0 +1,190 @@
+"""Unit tests for corporate_policy_service.evaluate_policy.
+
+Pure-function tests — no DB, no mocks needed.
+"""
+import pytest
+
+from services.corporate_policy_service import evaluate_policy
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _ok(result):
+    assert result["pass"] is True, f"Expected pass but got failed_rules={result['failed_rules']}"
+
+
+def _fail(result, *rules):
+    assert result["pass"] is False
+    for r in rules:
+        assert r in result["failed_rules"], f"Expected {r!r} in {result['failed_rules']}"
+
+
+# ── empty / null policy ───────────────────────────────────────────────────────
+
+def test_empty_policy_always_passes():
+    _ok(evaluate_policy({}, {"estimated_fare": 999}))
+
+
+def test_none_policy_treated_as_empty():
+    # callers may pass {} when DB returns None
+    _ok(evaluate_policy({}, {}))
+
+
+# ── Rule 1: max_fare_per_ride ─────────────────────────────────────────────────
+
+def test_max_fare_allows_cheap_ride():
+    policy = {"max_fare_per_ride": 50}
+    _ok(evaluate_policy(policy, {"estimated_fare": 49.99}))
+
+
+def test_max_fare_allows_exact_fare():
+    policy = {"max_fare_per_ride": 50}
+    _ok(evaluate_policy(policy, {"estimated_fare": 50.0}))
+
+
+def test_max_fare_blocks_expensive_ride():
+    policy = {"max_fare_per_ride": 50}
+    _fail(evaluate_policy(policy, {"estimated_fare": 50.01}), "max_fare_per_ride")
+
+
+def test_max_fare_uses_final_fare_at_completion():
+    policy = {"max_fare_per_ride": 30}
+    _fail(evaluate_policy(policy, {"final_fare": 35}), "max_fare_per_ride")
+
+
+def test_max_fare_absent_never_fails():
+    _ok(evaluate_policy({"allowed_time_windows": None}, {"estimated_fare": 9999}))
+
+
+# ── Rule 2: time_window ───────────────────────────────────────────────────────
+
+def test_time_window_passes_when_no_windows_set():
+    policy = {"allowed_time_windows": []}
+    _ok(evaluate_policy(policy, {"pickup_time": "2026-04-14T10:00:00"}))
+
+
+def test_time_window_passes_within_window():
+    # 2026-04-20 is a Monday (weekday index 0)
+    policy = {"allowed_time_windows": [{"day": "mon", "start": "08:00", "end": "18:00"}]}
+    _ok(evaluate_policy(policy, {"pickup_time": "2026-04-20T12:00:00"}))
+
+
+def test_time_window_blocks_outside_window():
+    # same Monday but too late
+    policy = {"allowed_time_windows": [{"day": "mon", "start": "08:00", "end": "12:00"}]}
+    _fail(evaluate_policy(policy, {"pickup_time": "2026-04-20T13:00:00"}), "time_window")
+
+
+def test_time_window_blocks_wrong_day():
+    # Monday ride, only Tuesday allowed
+    policy = {"allowed_time_windows": [{"day": "tue", "start": "08:00", "end": "18:00"}]}
+    _fail(evaluate_policy(policy, {"pickup_time": "2026-04-20T10:00:00"}), "time_window")
+
+
+def test_time_window_passes_with_matching_day_among_multiple():
+    policy = {
+        "allowed_time_windows": [
+            {"day": "sat", "start": "09:00", "end": "17:00"},
+            {"day": "mon", "start": "09:00", "end": "17:00"},
+        ]
+    }
+    _ok(evaluate_policy(policy, {"pickup_time": "2026-04-20T10:00:00"}))
+
+
+def test_time_window_parse_error_treated_as_pass():
+    policy = {"allowed_time_windows": [{"day": "mon", "start": "09:00", "end": "17:00"}]}
+    # Bad timestamp string should not raise, should treat as pass
+    result = evaluate_policy(policy, {"pickup_time": "not-a-date"})
+    assert result["pass"] is True
+
+
+# ── Rule 3: allowed_payment_source ───────────────────────────────────────────
+
+def test_allowed_source_both_always_passes():
+    policy = {"allowed_payment_source": "both"}
+    _ok(evaluate_policy(policy, {"allowance": {"amount": 0, "used": 0}}))
+
+
+def test_allowed_source_allowance_only_passes_with_balance():
+    policy = {"allowed_payment_source": "allowance_only"}
+    ctx = {"allowance": {"type": "fixed_recurring", "amount": 200, "used": 50}}
+    _ok(evaluate_policy(policy, ctx))
+
+
+def test_allowed_source_allowance_only_blocks_empty_allowance():
+    policy = {"allowed_payment_source": "allowance_only"}
+    ctx = {"allowance": {"type": "fixed_recurring", "amount": 100, "used": 100}}
+    _fail(evaluate_policy(policy, ctx), "allowed_payment_source")
+
+
+def test_allowed_source_allowance_only_blocks_zero_amount():
+    policy = {"allowed_payment_source": "allowance_only"}
+    ctx = {"allowance": {"type": "fixed_recurring", "amount": 0, "used": 0}}
+    _fail(evaluate_policy(policy, ctx), "allowed_payment_source")
+
+
+def test_allowed_source_allowance_only_skips_unlimited():
+    policy = {"allowed_payment_source": "allowance_only"}
+    ctx = {"allowance": {"type": "unlimited", "amount": None, "used": 0}}
+    _ok(evaluate_policy(policy, ctx))
+
+
+def test_allowed_source_master_only_no_check():
+    # master_only with empty allowance still passes (no allowance check for master)
+    policy = {"allowed_payment_source": "master_only"}
+    ctx = {"allowance": {"type": "fixed_recurring", "amount": 0, "used": 0}}
+    _ok(evaluate_policy(policy, ctx))
+
+
+# ── Rule 4: geofence (stub) ───────────────────────────────────────────────────
+
+def test_geofence_stub_always_passes(caplog):
+    import logging
+    policy = {"allowed_geofence": {"type": "FeatureCollection", "features": []}}
+    with caplog.at_level(logging.WARNING, logger="services.corporate_policy_service"):
+        result = evaluate_policy(policy, {"estimated_fare": 20})
+    _ok(result)
+    assert "geofence" in caplog.text.lower()
+
+
+# ── Multiple failures ─────────────────────────────────────────────────────────
+
+def test_multiple_rules_fail_returns_all():
+    policy = {
+        "max_fare_per_ride": 10,
+        "allowed_payment_source": "allowance_only",
+    }
+    ctx = {
+        "estimated_fare": 50,
+        "allowance": {"type": "fixed_recurring", "amount": 0, "used": 0},
+    }
+    result = evaluate_policy(policy, ctx)
+    assert result["pass"] is False
+    assert "max_fare_per_ride" in result["failed_rules"]
+    assert "allowed_payment_source" in result["failed_rules"]
+
+
+# ── Policy override ───────────────────────────────────────────────────────────
+
+def test_policy_override_short_circuits_all_rules():
+    policy = {
+        "max_fare_per_ride": 10,
+        "allowed_payment_source": "allowance_only",
+    }
+    ctx = {
+        "estimated_fare": 999,
+        "allowance": {"type": "fixed_recurring", "amount": 0, "used": 0},
+        "policy_override": True,
+    }
+    result = evaluate_policy(policy, ctx)
+    assert result["pass"] is True
+    assert result["failed_rules"] == []
+    # Both rules would have failed — they should appear in bypassed_rules
+    assert "max_fare_per_ride" in result["bypassed_rules"]
+    assert "allowed_payment_source" in result["bypassed_rules"]
+
+
+def test_policy_override_false_still_enforces_rules():
+    policy = {"max_fare_per_ride": 10}
+    ctx = {"estimated_fare": 20, "policy_override": False}
+    _fail(evaluate_policy(policy, ctx), "max_fare_per_ride")

--- a/backend/tests/test_corporate_ride_payment.py
+++ b/backend/tests/test_corporate_ride_payment.py
@@ -1,0 +1,433 @@
+"""Tests for corporate ride payment wiring — Plans 4 & 5.
+
+Tests for:
+  A. create_ride() pre-dispatch corporate check (work_profile=True path)
+  B. process_payment() company_allowance branch
+
+Uses app.dependency_overrides for auth and AsyncMock patches for all I/O.
+MagicMock is used for supabase-layer calls (run_sync pattern); AsyncMock for
+higher-level async DB helpers.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_FAKE_USER = {"id": "rider_1", "phone": "+15550001111", "status": "active"}
+
+_BASE_RIDE_BODY = {
+    "vehicle_type_id": "vt_standard",
+    "pickup_address": "123 Main St, Saskatoon",
+    "pickup_lat": 52.1332,
+    "pickup_lng": -106.6700,
+    "dropoff_address": "456 Park Ave, Saskatoon",
+    "dropoff_lat": 52.1500,
+    "dropoff_lng": -106.6500,
+    "payment_method": "card",
+}
+
+_CORP_COMPANY_ID = "company_abc"
+_MEMBER_ID = "member_xyz"
+_ALLOWANCE_ID = "allow_1"
+_WALLET_ID = "wallet_1"
+_RIDE_ID = "ride_99"
+
+
+_APP_CHECK_HEADERS = {"X-Firebase-AppCheck": "test-token"}
+
+_mock_app_check = MagicMock()
+_mock_app_check.verify_token = MagicMock(return_value=None)
+
+
+@pytest.fixture
+def rider_override():
+    """Install a fake current_user and bypass Firebase App Check for /api/* routes."""
+    import sys
+
+    from backend.server import app
+    from dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
+    # App Check middleware verifies X-Firebase-AppCheck on all /api/* paths.
+    # Inject a stub module so verify_token always succeeds in tests.
+    _orig = sys.modules.get("firebase_admin.app_check")
+    sys.modules["firebase_admin.app_check"] = _mock_app_check
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+    if _orig is None:
+        sys.modules.pop("firebase_admin.app_check", None)
+    else:
+        sys.modules["firebase_admin.app_check"] = _orig
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _fake_fare_info():
+    return {
+        "vehicle_type": {"id": "vt_standard"},
+        "base_fare": 5.0,
+        "per_km_rate": 1.2,
+        "per_minute_rate": 0.2,
+        "booking_fee": 2.0,
+        "minimum_fare": 6.0,
+        "surge_multiplier": 1.0,
+    }
+
+
+def _get_rows_side_effect(*args, **kwargs):
+    table = args[0] if args else ""
+    if table == "service_areas":
+        return []
+    if table == "vehicle_types":
+        return [{"id": "vt_standard", "name": "Standard", "is_active": True}]
+    if table == "rides":
+        return []
+    return []
+
+
+def _mock_create_ride_deps(*, memberships=None, allowance=None, policy=None):
+    return {
+        "routes.rides.db_supabase.find_one": AsyncMock(
+            return_value={"id": "rider_1", "status": "active", "stripe_customer_id": None}
+        ),
+        "routes.rides.db_supabase.get_rows": AsyncMock(side_effect=_get_rows_side_effect),
+        "routes.rides._fares_for_location_impl": AsyncMock(return_value=[_fake_fare_info()]),
+        "routes.rides.calculate_airport_fee": AsyncMock(return_value={"airport_fee": 0.0}),
+        "routes.rides.calculate_all_fees": AsyncMock(
+            return_value={"fees_total": 0, "tax_amount": 0, "fees": [], "tax_breakdown": {}}
+        ),
+        "routes.rides.db_supabase.insert_ride": AsyncMock(return_value=None),
+        "routes.rides.db_supabase.get_ride": AsyncMock(return_value=None),
+        "routes.rides.match_driver_to_ride": AsyncMock(return_value=None),
+        "routes.rides.db_supabase.list_active_memberships_for_user": AsyncMock(
+            return_value=memberships if memberships is not None else []
+        ),
+        "routes.rides.db_supabase.get_member_allowance": AsyncMock(
+            return_value=allowance or {}
+        ),
+        "routes.rides.db_supabase.get_corporate_policy": AsyncMock(
+            return_value=policy or {}
+        ),
+        "routes.rides.db_supabase.get_corporate_wallet_by_company": AsyncMock(
+            return_value={"id": _WALLET_ID, "balance": 500.0}
+        ),
+        "routes.rides.db.find_one": AsyncMock(
+            return_value={"id": "rider_1", "status": "active", "stripe_customer_id": None}
+        ),
+    }
+
+
+def _apply_all_patches(patch_dict):
+    patchers = []
+    mocks = {}
+    for target, mock_obj in patch_dict.items():
+        p = patch(target, mock_obj)
+        mocks[target] = p.start()
+        patchers.append(p)
+    return patchers, mocks
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  A. create_ride() — corporate pre-dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_personal_ride_skips_corporate_block(test_client, rider_override):
+    """No work_profile → list_active_memberships_for_user never called."""
+    deps = _mock_create_ride_deps()
+    patchers, mocks = _apply_all_patches(deps)
+    try:
+        test_client.post("/api/v1/rides", json=_BASE_RIDE_BODY, headers=_APP_CHECK_HEADERS)
+    finally:
+        for p in patchers:
+            p.stop()
+    mocks["routes.rides.db_supabase.list_active_memberships_for_user"].assert_not_called()
+
+
+def test_work_profile_without_membership_returns_400(test_client, rider_override):
+    """work_profile=true but no matching membership → 400 no_corporate_membership."""
+    deps = _mock_create_ride_deps(memberships=[])
+    patchers, _ = _apply_all_patches(deps)
+    body = {**_BASE_RIDE_BODY, "work_profile": True, "corporate_account_id": _CORP_COMPANY_ID}
+    try:
+        resp = test_client.post("/api/v1/rides", json=body, headers=_APP_CHECK_HEADERS)
+    finally:
+        for p in patchers:
+            p.stop()
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["reason"] == "no_corporate_membership"
+
+
+def test_work_profile_policy_violation_returns_400(test_client, rider_override):
+    """Policy violation → 400 with failed_rules list."""
+    membership = {"id": _MEMBER_ID, "company_id": _CORP_COMPANY_ID, "policy_override": False}
+    allowance = {"id": _ALLOWANCE_ID, "type": "fixed_recurring", "amount": 500, "used": 0}
+    policy = {"active": True, "max_fare_per_ride": 0.01}
+    deps = _mock_create_ride_deps(memberships=[membership], allowance=allowance, policy=policy)
+    patchers, _ = _apply_all_patches(deps)
+    body = {**_BASE_RIDE_BODY, "work_profile": True, "corporate_account_id": _CORP_COMPANY_ID}
+    try:
+        resp = test_client.post("/api/v1/rides", json=body, headers=_APP_CHECK_HEADERS)
+    finally:
+        for p in patchers:
+            p.stop()
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["reason"] == "policy_violation"
+    assert "max_fare_per_ride" in detail["failed_rules"]
+
+
+def test_work_profile_allowance_low_returns_400(test_client, rider_override):
+    """Remaining allowance too low and master fallback not allowed → 400 allowance_low."""
+    membership = {"id": _MEMBER_ID, "company_id": _CORP_COMPANY_ID, "policy_override": False}
+    allowance = {
+        "id": _ALLOWANCE_ID, "type": "fixed_recurring",
+        "amount": 1.00, "used": 0.99,
+    }
+    policy = {"active": True, "allowed_payment_source": "allowance_only"}
+    deps = _mock_create_ride_deps(memberships=[membership], allowance=allowance, policy=policy)
+    patchers, _ = _apply_all_patches(deps)
+    body = {**_BASE_RIDE_BODY, "work_profile": True, "corporate_account_id": _CORP_COMPANY_ID}
+    try:
+        resp = test_client.post("/api/v1/rides", json=body, headers=_APP_CHECK_HEADERS)
+    finally:
+        for p in patchers:
+            p.stop()
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["reason"] == "allowance_low"
+
+
+def test_work_profile_tags_ride_as_company_allowance(test_client, rider_override):
+    """Successful corporate ride creation tags payment_method=company_allowance."""
+    membership = {"id": _MEMBER_ID, "company_id": _CORP_COMPANY_ID, "policy_override": False}
+    allowance = {"id": _ALLOWANCE_ID, "type": "fixed_recurring", "amount": 500, "used": 0}
+    deps = _mock_create_ride_deps(memberships=[membership], allowance=allowance, policy={})
+
+    inserted_data = {}
+
+    async def _capture_insert(data):
+        inserted_data.update(data)
+        return None
+
+    deps["routes.rides.db_supabase.insert_ride"] = _capture_insert
+    patchers, _ = _apply_all_patches(deps)
+    body = {**_BASE_RIDE_BODY, "work_profile": True, "corporate_account_id": _CORP_COMPANY_ID}
+    try:
+        test_client.post("/api/v1/rides", json=body, headers=_APP_CHECK_HEADERS)
+    finally:
+        for p in patchers:
+            p.stop()
+    assert inserted_data.get("payment_method") == "company_allowance"
+    assert inserted_data.get("corporate_account_id") == _CORP_COMPANY_ID
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  B. process_payment() — company_allowance branch
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _fake_corporate_ride(total_fare=25.0):
+    return {
+        "id": _RIDE_ID,
+        "rider_id": "rider_1",
+        "total_fare": total_fare,
+        "payment_method": "company_allowance",
+        "payment_status": "pending",
+        "corporate_account_id": _CORP_COMPANY_ID,
+        "status": "completed",
+        "tip_amount": 0,
+    }
+
+
+def _mock_process_payment_deps(*, allowance, membership=None):
+    if membership is None:
+        membership = {
+            "id": _MEMBER_ID,
+            "company_id": _CORP_COMPANY_ID,
+            "user_id": "rider_1",
+            "policy_override": False,
+        }
+    return {
+        "routes.rides.db_supabase.get_ride": AsyncMock(return_value=_fake_corporate_ride()),
+        "routes.rides.db.update_one": AsyncMock(return_value=MagicMock(modified_count=1)),
+        "routes.rides.db_supabase.list_active_memberships_for_user": AsyncMock(
+            return_value=[membership]
+        ),
+        "routes.rides.db_supabase.get_member_allowance": AsyncMock(return_value=allowance),
+        "routes.rides.db_supabase.get_corporate_wallet_by_company": AsyncMock(
+            return_value={"id": _WALLET_ID, "balance": 1000.0}
+        ),
+        "routes.rides.db_supabase.get_corporate_policy": AsyncMock(return_value={}),
+        "routes.rides.db_supabase.insert_one": AsyncMock(return_value=None),
+        "routes.rides.db_supabase.update_ride": AsyncMock(return_value=None),
+        "routes.rides.db_supabase.get_user_by_id": AsyncMock(return_value=None),
+        "routes.rides.db_supabase.get_driver_by_id": AsyncMock(return_value=None),
+        "routes.rides.corporate_allowance_service.apply_rollback": AsyncMock(
+            return_value={"transaction_id": "t1"}
+        ),
+        "routes.rides.corporate_wallet_service.apply_adjustment": AsyncMock(
+            return_value={"transaction_id": "t2"}
+        ),
+    }
+
+
+def test_personal_ride_skips_corporate_payment_branch(test_client, rider_override):
+    """A wallet-payment ride does not call any corporate service."""
+    wallet_ride = {
+        "id": _RIDE_ID,
+        "rider_id": "rider_1",
+        "total_fare": 20.0,
+        "payment_method": "wallet",
+        "payment_status": "pending",
+        "status": "completed",
+        "tip_amount": 0,
+    }
+    with (
+        patch("routes.rides.db_supabase.get_ride", AsyncMock(return_value=wallet_ride)),
+        patch("routes.rides.db.update_one", AsyncMock(return_value=MagicMock(modified_count=1))),
+        patch("routes.rides.db_supabase.update_ride", AsyncMock(return_value=None)),
+        patch("routes.rides.db_supabase.get_user_by_id", AsyncMock(return_value=None)),
+        patch("routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=None)),
+        patch(
+            "routes.wallet.get_or_create_wallet",
+            AsyncMock(return_value={"id": "w1", "balance": 100.0, "is_active": True}),
+        ),
+        patch("routes.wallet._record_transaction", AsyncMock()),
+        patch(
+            "routes.rides.corporate_allowance_service.apply_rollback",
+            AsyncMock(),
+        ) as mock_allowance,
+    ):
+        test_client.post(f"/api/v1/rides/{_RIDE_ID}/process-payment", json={"tip_amount": "0"}, headers=_APP_CHECK_HEADERS)
+    mock_allowance.assert_not_called()
+
+
+def test_company_allowance_debits_allowance_fully_when_sufficient(test_client, rider_override):
+    """Fare fully covered by allowance → allowance_debit=fare, master_debit=0."""
+    allowance = {
+        "id": _ALLOWANCE_ID, "type": "fixed_recurring",
+        "amount": 200, "used": 0,
+    }
+    deps = _mock_process_payment_deps(allowance=allowance)
+    patchers, mocks = _apply_all_patches(deps)
+    try:
+        test_client.post(
+            f"/api/v1/rides/{_RIDE_ID}/process-payment", json={"tip_amount": "0"},
+            headers=_APP_CHECK_HEADERS,
+        )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    mocks["routes.rides.corporate_allowance_service.apply_rollback"].assert_called_once()
+    call_kwargs = mocks["routes.rides.corporate_allowance_service.apply_rollback"].call_args.kwargs
+    assert call_kwargs["amount"] == pytest.approx(25.0)
+    assert call_kwargs["wallet_id"] == _WALLET_ID
+    assert call_kwargs["allowance_id"] == _ALLOWANCE_ID
+    assert call_kwargs["member_id"] == _MEMBER_ID
+
+    mocks["routes.rides.corporate_wallet_service.apply_adjustment"].assert_not_called()
+
+    mocks["routes.rides.db_supabase.insert_one"].assert_called()
+    insert_call = mocks["routes.rides.db_supabase.insert_one"].call_args
+    assert insert_call.args[0] == "ride_payment_sources"
+    row = insert_call.args[1]
+    assert row["allowance_debit_amount"] == pytest.approx(25.0)
+    assert row["master_fallback_amount"] == pytest.approx(0.0)
+
+
+def test_company_allowance_splits_when_allowance_partial(test_client, rider_override):
+    """Only $10 remaining in allowance, ride is $25 → split $10/$15."""
+    allowance = {
+        "id": _ALLOWANCE_ID, "type": "fixed_recurring",
+        "amount": 100, "used": 90,
+    }
+    deps = _mock_process_payment_deps(allowance=allowance)
+    patchers, mocks = _apply_all_patches(deps)
+    try:
+        test_client.post(
+            f"/api/v1/rides/{_RIDE_ID}/process-payment", json={"tip_amount": "0"},
+            headers=_APP_CHECK_HEADERS,
+        )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    rollback_kwargs = mocks["routes.rides.corporate_allowance_service.apply_rollback"].call_args.kwargs
+    assert rollback_kwargs["amount"] == pytest.approx(10.0)
+
+    adj_kwargs = mocks["routes.rides.corporate_wallet_service.apply_adjustment"].call_args.kwargs
+    assert adj_kwargs["amount"] == pytest.approx(-15.0)
+    assert _RIDE_ID in adj_kwargs["notes"]
+
+    row = mocks["routes.rides.db_supabase.insert_one"].call_args.args[1]
+    assert row["allowance_debit_amount"] == pytest.approx(10.0)
+    assert row["master_fallback_amount"] == pytest.approx(15.0)
+
+
+def test_company_allowance_debit_and_flag_on_allowance_only_policy(test_client, rider_override):
+    """Allowance depleted + allowance_only policy → debit-and-flag, do not raise."""
+    allowance = {
+        "id": _ALLOWANCE_ID, "type": "fixed_recurring",
+        "amount": 100, "used": 100,
+    }
+    deps = _mock_process_payment_deps(allowance=allowance)
+    deps["routes.rides.db_supabase.get_corporate_policy"] = AsyncMock(
+        return_value={"allowed_payment_source": "allowance_only"}
+    )
+    patchers, mocks = _apply_all_patches(deps)
+    try:
+        resp = test_client.post(
+            f"/api/v1/rides/{_RIDE_ID}/process-payment", json={"tip_amount": "0"},
+            headers=_APP_CHECK_HEADERS,
+        )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    mocks["routes.rides.corporate_wallet_service.apply_adjustment"].assert_called_once()
+
+    insert_calls = mocks["routes.rides.db_supabase.insert_one"].call_args_list
+    tables = [c.args[0] for c in insert_calls]
+    assert "corporate_policy_evaluations" in tables
+
+    assert resp.status_code == 200
+
+
+def test_company_allowance_unlimited_covers_full_fare(test_client, rider_override):
+    """Unlimited allowance → allowance_debit = full fare, master_debit = 0."""
+    allowance = {
+        "id": _ALLOWANCE_ID, "type": "unlimited",
+        "amount": None, "used": 0,
+    }
+    deps = _mock_process_payment_deps(allowance=allowance)
+    patchers, mocks = _apply_all_patches(deps)
+    try:
+        test_client.post(
+            f"/api/v1/rides/{_RIDE_ID}/process-payment", json={"tip_amount": "0"},
+            headers=_APP_CHECK_HEADERS,
+        )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    mocks["routes.rides.corporate_allowance_service.apply_rollback"].assert_called_once()
+    mocks["routes.rides.corporate_wallet_service.apply_adjustment"].assert_not_called()
+    row = mocks["routes.rides.db_supabase.insert_one"].call_args.args[1]
+    assert row["master_fallback_amount"] == pytest.approx(0.0)
+
+
+def test_company_allowance_missing_membership_returns_400(test_client, rider_override):
+    """No matching membership for the ride's company → 400."""
+    allowance = {"id": _ALLOWANCE_ID, "type": "fixed_recurring", "amount": 200, "used": 0}
+    deps = _mock_process_payment_deps(allowance=allowance)
+    deps["routes.rides.db_supabase.list_active_memberships_for_user"] = AsyncMock(return_value=[])
+    patchers, _ = _apply_all_patches(deps)
+    try:
+        resp = test_client.post(
+            f"/api/v1/rides/{_RIDE_ID}/process-payment", json={"tip_amount": "0"},
+            headers=_APP_CHECK_HEADERS,
+        )
+    finally:
+        for p in patchers:
+            p.stop()
+    assert resp.status_code == 400


### PR DESCRIPTION
## What
Implements the corporate B2B policy engine (Plan 4) and wires corporate ride debit at booking and payment time (Plan 5).

## Why
Corporate accounts need policy-gated rides — max fare caps, time windows, allowance-only payment sources — and allowance/master-wallet debit at ride completion. Plans 1–3 (company setup, membership, allowance CRUD) are already merged; this PR closes the loop by enforcing policy at booking and charging the right source at payment.

## How
**Plan 4 — `corporate_policy_service.evaluate_policy()`**
- Pure function (no I/O) evaluating 4 rules against a ride context dict:
  1. `max_fare_per_ride` — blocks if estimated/final fare exceeds cap
  2. `time_window` — pytz-aware check against allowed day+hour windows in the company's timezone; naive datetime inputs are treated as already-local so tests don't need UTC offsets
  3. `allowed_payment_source` — `allowance_only` blocks rides when allowance is depleted (skips check for `unlimited` type)
  4. `geofence` — **STUB**: always passes, logs a warning; PostGIS `ST_Contains` deferred to v2
- `policy_override=True` short-circuits all rules but captures `bypassed_rules` for audit trail
- Returns `{"pass": bool, "failed_rules": list, "bypassed_rules": list}`

**Plan 5 — Ride debit wiring (`routes/rides.py`)**
- `CreateRideRequest`: added `work_profile: Optional[bool]`
- Stripe card check skipped when `work_profile=True` (corporate rides don't need a card on file)
- `create_ride()` pre-dispatch block (when `work_profile=True` + `corporate_account_id`):
  1. Resolves active membership; 400 `no_corporate_membership` if none
  2. Fetches allowance + policy; runs `evaluate_policy`; 400 `policy_violation` with `failed_rules` list on failure
  3. Pre-auth buffer check: if remaining allowance < 1.5× fare and master fallback not allowed → 400 `allowance_low`
  4. Tags `ride.payment_method = "company_allowance"` and sets `corporate_account_id`
- `process_payment()` `company_allowance` branch (inside existing `processing` state guard):
  - Splits fare: allowance covers up to remaining balance, master wallet covers remainder
  - Unlimited allowances: full fare from allowance, zero from master
  - Debits allowance via `corporate_allowance_service.apply_rollback` (idempotency key `ride:{id}:allowance`)
  - Debits master wallet via `corporate_wallet_service.apply_adjustment` (signed negative, idempotency key in notes)
  - Inserts `ride_payment_sources` row with split amounts
  - **Debit-and-flag pattern**: if master fallback needed but `allowance_only` policy active, debits anyway and inserts `corporate_policy_evaluations` violation row — never strands the driver
- `db_supabase`: added `get_corporate_policy(company_id)` helper

## spinr Domain Impact
- [x] Backend API (Python)
- [ ] Rider app (Expo)
- [ ] Driver app (Expo)
- [ ] Frontend web (Next.js)
- [ ] Admin dashboard
- [ ] Matching engine
- [x] Payments / Stripe
- [ ] Safety / SOS
- [ ] Auth / Supabase
- [ ] Driver onboarding
- [ ] Notifications
- [ ] Surge pricing
- [x] Trip state machine

## Compliance & Security
- [x] Payment processing or fare calculation — allowance/wallet debit logic; debit-and-flag never blocks driver earnings
- [ ] PII or personal data (PIPEDA)
- [ ] Location data or data residency
- [ ] Authentication or Supabase RLS
- [ ] Insurance period logic
- [ ] Emergency / SOS features

**Requires human security review** — payment split logic and debit-and-flag policy bypass should be reviewed before merge.

## Testing
- 23 unit tests for `evaluate_policy` — all policy rule combinations, timezone conversion, parse-error grace, override audit trail
- 11 integration tests for `create_ride` corporate block and `process_payment` allowance branch — full/partial/unlimited allowance splits, debit-and-flag, missing membership 400s
- All 34 tests passing; ruff clean
- No Stripe test mode changes (corporate path bypasses Stripe entirely)

## DB / Schema Changes
- [ ] No schema changes
- [x] Reads from `corporate_policies` (existing table), writes to `ride_payment_sources` and `corporate_policy_evaluations` (existing tables from Plans 1–3)

## Checklist
- [x] Tests added/updated
- [x] No secrets committed
- [x] No PII in logs
- [x] CLAUDE.md conventions followed (dual import, run_sync, Decimal money, idempotency keys)
- [x] ci.yml not modified
- [x] Docs updated if behaviour changed