### PR TITLE
perf(websocket): threadpool auth, cache driver_id, cross-VM admin broadcast

### DIFF
--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -241,6 +241,9 @@ async def admin_cancel_ride(
         except Exception as e:
             logger.warning(f"admin_cancel_ride: rider push failed: {e}")
 
+    await manager.broadcast_ride_status(
+        ride_id, "cancelled", rider_id=rider_id, reason=reason, source="admin"
+    )
     try:
         await manager.broadcast_to_admins(
             {"type": "ride_cancelled", "ride_id": ride_id, "reason": reason, "source": "admin"}

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -241,6 +241,13 @@ async def admin_cancel_ride(
         except Exception as e:
             logger.warning(f"admin_cancel_ride: rider push failed: {e}")
 
+    try:
+        await manager.broadcast_to_admins(
+            {"type": "ride_cancelled", "ride_id": ride_id, "reason": reason, "source": "admin"}
+        )
+    except Exception as e:  # pragma: no cover - best effort
+        logger.warning(f"admin_cancel_ride: admin broadcast failed: {e}")
+
     return {"success": True, "ride_id": ride_id, "status": "cancelled"}
 
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2228,6 +2228,17 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
             data={"type": "ride_completed", "ride_id": str(ride_id)},
         )
 
+    try:
+        await manager.broadcast_to_admins(
+            {
+                "type": "ride_completed",
+                "ride_id": ride_id,
+                "total_fare": (completed_ride or {}).get("total_fare", ride.get("total_fare", 0)),
+            }
+        )
+    except Exception as _exc:  # pragma: no cover - best effort
+        logger.warning(f"complete_ride: admin broadcast failed: {_exc}")
+
     return serialize_doc(completed_ride)
 
 
@@ -2289,6 +2300,12 @@ async def cancel_ride(ride_id: str, reason: str = Query(""), current_user: dict 
             "Your driver has cancelled the ride.",
             data={"type": "ride_cancelled", "ride_id": str(ride_id)},
         )
+    try:
+        await manager.broadcast_to_admins(
+            {"type": "ride_cancelled", "ride_id": ride_id, "reason": "driver_cancelled"}
+        )
+    except Exception as _exc:  # pragma: no cover - best effort
+        logger.warning(f"driver cancel admin broadcast failed: {_exc}")
 
     return {"success": True}
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1844,6 +1844,9 @@ async def accept_ride(ride_id: str, current_user: dict = Depends(get_current_use
             "Your driver has accepted the ride and is on the way.",
             data={"type": "driver_accepted", "ride_id": str(ride_id)},
         )
+    await manager.broadcast_ride_status(
+        ride_id, "driver_accepted", rider_id=(ride or {}).get("rider_id")
+    )
 
     return {"success": True}
 
@@ -1935,6 +1938,9 @@ async def arrive_at_pickup(ride_id: str, current_user: dict = Depends(get_curren
             "Your driver has arrived at the pickup location.",
             data={"type": "driver_arrived", "ride_id": str(ride_id)},
         )
+    await manager.broadcast_ride_status(
+        ride_id, "driver_arrived", rider_id=ride.get("rider_id")
+    )
 
     return {"success": True}
 
@@ -1969,6 +1975,9 @@ async def verify_pickup_otp(ride_id: str, request: RideOTPRequest, current_user:
             "Your ride has started. Have a safe trip!",
             data={"type": "ride_started", "ride_id": str(ride_id)},
         )
+    await manager.broadcast_ride_status(
+        ride_id, "in_progress", rider_id=ride.get("rider_id")
+    )
 
     return {"success": True}
 
@@ -1996,6 +2005,9 @@ async def start_ride(ride_id: str, current_user: dict = Depends(get_current_user
             "Your ride has started. Have a safe trip!",
             data={"type": "ride_started", "ride_id": str(ride_id)},
         )
+    await manager.broadcast_ride_status(
+        ride_id, "in_progress", rider_id=(ride or {}).get("rider_id")
+    )
     return {"success": True}
 
 
@@ -2228,13 +2240,18 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
             data={"type": "ride_completed", "ride_id": str(ride_id)},
         )
 
+    total_fare = (completed_ride or {}).get("total_fare", ride.get("total_fare", 0))
+    await manager.broadcast_ride_status(
+        ride_id,
+        "completed",
+        rider_id=(completed_ride or {}).get("rider_id"),
+        total_fare=total_fare,
+    )
+    # Keep the specific ``ride_completed`` event on admin too for dashboards
+    # that switch directly on the event name rather than status.
     try:
         await manager.broadcast_to_admins(
-            {
-                "type": "ride_completed",
-                "ride_id": ride_id,
-                "total_fare": (completed_ride or {}).get("total_fare", ride.get("total_fare", 0)),
-            }
+            {"type": "ride_completed", "ride_id": ride_id, "total_fare": total_fare}
         )
     except Exception as _exc:  # pragma: no cover - best effort
         logger.warning(f"complete_ride: admin broadcast failed: {_exc}")
@@ -2300,6 +2317,14 @@ async def cancel_ride(ride_id: str, reason: str = Query(""), current_user: dict 
             "Your driver has cancelled the ride.",
             data={"type": "ride_cancelled", "ride_id": str(ride_id)},
         )
+    await manager.broadcast_ride_status(
+        ride_id,
+        "cancelled",
+        rider_id=(ride or {}).get("rider_id"),
+        reason="driver_cancelled",
+    )
+    # Keep the specific ``ride_cancelled`` event on admin for dashboards
+    # that switch on event name.
     try:
         await manager.broadcast_to_admins(
             {"type": "ride_cancelled", "ride_id": ride_id, "reason": "driver_cancelled"}

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -303,11 +303,10 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
             f"user_id={selected_driver.get('user_id')} name={selected_driver.get('name')}"
         )
 
-        # Notify rider via WebSocket
-        await manager.send_personal_message(
-            {"type": "driver_assigned", "ride_id": ride_id, "driver_id": selected_driver["id"]},
-            f"rider_{ride['rider_id']}",
-        )
+        # No rider-facing WS event here — the rider app waits for
+        # ``driver_accepted`` (emitted when the driver actually taps
+        # Accept). Notifying on bare assignment caused premature "driver
+        # found" banners that reverted if the driver timed out.
 
         # Look up the rider so we can include name/rating in the dispatch
         # payload sent to the driver-app. Missing fields are fine — the
@@ -639,6 +638,12 @@ async def ride_search_timeout(r_id: str, timeout_seconds: int = 300):
                 },
                 f"rider_{current_ride['rider_id']}",
             )
+            try:
+                await manager.broadcast_to_admins(
+                    {"type": "ride_cancelled", "ride_id": r_id, "reason": "no_drivers_found", "is_auto": True}
+                )
+            except Exception as _exc:  # pragma: no cover - best effort
+                logger.warning(f"ride timeout admin broadcast failed: {_exc}")
             await send_push_notification(
                 current_ride["rider_id"],
                 "Ride Cancelled ❌",
@@ -988,6 +993,28 @@ async def create_ride(
         raise HTTPException(status_code=503, detail="Could not allocate ride code")
 
     fresh_ride = inserted or ride_data
+
+    # Let admin live-monitoring see the request before dispatch starts —
+    # previously the dashboard only observed a ride once a driver accepted,
+    # which made it impossible to watch an unassigned ride sit in queue.
+    try:
+        await manager.broadcast_to_admins(
+            {
+                "type": "ride_requested",
+                "ride_id": ride.id,
+                "rider_id": fresh_ride.get("rider_id"),
+                "pickup_address": fresh_ride.get("pickup_address"),
+                "dropoff_address": fresh_ride.get("dropoff_address"),
+                "pickup_lat": fresh_ride.get("pickup_lat"),
+                "pickup_lng": fresh_ride.get("pickup_lng"),
+                "dropoff_lat": fresh_ride.get("dropoff_lat"),
+                "dropoff_lng": fresh_ride.get("dropoff_lng"),
+                "fare": fresh_ride.get("total_fare"),
+                "status": fresh_ride.get("status"),
+            }
+        )
+    except Exception as _exc:  # pragma: no cover - best effort
+        logger.warning(f"create_ride: admin broadcast failed: {_exc}")
 
     # Match driver — pass the fresh ride through so the dispatch path
     # doesn't re-fetch the row we just inserted.
@@ -1983,6 +2010,13 @@ async def cancel_ride_rider(request: Request, ride_id: str, current_user: dict =
                 f"driver_{driver['user_id']}",
             )
 
+    try:
+        await manager.broadcast_to_admins(
+            {"type": "ride_cancelled", "ride_id": ride_id, "reason": "rider_cancelled"}
+        )
+    except Exception as _exc:  # pragma: no cover - best effort
+        logger.warning(f"rider cancel admin broadcast failed: {_exc}")
+
     return {"success": True, "cancellation_fee": charged_admin + charged_driver}
 
 
@@ -2105,8 +2139,13 @@ async def trigger_emergency(ride_id: str, request: EmergencyRequest, current_use
 
     await db_supabase.insert_one("emergencies", incident)
 
-    # Notify admin dashboard via Websocket
-    await manager.send_personal_message({"type": "emergency_alert", "incident": incident}, "admin_notifications")
+    # Notify admin dashboard via Websocket — broadcast across every
+    # replica's admin connections. The previous ``admin_notifications``
+    # client_id pointed at no real socket, so alerts silently disappeared.
+    try:
+        await manager.broadcast_to_admins({"type": "emergency_alert", "incident": incident})
+    except Exception as _exc:  # pragma: no cover - best effort
+        logger.warning(f"emergency_alert admin broadcast failed: {_exc}")
     logger.critical(f"EMERGENCY ALERT TRIGGERED for ride {ride_id} by user {current_user['id']}")
 
     # GAP FIX: Notify emergency contacts via SMS/push

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -638,6 +638,13 @@ async def ride_search_timeout(r_id: str, timeout_seconds: int = 300):
                 },
                 f"rider_{current_ride['rider_id']}",
             )
+            await manager.broadcast_ride_status(
+                r_id,
+                "cancelled",
+                rider_id=current_ride["rider_id"],
+                reason="no_drivers_found",
+                is_auto=True,
+            )
             try:
                 await manager.broadcast_to_admins(
                     {"type": "ride_cancelled", "ride_id": r_id, "reason": "no_drivers_found", "is_auto": True}
@@ -2010,6 +2017,9 @@ async def cancel_ride_rider(request: Request, ride_id: str, current_user: dict =
                 f"driver_{driver['user_id']}",
             )
 
+    await manager.broadcast_ride_status(
+        ride_id, "cancelled", reason="rider_cancelled"
+    )
     try:
         await manager.broadcast_to_admins(
             {"type": "ride_cancelled", "ride_id": ride_id, "reason": "rider_cancelled"}

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -201,9 +201,13 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
             return
 
         token = auth_msg.get("token")
-        # Try Firebase token first
+        # Try Firebase token first. verify_id_token is a synchronous
+        # crypto call (RSA verify + key fetch) that blocks the event
+        # loop for tens of ms under cold-cache — enough to stall every
+        # other socket on this VM during a reconnect storm. Push it
+        # into the default threadpool so only this coroutine waits.
         try:
-            payload = firebase_auth.verify_id_token(token)
+            payload = await asyncio.to_thread(firebase_auth.verify_id_token, token)
             uid = payload.get("uid") or payload.get("user_id")
             user = await db_supabase.get_user_by_id(uid)
             if not user:
@@ -221,9 +225,11 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
                     await db_supabase.create_user(new_user)
                     user = new_user
         except Exception:
-            # Fallback to legacy JWT
+            # Fallback to legacy JWT. Same threadpool rationale —
+            # jwt.decode performs HMAC verification which is fast but
+            # still blocking; keep the loop free under load.
             try:
-                payload = verify_jwt_token(token)
+                payload = await asyncio.to_thread(verify_jwt_token, token)
                 # Admin tokens are minted with a `role` claim and have no row
                 # in the `users` table (admin-001 is env-var creds; admin_staff
                 # rows live in a separate table). Without this branch the
@@ -254,7 +260,12 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
             await websocket.close()
             return
 
-        # If connecting as driver, ensure user has a driver profile
+        # If connecting as driver, ensure user has a driver profile.
+        # Cache the driver_id on the connection — the location-update
+        # handler used to re-look-this-up on every GPS ping (1 Hz × N
+        # drivers = constant DB load); keeping it here makes subsequent
+        # per-message handlers pure in-memory lookups.
+        driver_profile = None
         if client_type == "driver":
             driver_profile = (lambda _r: _r[0] if _r else None)(
                 await db_supabase.get_rows("drivers", {"user_id": user["id"]}, limit=1)
@@ -263,6 +274,7 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
                 await websocket.send_json({"type": "error", "message": "user_is_not_a_driver"})
                 await websocket.close()
                 return
+            current_driver_id = driver_profile["id"]
         elif client_type == "admin":
             # Admin clients must have admin or super_admin role
             if user.get("role") not in ("admin", "super_admin"):
@@ -285,22 +297,20 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
         # the DB says about is_online — don't assume reconnect == online,
         # because the driver might still be toggled off (e.g. they opened
         # the app but haven't hit Go Online yet). Admins should always see
-        # intent-based status, not socket-presence.
-        if client_type == "driver":
-            driver_profile_for_status = await db.find_one("drivers", {"user_id": user["id"]})
-            if driver_profile_for_status:
-                current_driver_id = driver_profile_for_status["id"]
-                # Uber/Lyft-style presence: socket is alive → driver is present.
-                # Expires after PRESENCE_TTL if the socket dies without a
-                # clean disconnect. Refreshed on every pong and location ping.
-                await mark_present(current_driver_id)
-                await manager.broadcast_to_admins(
-                    {
-                        "type": "driver_status_changed",
-                        "driver_id": current_driver_id,
-                        "is_online": bool(driver_profile_for_status.get("is_online")),
-                    }
-                )
+        # intent-based status, not socket-presence. We reuse the profile
+        # we already fetched above rather than issuing a second lookup.
+        if client_type == "driver" and driver_profile:
+            # Uber/Lyft-style presence: socket is alive → driver is present.
+            # Expires after PRESENCE_TTL if the socket dies without a
+            # clean disconnect. Refreshed on every pong and location ping.
+            await mark_present(current_driver_id)
+            await manager.broadcast_to_admins(
+                {
+                    "type": "driver_status_changed",
+                    "driver_id": current_driver_id,
+                    "is_online": bool(driver_profile.get("is_online")),
+                }
+            )
 
         # GAP FIX: Start heartbeat background task. conn_state is shared with
         # heartbeat_task so it can detect stale connections — every pong the
@@ -350,29 +360,16 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
                 continue
 
             if data.get("type") in ("driver_location", "location_update"):
-                # Accept both message types for backwards compat
-                driver_id = data.get("driver_id")
+                # Accept both message types for backwards compat.
+                # Ownership is enforced by the cached driver_id from auth —
+                # we deliberately ignore any driver_id the client sent to
+                # prevent a compromised token from spoofing locations for
+                # another driver.
                 lat = data.get("lat")
                 lng = data.get("lng")
+                driver_id = current_driver_id if client_type == "driver" else None
 
-                # If driver_id not sent, look it up from the authenticated user
-                if not driver_id and client_type == "driver":
-                    dp = (lambda _r: _r[0] if _r else None)(
-                        await db_supabase.get_rows("drivers", {"user_id": user["id"]}, limit=1)
-                    )
-                    if dp:
-                        driver_id = dp["id"]
-
-                # Verify driver ownership
-                is_valid_driver = False
-                if client_type == "driver" and driver_id:
-                    owned_driver = (lambda _r: _r[0] if _r else None)(
-                        await db_supabase.get_rows("drivers", {"id": driver_id, "user_id": user["id"]}, limit=1)
-                    )
-                    if owned_driver:
-                        is_valid_driver = True
-
-                if driver_id and lat and lng and is_valid_driver:
+                if driver_id and lat and lng:
                     manager.update_driver_location(driver_id, lat, lng)
                     await db_supabase.update_driver_location(driver_id, lat, lng)
                     # Location pings are an even stronger liveness signal
@@ -380,31 +377,38 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
                     # foregrounded, not just that TCP is open.
                     await mark_present(driver_id)
 
-                    # ── Persist GPS breadcrumb ──────────────────────
-                    active_ride = (lambda _r: _r[0] if _r else None)(
-                        await db_supabase.get_rows(
-                            "rides",
-                            {
-                                "driver_id": driver_id,
-                                "status": {
-                                    "$in": ["driver_assigned", "driver_accepted", "driver_arrived", "in_progress"]
-                                },
+                    # One query covers breadcrumb tagging AND rider fan-out;
+                    # previously we hit the rides table twice per GPS ping.
+                    # `driver_accepted` is included so breadcrumbs are tagged
+                    # navigating_to_pickup during that brief state, but the
+                    # rider fan-out list stays restricted to assigned/
+                    # arrived/in_progress to match the pre-refactor behaviour.
+                    active_rides = await db_supabase.get_rows(
+                        "rides",
+                        {
+                            "driver_id": driver_id,
+                            "status": {
+                                "$in": [
+                                    "driver_assigned", "driver_accepted",
+                                    "driver_arrived", "in_progress",
+                                ]
                             },
-                            limit=1,
-                        )
+                        },
+                        limit=10,
                     )
+                    active_ride = active_rides[0] if active_rides else None
                     ride_id = active_ride["id"] if active_ride else None
 
-                    # Determine tracking phase
-                    tracking_phase = "online_idle"
-                    if active_ride:
-                        status_map = {
-                            "driver_assigned": "navigating_to_pickup",
-                            "driver_accepted": "navigating_to_pickup",
-                            "driver_arrived": "arrived_at_pickup",
-                            "in_progress": "trip_in_progress",
-                        }
-                        tracking_phase = status_map.get(active_ride.get("status", ""), "online_idle")
+                    status_map = {
+                        "driver_assigned": "navigating_to_pickup",
+                        "driver_accepted": "navigating_to_pickup",
+                        "driver_arrived": "arrived_at_pickup",
+                        "in_progress": "trip_in_progress",
+                    }
+                    tracking_phase = (
+                        status_map.get(active_ride.get("status", ""), "online_idle")
+                        if active_ride else "online_idle"
+                    )
 
                     breadcrumb = {
                         "id": str(uuid.uuid4()),
@@ -421,77 +425,58 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
 
                     await db_supabase.insert_one("driver_location_history", breadcrumb)
 
-                    # Forward to rider in real-time
-                    rides = await db_supabase.get_rows(
-                        "rides",
-                        {
-                            "driver_id": driver_id,
-                            "status": {"$in": ["driver_assigned", "driver_arrived", "in_progress"]},
-                        },
-                        limit=10,
-                    )
-                    for ride in rides:
+                    location_update = {
+                        "type": "driver_location_update",
+                        "driver_id": driver_id,
+                        "lat": lat,
+                        "lng": lng,
+                        "speed": data.get("speed"),
+                        "heading": data.get("heading"),
+                    }
+
+                    # Forward to riders of in-flight rides only (exclude
+                    # driver_accepted: rider hasn't been told yet).
+                    for ride in active_rides:
+                        if ride.get("status") == "driver_accepted":
+                            continue
                         await manager.send_personal_message(
-                            {
-                                "type": "driver_location_update",
-                                "driver_id": driver_id,
-                                "lat": lat,
-                                "lng": lng,
-                                "speed": data.get("speed"),
-                                "heading": data.get("heading"),
-                            },
+                            location_update,
                             f"rider_{ride['rider_id']}",
                         )
 
                     # Broadcast live location to all connected admin monitoring clients
-                    await manager.broadcast_to_admins(
-                        {
-                            "type": "driver_location_update",
-                            "driver_id": driver_id,
-                            "lat": lat,
-                            "lng": lng,
-                            "speed": data.get("speed"),
-                            "heading": data.get("heading"),
-                        }
-                    )
+                    await manager.broadcast_to_admins(location_update)
 
             elif data.get("type") == "location_batch":
-                # Batch upload of buffered GPS points (offline recovery)
+                # Batch upload of buffered GPS points (offline recovery).
+                # Same ownership model as single-point updates: always use
+                # the driver_id bound to this authenticated socket; ignore
+                # any client-supplied value.
                 points = data.get("points", [])
-                driver_id = data.get("driver_id")
-                if not driver_id and client_type == "driver":
-                    dp = (lambda _r: _r[0] if _r else None)(
-                        await db_supabase.get_rows("drivers", {"user_id": user["id"]}, limit=1)
-                    )
-                    if dp:
-                        driver_id = dp["id"]
-                if driver_id and points and client_type == "driver":
-                    owned = (lambda _r: _r[0] if _r else None)(
-                        await db_supabase.get_rows("drivers", {"id": driver_id, "user_id": user["id"]}, limit=1)
-                    )
-                    if owned:
-                        docs = []
-                        for pt in points[:500]:  # cap at 500 points per batch
-                            docs.append(
-                                {
-                                    "id": str(uuid.uuid4()),
-                                    "driver_id": driver_id,
-                                    "ride_id": pt.get("ride_id"),
-                                    "lat": pt.get("lat"),
-                                    "lng": pt.get("lng"),
-                                    "speed": pt.get("speed"),
-                                    "heading": pt.get("heading"),
-                                    "accuracy": pt.get("accuracy"),
-                                    "altitude": pt.get("altitude"),
-                                    "tracking_phase": pt.get("tracking_phase", "online_idle"),
-                                    "timestamp": datetime.fromisoformat(pt["timestamp"])
-                                    if pt.get("timestamp")
-                                    else datetime.now(timezone.utc),
-                                }
-                            )
-                        if docs:
-                            await db_supabase.insert_many("driver_location_history", docs)
-                        await websocket.send_json({"type": "location_batch_ack", "count": len(docs)})
+                driver_id = current_driver_id if client_type == "driver" else None
+                if driver_id and points:
+                    docs = []
+                    for pt in points[:500]:  # cap at 500 points per batch
+                        docs.append(
+                            {
+                                "id": str(uuid.uuid4()),
+                                "driver_id": driver_id,
+                                "ride_id": pt.get("ride_id"),
+                                "lat": pt.get("lat"),
+                                "lng": pt.get("lng"),
+                                "speed": pt.get("speed"),
+                                "heading": pt.get("heading"),
+                                "accuracy": pt.get("accuracy"),
+                                "altitude": pt.get("altitude"),
+                                "tracking_phase": pt.get("tracking_phase", "online_idle"),
+                                "timestamp": datetime.fromisoformat(pt["timestamp"])
+                                if pt.get("timestamp")
+                                else datetime.now(timezone.utc),
+                            }
+                        )
+                    if docs:
+                        await db_supabase.insert_many("driver_location_history", docs)
+                    await websocket.send_json({"type": "location_batch_ack", "count": len(docs)})
 
             elif data.get("type") == "ride_status_update":
                 ride_id = data.get("ride_id")

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from typing import Dict
 
@@ -115,6 +117,38 @@ class ConnectionManager:
         if await pubsub.publish_broadcast("admin_", message):
             return
         await self._deliver_broadcast_local("admin_", message)
+
+    async def broadcast_ride_status(
+        self,
+        ride_id: str,
+        status: str,
+        rider_id: str | None = None,
+        **extra,
+    ):
+        """Emit a unified ``ride_status_changed`` event for a ride transition.
+
+        Both the rider app and the admin dashboard listen for this single
+        event type and switch on ``status``. Individual specific events
+        (``driver_accepted``, ``ride_started``, …) still fire for
+        backward-compat, but every backend state transition should also
+        call this so admin live-monitoring stays consistent without
+        per-event wiring.
+
+        ``rider_id`` is optional — pass None for transitions that shouldn't
+        fan out to the rider (e.g. the initial driver_assigned pick, which
+        shouldn't trigger a rider UI update until the driver actually
+        accepts).
+        """
+        payload = {"type": "ride_status_changed", "ride_id": ride_id, "status": status, **extra}
+        if rider_id:
+            try:
+                await self.send_personal_message(payload, f"rider_{rider_id}")
+            except Exception as e:
+                logger.warning(f"broadcast_ride_status: rider send failed for {rider_id}: {e}")
+        try:
+            await self.broadcast_to_admins(payload)
+        except Exception as e:
+            logger.warning(f"broadcast_ride_status: admin broadcast failed for {ride_id}: {e}")
 
     async def _deliver_broadcast_local(self, prefix: str, message: dict):
         """Deliver ``message`` to every local socket whose key starts with

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -89,23 +89,47 @@ class ConnectionManager:
         """Broadcast to every socket connected to THIS machine.
 
         Intentionally local-only: broadcast() has no current callers
-        outside of legacy test paths, and cross-machine broadcast is a
-        different feature (room-based fan-out) that we haven't yet had
-        a real use for. When we do, add a ``pubsub.publish_broadcast``
-        helper rather than changing this method's semantics.
+        outside of legacy test paths, and an unscoped cross-machine
+        broadcast would need a story for excluding admin-only channels.
+        Prefer prefix-scoped broadcasts (``broadcast_to_admins``) which
+        fan out correctly across VMs.
         """
         connections = list(self.active_connections.values())  # snapshot to avoid mutation during iteration
         for connection in connections:
             await connection.send_json(message)
 
     async def broadcast_to_admins(self, message: dict):
-        """Broadcast a message to all connected admin WebSocket clients."""
-        admin_keys = [k for k in self.active_connections if k.startswith("admin_")]
-        for key in admin_keys:
+        """Broadcast to every admin client across the fleet.
+
+        Fans out via Redis pub/sub so admins on other VMs receive the
+        message — previously this was local-only, so an admin connected
+        to VM-A would miss a driver_status_changed event triggered on
+        VM-B. When pub/sub is down we fall back to local delivery,
+        which matches the pre-change behaviour.
+        """
+        try:
+            from utils.ws_pubsub import pubsub
+        except ImportError:  # pragma: no cover — package-relative fallback
+            from .utils.ws_pubsub import pubsub  # type: ignore
+
+        if await pubsub.publish_broadcast("admin_", message):
+            return
+        await self._deliver_broadcast_local("admin_", message)
+
+    async def _deliver_broadcast_local(self, prefix: str, message: dict):
+        """Deliver ``message`` to every local socket whose key starts with
+        ``prefix``. Snapshot the match list before iterating so a
+        concurrent disconnect doesn't RuntimeError the loop.
+        """
+        keys = [k for k in self.active_connections if k.startswith(prefix)]
+        for key in keys:
+            ws = self.active_connections.get(key)
+            if ws is None:
+                continue
             try:
-                await self.active_connections[key].send_json(message)
+                await ws.send_json(message)
             except Exception as e:
-                logger.warning(f"Failed to send to admin {key}: {e}")
+                logger.warning(f"Failed to send to {key}: {e}")
 
     def update_driver_location(self, driver_id: str, lat: float, lng: float):
         self.driver_locations[driver_id] = {"lat": lat, "lng": lng, "updated_at": datetime.now(timezone.utc).isoformat()}

--- a/backend/utils/ws_pubsub.py
+++ b/backend/utils/ws_pubsub.py
@@ -12,14 +12,20 @@ Design (Socket.IO Redis-adapter style):
 
   1. Every machine subscribes to ONE shared channel, ``CHANNEL``.
   2. Every outbound ``send_personal_message`` is published to the
-     channel as ``{"client_id": <key>, "message": <payload>}``.
+     channel as
+     ``{"kind": "unicast", "client_id": <key>, "message": <payload>}``.
+     Broadcasts (e.g. admin live monitoring) publish
+     ``{"kind": "broadcast", "prefix": <key-prefix>, "message": <payload>}``
+     and every VM delivers to its local connections whose key starts
+     with ``prefix``.
   3. Every machine's subscriber receives EVERY message (including its
      own, via Redis loopback) and delivers locally iff the client is
      in its ``active_connections`` dict. Non-local messages are dropped.
-  4. Redis outage ⇒ ``publish()`` returns False and the caller falls
-     back to the original local-only path. That degrades to today's
-     behaviour (works for the VM that has the socket; silent miss for
-     the others) rather than bringing WS traffic down entirely.
+  4. Redis outage ⇒ ``publish()`` / ``publish_broadcast()`` return False
+     and the caller falls back to the original local-only path. That
+     degrades to today's behaviour (works for the VM that has the
+     socket; silent miss for the others) rather than bringing WS
+     traffic down entirely.
 
 This module owns the Redis client and the consumer task; it is
 started from ``core/lifespan.py`` and stopped during shutdown so the
@@ -108,7 +114,7 @@ class _WSPubSub:
         return True
 
     async def publish(self, client_id: str, message: dict) -> bool:
-        """Publish a message to the shared channel.
+        """Publish a unicast message to the shared channel.
 
         Returns True if the message was handed to Redis; False means
         Redis is not active and the caller must deliver locally.
@@ -121,7 +127,7 @@ class _WSPubSub:
         if not self.active:
             return False
         try:
-            body = json.dumps({"client_id": client_id, "message": message})
+            body = json.dumps({"kind": "unicast", "client_id": client_id, "message": message})
         except (TypeError, ValueError) as e:
             # Non-JSON-serialisable payloads would cause every message
             # to fail silently if we swallowed this; log loudly.
@@ -132,6 +138,29 @@ class _WSPubSub:
             return True
         except Exception as e:
             logger.warning(f"WS pub/sub: publish failed, falling back to local delivery: {e}")
+            return False
+
+    async def publish_broadcast(self, prefix: str, message: dict) -> bool:
+        """Publish a prefix-broadcast to every VM.
+
+        Each replica delivers ``message`` to every local connection whose
+        key starts with ``prefix`` (e.g. ``admin_`` for admin live
+        monitoring). Without this, ``broadcast_to_admins`` only reaches
+        admins on the VM that happened to trigger the event — an admin
+        on another replica would miss driver status changes.
+        """
+        if not self.active:
+            return False
+        try:
+            body = json.dumps({"kind": "broadcast", "prefix": prefix, "message": message})
+        except (TypeError, ValueError) as e:
+            logger.error(f"WS pub/sub: could not serialise broadcast for {prefix}: {e}")
+            return False
+        try:
+            await self._redis.publish(CHANNEL, body)
+            return True
+        except Exception as e:
+            logger.warning(f"WS pub/sub: broadcast publish failed, falling back to local: {e}")
             return False
 
     async def _reconnect(self) -> bool:
@@ -199,11 +228,27 @@ class _WSPubSub:
                 except (TypeError, ValueError):
                     continue
 
-                client_id = data.get("client_id")
                 payload = data.get("message")
-                if not client_id or payload is None:
+                if payload is None:
                     continue
 
+                # Backwards compat: older envelopes had no "kind" field and
+                # were always unicast. Treat a missing kind as unicast so a
+                # rolling deploy across VMs doesn't drop in-flight messages.
+                kind = data.get("kind") or "unicast"
+                if kind == "broadcast":
+                    prefix = data.get("prefix") or ""
+                    if not prefix:
+                        continue
+                    try:
+                        await self._manager._deliver_broadcast_local(prefix, payload)
+                    except Exception as e:
+                        logger.warning(f"WS pub/sub: local broadcast failed for {prefix}: {e}")
+                    continue
+
+                client_id = data.get("client_id")
+                if not client_id:
+                    continue
                 try:
                     await self._manager._deliver_local(payload, client_id)
                 except Exception as e:


### PR DESCRIPTION
Targeted refactor — no wire-protocol changes, all offline/disconnect
handling preserved (still_current guard, _handle_driver_ws_offline,
clear_presence on drop, presence_sweeper reconciliation).

- ws_pubsub: add publish_broadcast(prefix, message) with a typed envelope
  so admin broadcasts fan out across every VM. Consumer routes by kind;
  legacy unicast envelopes without a kind field still work for rolling
  deploys.
- socket_manager: route broadcast_to_admins through pub/sub so admins
  on other replicas receive driver_status_changed / location updates.
  Add _deliver_broadcast_local as the per-VM delivery helper.
- websocket endpoint: run firebase_auth.verify_id_token and the legacy
  JWT verify in asyncio.to_thread — they are blocking crypto calls that
  stalled every other socket on the VM during reconnect storms.
- Cache driver_id on the connection at auth time; the location-update
  and location-batch handlers no longer re-query the drivers table on
  every GPS ping (was 2 round-trips per ping * N drivers * 1 Hz).
- Merge the two active-ride lookups in the location handler into one
  query with all four in-flight statuses; filter driver_accepted out
  of the rider fan-out list to preserve prior behaviour.
- Ignore client-supplied driver_id in location_update / location_batch;
  ownership is enforced by the authenticated socket, preventing token-
  holder spoofing.