### PR TITLE
Add health check endpoint for Railway deployment

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -45,6 +45,17 @@ init_firebase()
 
 app = FastAPI(title="Spinr API", version="1.0.0", lifespan=lifespan, redirect_slashes=False)
 
+
+# Railway's healthcheckPath in railway.json is /health. If that endpoint
+# returns anything other than 2xx the deployment never goes live and every
+# request to the public domain is answered with "Application failed to
+# respond". Mount it on the root app (not behind /api) so the probe hits it
+# before any auth middleware.
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}
+
+
 # Initialize middleware
 init_middleware(app)
 


### PR DESCRIPTION
## Summary
Added a `/health` endpoint to support Railway's deployment health checks, ensuring the application goes live and responds to requests on the public domain.

## Key Changes
- Added a new `/health` GET endpoint that returns `{"status": "healthy"}`
- Mounted the endpoint on the root app (not behind `/api`) to ensure it's accessible before any authentication middleware
- This allows Railway's healthcheckPath probe to successfully validate the deployment

## Implementation Details
The health check endpoint is intentionally placed before middleware initialization so that it can be reached without authentication, allowing Railway's deployment health checks to pass and the application to go live properly.

https://claude.ai/code/session_015Xz7uxNksYLn8MeCB5hCLo