### PR TITLE
fix(auth): preserve refresh token on transient refresh failures

### DIFF
--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -168,9 +168,18 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
       const { token, refresh_token: newRefresh, expires_in } = res.data as any;
       await get().setTokens(token, newRefresh, expires_in);
       return true;
-    } catch (e) {
-      console.log('[Auth] Token refresh failed — logging out');
-      await get().logout();
+    } catch (e: any) {
+      // Only wipe the session when the server explicitly rejects the refresh
+      // token (401). Network errors, timeouts, and 5xx are transient — keeping
+      // the refresh token lets the next app launch / request try again instead
+      // of forcing the user back to the OTP screen on a flaky connection.
+      const status = e?.response?.status;
+      if (status === 401) {
+        console.log('[Auth] Refresh token rejected (401) — logging out');
+        await get().logout();
+      } else {
+        console.log('[Auth] Token refresh failed transiently, keeping session:', status ?? e?.message);
+      }
       return false;
     }
   },


### PR DESCRIPTION
Previously refreshTokens() called logout() on any exception, so a network error or timeout during cold-start refresh (e.g. backend cold start, flaky connection) wiped the refresh token from secure storage and forced the user back to the OTP screen. Only logout on an explicit 401 from /auth/refresh; keep the session intact on network errors and 5xx so the next launch or request can retry.

https://claude.ai/code/session_01MM64y7MtVr5ZpiWx8ji5Cm