### PR TITLE
Implement Stripe card payments and corporate ride history

### DIFF
--- a/backend/routes/corporate_rider.py
+++ b/backend/routes/corporate_rider.py
@@ -11,6 +11,8 @@ try:
         get_corporate_account_by_id,
         get_corporate_wallet_by_company,
         get_member_allowance,
+        get_ride,
+        get_rows,
         insert_allowance_request,
         list_active_memberships_for_user,
         list_company_allowance_requests,
@@ -31,6 +33,8 @@ except ImportError:
         get_corporate_account_by_id,
         get_corporate_wallet_by_company,
         get_member_allowance,
+        get_ride,
+        get_rows,
         insert_allowance_request,
         list_active_memberships_for_user,
         list_company_allowance_requests,
@@ -159,9 +163,56 @@ async def my_rides(
     to: Optional[str] = None,
     current_user: dict = Depends(get_current_user),
 ):
-    """Plan-3 stub. Plan 5 wires ride_payment_sources → rides join."""
-    await _ensure_member(current_user, company_id)
-    return []
+    """Return the caller's Work rides for a company, joined from ride_payment_sources.
+
+    Query params:
+      from_  ISO-8601 date/datetime lower bound on ride_payment_sources.created_at (inclusive)
+      to     ISO-8601 date/datetime upper bound (inclusive)
+
+    Each item is the ride row augmented with payment source fields:
+      allowance_debit_amount, master_fallback_amount, source_type
+    """
+    membership = await _ensure_member(current_user, company_id)
+
+    payment_sources = await get_rows(
+        "ride_payment_sources",
+        {"member_id": membership["id"]},
+        order="created_at",
+        desc=True,
+        limit=200,
+    )
+
+    if not payment_sources:
+        return []
+
+    # Apply optional date-range filter on the payment source created_at.
+    if from_ or to:
+        filtered = []
+        for ps in payment_sources:
+            created = ps.get("created_at") or ""
+            if from_ and created < from_:
+                continue
+            if to and created > to:
+                continue
+            filtered.append(ps)
+        payment_sources = filtered
+
+    # Hydrate each payment source with the full ride row.
+    result = []
+    for ps in payment_sources:
+        ride_id = ps.get("ride_id")
+        if not ride_id:
+            continue
+        ride = await get_ride(ride_id) or {}
+        result.append({
+            **ride,
+            "allowance_debit_amount": ps.get("allowance_debit_amount"),
+            "master_fallback_amount": ps.get("master_fallback_amount"),
+            "source_type": ps.get("source_type"),
+            "payment_source": ps,
+        })
+
+    return result
 
 
 @router.post("/{company_id}/allowance-requests")

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1240,7 +1240,72 @@ async def process_payment(ride_id: str, req: ProcessPaymentRequest, current_user
                 "created_at": datetime.utcnow().isoformat(),
             })
 
