### PR TITLE
fix(p1): CI secrets scan, rider PrivacyInfo manifest, Stripe decline test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
         working-directory: driver-app
         run: yarn test --ci --coverage --reporters=default
 
+
       - name: Upload coverage
         if: always()
         uses: codecov/codecov-action@v4
@@ -195,6 +196,14 @@ jobs:
       - name: Install dependencies
         working-directory: rider-app
         run: yarn install --frozen-lockfile
+
+      - name: Check for exposed API keys in EXPO_PUBLIC vars
+        run: |
+          if grep -rE "EXPO_PUBLIC_(ANTHROPIC|STRIPE_SECRET|SUPABASE_SERVICE_ROLE|JWT_SECRET)" \
+            rider-app/.env* rider-app/app.config.ts 2>/dev/null; then
+            echo "ERROR: Private key found in EXPO_PUBLIC_ variable — never embed server-side secrets in mobile builds"
+            exit 1
+          fi
 
       - name: Run rider app tests
         working-directory: rider-app
@@ -252,7 +261,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     defaults:
       run:
-        working-directory: spinr/admin-dashboard
+        working-directory: admin-dashboard
     steps:
       - uses: actions/checkout@v4
 
@@ -260,7 +269,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: spinr/admin-dashboard/package-lock.json
+          cache-dependency-path: admin-dashboard/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -287,7 +296,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: spinr/admin-dashboard/playwright-report/
+          path: admin-dashboard/playwright-report/
           retention-days: 7
 
   # Deploy Backend
@@ -423,9 +432,14 @@ jobs:
 
       - name: Secrets scan
         run: |
-          trufflehog git file://. \
-            --since-commit origin/${{ github.base_ref }} \
-            --fail
+          # On PRs use the target branch as the scan baseline; on push to main scan HEAD~1.
+          BASE_REF="${{ github.base_ref }}"
+          if [ -n "$BASE_REF" ]; then
+            SINCE="origin/${BASE_REF}"
+          else
+            SINCE="HEAD~1"
+          fi
+          trufflehog git file://. --since-commit "$SINCE" --fail
 
       - name: Run Trivy vulnerability scanner (filesystem)
         uses: aquasecurity/trivy-action@v0.35.0
@@ -488,7 +502,7 @@ jobs:
     name: Post-deploy smoke test
     runs-on: ubuntu-latest
     needs: [deploy-backend]
-    if: false  # Enable when deploys are re-activated
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Health check
         env:

--- a/backend/tests/test_p0_ship_blockers.py
+++ b/backend/tests/test_p0_ship_blockers.py
@@ -688,26 +688,59 @@ class TestPaymentFailureAtComplete:
             "lock. Rider is now blocked from retrying with a card."
         )
 
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "Card payment path is a stub. See rides.py:1088: "
-            "'Card path is still a stub — Stripe charge to be wired separately'. "
-            "Complete-ride handler marks payment_status='completed' regardless "
-            "of actual charge outcome (drivers.py:1997). A real Stripe decline "
-            "today silently leaves the ride as 'paid' in our DB. Fix: wire "
-            "Stripe PaymentIntent.confirm(), map decline → payment_status="
-            "'failed', surface retry UX."
-        ),
-    )
-    def test_card_decline_marks_payment_failed_and_allows_retry(self):
-        """DOCUMENTS THE GAP — will pass once card path is wired to Stripe.
+    async def test_card_decline_marks_payment_failed_and_allows_retry(self):
+        """Card decline → payment_status='failed', response surfaces card_declined code.
 
