### PR TITLE
fix(driver-app): keep UI online when background-location permission throws (Android)

### DIFF
--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -686,9 +686,6 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     setIsOnline(next);
     try {
       await updateDriverStatus(next);
-      if (next) {
-        await Location.requestBackgroundPermissionsAsync();
-      }
     } catch (err: any) {
       setIsOnline(!next);
 
@@ -708,6 +705,28 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
           "Cannot Go Online",
           err.response?.data?.detail || "Failed to update status. Please try again.",
           'danger'
+        );
+      }
+      return;
+    }
+
+    // Ask for background location AFTER the status update resolved.
+    // Keeping this in the same try block would roll the UI back to
+    // offline on any permission failure even though the backend
+    // already has is_online=true — the mismatch drivers see as
+    // "tapped Go Online, app shows offline a second later".
+    // Android is strict about background-location ("Allow all the
+    // time" vs "While using") and reject flows can throw from this
+    // call; a rejection should NOT undo a successful Go Online, it
+    // should just warn that background tracking is unavailable.
+    if (next) {
+      try {
+        await Location.requestBackgroundPermissionsAsync();
+      } catch {
+        showDashAlert(
+          "Background location needed",
+          "You're online, but background location is required to keep getting ride offers while the app is minimized. Enable 'Allow all the time' in Settings.",
+          'warning'
         );
       }
     }


### PR DESCRIPTION
## What
Stop the driver-app from rolling the UI back to offline when `Location.requestBackgroundPermissionsAsync()` throws, even though the backend successfully accepted Go Online.

## Why
Android reports from the field: driver taps **Go Online**, Railway log shows `is_online: True, is_available: True` landing against the correct driver row, but the phone UI shows offline a second later. No second offline write ever fires on the backend — the frontend is lying about the state.

Root cause lives in `driver-app/hooks/useDriverDashboard.ts` (the `toggleOnline` handler):

```ts
try {
  await updateDriverStatus(next);                       // ✓ backend is_online=true
  if (next) {
    await Location.requestBackgroundPermissionsAsync(); // ⚠ can throw on Android
  }
} catch (err) {
  setIsOnline(!next);                                   // rolls UI back — wrongly
  ...
}
```

Android's stricter background-location model ("Allow all the time" vs "While using", plus OEM rationale dialogs on Xiaomi/Samsung/etc.) makes the permission request throw more often than on iOS. When it does, the shared catch rolls the UI state back but **not** the backend write — producing the exact intent-vs-UI mismatch the user sees.

This was invisible before PR #48 because the backend used to flip `is_online=false` on WS disconnect and reconciled the mismatch for us. PR #48 stopped that write, which correctly left the backend in its true state (online) and exposed the frontend bug.

## How
Split the two concerns. Status update and permission request now have independent try/catch blocks:

1. `updateDriverStatus` first. If it fails → revert UI → show 402/generic alert → `return`.
2. Only after the backend has confirmed `is_online=true`, request background permission. A rejection or exception shows a non-blocking warning ("enable Allow all the time") but leaves the online state intact. The backend already said yes; we respect that.

This matches Uber/Lyft: you can go online with foreground-only permission and the app nags you to upgrade to background.

## spinr Domain Impact
- [ ] Backend API (Python)
- [ ] Rider app (Expo)
- [x] Driver app (Expo)
- [ ] Frontend web (Next.js)
- [ ] Admin dashboard
- [ ] Matching engine
- [ ] Payments / Stripe
- [ ] Safety / SOS
- [ ] Auth / Supabase
- [x] Driver onboarding
- [ ] Notifications
- [ ] Surge pricing
- [ ] Trip state machine

## Compliance & Security
- [ ] PII or personal data (PIPEDA)
- [ ] Payment processing or fare calculation
- [x] Location data or data residency
- [ ] Authentication or Supabase RLS
- [ ] Insurance period logic
- [ ] Emergency / SOS features

Touches location permission flow only — no new data collected, no data-residency change. Background location is still requested; only the UI's reaction to rejection changes.

## Testing
- Manual walk-through of all four branches of `toggleOnline`: backend OK + permission OK (online), backend OK + permission rejected (online + warning), backend 402 (offline + subscribe prompt), backend generic fail (offline + alert).
- Needs on-device Android validation: (1) tap Go Online with "Allow all the time" already granted → online, no warning; (2) tap Go Online and choose "While using the app" → online, warning shown; (3) tap Go Online and "Deny" → online, warning shown; (4) revoke Spinr Pass then tap Go Online → offline, subscribe prompt.

## DB / Schema Changes
- [x] No schema changes
- [ ] Supabase migration included at: ___

## Checklist
- [ ] Tests added/updated — follow-up; a Jest unit test on `toggleOnline` covering permission rejection would lock the contract in.
- [x] No secrets committed
- [x] No PII in logs
- [x] CLAUDE.md conventions followed
- [x] ci.yml not modified
- [x] Docs updated if behaviour changed (inline comment explaining the split)

https://claude.ai/code/session_0191FeZMSw9kPiTxsfTw2NYS

---
_Generated by [Claude Code](https://claude.ai/code/session_0191FeZMSw9kPiTxsfTw2NYS)_