### PR TITLE
fix(presence): sweeper grace period + driver-app reconnecting banner

### DIFF
--- a/backend/utils/presence_sweeper.py
+++ b/backend/utils/presence_sweeper.py
@@ -70,7 +70,31 @@ async def _sweep_once() -> int:
     if not online_drivers:
         return 0
 
-    ids = [d["id"] for d in online_drivers if d.get("id")]
+    # Grace period — a driver who just flipped online needs time for the WS
+    # to connect and mark_present to land. Without this buffer, a sweeper
+    # tick landing in the gap between the Go-Online DB write and presence
+    # registration would race the handler's verify step and bounce the
+    # driver right back offline (the bug surfaced as 500s on tap-to-go-online).
+    now = datetime.now(timezone.utc)
+    grace_seconds = SWEEP_INTERVAL_SECONDS * 2  # 120s → always >= one full tick
+
+    def _within_grace(d: dict) -> bool:
+        ts_str = d.get("last_status_changed_at")
+        if not ts_str:
+            return False
+        try:
+            ts = datetime.fromisoformat(str(ts_str).replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            return (now - ts).total_seconds() < grace_seconds
+        except Exception:
+            return False
+
+    eligible = [d for d in online_drivers if not _within_grace(d)]
+    if not eligible:
+        return 0
+
+    ids = [d["id"] for d in eligible if d.get("id")]
     try:
         present = await present_driver_ids(ids)
     except Exception as exc:
@@ -80,11 +104,11 @@ async def _sweep_once() -> int:
         logger.warning(f"[presence_sweeper] presence lookup failed, skipping tick: {exc}")
         return 0
 
-    ghosts = [d for d in online_drivers if d["id"] not in present]
+    ghosts = [d for d in eligible if d["id"] not in present]
     if not ghosts:
         return 0
 
-    now_iso = datetime.now(timezone.utc).isoformat()
+    now_iso = now.isoformat()
     flipped = 0
     for d in ghosts:
         try:

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -484,6 +484,14 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     // edge proxy rejects plain ws:// with "Invalid Sec-WebSocket-Accept response".
     const useSecure = API_URL.startsWith('https');
     const wsUrl = `${API_URL.replace(/^https?/, useSecure ? 'wss' : 'ws')}/ws/driver/${currentUser.id}`;
+    // Flip the banner to 'reconnecting' the moment we start connecting.
+    // The initial state is 'disconnected', which renders as the red
+    // "Connection Lost" banner — if we leave it there during the TLS +
+    // auth-handshake window (easily 1–2 s on Railway cold starts), the
+    // driver sees an alarming banner while the socket is actually coming
+    // up fine. 'reconnecting' renders as the amber "Reconnecting…" state
+    // which correctly signals work-in-progress.
+    setConnectionState('reconnecting');
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 


### PR DESCRIPTION
## Summary

Two follow-ups to the presence work already on `main` (PRs #43, #44), prompted by a field bug where tapping **Go Online** showed a 500 "Cannot Go Online" alert and, after that was cleared, a red "Connection Lost" banner flashed for 1–2s on every online toggle.

- **Backend — presence sweeper grace period** (`2e57b29`)
  The 60s reconciliation sweeper fired on any `is_online=True` row whose Redis presence key was missing, which raced the Go-Online handler: between the DB write setting `is_online=True` and the WS reconnect calling `mark_present`, a sweeper tick in that gap flipped the driver back offline. The handler's post-write verify step then surfaced that as a 500. Now the sweeper skips any driver whose `last_status_changed_at` is within `2 * SWEEP_INTERVAL_SECONDS` (120s), well past the WS reconnect + first heartbeat window.

- **Driver app — banner state during WS handshake** (`8ea706f`)
  `connectionState` initial value is `'disconnected'`, which renders the red **Connection Lost** banner. While the WS was opening + doing its auth handshake on Railway (1–2s), that initial state was still visible — an alarming red bar appearing right after a successful Go Online. Flip to `'reconnecting'` the moment `connectWebSocket()` fires so the banner correctly reads amber "Reconnecting…" until the backend's `auth_success` lands.

## Test plan

- [ ] Driver taps Go Online → HTTP 200, no "Cannot Go Online" alert
- [ ] While a driver is just-online (<120s since flip), `/admin/.../sweep` log shows no ghost flip
- [ ] WS handshake window shows amber "Reconnecting…" (not red "Connection Lost")
- [ ] After WS auth_success, banner disappears and driver badge shows green
- [ ] A truly-dead driver (force-quit app) still gets swept offline after grace + TTL window (~3 min worst case)

https://claude.ai/code/session_01MM64y7MtVr5ZpiWx8ji5Cm

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM64y7MtVr5ZpiWx8ji5Cm)_