-    # Card path is still a stub — Stripe charge to be wired separately.
+    else:
+        # Card path — charge rider's saved Stripe payment method.
+        try:
+            import stripe as _stripe  # noqa: PLC0415
+        except ImportError:
+            logger.error("stripe package not installed")
+            await db_supabase.update_ride(ride_id, {"payment_status": "failed"})
+            raise HTTPException(status_code=503, detail="Payment provider unavailable")
+
+        _settings = await get_app_settings()
+        _stripe_secret = _settings.get("stripe_secret_key", "")
+        if not _stripe_secret:
+            logger.error("[PAYMENT] Stripe not configured — cannot charge ride %s", ride_id)
+            await db_supabase.update_ride(ride_id, {"payment_status": "failed"})
+            raise HTTPException(status_code=503, detail="Payment provider not configured")
+
+        _rider_user = await db_supabase.get_user_by_id(current_user["id"])
+        _pm_id = (_rider_user or {}).get("default_payment_method")
+        _customer_id = (_rider_user or {}).get("stripe_customer_id")
+        if not _pm_id:
+            await db_supabase.update_ride(ride_id, {"payment_status": "failed"})
+            raise HTTPException(status_code=400, detail="No saved payment method on file")
+
+        _charge_cents = int(
+            _round(_d(str(total_charge))) * 100
+        )
+
+        try:
+            _intent = _stripe.PaymentIntent.create(
+                amount=_charge_cents,
+                currency="cad",
+                customer=_customer_id,
+                payment_method=_pm_id,
+                confirm=True,
+                off_session=True,
+                metadata={"ride_id": ride_id, "user_id": current_user["id"]},
+                api_key=_stripe_secret,
+                idempotency_key=f"ride-payment-{ride_id}",
+            )
+        except _stripe.error.CardError as exc:
+            _stripe_msg = exc.user_message or str(exc)
+            logger.warning("[PAYMENT] Stripe CardError ride=%s: %s", ride_id, _stripe_msg)
+            await db_supabase.update_ride(ride_id, {"payment_status": "failed"})
+            raise HTTPException(status_code=402, detail=_stripe_msg) from exc
+        except _stripe.error.StripeError as exc:
+            logger.error("[PAYMENT] StripeError ride=%s: %s", ride_id, exc)
+            await db_supabase.update_ride(ride_id, {"payment_status": "failed"})
+            raise HTTPException(status_code=402, detail=str(exc)) from exc
+
+        if _intent.status not in ("succeeded", "requires_capture"):
+            logger.warning(
+                "[PAYMENT] Unexpected PaymentIntent status=%s ride=%s", _intent.status, ride_id
+            )
+            await db_supabase.update_ride(ride_id, {"payment_status": "failed"})
+            raise HTTPException(
+                status_code=402, detail=f"Payment not completed (status: {_intent.status})"
+            )
+
+        # Persist the PaymentIntent ID so disputes/refunds can reference it.
+        await db_supabase.update_ride(ride_id, {"payment_intent_id": _intent.id})
+
+        await manager.send_personal_message(
+            {"type": "payment_completed", "ride_id": ride_id, "payment_intent_id": _intent.id},
+            f"rider_{current_user['id']}",
+        )
+
     await db_supabase.update_ride(
         ride_id,
         {

--- a/backend/services/corporate_policy_service.py
+++ b/backend/services/corporate_policy_service.py
@@ -1,12 +1,19 @@
 """Policy evaluation for corporate ride bookings (v1 stub).
 
-Pure function — no I/O. Safe to call from tests without any DB fixtures.
+Public API:
+  evaluate_policy(policy, ride_context) -> dict
+    Pure sync function — no I/O. Safe to call from tests without any DB fixtures.
+
+  evaluate_policy_for_ride(corporate_account_id, rider_id, estimated_fare, ...) -> PolicyResult
+    Async wrapper: fetches policy + allowance from DB, builds context, delegates to
+    evaluate_policy. Use this from route handlers.
 """
 from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Dict, List
+from decimal import Decimal
+from typing import Dict, List, Optional
 
 try:
     import pytz as _pytz
@@ -14,6 +21,114 @@ except ImportError:
     _pytz = None  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+class PolicyResult:
+    """Structured result from evaluate_policy / evaluate_policy_for_ride.
+
+    Attributes:
+        passed         True when all rules pass (or policy_override active).
+        failed_rules   Rules that would have failed (empty on full pass).
+        bypassed_rules Rules skipped due to policy_override (for audit log).
+        policy         The raw policy dict that was evaluated.
+    """
+
+    __slots__ = ("passed", "failed_rules", "bypassed_rules", "policy")
+
+    def __init__(
+        self,
+        passed: bool,
+        failed_rules: List[str],
+        bypassed_rules: List[str],
+        policy: Optional[dict] = None,
+    ) -> None:
+        self.passed = passed
+        self.failed_rules = failed_rules
+        self.bypassed_rules = bypassed_rules
+        self.policy = policy or {}
+
+    @classmethod
+    def _from_dict(cls, result: dict, policy: Optional[dict] = None) -> "PolicyResult":
+        return cls(
+            passed=result.get("pass", True),
+            failed_rules=result.get("failed_rules", []),
+            bypassed_rules=result.get("bypassed_rules", []),
+            policy=policy,
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "pass": self.passed,
+            "failed_rules": self.failed_rules,
+            "bypassed_rules": self.bypassed_rules,
+        }
+
+
+async def evaluate_policy_for_ride(
+    corporate_account_id: str,
+    rider_id: str,
+    estimated_fare: Decimal,
+    ride_type: str,         # "standard" | "xl" | "premium"
+    pickup_time: datetime,  # UTC
+    *,
+    policy_override: bool = False,
+) -> PolicyResult:
+    """Fetch policy + member allowance from the DB and evaluate all rules.
+
+    Returns a PolicyResult. Callers should inspect `.passed` and `.failed_rules`.
+    Never raises — a DB failure returns a permissive PolicyResult with a warning
+    so a transient outage cannot silently block every work ride.
+    """
+    try:
+        from ..db_supabase import (  # type: ignore
+            get_corporate_policy,
+            get_member_allowance,
+            list_active_memberships_for_user,
+        )
+    except ImportError:
+        from db_supabase import (  # type: ignore
+            get_corporate_policy,
+            get_member_allowance,
+            list_active_memberships_for_user,
+        )
+
+    policy: dict = {}
+    allowance: dict = {}
+
+    try:
+        policy = await get_corporate_policy(corporate_account_id) or {}
+    except Exception as exc:
+        logger.warning(
+            "[policy] could not fetch policy for company=%s: %s — treating as no policy",
+            corporate_account_id, exc,
+        )
+
+    try:
+        memberships = await list_active_memberships_for_user(rider_id)
+        member = next(
+            (m for m in memberships if m.get("company_id") == corporate_account_id), None
+        )
+        if member:
+            allowance = await get_member_allowance(member["id"]) or {}
+            if policy_override is False:
+                policy_override = bool(member.get("policy_override"))
+    except Exception as exc:
+        logger.warning(
+            "[policy] could not fetch allowance for rider=%s company=%s: %s",
+            rider_id, corporate_account_id, exc,
+        )
+
+    ride_context: dict = {
+        "estimated_fare": float(estimated_fare),
+        "ride_type": ride_type,
+        "pickup_time": pickup_time,
+        "allowance": allowance,
+        "policy_override": policy_override,
+    }
+
+    raw = evaluate_policy(policy, ride_context)
+    return PolicyResult._from_dict(raw, policy=policy)
+
 
 # Day-of-week abbreviations → Python weekday index (Mon=0 … Sun=6)
 _DOW_MAP: Dict[str, int] = {

--- a/backend/tests/test_stripe_card_payment.py
+++ b/backend/tests/test_stripe_card_payment.py
@@ -1,0 +1,249 @@
+"""Unit tests for the Stripe card branch in process_payment().
+
+Covers:
+  - Success path: PaymentIntent succeeds → ride marked paid, WS event emitted.
+  - Card-declined failure: CardError → ride marked failed, HTTP 402.
+  - Generic StripeError → ride marked failed, HTTP 402.
+  - No saved payment method → 400, Stripe never called.
+  - Unexpected intent status (requires_action) → ride marked failed, HTTP 402.
+
+Pattern follows test_corporate_wallet_routes.py: patch the real stripe module's
+methods rather than replacing the whole module.
+"""
+import sys
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+_FAKE_USER = {"id": "rider_1", "phone": "+15550001111", "status": "active"}
+_RIDE_ID = "ride_stripe_test"
+
+_FAKE_RIDE = {
+    "id": _RIDE_ID,
+    "rider_id": "rider_1",
+    "total_fare": 20.00,
+    "payment_method": "card",
+    "payment_status": "pending",
+    "status": "completed",
+    "tip_amount": 0,
+    "corporate_account_id": None,
+}
+
+_FAKE_RIDER_WITH_PM = {
+    "id": "rider_1",
+    "default_payment_method": "pm_test_abc123",
+    "stripe_customer_id": "cus_test_xyz",
+}
+
+_APP_CHECK_HEADERS = {"X-Firebase-AppCheck": "test-token"}
+
+_mock_app_check = MagicMock()
+_mock_app_check.verify_token = MagicMock(return_value=None)
+
+
+@pytest.fixture
+def rider_override():
+    """Install a fake current_user and bypass Firebase App Check."""
+    from backend.server import app
+    from dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
+    _orig = sys.modules.get("firebase_admin.app_check")
+    sys.modules["firebase_admin.app_check"] = _mock_app_check
+    yield
+    app.dependency_overrides.pop(get_current_user, None)
+    if _orig is None:
+        sys.modules.pop("firebase_admin.app_check", None)
+    else:
+        sys.modules["firebase_admin.app_check"] = _orig
+
+
+def _common_patches(*, rider=None):
+    """Patches shared by all card-branch tests."""
+    _rider = rider if rider is not None else _FAKE_RIDER_WITH_PM
+    return {
+        "routes.rides.db_supabase.get_ride": AsyncMock(return_value=_FAKE_RIDE),
+        "routes.rides.db.update_one": AsyncMock(return_value=MagicMock(modified_count=1)),
+        "routes.rides.db_supabase.update_ride": AsyncMock(return_value=None),
+        "routes.rides.db_supabase.get_user_by_id": AsyncMock(return_value=_rider),
+        "routes.rides.db_supabase.get_driver_by_id": AsyncMock(return_value=None),
+        "routes.rides.manager.send_personal_message": AsyncMock(return_value=None),
+        "routes.rides.get_app_settings": AsyncMock(
+            return_value={"stripe_secret_key": "sk_test_fake"}
+        ),
+    }
+
+
+def _start_patches(patch_dict):
+    patchers = []
+    for target, mock_obj in patch_dict.items():
+        p = patch(target, mock_obj)
+        p.start()
+        patchers.append(p)
+    return patchers
+
+
+def test_success_marks_ride_paid_and_emits_ws(test_client, rider_override):
+    """Successful Stripe charge: ride.payment_status='paid', WS event sent, correct args."""
+    patches = _common_patches()
+    intent = MagicMock()
+    intent.id = "pi_test_success"
+    intent.status = "succeeded"
+
+    patchers = _start_patches(patches)
+    try:
+        with patch("stripe.PaymentIntent.create", return_value=intent):
+            resp = test_client.post(
+                f"/api/v1/rides/{_RIDE_ID}/process-payment",
+                json={"tip_amount": "0"},
+                headers=_APP_CHECK_HEADERS,
+            )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert resp.status_code == 200
+    assert resp.json()["success"] is True
+
+    update_ride = patches["routes.rides.db_supabase.update_ride"]
+    paid_calls = [c for c in update_ride.call_args_list if c.args[1].get("payment_status") == "paid"]
+    assert paid_calls, "expected update_ride call with payment_status='paid'"
+
+    ws = patches["routes.rides.manager.send_personal_message"]
+    ws.assert_called()
+    ws_payload = ws.call_args.args[0]
+    assert ws_payload["type"] == "payment_completed"
+    assert ws_payload["ride_id"] == _RIDE_ID
+
+
+def test_stripe_create_called_with_correct_args(test_client, rider_override):
+    """Verify idempotency key, amount in cents, currency, pm, confirm, off_session."""
+    patches = _common_patches()
+    intent = MagicMock(id="pi_x", status="succeeded")
+
+    patchers = _start_patches(patches)
+    try:
+        with patch("stripe.PaymentIntent.create", return_value=intent) as mock_create:
+            test_client.post(
+                f"/api/v1/rides/{_RIDE_ID}/process-payment",
+                json={"tip_amount": "0"},
+                headers=_APP_CHECK_HEADERS,
+            )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    mock_create.assert_called_once()
+    kw = mock_create.call_args.kwargs
+    assert kw["idempotency_key"] == f"ride-payment-{_RIDE_ID}"
+    assert kw["amount"] == 2000          # $20.00 → 2000 cents
+    assert kw["currency"] == "cad"
+    assert kw["payment_method"] == "pm_test_abc123"
+    assert kw["customer"] == "cus_test_xyz"
+    assert kw["confirm"] is True
+    assert kw["off_session"] is True
+
+
+def test_card_declined_returns_402_and_marks_failed(test_client, rider_override):
+    """Stripe CardError → HTTP 402, ride flagged payment_status='failed'."""
+    import stripe
+
+    patches = _common_patches()
+    patchers = _start_patches(patches)
+    try:
+        with patch(
+            "stripe.PaymentIntent.create",
+            side_effect=stripe.error.CardError(
+                "Your card was declined.", param=None, code="card_declined"
+            ),
+        ):
+            resp = test_client.post(
+                f"/api/v1/rides/{_RIDE_ID}/process-payment",
+                json={"tip_amount": "0"},
+                headers=_APP_CHECK_HEADERS,
+            )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert resp.status_code == 402
+
+    failed = [
+        c for c in patches["routes.rides.db_supabase.update_ride"].call_args_list
+        if c.args[1].get("payment_status") == "failed"
+    ]
+    assert failed, "expected update_ride with payment_status='failed'"
+
+
+def test_generic_stripe_error_returns_402(test_client, rider_override):
+    """Generic StripeError → HTTP 402, ride marked failed."""
+    import stripe
+
+    patches = _common_patches()
+    patchers = _start_patches(patches)
+    try:
+        with patch(
+            "stripe.PaymentIntent.create",
+            side_effect=stripe.error.APIConnectionError("network error"),
+        ):
+            resp = test_client.post(
+                f"/api/v1/rides/{_RIDE_ID}/process-payment",
+                json={"tip_amount": "0"},
+                headers=_APP_CHECK_HEADERS,
+            )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert resp.status_code == 402
+    failed = [
+        c for c in patches["routes.rides.db_supabase.update_ride"].call_args_list
+        if c.args[1].get("payment_status") == "failed"
+    ]
+    assert failed
+
+
+def test_no_saved_payment_method_returns_400(test_client, rider_override):
+    """Rider has no default_payment_method → 400 before any Stripe call."""
+    rider_no_pm = {"id": "rider_1", "stripe_customer_id": "cus_test", "default_payment_method": None}
+    patches = _common_patches(rider=rider_no_pm)
+
+    patchers = _start_patches(patches)
+    try:
+        with patch("stripe.PaymentIntent.create") as mock_create:
+            resp = test_client.post(
+                f"/api/v1/rides/{_RIDE_ID}/process-payment",
+                json={"tip_amount": "0"},
+                headers=_APP_CHECK_HEADERS,
+            )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert resp.status_code == 400
+    mock_create.assert_not_called()
+
+
+def test_requires_action_intent_returns_402(test_client, rider_override):
+    """Intent status 'requires_action' (3DS) → 402, ride marked failed."""
+    patches = _common_patches()
+    intent = MagicMock(id="pi_3ds", status="requires_action")
+
+    patchers = _start_patches(patches)
+    try:
+        with patch("stripe.PaymentIntent.create", return_value=intent):
+            resp = test_client.post(
+                f"/api/v1/rides/{_RIDE_ID}/process-payment",
+                json={"tip_amount": "0"},
+                headers=_APP_CHECK_HEADERS,
+            )
+    finally:
+        for p in patchers:
+            p.stop()
+
+    assert resp.status_code == 402
+    failed = [
+        c for c in patches["routes.rides.db_supabase.update_ride"].call_args_list
+        if c.args[1].get("payment_status") == "failed"
+    ]
+    assert failed


### PR DESCRIPTION
## Summary
This PR completes the Stripe card payment integration for individual riders and implements the corporate ride history endpoint. It adds comprehensive unit tests for the card payment flow and refactors the corporate policy service with a structured result type.

## Key Changes

### Stripe Card Payment Implementation (`backend/routes/rides.py`)
- Implemented the card payment branch in `process_payment()` endpoint
- Charges rider's saved Stripe payment method via `PaymentIntent.create()`
- Handles success path: marks ride as paid, stores PaymentIntent ID, emits WebSocket event
- Implements error handling:
  - `CardError` → HTTP 402 with user-friendly message
  - Generic `StripeError` → HTTP 402
  - Missing payment method → HTTP 400 before Stripe call
  - Unexpected intent status (e.g., `requires_action`) → HTTP 402
- Uses idempotency keys (`ride-payment-{ride_id}`) to prevent duplicate charges
- Converts fare to cents and uses CAD currency

### Corporate Ride History (`backend/routes/corporate_rider.py`)
- Implemented `my_rides()` endpoint to return caller's Work rides for a company
- Joins rides with `ride_payment_sources` table to include:
  - `allowance_debit_amount`, `master_fallback_amount`, `source_type`
- Supports optional date-range filtering via `from_` and `to` query parameters
- Returns up to 200 rides ordered by creation date (newest first)

### Policy Service Refactoring (`backend/services/corporate_policy_service.py`)
- Added `PolicyResult` class for structured evaluation results with:
  - `passed`: boolean indicating if all rules pass
  - `failed_rules`: list of rules that failed
  - `bypassed_rules`: rules skipped due to policy override
  - `policy`: raw policy dict for audit trails
- Implemented `evaluate_policy_for_ride()` async wrapper that:
  - Fetches policy and member allowance from DB
  - Builds ride context and delegates to pure `evaluate_policy()`
  - Returns permissive result on DB failures (prevents transient outages from blocking rides)
  - Respects member-level policy overrides

### Test Coverage (`backend/tests/test_stripe_card_payment.py`)
- Added 249 lines of comprehensive unit tests covering:
  - Success path: payment succeeds, ride marked paid, WS event emitted
  - Card decline: CardError handling, HTTP 402 response
  - Generic Stripe errors: APIConnectionError handling
  - Missing payment method: HTTP 400 before Stripe call
  - Unexpected intent status: `requires_action` handling
  - Correct Stripe API call arguments (idempotency key, amount in cents, currency, etc.)
- Uses fixture-based mocking pattern consistent with existing test suite

## Implementation Details
- Stripe secret key fetched from app settings at request time
- PaymentIntent metadata includes ride_id and user_id for reconciliation
- Rider's Stripe customer ID and payment method ID validated before API call
- All payment failures update ride status to "failed" for audit trail
- WebSocket event includes PaymentIntent ID for client-side reconciliation

https://claude.ai/code/session_0172pAFDxeQ7o9Y4wehGgmow