### PR TITLE
fix(railway): wrap startCommand in sh -c so $PORT expands

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "backend/Dockerfile"
   },
   "deploy": {
-    "startCommand": "uvicorn server:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${UVICORN_WORKERS:-4}",
+    "startCommand": "sh -c 'uvicorn server:app --host 0.0.0.0 --port ${PORT:-8000} --workers ${UVICORN_WORKERS:-4}'",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
Railway's startCommand is not processed by a shell by default, so
`${PORT:-8000}` and `${UVICORN_WORKERS:-4}` were passed to uvicorn as
literal strings, producing:

    Error: Invalid value for '--port': '${PORT:-8000}' is not a valid integer.

Wrapping in `sh -c '...'` forces shell expansion of the env vars.