### PR TITLE
fix(ci): establish 6% coverage baseline and fix guardrails ValueError (CR-2026-001)

### DIFF
--- a/.github/workflows/ci-guardrails.yml
+++ b/.github/workflows/ci-guardrails.yml
@@ -85,11 +85,13 @@ jobs:
       - name: Assert no regression
         run: |
           PR_PCT=$(cat .coverage-pr)
-          BASE_PCT="${{ steps.base_coverage.outputs.base_pct }}"
+          # GHA expressions are expanded before the shell runs, so
+          # ${{ ... }} works even inside a single-quoted <<'PYEOF' heredoc.
+          # A plain shell variable ($BASE_PCT) would NOT be expanded there.
           python3 - <<'PYEOF'
           import sys
           pr_pct   = float(open('.coverage-pr').read().strip() or 0)
-          base_pct = float("$BASE_PCT" or 0)
+          base_pct = float("${{ steps.base_coverage.outputs.base_pct }}" or 0)
           # Allow up to 2% regression before blocking (accounts for flaky mocks)
           TOLERANCE = 2.0
           delta = pr_pct - base_pct

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -4,19 +4,18 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 asyncio_mode = auto
-addopts = 
+addopts =
     -v
     --tb=short
     --strict-markers
-    --cov=backend
+    --cov=.
     --cov-report=term-missing
     --cov-report=html:htmlcov
     --cov-report=xml:coverage.xml
-# Coverage is reported but NOT gated. The 80% target was aspirational and has
-# never been met against the current Supabase-backed code path (baseline is
-# ~6%). Restoring a meaningful --cov-fail-under threshold is part of the P1
-# test-suite repair (see docs/audit/production-readiness-2026-04/
-# 09_ROADMAP_CHECKLIST.md § Testing).
+    --cov-fail-under=6
+# Baseline: ~6% reflects the current Supabase-backed test suite where most
+# paths require a live DB. Raise this incrementally as unit-testable modules
+# gain mocked coverage. CR-2026-001 tracks this work.
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     integration: marks tests as integration tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -75,6 +75,9 @@ sentry-sdk>=2.58.0
 
 # Testing
 pytest>=9.0.3
+pytest-cov>=5.0.0
+pytest-asyncio>=0.24.0
+pytest-env>=1.1.0
 
 # Development tools
 black>=26.3.1


### PR DESCRIPTION
## Summary

Closes CR-2026-001. Three targeted fixes across three files.

### Problem 1 — `Coverage regression check` fails with `ValueError` on every PR

**Root cause:** `ci-guardrails.yml` line 92 uses `float("$BASE_PCT" or 0)` inside a `<<'PYEOF'` single-quoted heredoc. Single quotes suppress shell variable expansion, so Python receives the literal string `"$BASE_PCT"`. Since it's a non-empty string it's truthy, so `"$BASE_PCT" or 0` returns `"$BASE_PCT"`, and `float("$BASE_PCT")` raises `ValueError` every time.

**Fix:** Replace `"$BASE_PCT"` with `"${{ steps.base_coverage.outputs.base_pct }}"`. GitHub Actions expressions are pre-processed by the runner before the shell executes — they expand correctly even inside single-quoted heredocs.

### Problem 2 — No `--cov-fail-under` in `pytest.ini`

**Root cause:** The comment in `pytest.ini` acknowledged the 80% target was never met and coverage was ~6%, but left it ungated. Any PR could drop coverage to 0% with no signal.

**Fix:** Add `--cov-fail-under=6` — the real current baseline. This is a floor, not a target. Raise it incrementally as unit-testable modules gain mocked test coverage.

Also aligns `--cov=.` with what the guardrails workflow runs (was `--cov=backend` which produced different source paths in the JSON report).

### Problem 3 — Test dependencies not declared in `requirements.txt`

**Root cause:** `pytest-cov`, `pytest-asyncio`, `pytest-env` were installed ad-hoc in CI (`pip install pytest pytest-asyncio pytest-cov`) but absent from `requirements.txt`. A local `pip install -r requirements.txt && pytest` would fail immediately.

**Fix:** Declare all three with minimum version pins.

## Test plan

- [ ] `Coverage regression check` now runs to completion (no ValueError) — passes when Codecov has no baseline yet (base_pct=0 → tolerance check skipped)
- [ ] `pytest --cov=. --cov-fail-under=6` passes locally against the mocked test suite
- [ ] A PR that intentionally drops coverage below 6% fails the gate

https://claude.ai/code/session_01NjevKBbxYeKALs1bVSU4c5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjevKBbxYeKALs1bVSU4c5)_