### PR TITLE
feat(corporate): Plan 6 — company billing endpoints + tests

### DIFF
--- a/admin-dashboard/src/app/company-portal/[id]/activity/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/activity/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    BillingStatement,
+    getCompanyBillingStatement,
+} from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+function currentMonth(): string {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function formatCAD(n: number | undefined) {
+    return (n ?? 0).toLocaleString("en-CA", {
+        style: "currency",
+        currency: "CAD",
+    });
+}
+
+const POLICY_RESULT_COLORS: Record<string, string> = {
+    pass: "bg-emerald-100 text-emerald-800",
+    override: "bg-blue-100 text-blue-800",
+    fail: "bg-red-100 text-red-700",
+};
+
+export default function ActivityPage() {
+    const { id } = useParams<{ id: string }>();
+    const [month, setMonth] = useState<string>(currentMonth());
+    const [memberFilter, setMemberFilter] = useState<string>("");
+    const [statement, setStatement] = useState<BillingStatement | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const st = await getCompanyBillingStatement(id, month);
+            setStatement(st);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id, month]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const rows = statement?.line_items ?? [];
+    const filtered = memberFilter
+        ? rows.filter((r) => r.member_id?.includes(memberFilter))
+        : rows;
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="text-2xl font-semibold">Activity</h1>
+                <p className="text-muted-foreground">
+                    Every work-billed ride for the selected month.
+                </p>
+            </header>
+
+            <div className="flex flex-wrap items-end gap-3">
+                <div>
+                    <Label htmlFor="month">Month</Label>
+                    <Input
+                        id="month"
+                        type="month"
+                        value={month}
+                        onChange={(e) => setMonth(e.target.value)}
+                    />
+                </div>
+                <div className="grow">
+                    <Label htmlFor="mfilter">Filter by member id</Label>
+                    <Input
+                        id="mfilter"
+                        placeholder="Paste member id…"
+                        value={memberFilter}
+                        onChange={(e) => setMemberFilter(e.target.value)}
+                    />
+                </div>
+            </div>
+
+            {error && (
+                <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>
+            )}
+
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Date</TableHead>
+                                <TableHead>Member</TableHead>
+                                <TableHead>Source</TableHead>
+                                <TableHead>Allowance</TableHead>
+                                <TableHead>Master</TableHead>
+                                <TableHead>Policy</TableHead>
+                                <TableHead className="text-right">Total</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {loading && (
+                                <TableRow>
+                                    <TableCell colSpan={7} className="text-center text-muted-foreground">
+                                        Loading…
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {!loading && filtered.length === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={7} className="text-center text-muted-foreground">
+                                        No rides for this filter.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {filtered.map((r) => (
+                                <TableRow key={r.ride_id}>
+                                    <TableCell className="text-xs text-muted-foreground">
+                                        {r.created_at?.slice(0, 16).replace("T", " ")}
+                                    </TableCell>
+                                    <TableCell className="font-mono text-xs">
+                                        {r.member_id}
+                                    </TableCell>
+                                    <TableCell className="text-xs">{r.source_type}</TableCell>
+                                    <TableCell>{formatCAD(r.allowance_debit_amount)}</TableCell>
+                                    <TableCell>{formatCAD(r.master_fallback_amount)}</TableCell>
+                                    <TableCell>
+                                        {r.policy_check_result && (
+                                            <Badge
+                                                className={
+                                                    POLICY_RESULT_COLORS[r.policy_check_result] ?? ""
+                                                }
+                                            >
+                                                {r.policy_check_result}
+                                            </Badge>
+                                        )}
+                                    </TableCell>
+                                    <TableCell className="text-right font-medium">
+                                        {formatCAD(
+                                            (r.allowance_debit_amount ?? 0) +
+                                                (r.master_fallback_amount ?? 0)
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/allowance-requests/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/allowance-requests/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    AllowanceRequestRow,
+    decideAllowanceRequest,
+    listCompanyAllowanceRequests,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { Check, X } from "lucide-react";
+
+type Filter = AllowanceRequestRow["status"] | "all";
+
+const STATUS_COLORS: Record<AllowanceRequestRow["status"], string> = {
+    pending: "bg-yellow-100 text-yellow-800",
+    approved: "bg-emerald-100 text-emerald-800",
+    auto_approved: "bg-blue-100 text-blue-800",
+    denied: "bg-red-100 text-red-700",
+};
+
+export default function AllowanceRequestsPage() {
+    const { id } = useParams<{ id: string }>();
+    const [rows, setRows] = useState<AllowanceRequestRow[]>([]);
+    const [filter, setFilter] = useState<Filter>("pending");
+    const [loading, setLoading] = useState(true);
+    const [decision, setDecision] = useState<{ row: AllowanceRequestRow; approve: boolean } | null>(null);
+    const [note, setNote] = useState("");
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        try {
+            const data = await listCompanyAllowanceRequests(id, filter === "all" ? "" : filter);
+            setRows(data);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id, filter]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const submitDecision = async () => {
+        if (!id || !decision) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await decideAllowanceRequest(id, decision.row.id, {
+                approve: decision.approve,
+                note: note.trim() || undefined,
+            });
+            setDecision(null);
+            setNote("");
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="text-2xl font-semibold">Allowance Requests</h1>
+                <p className="text-muted-foreground">
+                    Approve or deny requests from members for additional funds.
+                </p>
+            </header>
+
+            <div className="flex gap-2">
+                {(["pending", "approved", "denied", "all"] as Filter[]).map((f) => (
+                    <Button
+                        key={f}
+                        size="sm"
+                        variant={filter === f ? "default" : "outline"}
+                        onClick={() => setFilter(f)}
+                        className="capitalize"
+                    >
+                        {f}
+                    </Button>
+                ))}
+            </div>
+
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Amount</TableHead>
+                                <TableHead>Reason</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead>Requested</TableHead>
+                                <TableHead className="text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {loading && (
+                                <TableRow>
+                                    <TableCell colSpan={5} className="text-center text-muted-foreground">
+                                        Loading…
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {!loading && rows.length === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={5} className="text-center text-muted-foreground">
+                                        No requests.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {rows.map((r) => (
+                                <TableRow key={r.id}>
+                                    <TableCell className="font-medium">
+                                        {r.amount.toLocaleString("en-CA", {
+                                            style: "currency",
+                                            currency: "CAD",
+                                        })}
+                                    </TableCell>
+                                    <TableCell className="max-w-[40ch] truncate">
+                                        {r.reason}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge className={STATUS_COLORS[r.status]}>
+                                            {r.status}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell className="text-xs text-muted-foreground">
+                                        {r.created_at?.slice(0, 10)}
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        {r.status === "pending" && (
+                                            <div className="flex justify-end gap-2">
+                                                <Button
+                                                    size="sm"
+                                                    variant="default"
+                                                    onClick={() => setDecision({ row: r, approve: true })}
+                                                >
+                                                    <Check className="mr-1 h-3.5 w-3.5" /> Approve
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    onClick={() => setDecision({ row: r, approve: false })}
+                                                >
+                                                    <X className="mr-1 h-3.5 w-3.5" /> Deny
+                                                </Button>
+                                            </div>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            {error && (
+                <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>
+            )}
+
+            <Dialog open={!!decision} onOpenChange={(open) => !open && setDecision(null)}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            {decision?.approve ? "Approve request" : "Deny request"}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-2 py-2 text-sm">
+                        <p>
+                            <span className="text-muted-foreground">Amount: </span>
+                            <span className="font-medium">
+                                {decision?.row.amount.toLocaleString("en-CA", {
+                                    style: "currency",
+                                    currency: "CAD",
+                                })}
+                            </span>
+                        </p>
+                        <p>
+                            <span className="text-muted-foreground">Reason: </span>
+                            {decision?.row.reason}
+                        </p>
+                        <Textarea
+                            placeholder="Optional note for the member…"
+                            value={note}
+                            onChange={(e) => setNote(e.target.value)}
+                        />
+                    </div>
+                    <DialogFooter>
+                        <Button variant="outline" onClick={() => setDecision(null)}>
+                            Cancel
+                        </Button>
+                        <Button onClick={submitDecision} disabled={busy}>
+                            {busy ? "Submitting…" : decision?.approve ? "Approve" : "Deny"}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/allowances/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/allowances/page.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    AllowanceTypeValue,
+    CorporateMember,
+    getMemberAllowance,
+    listCompanyMembers,
+    putMemberAllowance,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+interface AllowanceDraft {
+    type: AllowanceTypeValue;
+    amount: string;
+    period_start: string;
+    period_end: string;
+    rollover: boolean;
+}
+
+function emptyDraft(): AllowanceDraft {
+    const today = new Date().toISOString().slice(0, 10);
+    return { type: "fixed_recurring", amount: "300", period_start: today, period_end: today, rollover: false };
+}
+
+export default function AllowancesPage() {
+    const { id } = useParams<{ id: string }>();
+    const [members, setMembers] = useState<CorporateMember[]>([]);
+    const [balances, setBalances] = useState<Record<string, number | null>>({});
+    const [selectedMemberId, setSelectedMemberId] = useState<string>("");
+    const [draft, setDraft] = useState<AllowanceDraft>(emptyDraft());
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        try {
+            const rows = await listCompanyMembers(id, "active");
+            setMembers(rows);
+            // fetch allowances in parallel to render per-member
+            const entries = await Promise.all(
+                rows.map(async (m) => {
+                    try {
+                        const a = await getMemberAllowance(id, m.id);
+                        if (!a || !("amount" in a)) return [m.id, null] as const;
+                        const amt = a.amount ?? null;
+                        const used = a.used ?? 0;
+                        return [m.id, amt == null ? null : amt - Math.max(used, 0)] as const;
+                    } catch {
+                        return [m.id, null] as const;
+                    }
+                })
+            );
+            setBalances(Object.fromEntries(entries));
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const save = async () => {
+        if (!id || !selectedMemberId) return;
+        setSaving(true);
+        setError(null);
+        setFeedback(null);
+        try {
+            const body = {
+                type: draft.type,
+                amount: draft.type === "unlimited" ? null : Number(draft.amount),
+                period_start: draft.type === "fixed_recurring" ? draft.period_start : null,
+                period_end: draft.type === "fixed_recurring" ? draft.period_end : null,
+                rollover: draft.rollover,
+            };
+            await putMemberAllowance(id, selectedMemberId, body);
+            setFeedback("Allowance saved");
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Save failed");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="text-2xl font-semibold">Allowances</h1>
+                <p className="text-muted-foreground">
+                    Set a recurring or one-time spend limit per member.
+                </p>
+            </header>
+
+            <Card>
+                <CardContent className="space-y-4 p-4">
+                    <div className="grid gap-3 md:grid-cols-2">
+                        <div>
+                            <Label>Member</Label>
+                            <Select value={selectedMemberId} onValueChange={setSelectedMemberId}>
+                                <SelectTrigger>
+                                    <SelectValue placeholder="Select active member…" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {members.map((m) => (
+                                        <SelectItem key={m.id} value={m.id}>
+                                            {m.invited_email || m.user_id || m.id}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div>
+                            <Label>Type</Label>
+                            <Select
+                                value={draft.type}
+                                onValueChange={(v) => setDraft({ ...draft, type: v as AllowanceTypeValue })}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="fixed_recurring">Fixed recurring</SelectItem>
+                                    <SelectItem value="one_time">One-time</SelectItem>
+                                    <SelectItem value="unlimited">Unlimited</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+
+                    {draft.type !== "unlimited" && (
+                        <div>
+                            <Label>Amount (CAD)</Label>
+                            <Input
+                                type="number"
+                                min={1}
+                                value={draft.amount}
+                                onChange={(e) => setDraft({ ...draft, amount: e.target.value })}
+                            />
+                        </div>
+                    )}
+
+                    {draft.type === "fixed_recurring" && (
+                        <div className="grid gap-3 md:grid-cols-2">
+                            <div>
+                                <Label>Period start</Label>
+                                <Input
+                                    type="date"
+                                    value={draft.period_start}
+                                    onChange={(e) =>
+                                        setDraft({ ...draft, period_start: e.target.value })
+                                    }
+                                />
+                            </div>
+                            <div>
+                                <Label>Period end</Label>
+                                <Input
+                                    type="date"
+                                    value={draft.period_end}
+                                    onChange={(e) =>
+                                        setDraft({ ...draft, period_end: e.target.value })
+                                    }
+                                />
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="flex items-center justify-between">
+                        <label className="flex items-center gap-2 text-sm">
+                            <input
+                                type="checkbox"
+                                checked={draft.rollover}
+                                onChange={(e) => setDraft({ ...draft, rollover: e.target.checked })}
+                            />
+                            Rollover unused amount
+                        </label>
+                        <Button onClick={save} disabled={saving || !selectedMemberId}>
+                            {saving ? "Saving…" : "Save allowance"}
+                        </Button>
+                    </div>
+
+                    {feedback && (
+                        <p className="rounded bg-emerald-50 p-2 text-xs text-emerald-800">
+                            {feedback}
+                        </p>
+                    )}
+                    {error && (
+                        <p className="rounded bg-red-50 p-2 text-xs text-red-700">{error}</p>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="p-4">
+                    <h2 className="mb-3 font-medium">Current allowances</h2>
+                    {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+                    {!loading && members.length === 0 && (
+                        <p className="text-sm text-muted-foreground">No active members.</p>
+                    )}
+                    <ul className="divide-y divide-border">
+                        {members.map((m) => {
+                            const bal = balances[m.id];
+                            return (
+                                <li
+                                    key={m.id}
+                                    className="flex items-center justify-between py-2 text-sm"
+                                >
+                                    <span>{m.invited_email || m.id}</span>
+                                    {bal == null ? (
+                                        <Badge variant="outline" className="text-[10px]">
+                                            No allowance
+                                        </Badge>
+                                    ) : (
+                                        <span className="font-medium">
+                                            {bal.toLocaleString("en-CA", {
+                                                style: "currency",
+                                                currency: "CAD",
+                                            })}
+                                        </span>
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/billing/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/billing/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    BillingStatement,
+    BillingSummary,
+    BillingTransactionsPage,
+    getCompanyBillingStatement,
+    getCompanyBillingSummary,
+    getCompanyBillingTransactions,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { Download } from "lucide-react";
+
+function monthOptions(): string[] {
+    const out: string[] = [];
+    const now = new Date();
+    for (let i = 0; i < 12; i++) {
+        const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+        out.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`);
+    }
+    return out;
+}
+
+function formatCAD(n: number | undefined) {
+    return (n ?? 0).toLocaleString("en-CA", {
+        style: "currency",
+        currency: "CAD",
+    });
+}
+
+function toCSV(statement: BillingStatement): string {
+    const header = [
+        "ride_id",
+        "member_id",
+        "source_type",
+        "allowance_debit_amount",
+        "master_fallback_amount",
+        "policy_check_result",
+        "created_at",
+    ].join(",");
+    const body = statement.line_items
+        .map((r) =>
+            [
+                r.ride_id,
+                r.member_id,
+                r.source_type,
+                r.allowance_debit_amount,
+                r.master_fallback_amount,
+                r.policy_check_result ?? "",
+                r.created_at,
+            ].join(",")
+        )
+        .join("\n");
+    return `${header}\n${body}`;
+}
+
+export default function BillingPage() {
+    const { id } = useParams<{ id: string }>();
+    const months = monthOptions();
+    const [month, setMonth] = useState<string>(months[0]);
+    const [summary, setSummary] = useState<BillingSummary | null>(null);
+    const [statement, setStatement] = useState<BillingStatement | null>(null);
+    const [txns, setTxns] = useState<BillingTransactionsPage | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        setError(null);
+        try {
+            const [s, st, t] = await Promise.all([
+                getCompanyBillingSummary(id, month),
+                getCompanyBillingStatement(id, month),
+                getCompanyBillingTransactions(id, 0, 50).catch(() => null),
+            ]);
+            setSummary(s);
+            setStatement(st);
+            setTxns(t);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id, month]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const downloadCSV = () => {
+        if (!statement) return;
+        const blob = new Blob([toCSV(statement)], { type: "text/csv" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `spinr-statement-${month}.csv`;
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    return (
+        <div className="space-y-6">
+            <header className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                    <h1 className="text-2xl font-semibold">Billing</h1>
+                    <p className="text-muted-foreground">
+                        Month-to-date spend, monthly statements, wallet ledger.
+                    </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <select
+                        className="rounded border border-input bg-background px-2 py-1.5 text-sm"
+                        value={month}
+                        onChange={(e) => setMonth(e.target.value)}
+                    >
+                        {months.map((m) => (
+                            <option key={m} value={m}>
+                                {m}
+                            </option>
+                        ))}
+                    </select>
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={downloadCSV}
+                        disabled={!statement}
+                    >
+                        <Download className="mr-1 h-4 w-4" /> CSV
+                    </Button>
+                </div>
+            </header>
+
+            {error && (
+                <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <Metric label="Wallet balance" value={formatCAD(summary?.wallet_balance)} />
+                <Metric
+                    label="Total spend"
+                    value={formatCAD(summary?.total)}
+                    sub={`${summary?.ride_count ?? 0} rides`}
+                />
+                <Metric
+                    label="Allowance"
+                    value={formatCAD(summary?.allowance_total)}
+                    sub="Member allowances"
+                />
+                <Metric
+                    label="Master fallback"
+                    value={formatCAD(summary?.master_total)}
+                    sub="Overflow debits"
+                />
+            </div>
+
+            <Card>
+                <CardContent className="p-4">
+                    <h2 className="mb-3 font-medium">By member</h2>
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Member</TableHead>
+                                <TableHead>Rides</TableHead>
+                                <TableHead>Allowance</TableHead>
+                                <TableHead>Master</TableHead>
+                                <TableHead className="text-right">Total</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {loading && (
+                                <TableRow>
+                                    <TableCell colSpan={5} className="text-center text-muted-foreground">
+                                        Loading…
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {!loading && (summary?.by_member?.length ?? 0) === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={5} className="text-center text-muted-foreground">
+                                        No work rides for this month.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {summary?.by_member?.map((m) => (
+                                <TableRow key={m.member_id}>
+                                    <TableCell className="font-mono text-xs">
+                                        {m.member_id}
+                                    </TableCell>
+                                    <TableCell>{m.ride_count}</TableCell>
+                                    <TableCell>{formatCAD(m.allowance_total)}</TableCell>
+                                    <TableCell>{formatCAD(m.master_total)}</TableCell>
+                                    <TableCell className="text-right font-medium">
+                                        {formatCAD(m.total)}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="p-4">
+                    <h2 className="mb-3 font-medium">Wallet ledger</h2>
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Date</TableHead>
+                                <TableHead>Type</TableHead>
+                                <TableHead>Notes</TableHead>
+                                <TableHead className="text-right">Amount</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {!txns && !loading && (
+                                <TableRow>
+                                    <TableCell colSpan={4} className="text-center text-muted-foreground">
+                                        No wallet configured.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {txns?.transactions.length === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={4} className="text-center text-muted-foreground">
+                                        No transactions.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {txns?.transactions.map((t) => (
+                                <TableRow key={t.id}>
+                                    <TableCell className="text-xs text-muted-foreground">
+                                        {t.created_at?.slice(0, 10)}
+                                    </TableCell>
+                                    <TableCell>
+                                        <Badge variant="secondary" className="text-[10px]">
+                                            {t.type}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell className="max-w-[40ch] truncate text-xs">
+                                        {t.notes ?? ""}
+                                    </TableCell>
+                                    <TableCell className="text-right font-medium">
+                                        {formatCAD(t.amount)}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+function Metric({
+    label,
+    value,
+    sub,
+}: {
+    label: string;
+    value: string;
+    sub?: string;
+}) {
+    return (
+        <Card>
+            <CardContent className="p-4">
+                <div className="text-xs text-muted-foreground">{label}</div>
+                <div className="text-2xl font-semibold">{value}</div>
+                {sub && <div className="text-xs text-muted-foreground">{sub}</div>}
+            </CardContent>
+        </Card>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/layout.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/layout.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import {
+    ArrowLeft,
+    Building2,
+    LayoutDashboard,
+    Receipt,
+    ScrollText,
+    Settings,
+    ShieldCheck,
+    Users,
+    Wallet,
+} from "lucide-react";
+import {
+    CorporateAccount,
+    getCorporateAccount,
+} from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+
+interface NavItem {
+    href: string;
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+}
+
+function buildNav(id: string): NavItem[] {
+    return [
+        { href: `/company-portal/${id}/overview`, label: "Overview", icon: LayoutDashboard },
+        { href: `/company-portal/${id}/members`, label: "Members", icon: Users },
+        { href: `/company-portal/${id}/allowances`, label: "Allowances", icon: Wallet },
+        { href: `/company-portal/${id}/allowance-requests`, label: "Requests", icon: ScrollText },
+        { href: `/company-portal/${id}/policy`, label: "Policy", icon: ShieldCheck },
+        { href: `/company-portal/${id}/billing`, label: "Billing", icon: Receipt },
+        { href: `/company-portal/${id}/activity`, label: "Activity", icon: LayoutDashboard },
+        { href: `/company-portal/${id}/settings`, label: "Settings", icon: Settings },
+    ];
+}
+
+export default function CompanyPortalLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    const params = useParams();
+    const pathname = usePathname();
+    const router = useRouter();
+    const id = typeof params?.id === "string" ? params.id : "";
+    const [company, setCompany] = useState<CorporateAccount | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!id) return;
+        getCorporateAccount(id)
+            .then(setCompany)
+            .catch((e) => {
+                const msg = e instanceof Error ? e.message : "Failed to load";
+                setError(msg);
+                if (/forbidden|not a company/i.test(msg)) {
+                    router.push("/company-portal");
+                }
+            });
+    }, [id, router]);
+
+    const nav = buildNav(id);
+
+    return (
+        <div className="flex min-h-screen flex-col md:flex-row">
+            <aside className="md:w-64 md:shrink-0 md:border-r border-border bg-muted/20">
+                <div className="p-4 md:p-6">
+                    <Link
+                        href="/company-portal"
+                        className="mb-4 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                    >
+                        <ArrowLeft className="h-3.5 w-3.5" /> Switch company
+                    </Link>
+                    <div className="flex items-center gap-2">
+                        <div className="rounded-md bg-emerald-50 p-2">
+                            <Building2 className="h-5 w-5 text-emerald-600" />
+                        </div>
+                        <div>
+                            <div className="font-semibold leading-tight">
+                                {company?.name ?? "Loading…"}
+                            </div>
+                            {company?.status && (
+                                <Badge className="mt-1 text-[10px] bg-emerald-100 text-emerald-800 hover:bg-emerald-100">
+                                    {company.status}
+                                </Badge>
+                            )}
+                        </div>
+                    </div>
+                </div>
+                <nav className="flex gap-1 overflow-x-auto px-3 pb-3 md:flex-col md:gap-0.5 md:overflow-visible md:px-3">
+                    {nav.map((item) => {
+                        const Icon = item.icon;
+                        const active = pathname === item.href;
+                        return (
+                            <Link
+                                key={item.href}
+                                href={item.href}
+                                className={
+                                    "flex shrink-0 items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors " +
+                                    (active
+                                        ? "bg-primary/10 font-medium text-primary"
+                                        : "text-muted-foreground hover:bg-muted hover:text-foreground")
+                                }
+                            >
+                                <Icon className="h-4 w-4" />
+                                {item.label}
+                            </Link>
+                        );
+                    })}
+                </nav>
+            </aside>
+
+            <main className="flex-1">
+                {error && !/forbidden|not a company/i.test(error) && (
+                    <div className="m-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                        {error}
+                    </div>
+                )}
+                <div className="p-4 md:p-8">{children}</div>
+            </main>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/members/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/members/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    CorporateMember,
+    CorporateMemberRole,
+    CorporateMemberStatus,
+    inviteCompanyMember,
+    listCompanyMembers,
+    updateCompanyMember,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import { Mail, PauseCircle, PlayCircle, UserPlus } from "lucide-react";
+
+const STATUS_COLORS: Record<CorporateMemberStatus, string> = {
+    invited: "bg-yellow-100 text-yellow-800",
+    active: "bg-emerald-100 text-emerald-800",
+    suspended: "bg-orange-100 text-orange-800",
+    removed: "bg-gray-200 text-gray-600",
+};
+
+type Filter = "all" | CorporateMemberStatus;
+
+export default function MembersPage() {
+    const { id } = useParams<{ id: string }>();
+    const [members, setMembers] = useState<CorporateMember[]>([]);
+    const [filter, setFilter] = useState<Filter>("all");
+    const [loading, setLoading] = useState(true);
+    const [inviteEmail, setInviteEmail] = useState("");
+    const [inviteRole, setInviteRole] = useState<CorporateMemberRole>("member");
+    const [inviting, setInviting] = useState(false);
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        try {
+            const rows = await listCompanyMembers(id);
+            setMembers(rows);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const filtered = members.filter(
+        (m) => filter === "all" || m.status === filter
+    );
+
+    const onInvite = async () => {
+        if (!id || !inviteEmail.trim()) return;
+        setInviting(true);
+        setError(null);
+        setFeedback(null);
+        try {
+            const res = await inviteCompanyMember(id, {
+                email: inviteEmail.trim(),
+                role: inviteRole,
+            });
+            setFeedback(`Invite sent — share: ${res.invite_url}`);
+            setInviteEmail("");
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Invite failed");
+        } finally {
+            setInviting(false);
+        }
+    };
+
+    const toggleStatus = async (m: CorporateMember) => {
+        if (!id) return;
+        const target: CorporateMemberStatus =
+            m.status === "suspended" ? "active" : "suspended";
+        try {
+            await updateCompanyMember(id, m.id, { status: target });
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Update failed");
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <header className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-semibold">Members</h1>
+                    <p className="text-muted-foreground">
+                        Invite, suspend, and reactivate members.
+                    </p>
+                </div>
+            </header>
+
+            <Card>
+                <CardContent className="space-y-3 p-4">
+                    <div className="grid gap-3 sm:grid-cols-[1fr_150px_auto]">
+                        <div>
+                            <Label htmlFor="invite-email">Invite by email</Label>
+                            <Input
+                                id="invite-email"
+                                type="email"
+                                placeholder="name@company.com"
+                                value={inviteEmail}
+                                onChange={(e) => setInviteEmail(e.target.value)}
+                            />
+                        </div>
+                        <div>
+                            <Label>Role</Label>
+                            <Select
+                                value={inviteRole}
+                                onValueChange={(v) => setInviteRole(v as CorporateMemberRole)}
+                            >
+                                <SelectTrigger>
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="member">Member</SelectItem>
+                                    <SelectItem value="admin">Admin</SelectItem>
+                                    <SelectItem value="owner">Owner</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="flex items-end">
+                            <Button onClick={onInvite} disabled={inviting || !inviteEmail.trim()}>
+                                <UserPlus className="mr-2 h-4 w-4" />
+                                {inviting ? "Sending…" : "Send invite"}
+                            </Button>
+                        </div>
+                    </div>
+                    {feedback && (
+                        <p className="rounded bg-emerald-50 p-2 text-xs text-emerald-800">
+                            {feedback}
+                        </p>
+                    )}
+                    {error && (
+                        <p className="rounded bg-red-50 p-2 text-xs text-red-700">{error}</p>
+                    )}
+                </CardContent>
+            </Card>
+
+            <div className="flex gap-2">
+                {(["all", "active", "invited", "suspended", "removed"] as Filter[]).map(
+                    (f) => (
+                        <Button
+                            key={f}
+                            size="sm"
+                            variant={filter === f ? "default" : "outline"}
+                            onClick={() => setFilter(f)}
+                        >
+                            {f}
+                        </Button>
+                    )
+                )}
+            </div>
+
+            <Card>
+                <CardContent className="p-0">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Email</TableHead>
+                                <TableHead>Role</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead className="text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {loading && (
+                                <TableRow>
+                                    <TableCell colSpan={4} className="text-center text-muted-foreground">
+                                        Loading…
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {!loading && filtered.length === 0 && (
+                                <TableRow>
+                                    <TableCell colSpan={4} className="text-center text-muted-foreground">
+                                        No members.
+                                    </TableCell>
+                                </TableRow>
+                            )}
+                            {filtered.map((m) => (
+                                <TableRow key={m.id}>
+                                    <TableCell className="flex items-center gap-2">
+                                        <Mail className="h-3.5 w-3.5 text-muted-foreground" />
+                                        {m.invited_email || m.user_id || m.id}
+                                    </TableCell>
+                                    <TableCell className="capitalize">{m.role}</TableCell>
+                                    <TableCell>
+                                        <Badge className={STATUS_COLORS[m.status]}>
+                                            {m.status}
+                                        </Badge>
+                                    </TableCell>
+                                    <TableCell className="text-right">
+                                        {m.status === "active" && (
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                onClick={() => toggleStatus(m)}
+                                            >
+                                                <PauseCircle className="mr-1 h-3.5 w-3.5" />
+                                                Suspend
+                                            </Button>
+                                        )}
+                                        {m.status === "suspended" && (
+                                            <Button
+                                                size="sm"
+                                                variant="ghost"
+                                                onClick={() => toggleStatus(m)}
+                                            >
+                                                <PlayCircle className="mr-1 h-3.5 w-3.5" />
+                                                Reactivate
+                                            </Button>
+                                        )}
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/overview/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/overview/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+    BillingSummary,
+    CorporateMember,
+    AllowanceRequestRow,
+    getCompanyBillingSummary,
+    listCompanyMembers,
+    listCompanyAllowanceRequests,
+} from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+    Activity,
+    ArrowRight,
+    CreditCard,
+    ScrollText,
+    Users,
+    Wallet,
+} from "lucide-react";
+
+function formatCAD(n: number | undefined) {
+    return (n ?? 0).toLocaleString("en-CA", {
+        style: "currency",
+        currency: "CAD",
+    });
+}
+
+export default function OverviewPage() {
+    const { id } = useParams<{ id: string }>();
+    const [summary, setSummary] = useState<BillingSummary | null>(null);
+    const [members, setMembers] = useState<CorporateMember[]>([]);
+    const [pending, setPending] = useState<AllowanceRequestRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!id) return;
+        Promise.all([
+            getCompanyBillingSummary(id).catch(() => null),
+            listCompanyMembers(id).catch(() => []),
+            listCompanyAllowanceRequests(id, "pending").catch(() => []),
+        ])
+            .then(([s, m, p]) => {
+                setSummary(s);
+                setMembers(m);
+                setPending(p);
+            })
+            .catch((e) =>
+                setError(e instanceof Error ? e.message : "Failed to load")
+            )
+            .finally(() => setLoading(false));
+    }, [id]);
+
+    const activeMembers = members.filter((m) => m.status === "active").length;
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="text-2xl font-semibold">Overview</h1>
+                <p className="text-muted-foreground">
+                    Key metrics for the current month.
+                </p>
+            </header>
+
+            {error && (
+                <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>
+            )}
+
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <MetricCard
+                    icon={Wallet}
+                    label="Wallet balance"
+                    value={formatCAD(summary?.wallet_balance)}
+                    sub={summary?.wallet_currency ?? "CAD"}
+                />
+                <MetricCard
+                    icon={CreditCard}
+                    label="MTD spend"
+                    value={formatCAD(summary?.total)}
+                    sub={`${summary?.ride_count ?? 0} rides`}
+                />
+                <MetricCard
+                    icon={Activity}
+                    label="Avg fare"
+                    value={formatCAD(summary?.avg_fare)}
+                    sub="Per work ride"
+                />
+                <MetricCard
+                    icon={Users}
+                    label="Active members"
+                    value={String(activeMembers)}
+                    sub={`${members.length} total`}
+                />
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+                <Card>
+                    <CardContent className="p-6">
+                        <div className="mb-4 flex items-center justify-between">
+                            <h2 className="font-medium">Top spend this month</h2>
+                            <Link
+                                href={`/company-portal/${id}/billing`}
+                                className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+                            >
+                                Full report <ArrowRight className="h-3 w-3" />
+                            </Link>
+                        </div>
+                        {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+                        {!loading && (summary?.by_member?.length ?? 0) === 0 && (
+                            <p className="text-sm text-muted-foreground">No work rides yet.</p>
+                        )}
+                        <ul className="divide-y divide-border">
+                            {summary?.by_member?.slice(0, 5).map((row) => (
+                                <li
+                                    key={row.member_id}
+                                    className="flex items-center justify-between py-2 text-sm"
+                                >
+                                    <span className="font-mono text-xs">{row.member_id}</span>
+                                    <span className="flex items-center gap-2">
+                                        <Badge variant="secondary" className="text-[10px]">
+                                            {row.ride_count} rides
+                                        </Badge>
+                                        <span className="font-medium">
+                                            {formatCAD(row.total)}
+                                        </span>
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardContent className="p-6">
+                        <div className="mb-4 flex items-center justify-between">
+                            <h2 className="font-medium">Pending allowance requests</h2>
+                            <Link
+                                href={`/company-portal/${id}/allowance-requests`}
+                                className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+                            >
+                                Review <ArrowRight className="h-3 w-3" />
+                            </Link>
+                        </div>
+                        {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+                        {!loading && pending.length === 0 && (
+                            <p className="text-sm text-muted-foreground">
+                                No requests awaiting review.
+                            </p>
+                        )}
+                        <ul className="divide-y divide-border">
+                            {pending.slice(0, 5).map((r) => (
+                                <li
+                                    key={r.id}
+                                    className="flex items-center justify-between py-2 text-sm"
+                                >
+                                    <span className="max-w-[60%] truncate">
+                                        {r.reason}
+                                    </span>
+                                    <span className="flex items-center gap-2">
+                                        <ScrollText className="h-3.5 w-3.5 text-muted-foreground" />
+                                        <span className="font-medium">
+                                            {formatCAD(r.amount)}
+                                        </span>
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </CardContent>
+                </Card>
+            </div>
+        </div>
+    );
+}
+
+function MetricCard({
+    icon: Icon,
+    label,
+    value,
+    sub,
+}: {
+    icon: React.ComponentType<{ className?: string }>;
+    label: string;
+    value: string;
+    sub: string;
+}) {
+    return (
+        <Card>
+            <CardContent className="p-4">
+                <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+                    <Icon className="h-4 w-4" />
+                    {label}
+                </div>
+                <div className="text-2xl font-semibold">{value}</div>
+                <div className="text-xs text-muted-foreground">{sub}</div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+export default function CompanyPortalIndex() {
+    const params = useParams();
+    const router = useRouter();
+    useEffect(() => {
+        const id = typeof params?.id === "string" ? params.id : "";
+        if (id) router.replace(`/company-portal/${id}/overview`);
+    }, [params, router]);
+    return null;
+}

--- a/admin-dashboard/src/app/company-portal/[id]/policy/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/policy/page.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    CorporatePolicy,
+    PaymentSourcePolicy,
+    TimeWindowPolicy,
+    getCompanyPolicy,
+    patchCompanyPolicy,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Plus, Save, Trash2 } from "lucide-react";
+
+const DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"] as const;
+
+const DAY_LABEL: Record<(typeof DAYS)[number], string> = {
+    mon: "Mon", tue: "Tue", wed: "Wed", thu: "Thu", fri: "Fri", sat: "Sat", sun: "Sun",
+};
+
+const PAYMENT_LABELS: Record<PaymentSourcePolicy, string> = {
+    allowance_only: "Allowance only",
+    master_only: "Master wallet only",
+    both: "Allowance or personal card",
+};
+
+interface Draft {
+    active: boolean;
+    max_fare_per_ride: string;
+    allowed_payment_source: PaymentSourcePolicy;
+    allowed_time_windows: TimeWindowPolicy[];
+}
+
+function emptyWindow(): TimeWindowPolicy {
+    return { day: "mon", start: "09:00", end: "18:00" };
+}
+
+function policyToDraft(p: CorporatePolicy | null): Draft {
+    return {
+        active: p?.active ?? true,
+        max_fare_per_ride: p?.max_fare_per_ride ? String(p.max_fare_per_ride) : "",
+        allowed_payment_source: p?.allowed_payment_source ?? "both",
+        allowed_time_windows: p?.allowed_time_windows ?? [],
+    };
+}
+
+export default function PolicyPage() {
+    const { id } = useParams<{ id: string }>();
+    const [draft, setDraft] = useState<Draft>(policyToDraft(null));
+    const [existing, setExisting] = useState<CorporatePolicy | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        try {
+            const p = await getCompanyPolicy(id);
+            const hasFields = p && "active" in p;
+            setExisting(hasFields ? (p as CorporatePolicy) : null);
+            setDraft(policyToDraft(hasFields ? (p as CorporatePolicy) : null));
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const addWindow = () =>
+        setDraft({ ...draft, allowed_time_windows: [...draft.allowed_time_windows, emptyWindow()] });
+
+    const updateWindow = (i: number, patch: Partial<TimeWindowPolicy>) => {
+        const windows = draft.allowed_time_windows.map((w, idx) =>
+            idx === i ? { ...w, ...patch } : w
+        );
+        setDraft({ ...draft, allowed_time_windows: windows });
+    };
+
+    const removeWindow = (i: number) => {
+        setDraft({
+            ...draft,
+            allowed_time_windows: draft.allowed_time_windows.filter((_, idx) => idx !== i),
+        });
+    };
+
+    const invalidWindow = draft.allowed_time_windows.find((w) => w.end <= w.start);
+
+    const save = async () => {
+        if (!id) return;
+        if (invalidWindow) {
+            setError("Every time window end must be after its start.");
+            return;
+        }
+        setSaving(true);
+        setError(null);
+        setFeedback(null);
+        try {
+            await patchCompanyPolicy(id, {
+                active: draft.active,
+                max_fare_per_ride: draft.max_fare_per_ride
+                    ? Number(draft.max_fare_per_ride)
+                    : null,
+                allowed_payment_source: draft.allowed_payment_source,
+                allowed_time_windows:
+                    draft.allowed_time_windows.length > 0
+                        ? draft.allowed_time_windows
+                        : null,
+            });
+            setFeedback("Policy saved");
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Save failed");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <header className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-semibold">Policy</h1>
+                    <p className="text-muted-foreground">
+                        Limits and allowed windows for all work rides.
+                    </p>
+                </div>
+                <Badge
+                    className={
+                        existing
+                            ? "bg-emerald-100 text-emerald-800"
+                            : "bg-gray-200 text-gray-700"
+                    }
+                >
+                    {existing ? "Configured" : "Not set"}
+                </Badge>
+            </header>
+
+            {loading ? (
+                <p className="text-sm text-muted-foreground">Loading…</p>
+            ) : (
+                <>
+                    <Card>
+                        <CardContent className="space-y-4 p-4">
+                            <div className="flex items-center justify-between">
+                                <Label>Policy active</Label>
+                                <Switch
+                                    checked={draft.active}
+                                    onCheckedChange={(v) => setDraft({ ...draft, active: v })}
+                                />
+                            </div>
+
+                            <div>
+                                <Label>Max fare per ride (CAD)</Label>
+                                <Input
+                                    type="number"
+                                    placeholder="No cap"
+                                    value={draft.max_fare_per_ride}
+                                    onChange={(e) =>
+                                        setDraft({ ...draft, max_fare_per_ride: e.target.value })
+                                    }
+                                />
+                            </div>
+
+                            <div>
+                                <Label>Payment source</Label>
+                                <Select
+                                    value={draft.allowed_payment_source}
+                                    onValueChange={(v) =>
+                                        setDraft({ ...draft, allowed_payment_source: v as PaymentSourcePolicy })
+                                    }
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {(Object.keys(PAYMENT_LABELS) as PaymentSourcePolicy[]).map((k) => (
+                                            <SelectItem key={k} value={k}>
+                                                {PAYMENT_LABELS[k]}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardContent className="space-y-3 p-4">
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <h2 className="font-medium">Allowed time windows</h2>
+                                    <p className="text-xs text-muted-foreground">
+                                        Leave empty for 24/7 bookings.
+                                    </p>
+                                </div>
+                                <Button size="sm" variant="outline" onClick={addWindow}>
+                                    <Plus className="mr-1 h-3.5 w-3.5" /> Add window
+                                </Button>
+                            </div>
+                            {draft.allowed_time_windows.length === 0 && (
+                                <p className="text-sm text-muted-foreground">No windows set.</p>
+                            )}
+                            {draft.allowed_time_windows.map((w, i) => (
+                                <div
+                                    key={i}
+                                    className="grid gap-2 sm:grid-cols-[120px_1fr_1fr_auto] items-center"
+                                >
+                                    <Select
+                                        value={w.day}
+                                        onValueChange={(v) =>
+                                            updateWindow(i, { day: v as TimeWindowPolicy["day"] })
+                                        }
+                                    >
+                                        <SelectTrigger>
+                                            <SelectValue />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {DAYS.map((d) => (
+                                                <SelectItem key={d} value={d}>
+                                                    {DAY_LABEL[d]}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <Input
+                                        type="time"
+                                        value={w.start}
+                                        onChange={(e) => updateWindow(i, { start: e.target.value })}
+                                    />
+                                    <Input
+                                        type="time"
+                                        value={w.end}
+                                        onChange={(e) => updateWindow(i, { end: e.target.value })}
+                                    />
+                                    <Button
+                                        size="icon"
+                                        variant="ghost"
+                                        onClick={() => removeWindow(i)}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            ))}
+                            {invalidWindow && (
+                                <p className="text-xs text-red-600">
+                                    Every window end must be after start.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    <div className="flex items-center gap-3">
+                        <Button onClick={save} disabled={saving}>
+                            <Save className="mr-1 h-4 w-4" />
+                            {saving ? "Saving…" : "Save policy"}
+                        </Button>
+                        {feedback && (
+                            <span className="text-xs text-emerald-700">{feedback}</span>
+                        )}
+                        {error && <span className="text-xs text-red-600">{error}</span>}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/settings/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/settings/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import {
+    AllowedDomainRow,
+    CorporateAccount,
+    addAllowedDomain,
+    getCorporateAccount,
+    listAllowedDomains,
+    removeAllowedDomain,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Globe, Trash2 } from "lucide-react";
+
+export default function SettingsPage() {
+    const { id } = useParams<{ id: string }>();
+    const [company, setCompany] = useState<CorporateAccount | null>(null);
+    const [domains, setDomains] = useState<AllowedDomainRow[]>([]);
+    const [newDomain, setNewDomain] = useState("");
+    const [busy, setBusy] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [feedback, setFeedback] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!id) return;
+        setLoading(true);
+        try {
+            const [c, d] = await Promise.all([
+                getCorporateAccount(id).catch(() => null),
+                listAllowedDomains(id).catch(() => []),
+            ]);
+            setCompany(c);
+            setDomains(d);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const onAdd = async () => {
+        if (!id || !newDomain.trim()) return;
+        setBusy(true);
+        setError(null);
+        setFeedback(null);
+        try {
+            await addAllowedDomain(id, newDomain.trim().toLowerCase());
+            setNewDomain("");
+            setFeedback("Domain added.");
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const onRemove = async (domain: string) => {
+        if (!id) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await removeAllowedDomain(id, domain);
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="text-2xl font-semibold">Settings</h1>
+                <p className="text-muted-foreground">
+                    Company details and approved email domains.
+                </p>
+            </header>
+
+            <Card>
+                <CardContent className="space-y-2 p-4 text-sm">
+                    {loading ? (
+                        <p className="text-muted-foreground">Loading…</p>
+                    ) : (
+                        <>
+                            <Row label="Name" value={company?.name} />
+                            <Row label="Legal name" value={company?.legal_name} />
+                            <Row label="Business number" value={company?.business_number} />
+                            <Row label="Tax region" value={company?.tax_region} />
+                            <Row
+                                label="Billing email"
+                                value={company?.billing_email ?? "—"}
+                            />
+                            <Row label="Contact name" value={company?.contact_name} />
+                            <Row label="Contact email" value={company?.contact_email} />
+                            <Row label="Contact phone" value={company?.contact_phone} />
+                            <Row label="Size tier" value={company?.size_tier} />
+                            <Row
+                                label="Status"
+                                value={
+                                    <Badge className="bg-emerald-100 text-emerald-800">
+                                        {company?.status}
+                                    </Badge>
+                                }
+                            />
+                        </>
+                    )}
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="space-y-4 p-4">
+                    <div>
+                        <h2 className="font-medium">Allowed email domains</h2>
+                        <p className="text-xs text-muted-foreground">
+                            Members whose verified email matches an allowed domain can
+                            join without an explicit invite.
+                        </p>
+                    </div>
+
+                    <div className="flex gap-2">
+                        <div className="grow">
+                            <Label htmlFor="domain" className="sr-only">
+                                Domain
+                            </Label>
+                            <Input
+                                id="domain"
+                                placeholder="example.com"
+                                value={newDomain}
+                                onChange={(e) => setNewDomain(e.target.value)}
+                            />
+                        </div>
+                        <Button
+                            onClick={onAdd}
+                            disabled={busy || !newDomain.trim()}
+                        >
+                            Add
+                        </Button>
+                    </div>
+
+                    {feedback && (
+                        <p className="rounded bg-emerald-50 p-2 text-xs text-emerald-800">
+                            {feedback}
+                        </p>
+                    )}
+                    {error && (
+                        <p className="rounded bg-red-50 p-2 text-xs text-red-700">{error}</p>
+                    )}
+
+                    <ul className="divide-y divide-border">
+                        {domains.map((d) => (
+                            <li
+                                key={d.domain}
+                                className="flex items-center justify-between py-2"
+                            >
+                                <span className="flex items-center gap-2 text-sm">
+                                    <Globe className="h-3.5 w-3.5 text-muted-foreground" />
+                                    {d.domain}
+                                </span>
+                                <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    onClick={() => onRemove(d.domain)}
+                                    disabled={busy}
+                                >
+                                    <Trash2 className="h-4 w-4" />
+                                </Button>
+                            </li>
+                        ))}
+                        {domains.length === 0 && !loading && (
+                            <li className="py-2 text-sm text-muted-foreground">
+                                No allowed domains yet.
+                            </li>
+                        )}
+                    </ul>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+function Row({
+    label,
+    value,
+}: {
+    label: string;
+    value?: React.ReactNode;
+}) {
+    return (
+        <div className="flex items-center justify-between border-b border-border py-1.5 last:border-b-0">
+            <span className="text-muted-foreground">{label}</span>
+            <span className="font-medium">{value ?? "—"}</span>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/layout.tsx
+++ b/admin-dashboard/src/app/company-portal/layout.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStore } from "@/store/authStore";
+
+export default function CompanyPortalRootLayout({
+    children,
+}: {
+    children: React.ReactNode;
+}) {
+    const router = useRouter();
+    const { isAuthenticated, isLoading } = useAuthStore();
+
+    useEffect(() => {
+        if (!isLoading && !isAuthenticated) {
+            router.push("/login?next=/company-portal");
+        }
+    }, [isAuthenticated, isLoading, router]);
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center min-h-screen bg-background">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) return null;
+
+    return <div className="min-h-screen bg-background">{children}</div>;
+}

--- a/admin-dashboard/src/app/company-portal/page.tsx
+++ b/admin-dashboard/src/app/company-portal/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Building2, ChevronRight } from "lucide-react";
+import { getCorporateAccounts, CorporateAccount } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+export default function CompanyPortalLandingPage() {
+    const [companies, setCompanies] = useState<CorporateAccount[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        getCorporateAccounts()
+            .then((rows) => setCompanies(rows.filter((c) => c.status === "active")))
+            .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
+            .finally(() => setLoading(false));
+    }, []);
+
+    return (
+        <div className="mx-auto max-w-3xl p-6 md:p-10">
+            <header className="mb-8">
+                <h1 className="text-2xl font-semibold">Company Portal</h1>
+                <p className="text-muted-foreground">
+                    Select a company to manage members, policies, and billing.
+                </p>
+            </header>
+
+            {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+            {error && (
+                <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>
+            )}
+
+            <div className="space-y-3">
+                {companies.map((c) => (
+                    <Link
+                        key={c.id}
+                        href={`/company-portal/${c.id}/overview`}
+                        className="block"
+                    >
+                        <Card className="transition-colors hover:bg-muted/40">
+                            <CardContent className="flex items-center justify-between gap-4 p-4">
+                                <div className="flex items-center gap-3">
+                                    <div className="rounded-md bg-emerald-50 p-2">
+                                        <Building2 className="h-5 w-5 text-emerald-600" />
+                                    </div>
+                                    <div>
+                                        <div className="font-medium">{c.name}</div>
+                                        <div className="text-xs text-muted-foreground">
+                                            {c.legal_name ?? c.tax_region ?? c.size_tier}
+                                        </div>
+                                    </div>
+                                </div>
+                                <div className="flex items-center gap-3">
+                                    <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">
+                                        {c.status}
+                                    </Badge>
+                                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </Link>
+                ))}
+                {!loading && companies.length === 0 && !error && (
+                    <Card>
+                        <CardContent className="p-6 text-center text-sm text-muted-foreground">
+                            No active companies found.
+                        </CardContent>
+                    </Card>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -657,6 +657,111 @@ export const patchCompanyPolicy = (
         body: JSON.stringify(body),
     });
 
+/* ── Company allowed domains (Plan 7) ── */
+export interface AllowedDomainRow {
+    company_id: string;
+    domain: string;
+}
+
+export const listAllowedDomains = (companyId: string) =>
+    request<AllowedDomainRow[]>(`/company/${companyId}/allowed-domains`);
+
+export const addAllowedDomain = (companyId: string, domain: string) =>
+    request<AllowedDomainRow>(`/company/${companyId}/allowed-domains`, {
+        method: "POST",
+        body: JSON.stringify({ domain }),
+    });
+
+export const removeAllowedDomain = (companyId: string, domain: string) =>
+    request<{ status: string }>(
+        `/company/${companyId}/allowed-domains/${encodeURIComponent(domain)}`,
+        { method: "DELETE" }
+    );
+
+/* ── Company billing (Plan 6) ── */
+export interface BillingMemberBreakdown {
+    member_id: string;
+    ride_count: number;
+    allowance_total: number;
+    master_total: number;
+    total: number;
+}
+
+export interface BillingSummary {
+    month: string;
+    wallet_balance: number;
+    wallet_currency: string;
+    ride_count: number;
+    allowance_total: number;
+    master_total: number;
+    total: number;
+    avg_fare: number;
+    by_member: BillingMemberBreakdown[];
+}
+
+export interface BillingLineItem {
+    ride_id: string;
+    member_id: string;
+    source_type: string;
+    allowance_debit_amount: number;
+    master_fallback_amount: number;
+    policy_check_result?: string;
+    created_at: string;
+}
+
+export interface BillingStatement {
+    month: string;
+    from: string;
+    to: string;
+    line_items: BillingLineItem[];
+    summary: {
+        ride_count: number;
+        allowance_total: number;
+        master_total: number;
+        total: number;
+        avg_fare: number;
+        by_member: BillingMemberBreakdown[];
+    };
+}
+
+export interface BillingTransaction {
+    id: string;
+    type: string;
+    amount: number;
+    balance_after?: number;
+    notes?: string | null;
+    ride_id?: string | null;
+    member_id?: string | null;
+    stripe_payment_intent_id?: string | null;
+    created_at: string;
+}
+
+export interface BillingTransactionsPage {
+    wallet_id: string;
+    balance: number;
+    currency: string;
+    transactions: BillingTransaction[];
+}
+
+export const getCompanyBillingSummary = (companyId: string, month?: string) => {
+    const qs = month ? `?month=${encodeURIComponent(month)}` : "";
+    return request<BillingSummary>(`/company/${companyId}/billing/summary${qs}`);
+};
+
+export const getCompanyBillingStatement = (companyId: string, month: string) =>
+    request<BillingStatement>(
+        `/company/${companyId}/billing/statements/${encodeURIComponent(month)}`
+    );
+
+export const getCompanyBillingTransactions = (
+    companyId: string,
+    skip = 0,
+    limit = 50
+) =>
+    request<BillingTransactionsPage>(
+        `/company/${companyId}/billing/transactions?skip=${skip}&limit=${limit}`
+    );
+
 /* ── Cloud Messaging (merged with Notifications) ── */
 export const getCloudMessages = (status?: string, audience?: string) => {
     const params = new URLSearchParams();

--- a/backend/db_supabase.py
+++ b/backend/db_supabase.py
@@ -1821,6 +1821,41 @@ async def find_companies_by_email_domain(domain: str) -> List[Dict[str, Any]]:
     return await run_sync(_fn)
 
 
+# ---------- Billing (Plan 6) ----------
+async def list_company_ride_payment_sources(
+    *,
+    company_id: str,
+    from_iso: Optional[str] = None,
+    to_iso: Optional[str] = None,
+    member_id: Optional[str] = None,
+    limit: int = 500,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
+    """Return ride_payment_sources rows for a company, newest first.
+
+    Each row is the source of truth for a work ride's billing split:
+    allowance_debit_amount + master_fallback_amount = total billed to company.
+    """
+    upper = offset + max(limit, 1) - 1
+
+    def _fn():
+        q = (
+            supabase.table("ride_payment_sources")
+            .select("*")
+            .eq("company_id", company_id)
+        )
+        if member_id:
+            q = q.eq("member_id", member_id)
+        if from_iso:
+            q = q.gte("created_at", from_iso)
+        if to_iso:
+            q = q.lte("created_at", to_iso)
+        res = q.order("created_at", desc=True).range(offset, upper).execute()
+        return _rows_from_res(res)
+
+    return await run_sync(_fn)
+
+
 async def get_corporate_policy(company_id: str) -> Optional[Dict[str, Any]]:
     """Fetch the active corporate_policies row for a company."""
     def _fn():

--- a/backend/routes/corporate_company.py
+++ b/backend/routes/corporate_company.py
@@ -23,6 +23,8 @@ try:
         list_company_allowance_requests,
         list_company_allowances,
         list_company_members,
+        list_company_ride_payment_sources,
+        list_wallet_transactions,
         update_allowance_request,
         update_corporate_member,
         upsert_corporate_policy,
@@ -57,6 +59,8 @@ except ImportError:
         list_company_allowance_requests,
         list_company_allowances,
         list_company_members,
+        list_company_ride_payment_sources,
+        list_wallet_transactions,
         update_allowance_request,
         update_corporate_member,
         upsert_corporate_policy,
@@ -343,3 +347,124 @@ async def patch_policy(
         ]
 
     return await upsert_corporate_policy(company_id, patch)
+
+
+# ---------- Billing (Plan 6) ----------
+
+def _month_bounds(month: str) -> tuple[str, str]:
+    """Return (from_iso, to_iso) [inclusive-exclusive] bounds for YYYY-MM."""
+    from datetime import datetime as _dt
+
+    try:
+        anchor = _dt.strptime(month, "%Y-%m")
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="month must be YYYY-MM") from exc
+    if anchor.month == 12:
+        end = anchor.replace(year=anchor.year + 1, month=1)
+    else:
+        end = anchor.replace(month=anchor.month + 1)
+    return anchor.isoformat(), end.isoformat()
+
+
+def _aggregate_rows(rows: list[dict]) -> dict:
+    allowance_total = 0.0
+    master_total = 0.0
+    by_member: dict[str, dict] = {}
+    for r in rows:
+        ad = float(r.get("allowance_debit_amount") or 0)
+        md = float(r.get("master_fallback_amount") or 0)
+        allowance_total += ad
+        master_total += md
+        mid = r.get("member_id") or "unknown"
+        slot = by_member.setdefault(
+            mid,
+            {"member_id": mid, "ride_count": 0, "allowance_total": 0.0, "master_total": 0.0, "total": 0.0},
+        )
+        slot["ride_count"] += 1
+        slot["allowance_total"] += ad
+        slot["master_total"] += md
+        slot["total"] += ad + md
+    total = allowance_total + master_total
+    return {
+        "ride_count": len(rows),
+        "allowance_total": round(allowance_total, 2),
+        "master_total": round(master_total, 2),
+        "total": round(total, 2),
+        "avg_fare": round(total / len(rows), 2) if rows else 0.0,
+        "by_member": sorted(by_member.values(), key=lambda m: m["total"], reverse=True),
+    }
+
+
+@router.get("/billing/summary")
+async def billing_summary(
+    company_id: str,
+    month: Optional[str] = None,
+    guard=Depends(require_company_admin),
+):
+    """Aggregate spend for a month (defaults to the current month in UTC).
+
+    Returns ride count, total company spend (allowance + master fallback),
+    average fare, and per-member breakdown sorted by total desc.
+    """
+    from datetime import datetime as _dt
+
+    if month is None:
+        month = _dt.utcnow().strftime("%Y-%m")
+    from_iso, to_iso = _month_bounds(month)
+    rows = await list_company_ride_payment_sources(
+        company_id=company_id, from_iso=from_iso, to_iso=to_iso, limit=1000,
+    )
+    wallet = await get_corporate_wallet_by_company(company_id) or {}
+    return {
+        "month": month,
+        "wallet_balance": float(wallet.get("balance") or 0),
+        "wallet_currency": wallet.get("currency") or "CAD",
+        **_aggregate_rows(rows),
+    }
+
+
+@router.get("/billing/statements/{month}")
+async def billing_statement(
+    company_id: str,
+    month: str,
+    guard=Depends(require_company_admin),
+):
+    """Full monthly statement: per-ride line items + summary totals.
+
+    `month` is YYYY-MM; returns 422 if the string is malformed.
+    """
+    from_iso, to_iso = _month_bounds(month)
+    rows = await list_company_ride_payment_sources(
+        company_id=company_id, from_iso=from_iso, to_iso=to_iso, limit=5000,
+    )
+    return {
+        "month": month,
+        "from": from_iso,
+        "to": to_iso,
+        "line_items": rows,
+        "summary": _aggregate_rows(rows),
+    }
+
+
+@router.get("/billing/transactions")
+async def billing_transactions(
+    company_id: str,
+    skip: int = 0,
+    limit: int = 50,
+    guard=Depends(require_company_admin),
+):
+    """Paged corporate wallet ledger (top-ups, debits, adjustments)."""
+    wallet = await get_corporate_wallet_by_company(company_id)
+    if not wallet:
+        raise HTTPException(status_code=404, detail="Wallet not found")
+    txns = await list_wallet_transactions(
+        wallet_id=wallet["id"],
+        skip=max(skip, 0),
+        limit=min(max(limit, 1), 200),
+    )
+    return {
+        "wallet_id": wallet["id"],
+        "balance": float(wallet.get("balance") or 0),
+        "currency": wallet.get("currency") or "CAD",
+        "transactions": txns,
+    }

--- a/backend/tests/test_corporate_company_routes.py
+++ b/backend/tests/test_corporate_company_routes.py
@@ -281,3 +281,142 @@ def test_patch_policy_with_time_windows(test_client, rider_override):
     assert resp.status_code == 200, resp.text
     stored_windows = m_upsert.await_args.args[1]["allowed_time_windows"]
     assert stored_windows == windows
+
+
+# ─── Billing (Plan 6) ───────────────────────────────────────────────────────
+
+_BILLING_ROWS = [
+    {
+        "ride_id": "r1",
+        "member_id": "m1",
+        "allowance_debit_amount": 20.0,
+        "master_fallback_amount": 5.0,
+        "created_at": "2026-04-02T10:00:00",
+    },
+    {
+        "ride_id": "r2",
+        "member_id": "m1",
+        "allowance_debit_amount": 15.0,
+        "master_fallback_amount": 0.0,
+        "created_at": "2026-04-05T10:00:00",
+    },
+    {
+        "ride_id": "r3",
+        "member_id": "m2",
+        "allowance_debit_amount": 0.0,
+        "master_fallback_amount": 40.0,
+        "created_at": "2026-04-10T10:00:00",
+    },
+]
+
+
+def test_billing_summary_aggregates_rows(test_client, rider_override):
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=_ADMIN_MEMBERSHIPS),
+    ), patch(
+        "routes.corporate_company.list_company_ride_payment_sources",
+        AsyncMock(return_value=_BILLING_ROWS),
+    ), patch(
+        "routes.corporate_company.get_corporate_wallet_by_company",
+        AsyncMock(return_value={"balance": 120.0, "currency": "CAD"}),
+    ):
+        resp = test_client.get("/company/c1/billing/summary?month=2026-04")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["month"] == "2026-04"
+    assert body["ride_count"] == 3
+    assert body["allowance_total"] == 35.0
+    assert body["master_total"] == 45.0
+    assert body["total"] == 80.0
+    assert body["wallet_balance"] == 120.0
+    # by_member sorted by total desc
+    assert body["by_member"][0]["member_id"] == "m2"
+    assert body["by_member"][0]["total"] == 40.0
+    assert body["by_member"][1]["member_id"] == "m1"
+    assert body["by_member"][1]["ride_count"] == 2
+
+
+def test_billing_summary_defaults_to_current_month(test_client, rider_override):
+    list_mock = AsyncMock(return_value=[])
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=_ADMIN_MEMBERSHIPS),
+    ), patch(
+        "routes.corporate_company.list_company_ride_payment_sources",
+        list_mock,
+    ), patch(
+        "routes.corporate_company.get_corporate_wallet_by_company",
+        AsyncMock(return_value={}),
+    ):
+        resp = test_client.get("/company/c1/billing/summary")
+    assert resp.status_code == 200, resp.text
+    # month bounds were derived from a YYYY-MM string (first of the month)
+    kwargs = list_mock.await_args.kwargs
+    assert kwargs["from_iso"].endswith("-01T00:00:00")
+
+
+def test_billing_summary_rejects_non_admin(test_client, rider_override):
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=[{"company_id": "c1", "role": "member"}]),
+    ):
+        resp = test_client.get("/company/c1/billing/summary?month=2026-04")
+    assert resp.status_code == 403
+
+
+def test_billing_statement_returns_line_items(test_client, rider_override):
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=_ADMIN_MEMBERSHIPS),
+    ), patch(
+        "routes.corporate_company.list_company_ride_payment_sources",
+        AsyncMock(return_value=_BILLING_ROWS),
+    ):
+        resp = test_client.get("/company/c1/billing/statements/2026-04")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["line_items"]) == 3
+    assert body["summary"]["total"] == 80.0
+    assert body["summary"]["avg_fare"] == round(80.0 / 3, 2)
+
+
+def test_billing_statement_rejects_bad_month(test_client, rider_override):
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=_ADMIN_MEMBERSHIPS),
+    ):
+        resp = test_client.get("/company/c1/billing/statements/bad")
+    assert resp.status_code == 422
+
+
+def test_billing_transactions_returns_paged_ledger(test_client, rider_override):
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=_ADMIN_MEMBERSHIPS),
+    ), patch(
+        "routes.corporate_company.get_corporate_wallet_by_company",
+        AsyncMock(return_value={"id": "w1", "balance": 250.0, "currency": "CAD"}),
+    ), patch(
+        "routes.corporate_company.list_wallet_transactions",
+        AsyncMock(return_value=[{"id": "t1", "amount": 100}]),
+    ) as m_list:
+        resp = test_client.get("/company/c1/billing/transactions?skip=0&limit=25")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["wallet_id"] == "w1"
+    assert body["balance"] == 250.0
+    assert len(body["transactions"]) == 1
+    m_list.assert_awaited_once_with(wallet_id="w1", skip=0, limit=25)
+
+
+def test_billing_transactions_404_when_no_wallet(test_client, rider_override):
+    with patch(
+        "dependencies.company_guard.list_active_memberships_for_user",
+        AsyncMock(return_value=_ADMIN_MEMBERSHIPS),
+    ), patch(
+        "routes.corporate_company.get_corporate_wallet_by_company",
+        AsyncMock(return_value=None),
+    ):
+        resp = test_client.get("/company/c1/billing/transactions")
+    assert resp.status_code == 404

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -19,6 +19,7 @@ import { Ionicons } from '@expo/vector-icons';
 import MapView, { Marker, Circle, Polyline, PROVIDER_GOOGLE } from 'react-native-maps';
 import MapViewDirections from 'react-native-maps-directions';
 import { useRideStore } from '../store/rideStore';
+import { useWorkProfileStore } from '../store/workProfileStore';
 import CustomAlert from '@shared/components/CustomAlert';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
@@ -52,6 +53,16 @@ function RideOptionsScreenContent() {
     fetchAvailablePromos,
     applyPromo,
   } = useRideStore();
+
+  const workModeEnabled = useWorkProfileStore(s => s.workModeEnabled);
+  const activeCompanyId = useWorkProfileStore(s => s.activeCompanyId);
+  const workProfiles = useWorkProfileStore(s => s.profiles);
+  const fetchPolicy = useWorkProfileStore(s => s.fetchPolicy);
+  const checkRide = useWorkProfileStore(s => s.checkRide);
+  const activeCompanyName = useMemo(
+    () => workProfiles.find(p => p.company.id === activeCompanyId)?.company.name ?? null,
+    [workProfiles, activeCompanyId],
+  );
 
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -95,6 +106,13 @@ function RideOptionsScreenContent() {
       return () => clearInterval(interval);
     }
   }, [pickup, dropoff]);
+
+  // Refresh work policy when work mode is active
+  useEffect(() => {
+    if (workModeEnabled && activeCompanyId) {
+      fetchPolicy();
+    }
+  }, [workModeEnabled, activeCompanyId]);
 
   // Fetch promos when estimates are ready
   useEffect(() => {
@@ -168,6 +186,25 @@ function RideOptionsScreenContent() {
     if (isScheduling && !scheduledTime) {
       setAlertState({ visible: true, title: 'Select Time', message: 'Please pick a date and time for your scheduled ride.', variant: 'warning' });
       return;
+    }
+    if (workModeEnabled && activeCompanyId && selectedEstimate) {
+      const when = isScheduling && scheduledTime ? scheduledTime : undefined;
+      const check = checkRide(selectedEstimate.total_fare, when);
+      if (!check.ok) {
+        setAlertState({
+          visible: true,
+          title: 'Blocked by company policy',
+          message: check.reasons.join('\n'),
+          variant: 'warning',
+          buttons: [
+            { text: 'Turn off work mode', style: 'destructive', onPress: () => {
+              useWorkProfileStore.getState().setWorkMode(false);
+            }},
+            { text: 'Change ride', style: 'cancel' },
+          ],
+        });
+        return;
+      }
     }
     router.push('/payment-confirm');
   };
@@ -403,6 +440,21 @@ function RideOptionsScreenContent() {
           )}
           <Ionicons name="chevron-forward" size={14} color="#999" />
         </TouchableOpacity>
+      )}
+
+      {/* Work Mode Banner */}
+      {workModeEnabled && activeCompanyId && (
+        <View style={styles.workBanner}>
+          <Ionicons name="briefcase" size={16} color="#1D4ED8" />
+          <View style={{ flex: 1 }}>
+            <Text style={styles.workBannerTitle}>
+              Billed to {activeCompanyName ?? 'your employer'}
+            </Text>
+            <Text style={styles.workBannerSubtitle}>
+              This ride will be covered by your work allowance.
+            </Text>
+          </View>
+        </View>
       )}
 
       {/* Options Header */}
@@ -966,6 +1018,31 @@ function createStyles(colors: ThemeColors) {
     fontSize: 18,
     fontFamily: 'PlusJakartaSans_700Bold',
     color: '#10B981',
+  },
+  workBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginHorizontal: 20,
+    marginTop: 8,
+    marginBottom: 4,
+    backgroundColor: '#EFF6FF',
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    gap: 10,
+    borderWidth: 1,
+    borderColor: '#BFDBFE',
+  },
+  workBannerTitle: {
+    fontSize: 13,
+    fontFamily: 'PlusJakartaSans_700Bold',
+    color: '#1E3A8A',
+  },
+  workBannerSubtitle: {
+    fontSize: 11,
+    fontFamily: 'PlusJakartaSans_400Regular',
+    color: '#1D4ED8',
+    marginTop: 1,
   },
   promoBanner: {
     flexDirection: 'row',

--- a/rider-app/store/workProfileStore.ts
+++ b/rider-app/store/workProfileStore.ts
@@ -29,11 +29,26 @@ export interface AllowanceBalance {
   status: string | null;
 }
 
+export interface WorkTimeWindow {
+  day: 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
+  start: string;
+  end: string;
+}
+
+export interface WorkPolicy {
+  active?: boolean;
+  max_fare_per_ride?: number | null;
+  allowed_geofence?: Record<string, unknown> | null;
+  allowed_time_windows?: WorkTimeWindow[] | null;
+  allowed_payment_source?: 'allowance_only' | 'master_only' | 'both';
+}
+
 interface WorkProfileState {
   profiles: WorkProfile[];
   activeCompanyId: string | null;
   workModeEnabled: boolean;
   balance: AllowanceBalance | null;
+  policy: WorkPolicy | null;
   requests: any[];
   isLoading: boolean;
   balanceLoading: boolean;
@@ -44,8 +59,10 @@ interface WorkProfileState {
   setActiveCompany(id: string): Promise<void>;
   setWorkMode(enabled: boolean): Promise<void>;
   fetchBalance(): Promise<void>;
+  fetchPolicy(): Promise<void>;
   fetchRequests(): Promise<void>;
   submitRequest(amount: number, reason: string): Promise<any>;
+  checkRide(fare: number, pickupAt?: Date): { ok: boolean; reasons: string[] };
 }
 
 const _persist = async (activeCompanyId: string | null, workModeEnabled: boolean) => {
@@ -59,6 +76,7 @@ export const useWorkProfileStore = create<WorkProfileState>((set, get) => ({
   activeCompanyId: null,
   workModeEnabled: false,
   balance: null,
+  policy: null,
   requests: [],
   isLoading: false,
   balanceLoading: false,
@@ -112,6 +130,39 @@ export const useWorkProfileStore = create<WorkProfileState>((set, get) => ({
     } catch {
       set({ balanceLoading: false });
     }
+  },
+
+  fetchPolicy: async () => {
+    const { activeCompanyId } = get();
+    if (!activeCompanyId) return;
+    try {
+      const res = await api.get<WorkPolicy>(`/company/${activeCompanyId}/policy`);
+      set({ policy: res.data ?? null });
+    } catch {
+      set({ policy: null });
+    }
+  },
+
+  checkRide: (fare, pickupAt) => {
+    const { policy, workModeEnabled } = get();
+    const reasons: string[] = [];
+    if (!workModeEnabled || !policy || policy.active === false) {
+      return { ok: true, reasons };
+    }
+    if (typeof policy.max_fare_per_ride === 'number' && fare > policy.max_fare_per_ride) {
+      reasons.push(`Fare exceeds company cap of $${policy.max_fare_per_ride.toFixed(2)}.`);
+    }
+    const windows = policy.allowed_time_windows;
+    if (windows && windows.length > 0) {
+      const when = pickupAt ?? new Date();
+      const dayKey = (['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const)[when.getDay()];
+      const hhmm = `${String(when.getHours()).padStart(2, '0')}:${String(when.getMinutes()).padStart(2, '0')}`;
+      const inWindow = windows.some(w => w.day === dayKey && hhmm >= w.start && hhmm <= w.end);
+      if (!inWindow) {
+        reasons.push('This time is outside the allowed work hours.');
+      }
+    }
+    return { ok: reasons.length === 0, reasons };
   },
 
   fetchRequests: async () => {


### PR DESCRIPTION
Adds three admin-gated read endpoints on /company/{id}/billing:
- GET /summary?month=YYYY-MM → wallet balance + MTD aggregates + by_member
- GET /statements/{month} → full line items for the selected month
- GET /transactions?skip=&limit= → paged corporate_wallet ledger

Introduces list_company_ride_payment_sources helper (filters by
company_id, date range, member_id) and _month_bounds / _aggregate_rows
utilities in corporate_company.py.

Tests cover happy-path aggregation, default-to-current-month behavior,
non-admin 403, bad-month 422, and 404-on-missing-wallet.