-        Expectation: Stripe returns card_declined, rides.payment_status
-        flips to 'failed', process_payment returns an error the client
-        can retry with a different card.
+        Stripe charge is wired (PR#25 / charge_ride helper). This test pins the
+        decline branch: ChargeOutcome(status='declined') must flip payment_status
+        to 'failed' so the rider can retry with a different card.
         """
-        assert False, "card path is a stub; Stripe charge not yet wired"
+        from fastapi import HTTPException
+
+        from backend.routes import rides as rides_mod
+        from backend.utils.stripe_charge import ChargeOutcome
+
+        completed = _ride(
+            status="completed",
+            payment_method="card",
+            total_fare=25.0,
+            payment_method_id="pm_decline",
+            stripe_customer_id="cus_test",
+        )
+
+        update_ride_calls: list[tuple] = []
+
+        async def _capture_update(ride_id, patch):
+            update_ride_calls.append((ride_id, patch))
+
+        declined_outcome = ChargeOutcome(
+            status="declined",
+            error_message="Your card was declined.",
+            decline_code="card_declined",
+        )
+
+        with (
+            patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=completed)),
+            patch("backend.routes.rides.db_supabase.update_ride", AsyncMock(side_effect=_capture_update)),
+            patch("backend.routes.rides.db_supabase.get_user_by_id", AsyncMock(return_value={"id": RIDER_ID, "email": "r@s.ca", "stripe_customer_id": "cus_test"})),
+            patch("backend.routes.rides.charge_ride", AsyncMock(return_value=declined_outcome)),
+        ):
+            from backend.routes.rides import ProcessPaymentRequest
+
+            req = ProcessPaymentRequest(tip_amount=0)
+            with pytest.raises(HTTPException) as exc:
+                await rides_mod.process_payment(
+                    ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID}
+                )
+
+        assert exc.value.status_code == 402
+        assert exc.value.detail.get("code") == "card_declined"
+
+        # payment_status must be set to 'failed' so the rider can retry
+        assert any(
+            p.get("payment_status") == "failed"
+            for _, p in update_ride_calls
+        ), "Card decline did not flip payment_status to 'failed' — rider cannot retry."
 
 
 # ── E3: Stripe charge at completion ─────────────────────────────────────────

--- a/rider-app/PrivacyInfo.xcprivacy
+++ b/rider-app/PrivacyInfo.xcprivacy
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  PrivacyInfo.xcprivacy — iOS Privacy Manifest (required from Apple May 2024)
+  https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+
+  This file mirrors the `privacyManifests` key in app.config.ts (used by EAS Build).
+  For bare/prebuild workflow place this at ios/SpinrRider/PrivacyInfo.xcprivacy and
+  add it to the Xcode target via Build Phases → Copy Bundle Resources.
+
+  Keep this file in sync with app.config.ts ios.privacyManifests whenever
+  adding a new SDK or collecting a new data category.
+
+  Rider-app differences from driver-app:
+    - PaymentInfo: Stripe card charges (rider pays for rides), not Stripe Connect payout
+    - No driver-licence / VIN / vehicle data collected by this app
+    - Coarse location added: used for home-screen city detection and surge display
+-->
+<plist version="1.0">
+<dict>
+    <!-- The app does NOT track users across other apps or websites -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+
+    <!-- Required-reason API declarations -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!-- File timestamps: Firebase Crashlytics reads .crash file timestamps;
+             app also reads timestamps of files it creates (cache management) -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+                <string>0A2A.1</string>
+            </array>
+        </dict>
+        <!-- NSUserDefaults: expo-secure-store, React Native bridge, Firebase SDK,
+             AsyncStorage (offline queue, language preference, auth tokens) -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <!-- System boot time: Firebase Crashlytics, LogRocket uptime metrics -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
+        <!-- Disk space: writing cached ride/map tiles, Crashlytics log rotation -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>E174.1</string>
+            </array>
+        </dict>
+    </array>
+
+    <!-- Data collection declarations (App Store privacy nutrition label) -->
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <!-- Precise GPS — ride booking, driver tracking during trip -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePreciseLocation</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Coarse location — home screen city/surge detection (no active ride needed) -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeCoarseLocation</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Rider name — profile display to drivers, ride receipt -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeName</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Phone number — OTP authentication -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePhoneNumber</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Email address — rider account, ride receipts -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeEmailAddress</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Payment info — Stripe card charges for ride fares (no raw card numbers stored;
+             tokenized via Stripe.js / stripe-react-native) -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePaymentInfo</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Device ID — Firebase FCM instance token for push notifications -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeDeviceID</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <!-- Crash data — Firebase Crashlytics (not linked to identity) -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeCrashData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+            </array>
+        </dict>
+        <!-- Performance data — LogRocket session replay metrics -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePerformanceData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/rider-app/app.config.ts
+++ b/rider-app/app.config.ts
@@ -37,6 +37,40 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             'applinks:spinr.app',
             'applinks:spinr-track.app',
         ],
+        // Required by Apple for any app using required-reason APIs (enforced from May 2024).
+        // Missing this causes App Store / TestFlight rejection at upload time (ITMS-91053).
+        privacyManifests: {
+            NSPrivacyTracking: false,
+            NSPrivacyAccessedAPITypes: [
+                {
+                    NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
+                    NSPrivacyAccessedAPITypeReasons: ['C617.1', '0A2A.1'],
+                },
+                {
+                    NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
+                    NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
+                },
+                {
+                    NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
+                    NSPrivacyAccessedAPITypeReasons: ['35F9.1'],
+                },
+                {
+                    NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
+                    NSPrivacyAccessedAPITypeReasons: ['E174.1'],
+                },
+            ],
+            NSPrivacyCollectedDataTypes: [
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePreciseLocation', NSPrivacyCollectedDataTypeLinked: true, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeCoarseLocation', NSPrivacyCollectedDataTypeLinked: false, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeName', NSPrivacyCollectedDataTypeLinked: true, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePhoneNumber', NSPrivacyCollectedDataTypeLinked: true, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailAddress', NSPrivacyCollectedDataTypeLinked: true, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePaymentInfo', NSPrivacyCollectedDataTypeLinked: true, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeDeviceID', NSPrivacyCollectedDataTypeLinked: true, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAppFunctionality'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeCrashData', NSPrivacyCollectedDataTypeLinked: false, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAnalytics'] },
+                { NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePerformanceData', NSPrivacyCollectedDataTypeLinked: false, NSPrivacyCollectedDataTypeTracking: false, NSPrivacyCollectedDataTypePurposes: ['NSPrivacyCollectedDataTypePurposeAnalytics'] },
+            ],
+        },
     },
     android: {
         adaptiveIcon: {


### PR DESCRIPTION
P1-1 · CI (ci.yml):
- rider-app-test: add EXPO_PUBLIC_ANTHROPIC_API_KEY / server-secret guard
- e2e-test: fix working-directory spinr/admin-dashboard → admin-dashboard;
  fix cache-dependency-path to match
- security-scan: secrets scan now handles push events (HEAD~1 fallback when
  github.base_ref is empty, e.g. push to main)
- smoke-test: remove 'if: false' guard; now runs on main after deploy-backend

P1-2 · rider-app/PrivacyInfo.xcprivacy (new):
- iOS privacy manifest required for App Store submission (ITMS-91053)
- Adapted from driver-app version: coarse location added, payment reflects
  card charges (not Stripe Connect payout), no driver-licence/VIN data
- rider-app/app.config.ts: wire ios.privacyManifests (EAS Build picks this up
  automatically — no separate Xcode step needed for managed workflow)

P1-3 · Stripe staging validation:
- Replace stale xfail in test_p0_ship_blockers.py with a live async test
- charge_ride() is wired since PR#25; card decline path now returns
  ChargeOutcome(status='declined') which must flip payment_status to 'failed'
- Test pins the 402 response code and the payment_status='failed' DB write

https://claude.ai/code/session_01NjevKBbxYeKALs1bVSU4c5