### PR TITLE
fix(apps): refresh location on app resume and locate-button tap

### DIFF
--- a/driver-app/app/driver/(tabs)/index.tsx
+++ b/driver-app/app/driver/(tabs)/index.tsx
@@ -77,6 +77,7 @@ function DriverDashboard() {
     showDashAlert,
     closeDashAlert,
     wsError,
+    refreshLocation,
   } = useDriverDashboard();
 
   // Route polyline coordinates for active rides
@@ -606,6 +607,7 @@ function DriverDashboard() {
         mapRef={mapRef}
         location={location}
         currentRegionRef={currentRegionRef}
+        onRecenter={() => refreshLocation(false)}
       />
 
       {/* Bottom Panels */}

--- a/driver-app/app/driver/(tabs)/index.tsx
+++ b/driver-app/app/driver/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { View, Text, StyleSheet, Platform, Linking, Animated, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, Platform, Linking, Animated, TouchableOpacity, ActivityIndicator, AppState } from 'react-native';
 import CustomAlert from '@shared/components/CustomAlert';
 import MapView, { Marker, Polyline, Heatmap, PROVIDER_GOOGLE } from 'react-native-maps';
 import MapViewDirections from 'react-native-maps-directions';
@@ -197,6 +197,35 @@ function DriverDashboard() {
     // transition, not on every GPS tick.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rideState]);
+
+  // When the app comes back to the foreground, arm a one-shot re-center
+  // for the next location update. `initialRegion` above is one-shot, so
+  // without this the map stays pinned to whatever fix was set before the
+  // user backgrounded — e.g. they left home, opened the app at work, and
+  // the map still shows home until the next app restart. Skipped during
+  // active rides so the ride camera framing isn't disrupted.
+  const pendingRecenterRef = useRef(false);
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') pendingRecenterRef.current = true;
+    });
+    return () => sub.remove();
+  }, []);
+  useEffect(() => {
+    if (!pendingRecenterRef.current) return;
+    if (!location?.coords || !mapRef.current) return;
+    if (rideState !== 'idle') return;
+    pendingRecenterRef.current = false;
+    mapRef.current.animateToRegion?.(
+      {
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+        latitudeDelta: 0.04,
+        longitudeDelta: 0.04,
+      },
+      400
+    );
+  }, [location, rideState]);
 
   // Error handling
   useEffect(() => {

--- a/driver-app/components/dashboard/MapControls.tsx
+++ b/driver-app/components/dashboard/MapControls.tsx
@@ -13,16 +13,20 @@ const COLORS = {
   accent: SpinrConfig.theme.colors.primary,
 };
 
+type LocationLike = { coords: { latitude: number; longitude: number } };
+
 interface MapControlsProps {
   mapRef: React.RefObject<MapView>;
-  location: { coords: { latitude: number; longitude: number } } | null;
+  location: LocationLike | null;
   currentRegionRef: React.RefObject<{ latitudeDelta: number; longitudeDelta: number }>;
+  onRecenter?: () => Promise<LocationLike | null | void> | LocationLike | null | void;
 }
 
 export const MapControls: React.FC<MapControlsProps> = ({
   mapRef,
   location,
   currentRegionRef,
+  onRecenter,
 }) => {
   const insets = useSafeAreaInsets();
   const handleZoomIn = () => {
@@ -47,11 +51,21 @@ export const MapControls: React.FC<MapControlsProps> = ({
     }
   };
 
-  const handleRecenter = () => {
-    if (location && mapRef.current) {
+  const handleRecenter = async () => {
+    // Fetch a fresh GPS fix first — just animating to the cached `location`
+    // prop would only zoom in on yesterday's position.
+    let fresh: LocationLike | null = null;
+    try {
+      const result = await onRecenter?.();
+      if (result && typeof result === 'object' && 'coords' in result) {
+        fresh = result as LocationLike;
+      }
+    } catch {}
+    const target = fresh ?? location;
+    if (target && mapRef.current) {
       mapRef.current.animateToRegion({
-        latitude: location.coords.latitude,
-        longitude: location.coords.longitude,
+        latitude: target.coords.latitude,
+        longitude: target.coords.longitude,
         latitudeDelta: 0.01,
         longitudeDelta: 0.01,
       }, 500);

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -43,6 +43,7 @@ interface UseDriverDashboardReturn {
   toggleOnline: () => Promise<void>;
   openNavigation: (lat: number, lng: number, label: string) => void;
   uploadLocationBatch: () => Promise<void>;
+  refreshLocation: (useCache: boolean) => Promise<Location.LocationObject | null>;
 
   // Refs for external use
   mapRef: React.RefObject<any>;
@@ -223,7 +224,7 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     }
 
     const { status } = await Location.requestForegroundPermissionsAsync();
-    if (status !== 'granted') return;
+    if (status !== 'granted') return null;
 
     if (useCache) {
       try {
@@ -232,16 +233,18 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       } catch {}
     }
 
-    Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })
-      .then(loc => {
-        setLocation(loc);
-        locationRef.current = loc;
-        try {
-          const AsyncStorage = require('@react-native-async-storage/async-storage').default;
-          AsyncStorage.setItem('spinr_driver_last_location', JSON.stringify({ lat: loc.coords.latitude, lng: loc.coords.longitude }));
-        } catch {}
-      })
-      .catch(() => {});
+    try {
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+      setLocation(loc);
+      locationRef.current = loc;
+      try {
+        const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+        AsyncStorage.setItem('spinr_driver_last_location', JSON.stringify({ lat: loc.coords.latitude, lng: loc.coords.longitude }));
+      } catch {}
+      return loc;
+    } catch {
+      return null;
+    }
   }, []);
 
   useEffect(() => {
@@ -855,6 +858,7 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     toggleOnline,
     openNavigation,
     uploadLocationBatch,
+    refreshLocation,
 
     // Refs
     mapRef,

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -205,9 +205,13 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
   }, [user, applyDriverConfig]);
 
   // ─── Location Tracking ───────────────────────────────────────────
-  useEffect(() => {
-    (async () => {
-      // 0. Load cached location from previous session
+  // Refresh on mount AND whenever the app returns to the foreground so
+  // the map doesn't keep showing a stale fix from the previous session
+  // (e.g. driver left home yesterday, opened app at work — without the
+  // AppState refresh the map would still point at home until
+  // watchPositionAsync starts after Go Online).
+  const refreshLocation = useCallback(async (useCache: boolean) => {
+    if (useCache) {
       try {
         const AsyncStorage = require('@react-native-async-storage/async-storage').default;
         const saved = await AsyncStorage.getItem('spinr_driver_last_location');
@@ -216,30 +220,38 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
           setLocation({ coords: { latitude: lat, longitude: lng, heading: 0, speed: 0, accuracy: 100, altitude: 0 }, timestamp: Date.now() } as any);
         }
       } catch {}
+    }
 
-      const { status } = await Location.requestForegroundPermissionsAsync();
-      if (status !== 'granted') return;
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') return;
 
-      // 1. Fast: OS cached location
+    if (useCache) {
       try {
         const lastKnown = await Location.getLastKnownPositionAsync();
         if (lastKnown) { setLocation(lastKnown); locationRef.current = lastKnown; }
       } catch {}
+    }
 
-      // 2. Accurate position (non-blocking)
-      Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })
-        .then(loc => {
-          setLocation(loc);
-          locationRef.current = loc;
-          // Save for next cold start
-          try {
-            const AsyncStorage = require('@react-native-async-storage/async-storage').default;
-            AsyncStorage.setItem('spinr_driver_last_location', JSON.stringify({ lat: loc.coords.latitude, lng: loc.coords.longitude }));
-          } catch {}
-        })
-        .catch(() => {});
-    })();
+    Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })
+      .then(loc => {
+        setLocation(loc);
+        locationRef.current = loc;
+        try {
+          const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+          AsyncStorage.setItem('spinr_driver_last_location', JSON.stringify({ lat: loc.coords.latitude, lng: loc.coords.longitude }));
+        } catch {}
+      })
+      .catch(() => {});
   }, []);
+
+  useEffect(() => {
+    refreshLocation(true);
+    const sub = AppState.addEventListener('change', (next) => {
+      // Skip cache on resume — we want a fresh fix, not yesterday's.
+      if (next === 'active') refreshLocation(false);
+    });
+    return () => sub.remove();
+  }, [refreshLocation]);
 
   // ─── Batch Location Upload ───────────────────────────────────────
   // G16: Persist buffer to AsyncStorage so crash doesn't lose GPS

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   Image,
   Linking,
+  AppState,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
@@ -76,36 +77,39 @@ export default function HomeScreen() {
     return null;
   };
 
-  const fetchHomeData = useCallback(async () => {
-    // 0. Load cached location INSTANTLY (from previous session)
-    const cached = await loadLastLocation();
-    if (cached) {
-      const cachedLoc = { coords: { latitude: cached.lat, longitude: cached.lng } };
-      setLocation(cachedLoc);
-      setUserLocation({ latitude: cached.lat, longitude: cached.lng });
+  // Fresh GPS fix + weather. Location is NOT TTL-gated — we always want a
+  // current fix when the user is looking at the map. Cache only primes the
+  // very first paint.
+  const refreshLocation = useCallback(async (useCache: boolean) => {
+    if (useCache) {
+      const cached = await loadLastLocation();
+      if (cached) {
+        const cachedLoc = { coords: { latitude: cached.lat, longitude: cached.lng } };
+        setLocation(cachedLoc);
+        setUserLocation({ latitude: cached.lat, longitude: cached.lng });
+      }
     }
 
-    let { status } = await Location.requestForegroundPermissionsAsync();
+    const { status } = await Location.requestForegroundPermissionsAsync();
     if (status !== 'granted') return;
 
-    // 1. Get last known from OS (cached GPS, faster than full fix)
-    try {
-      const lastKnown = await Location.getLastKnownPositionAsync();
-      if (lastKnown) {
-        setLocation(lastKnown);
-        setUserLocation({ latitude: lastKnown.coords.latitude, longitude: lastKnown.coords.longitude });
-        saveLastLocation(lastKnown.coords.latitude, lastKnown.coords.longitude);
-      }
-    } catch {}
+    if (useCache) {
+      try {
+        const lastKnown = await Location.getLastKnownPositionAsync();
+        if (lastKnown) {
+          setLocation(lastKnown);
+          setUserLocation({ latitude: lastKnown.coords.latitude, longitude: lastKnown.coords.longitude });
+          saveLastLocation(lastKnown.coords.latitude, lastKnown.coords.longitude);
+        }
+      } catch {}
+    }
 
-    // 2. Get accurate position in background; weather + saved places in parallel
     Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })
       .then(loc => {
         setLocation(loc);
         setUserLocation({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
         saveLastLocation(loc.coords.latitude, loc.coords.longitude);
 
-        // 3. Weather in parallel with position fix
         fetch(`https://api.open-meteo.com/v1/forecast?latitude=${loc.coords.latitude}&longitude=${loc.coords.longitude}&current_weather=true`)
           .then(r => r.json())
           .then(data => {
@@ -116,21 +120,59 @@ export default function HomeScreen() {
           .catch(() => {});
       })
       .catch(() => {});
+  }, [setUserLocation]);
 
-    // 4. Saved places (independent of GPS fix)
+  // Saved-places can be TTL-gated — they rarely change within a session.
+  const fetchHomeData = useCallback(async () => {
+    await refreshLocation(true);
     fetchSavedAddresses();
-  }, []);
+  }, [refreshLocation, fetchSavedAddresses]);
 
-  // Use useFocusEffect so tab switches don't re-fire all requests unless data
-  // is stale (older than HOME_DATA_TTL_MS). First mount always fetches.
   useFocusEffect(
     useCallback(() => {
       const now = Date.now();
-      if (now - lastFetchedAt.current < HOME_DATA_TTL_MS) return;
+      if (now - lastFetchedAt.current < HOME_DATA_TTL_MS) {
+        // Still refresh the location so a stale fix from a previous session
+        // (or from before a long commute) gets replaced. Skip the saved-
+        // places fetch — those don't change minute-to-minute.
+        refreshLocation(false);
+        return;
+      }
       lastFetchedAt.current = now;
       fetchHomeData();
-    }, [fetchHomeData])
+    }, [fetchHomeData, refreshLocation])
   );
+
+  // App resume — always grab a fresh fix, no cache. `initialRegion` on
+  // AppMap is one-shot, so we also re-center the map below when location
+  // changes post-mount.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') refreshLocation(false);
+    });
+    return () => sub.remove();
+  }, [refreshLocation]);
+
+  // Re-center the map when a fresh GPS fix lands after mount. `initialRegion`
+  // only applies on first render, so without this the map stays pinned to
+  // whatever (often cached) location was first set.
+  const hasCenteredRef = useRef(false);
+  const regionRef = useRef(region);
+  useEffect(() => { regionRef.current = region; }, [region]);
+  useEffect(() => {
+    if (!location || !mapRef.current) return;
+    if (!hasCenteredRef.current) {
+      // First location sets initialRegion; no need to animate.
+      hasCenteredRef.current = true;
+      return;
+    }
+    mapRef.current.animateToRegion?.({
+      latitude: location.coords.latitude,
+      longitude: location.coords.longitude,
+      latitudeDelta: regionRef.current?.latitudeDelta ?? 0.0922,
+      longitudeDelta: regionRef.current?.longitudeDelta ?? 0.0421,
+    }, 400);
+  }, [location]);
 
   const getGreeting = () => {
     const hour = new Date().getHours();

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -304,32 +304,29 @@ export default function HomeScreen() {
           />
         </View>
 
-        {/* Current Location Button - Fixed Logic */}
+        {/* Current Location Button — always fetches a fresh fix. Tapping
+            this is an explicit user request for "where am I now", so we
+            bypass any cached state and hit getCurrentPositionAsync. */}
         <TouchableOpacity style={styles.locationButton} onPress={async () => {
-          if (mapRef.current) {
-            let loc = location;
-            if (!loc) {
-              const { status } = await Location.requestForegroundPermissionsAsync();
-              if (status === 'granted') {
-                try {
-                  loc = await Location.getCurrentPositionAsync({});
-                } catch (e) {
-                  console.warn('Could not get current location, using fallback:', e);
-                  loc = { coords: { latitude: DEFAULT_LATITUDE, longitude: DEFAULT_LONGITUDE } };
-                }
-                setLocation(loc);
-              }
-            }
-
-            if (loc) {
-              mapRef.current.animateToRegion({
-                latitude: loc.coords.latitude,
-                longitude: loc.coords.longitude,
-                latitudeDelta: 0.01, // Zoom level
-                longitudeDelta: 0.01,
-              }, 1000);
-            }
+          if (!mapRef.current) return;
+          const { status } = await Location.requestForegroundPermissionsAsync();
+          if (status !== 'granted') return;
+          let loc: any;
+          try {
+            loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+          } catch (e) {
+            console.warn('Could not get current location, using fallback:', e);
+            loc = location ?? { coords: { latitude: DEFAULT_LATITUDE, longitude: DEFAULT_LONGITUDE } };
           }
+          setLocation(loc);
+          setUserLocation({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
+          saveLastLocation(loc.coords.latitude, loc.coords.longitude);
+          mapRef.current.animateToRegion({
+            latitude: loc.coords.latitude,
+            longitude: loc.coords.longitude,
+            latitudeDelta: 0.01,
+            longitudeDelta: 0.01,
+          }, 1000);
         }}>
           <Ionicons name="locate" size={24} color={colors.text} />
         </TouchableOpacity>


### PR DESCRIPTION
## Summary

- Both apps (rider and driver) re-fetch fresh GPS whenever the app returns to the foreground, so the map no longer shows yesterday's/home's position after you open the app somewhere new.
- The locate / recenter button now always calls `getCurrentPositionAsync` before animating, instead of zooming in on the last cached fix.
- Driver UI no longer reverts to "offline" when the OS denies the background-location prompt mid-flow.

## What changed

**App-resume refresh (commit `10838aa`)**
- `rider-app/app/(tabs)/index.tsx`: split `refreshLocation(useCache)` from `fetchHomeData` so location always refreshes on focus/resume even when the saved-places TTL hasn't elapsed. Added `AppState` 'active' listener. Added post-mount `animateToRegion` via `hasCenteredRef` since `MapView.initialRegion` is one-shot.
- `driver-app/hooks/useDriverDashboard.ts`: extracted `refreshLocation(useCache)`; cold start primes from AsyncStorage + `getLastKnownPositionAsync`, resume skips cache and forces a fresh fix.
- `driver-app/app/driver/(tabs)/index.tsx`: `pendingRecenterRef` one-shot that animates the map to the next fresh location after resume, but only when `rideState === 'idle'` so it doesn't disrupt an active ride's camera.

**Locate-button fresh fetch (commit `97a7ab2`)**
- `rider-app`: locate `TouchableOpacity` always awaits `getCurrentPositionAsync` (no more "only if location is null" branch), updates state + saved-location cache, then animates.
- `driver-app`: `refreshLocation` now awaits the GPS fix and returns the `LocationObject` (was fire-and-forget). `MapControls` accepts an `onRecenter` prop, awaits it, and animates to the returned coords — falling back to cached `location` only if the fresh fetch fails.

**Driver offline-revert fix (commit `b5e38a4`)**
- Prevents the UI from flipping back to offline when background-location permission is refused mid-toggle.

## Test plan

- [ ] Open rider app at a location different from yesterday's last GPS fix → map centers on current location, not the stale one.
- [ ] Open driver app at a new location → same.
- [ ] Background the app, move physically, foreground it → map recenters on the new location (rider), or recenters on next fix when idle (driver).
- [ ] Tap the locate button while the cached location is stale → map moves to the real current position, not just zooms into the stale spot.
- [ ] Tap locate during an active ride on driver → fresh fix fetched; cached ride camera not disrupted unexpectedly.
- [ ] Go Online on driver, deny the background-location prompt → UI stays online (doesn't revert).

https://claude.ai/code/session_0191FeZMSw9kPiTxsfTw2NYS

---
_Generated by [Claude Code](https://claude.ai/code/session_0191FeZMSw9kPiTxsfTw2NYS)_