### PR TITLE
fix(admin-login): exempt /api/admin from App Check + harden Railway deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -8,6 +8,10 @@ on:
       - 'backend/**'
       - 'railway.json'
       - '.github/workflows/deploy-backend.yml'
+  # Allow manual re-runs from the Actions tab (needed when a merge's
+  # deploy failed — previously there was no way to retry without
+  # pushing a new commit to backend/**).
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -18,9 +22,37 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Install Railway CLI
-        run: npm i -g @railway/cli
+
+      # Pin the Railway CLI so an upstream breaking change (a flag
+      # rename or new required arg) can't silently start returning
+      # exit code 1 on every merge the way it has done since early
+      # April. Bump this when an intentional upgrade is tested.
+      - name: Install Railway CLI (pinned)
+        run: npm i -g @railway/cli@3.20.0
+
+      - name: Show Railway CLI version
+        run: railway --version
+
+      # Fail fast with a readable error if the secret is missing or
+      # empty — previously this surfaced as "Process completed with
+      # exit code 1" from `railway up` and was indistinguishable from
+      # a real build failure.
+      - name: Verify RAILWAY_TOKEN secret is present
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          if [ -z "${RAILWAY_TOKEN}" ]; then
+            echo "::error::RAILWAY_TOKEN secret is not set in repo Settings → Secrets."
+            echo "Generate a project token at Railway → Project → Settings → Tokens"
+            echo "and add it as the RAILWAY_TOKEN repository secret."
+            exit 1
+          fi
+          echo "RAILWAY_TOKEN is set (length=${#RAILWAY_TOKEN})."
+
       - name: Deploy
         run: railway up --service backend --ci
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          # Optional — set in repo secrets when using an account-scoped
+          # token. Project-scoped tokens infer the project automatically.
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -30,7 +30,23 @@ _APP_CHECK_ENFORCEMENT = True
 #   - WebSocket connections (no HTTP headers)
 #   - OpenAPI docs served by FastAPI
 #   - Health / readiness probes
-_APP_CHECK_EXEMPT_PREFIXES = ("/ws/", "/docs", "/redoc", "/openapi.json", "/health")
+#   - Admin dashboard API (/api/admin/*): the dashboard is a Next.js web
+#     app, not a Firebase-registered mobile build, so it cannot attach a
+#     X-Firebase-AppCheck header. Admin endpoints are already gated by the
+#     admin JWT (get_admin_user dependency, see routes/admin/__init__.py)
+#     and the login endpoint is rate-limited (5/min/IP in
+#     routes/admin/auth.py), so the attack surface is bounded. Without this
+#     exemption /api/admin/auth/login returns 401 "App Check token
+#     required" before the login handler runs, and the dashboard at
+#     spinrvm.vercel.app can never authenticate.
+_APP_CHECK_EXEMPT_PREFIXES = (
+    "/ws/",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/health",
+    "/api/admin/",
+)
 
 
 class FirebaseAppCheckMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
## Summary

Follow-on to PR #34. That PR added `/health` to `backend/server.py` but the "Application failed to respond" error persisted in production because (a) the Railway deploy workflow has been failing silently on every merge and (b) once the deploy does land, the admin dashboard still 401s because of Firebase App Check middleware. This PR addresses both.

## Changes

**`backend/core/middleware.py`** — add `/api/admin/` to `_APP_CHECK_EXEMPT_PREFIXES`.

The admin dashboard is a Next.js web app at https://spinrvm.vercel.app; it cannot attach an `X-Firebase-AppCheck` header because App Check is a mobile/reCAPTCHA product and the dashboard isn't a registered Firebase build. With enforcement on, every `/api/admin/*` call (including `POST /api/admin/auth/login`) returned 401 `{"detail":"App Check token required"}` before the login handler ran.

Admin endpoints are already gated by the admin JWT (`get_admin_user` dependency in `routes/admin/__init__.py:55`) and the login route is rate-limited to 5/min/IP (`routes/admin/auth.py:146`), so adding `/api/admin/` to the exempt list does not materially change the admin attack surface — it just unblocks the dashboard.

**`.github/workflows/deploy-backend.yml`** — harden the Railway deploy workflow.

The workflow has been failing with a bare "Process completed with exit code 1" on every merge to main (PRs #29, #30, #32, #33, #34 all show failure). Three changes so the next retry is diagnosable and so upstream CLI churn can't keep silently breaking prod:

- `workflow_dispatch` — re-run manually from the Actions tab without having to push a dummy commit to `backend/**`.
- Pin `@railway/cli@3.20.0` — an upstream flag/behaviour change in the unpinned CLI is a likely cause of the consistent exit-1.
- Explicit `RAILWAY_TOKEN` presence check + `railway --version` log — turn the silent failure into either "RAILWAY_TOKEN secret is not set" or the real Railway error.

## Test plan

- [ ] Merge and confirm `Deploy Backend to Railway` workflow runs on the merge commit; if it fails, the new preflight log points at the actual cause (token missing / CLI version / Railway error).
- [ ] If deploy succeeds: `curl https://<railway-domain>/health` returns `{"status":"healthy"}` 200.
- [ ] `POST /api/admin/auth/login` with bad creds returns 401 `{"detail":"Invalid credentials"}` — NOT `{"detail":"App Check token required"}`.
- [ ] Log into https://spinrvm.vercel.app/login?next=%2Fdashboard%2Fpromotions with real credentials and confirm the dashboard loads.

## Known follow-ups (out of scope here)

- Mobile apps (`rider-app/`, `driver-app/`) initialise Firebase App Check in `shared/services/firebase.ts` but don't attach the token to outbound HTTP requests. Every mobile API call will 401 under current enforcement. Needs either client-side token attachment or an env-var kill-switch on the backend; flag this before anyone re-enables enforcement for mobile paths.
- `backend-test` CI job has been failing on `pip-audit` CVE scan — pre-existing, orthogonal to this fix.

https://claude.ai/code/session_015Xz7uxNksYLn8MeCB5hCLo