### PR TITLE
fix(admin): remediate 9 audit findings from 2026-04-25 admin panel audit

### DIFF
--- a/admin-dashboard/next.config.ts
+++ b/admin-dashboard/next.config.ts
@@ -5,8 +5,40 @@ const BACKEND_URL =
   process.env.NEXT_PUBLIC_API_URL ||
   "http://127.0.0.1:8000";
 
+const securityHeaders = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "X-Permitted-Cross-Domain-Policies", value: "none" },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self'",
+      "connect-src 'self' https:",
+      "frame-ancestors 'none'",
+    ].join("; "),
+  },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+];
+
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["192.168.68.63"],
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {

--- a/backend/dependencies/__init__.py
+++ b/backend/dependencies/__init__.py
@@ -203,14 +203,21 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
 
     # Admin tokens are minted by routes/admin/auth.py and carry `role` +
     # `email` + `modules` claims that regular rider/driver tokens do not
-    # have. Since the token is signed with our own JWT_SECRET, we can
-    # trust these claims and return the user directly without a DB lookup.
-    # Without this check, admin-001 (which has no users row) would be
-    # auto-created as a rider and fail the get_admin_user role check.
+    # have. admin-001 (super admin from env) has no DB row — trust JWT claims
+    # directly. All other staff are validated against admin_staff to enforce
+    # is_active and token_version revocation (fixes audit [03-2/03-3]).
     _admin_roles = {"admin", "super_admin", "operations", "support", "finance", "custom"}
     if payload.get("role") in _admin_roles and payload.get("email"):
+        user_id = payload["user_id"]
+        if user_id != "admin-001":
+            staff_rows = await db_supabase.get_rows("admin_staff", {"id": user_id}, limit=1)
+            staff = staff_rows[0] if staff_rows else None
+            if not staff or not staff.get("is_active", True):
+                raise HTTPException(status_code=401, detail="ERR_ACCOUNT_INACTIVE")
+            if _token_version_mismatch(payload, staff):
+                raise HTTPException(status_code=401, detail="ERR_SESSION_REVOKED")
         return {
-            "id": payload["user_id"],
+            "id": user_id,
             "email": payload.get("email"),
             "phone": payload.get("phone", ""),
             "role": payload["role"],
@@ -312,6 +319,36 @@ async def get_admin_user(current_user: dict = Depends(get_current_user)) -> dict
     if role not in ("admin", "super_admin", "operations", "support", "finance", "custom"):
         raise HTTPException(status_code=403, detail="Admin access required")
     return current_user
+
+
+def require_module(module: str):
+    """Return a FastAPI dependency that enforces module-level RBAC.
+
+    Usage::
+
+        @router.post("/wallet/credit")
+        async def credit(admin: dict = Depends(require_module("earnings"))):
+            ...
+
+    Or at include_router time::
+
+        admin_router.include_router(wallet_router, dependencies=[Depends(require_module("earnings"))])
+
+    super_admin always passes regardless of the modules claim.
+    """
+
+    async def _check(current_user: dict = Depends(get_admin_user)) -> dict:
+        if current_user.get("role") == "super_admin":
+            return current_user
+        modules: list = current_user.get("modules") or []
+        if module not in modules:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Access denied — module '{module}' not in your role permissions",
+            )
+        return current_user
+
+    return _check
 
 
 # Alias for backward compatibility

--- a/backend/routes/admin/__init__.py
+++ b/backend/routes/admin/__init__.py
@@ -23,9 +23,9 @@ can reach /api/admin/auth/login without a token.
 from fastapi import APIRouter, Depends
 
 try:
-    from ...dependencies import get_admin_user
+    from ...dependencies import get_admin_user, require_module
 except ImportError:
-    from dependencies import get_admin_user
+    from dependencies import get_admin_user, require_module
 
 from .analytics import api_router as analytics_router
 from .auth import admin_auth_router
@@ -56,28 +56,28 @@ admin_router = APIRouter(
     dependencies=[Depends(get_admin_user)],
 )
 
-# Include all sub-routers (no prefix — /admin is already set above).
-# `auth_router` is an empty placeholder re-exported from .auth for
-# include-order symmetry; the real login/session/logout routes live
-# on `admin_auth_router`, which server.py mounts separately so it
-# stays public.
+# Include all sub-routers with module-level RBAC (audit [03-1]).
+# require_module() raises 403 when the caller's JWT modules claim does not
+# include the required module. super_admin always passes.
+# `auth_router` is an empty placeholder; the real login/session/logout routes
+# live on `admin_auth_router`, mounted separately by server.py (no auth gate).
 admin_router.include_router(auth_router)
-admin_router.include_router(settings_router)
-admin_router.include_router(service_areas_router)
-admin_router.include_router(vehicle_fleet_router)
-admin_router.include_router(drivers_router)
-admin_router.include_router(rides_router)
-admin_router.include_router(users_router)
-admin_router.include_router(promotions_router)
-admin_router.include_router(support_router)
-admin_router.include_router(faqs_router)
-admin_router.include_router(legal_documents_router)
-admin_router.include_router(documents_router)
-admin_router.include_router(staff_router)
-admin_router.include_router(subscriptions_router)
-admin_router.include_router(messaging_router)
-admin_router.include_router(maintenance_router)
-admin_router.include_router(analytics_router)
-admin_router.include_router(wallet_router)
+admin_router.include_router(settings_router, dependencies=[Depends(require_module("settings"))])
+admin_router.include_router(service_areas_router, dependencies=[Depends(require_module("service_areas"))])
+admin_router.include_router(vehicle_fleet_router, dependencies=[Depends(require_module("vehicle_types"))])
+admin_router.include_router(drivers_router, dependencies=[Depends(require_module("drivers"))])
+admin_router.include_router(rides_router, dependencies=[Depends(require_module("rides"))])
+admin_router.include_router(users_router, dependencies=[Depends(require_module("users"))])
+admin_router.include_router(promotions_router, dependencies=[Depends(require_module("promotions"))])
+admin_router.include_router(support_router, dependencies=[Depends(require_module("support"))])
+admin_router.include_router(faqs_router, dependencies=[Depends(require_module("support"))])
+admin_router.include_router(legal_documents_router, dependencies=[Depends(require_module("documents"))])
+admin_router.include_router(documents_router, dependencies=[Depends(require_module("documents"))])
+admin_router.include_router(staff_router, dependencies=[Depends(require_module("staff"))])
+admin_router.include_router(subscriptions_router, dependencies=[Depends(require_module("earnings"))])
+admin_router.include_router(messaging_router, dependencies=[Depends(require_module("notifications"))])
+admin_router.include_router(maintenance_router, dependencies=[Depends(require_module("dashboard"))])
+admin_router.include_router(analytics_router, dependencies=[Depends(require_module("dashboard"))])
+admin_router.include_router(wallet_router, dependencies=[Depends(require_module("earnings"))])
 
 __all__ = ["admin_router", "admin_auth_router"]

--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -48,21 +48,18 @@ async def get_cancellation_breakdown(
     start_date = _parse_date_range(date_range)
 
     try:
-        filters = {"status": "cancelled"}
-        rides = await db.get_rows("rides", filters, limit=10000, order="created_at")
+        filters: dict = {
+            "status": "cancelled",
+            "created_at": {"$gte": start_date.isoformat()},
+        }
+        if service_area_id:
+            filters["service_area_id"] = service_area_id
+        filtered = await db.get_rows("rides", filters, limit=5000, order="created_at")
     except Exception as e:
-        logger.error(f"Failed to fetch cancelled rides: {e}")
-        rides = []
+        logger.error(f"Failed to fetch cancelled rides: {e}", exc_info=True)
+        from fastapi import HTTPException as _HTTPException
 
-    # Filter by date and optionally by service area
-    filtered = []
-    for r in rides:
-        created = r.get("created_at", "")
-        if isinstance(created, str) and created < start_date.isoformat():
-            continue
-        if service_area_id and r.get("service_area_id") != service_area_id:
-            continue
-        filtered.append(r)
+        raise _HTTPException(status_code=503, detail="Analytics data unavailable — database error")
 
     # Categorize cancellation reasons
     reason_counter = Counter()
@@ -151,21 +148,14 @@ async def get_driver_acceptance_rates(
     for driver in drivers:
         driver_id = driver["id"]
         try:
-            all_rides = await db.get_rows(
+            period_rides = await db.get_rows(
                 "rides",
-                {"driver_id": driver_id},
+                {"driver_id": driver_id, "created_at": {"$gte": start_date.isoformat()}},
                 limit=500,
                 order="created_at",
             )
         except Exception:
-            all_rides = []
-
-        # Filter by date range
-        period_rides = [
-            r
-            for r in all_rides
-            if isinstance(r.get("created_at", ""), str) and r.get("created_at", "") >= start_date.isoformat()
-        ]
+            period_rides = []
 
         total_assigned = len(period_rides)
         completed = sum(1 for r in period_rides if r.get("status") == "completed")
@@ -226,16 +216,17 @@ async def get_analytics_overview(
     start_date = _parse_date_range(date_range)
 
     try:
-        all_rides = await db.get_rows("rides", {}, limit=10000, order="created_at")
+        period_rides = await db.get_rows(
+            "rides",
+            {"created_at": {"$gte": start_date.isoformat()}},
+            limit=10000,
+            order="created_at",
+        )
     except Exception as e:
-        logger.error(f"Failed to fetch rides: {e}")
-        all_rides = []
+        logger.error(f"Failed to fetch rides: {e}", exc_info=True)
+        from fastapi import HTTPException as _HTTPException
 
-    period_rides = [
-        r
-        for r in all_rides
-        if isinstance(r.get("created_at", ""), str) and r.get("created_at", "") >= start_date.isoformat()
-    ]
+        raise _HTTPException(status_code=503, detail="Analytics data unavailable — database error")
 
     total = len(period_rides)
     completed = sum(1 for r in period_rides if r.get("status") == "completed")

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -96,12 +96,12 @@ class DriverVerifyRequest(BaseModel):
 
 
 class DriverActionRequest(BaseModel):
-    action: str  # approve, reject, suspend, ban, unban, reactivate
+    action: Literal["approve", "reject", "suspend", "ban", "unban", "reactivate"]
     reason: Optional[str] = None
 
 
 class DriverStatusOverride(BaseModel):
-    status: str  # pending, active, rejected, suspended, banned
+    status: Literal["pending", "active", "rejected", "suspended", "banned"]
     is_verified: Optional[bool] = None
     reason: Optional[str] = None
 

--- a/backend/routes/admin/messaging.py
+++ b/backend/routes/admin/messaging.py
@@ -1,9 +1,10 @@
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import List, Literal, Optional
 
 from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
 
 try:
     from ... import db_supabase
@@ -16,29 +17,30 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
+class CloudMessageRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=100)
+    description: str = Field(..., min_length=1, max_length=500)
+    audience: Literal["customers", "drivers", "particular_customer", "particular_driver", "all"] = "customers"
+    type: str = "info"
+    channels: List[Literal["push", "sms", "email"]] = ["push"]
+    particular_ids: Optional[List[str]] = None
+    scheduled_at: Optional[str] = None
+
+
 # ---------- Cloud Messaging ----------
 
 
 @router.post("/cloud-messaging/send")
-async def admin_send_cloud_message(payload: Dict[str, Any]):
+async def admin_send_cloud_message(payload: CloudMessageRequest):
     """Send or schedule a cloud message to users/drivers."""
-    title = payload.get("title", "")
-    description = payload.get("description", "")
-    audience = payload.get("audience", "customers")
-    msg_type = payload.get("type", "info")
-    channels = payload.get("channels")
-    if not channels:
-        channel = payload.get("channel", "push")
-        channels = [channel]
-    particular_ids = payload.get("particular_ids") or []
-    if not particular_ids:
-        pid = payload.get("particular_id")
-        if pid:
-            particular_ids = [pid]
-    scheduled_at = payload.get("scheduled_at")
-
-    if not title or not description:
-        raise HTTPException(status_code=400, detail="Title and description are required")
+    title = payload.title
+    description = payload.description
+    audience = payload.audience
+    msg_type = payload.type
+    channels = payload.channels
+    particular_ids = payload.particular_ids or []
+    scheduled_at = payload.scheduled_at
 
     is_scheduled = bool(scheduled_at)
     status = "scheduled" if is_scheduled else "sent"

--- a/backend/routes/admin/staff.py
+++ b/backend/routes/admin/staff.py
@@ -10,10 +10,12 @@ try:
     from ... import db_supabase
     from ...dependencies import get_admin_user
     from ...utils.password import hash_password
+    from ...utils.refresh_tokens import revoke_all_for_user
 except ImportError:
     import db_supabase
     from dependencies import get_admin_user
     from utils.password import hash_password
+    from utils.refresh_tokens import revoke_all_for_user
 
 db = db_supabase  # legacy alias
 
@@ -138,6 +140,19 @@ async def create_staff(req: StaffCreateRequest, admin: dict = Depends(get_admin_
     }
 
     await db_supabase.insert_one("admin_staff", staff)
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "staff_created",
+            "resource": "staff",
+            "resource_id": staff["id"],
+            "details": {"email": staff["email"], "role": staff["role"], "modules": staff["modules"]},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
     staff.pop("password_hash")
     return staff
 
@@ -163,7 +178,7 @@ async def get_staff(staff_id: str):
 
 
 @router.put("/staff/{staff_id}")
-async def update_staff(staff_id: str, req: StaffUpdateRequest):
+async def update_staff(staff_id: str, req: StaffUpdateRequest, admin: dict = Depends(get_admin_user)):
     """Update staff member role/modules/status."""
     s = (lambda _r: _r[0] if _r else None)(await db_supabase.get_rows("admin_staff", {"id": staff_id}, limit=1))
     if not s:
@@ -176,6 +191,11 @@ async def update_staff(staff_id: str, req: StaffUpdateRequest):
         updates["last_name"] = req.last_name
     if req.is_active is not None:
         updates["is_active"] = req.is_active
+        if req.is_active is False:
+            # Bump token_version so the dependency gate rejects all existing
+            # access tokens for this staff member immediately (audit [03-2]).
+            updates["token_version"] = int(s.get("token_version") or 0) + 1
+            await revoke_all_for_user(staff_id)
     if req.role is not None:
         updates["role"] = req.role
         if req.role in ROLE_PRESETS:
@@ -186,12 +206,42 @@ async def update_staff(staff_id: str, req: StaffUpdateRequest):
     if updates:
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
         await db_supabase.update_one("admin_staff", {"id": staff_id}, updates)
+        await db_supabase.insert_one(
+            "audit_logs",
+            {
+                "id": str(uuid.uuid4()),
+                "actor_id": admin["id"],
+                "actor_role": admin.get("role"),
+                "action": "staff_updated",
+                "resource": "staff",
+                "resource_id": staff_id,
+                "details": {k: v for k, v in updates.items() if k != "updated_at"},
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
 
     return {"success": True}
 
 
 @router.delete("/staff/{staff_id}")
-async def delete_staff(staff_id: str):
+async def delete_staff(staff_id: str, admin: dict = Depends(get_admin_user)):
     """Delete a staff member."""
+    s = (lambda _r: _r[0] if _r else None)(await db_supabase.get_rows("admin_staff", {"id": staff_id}, limit=1))
+    # Revoke all refresh tokens before the row is gone so any in-flight
+    # session cannot exchange a refresh token after deletion (audit [03-3]).
+    await revoke_all_for_user(staff_id)
     await db_supabase.delete_many("admin_staff", {"id": staff_id})
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "staff_deleted",
+            "resource": "staff",
+            "resource_id": staff_id,
+            "details": {"email": s.get("email") if s else None, "role": s.get("role") if s else None},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
     return {"success": True}

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, HTTPException
 
 try:
     from ... import db_supabase
+    from ...dependencies import get_admin_user
 except ImportError:
     import db_supabase
 
@@ -76,7 +77,7 @@ async def admin_get_user_details(user_id: str):
 
 
 @router.put("/users/{user_id}/status")
-async def admin_update_user_status(user_id: str, status_data: Dict[str, Any]):
+async def admin_update_user_status(user_id: str, status_data: Dict[str, Any], admin: dict = Depends(get_admin_user)):
     """Update user status (e.g., suspend, activate)."""
     valid_status = ["active", "suspended", "banned"]
     new_status = status_data.get("status")
@@ -84,7 +85,27 @@ async def admin_update_user_status(user_id: str, status_data: Dict[str, Any]):
     if new_status not in valid_status:
         raise HTTPException(status_code=400, detail=f"Invalid status. Must be one of: {valid_status}")
 
+    user = await db_supabase.get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    old_status = user.get("status")
+
     await db_supabase.update_one(
         "users", {"id": user_id}, {"status": new_status, "updated_at": datetime.now(timezone.utc).isoformat()}
     )
+
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "status_change",
+            "resource": "user",
+            "resource_id": user_id,
+            "details": {"old_status": old_status, "new_status": new_status},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
     return {"message": f"User status updated to {new_status}"}

--- a/backend/routes/admin/wallet.py
+++ b/backend/routes/admin/wallet.py
@@ -124,6 +124,26 @@ async def admin_credit_wallet(req: AdminCreditRequest, admin: dict = Depends(get
         metadata={"admin_id": admin["id"], "reason": req.reason},
     )
 
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "wallet_credit",
+            "resource": "user",
+            "resource_id": req.user_id,
+            "details": {
+                "amount": float(credit),
+                "old_balance": float(old_balance),
+                "new_balance": float(new_balance),
+                "reason": req.reason,
+                "transaction_id": txn["id"],
+            },
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
     return {
         "balance": float(new_balance),
         "transaction_id": txn["id"],
@@ -160,6 +180,26 @@ async def admin_debit_wallet(req: AdminDebitRequest, admin: dict = Depends(get_a
         balance_after=float(new_balance),
         description=f"Admin debit: {req.reason}",
         metadata={"admin_id": admin["id"], "reason": req.reason},
+    )
+
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "wallet_debit",
+            "resource": "user",
+            "resource_id": req.user_id,
+            "details": {
+                "amount": float(debit),
+                "old_balance": float(old_balance),
+                "new_balance": float(new_balance),
+                "reason": req.reason,
+                "transaction_id": txn["id"],
+            },
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
     )
 
     return {


### PR DESCRIPTION
Implements all outstanding P1/P2 items from reports/audits/2026-04-25-admin-panel-audit-v1.txt:

[03-1] require_module() RBAC — dependencies/__init__.py adds the factory;
  admin/__init__.py wires a per-module dependency to every sub-router so
  a "support" role cannot reach wallet, analytics, staff, or settings endpoints.

[03-2/03-3] Staff token invalidation — staff.py bumps token_version and calls
  revoke_all_for_user() when a staff member is deactivated or deleted.
  dependencies/__init__.py now validates non-admin-001 staff tokens against
  admin_staff (is_active + token_version) on every request.

[05-1] Audit log on user status change — users.py writes to audit_logs after
  every suspend/ban/activate action.

[05-2] Audit log on wallet credit/debit — wallet.py writes to audit_logs after
  every admin_credit_wallet and admin_debit_wallet call.

[05-3] Audit log on staff CRUD — staff.py writes to audit_logs on create,
  update, and delete; update/delete endpoints now require get_admin_user.

[08-2] Analytics DB-level date filtering — analytics.py passes created_at $gte
  filter to get_rows() instead of loading 10k rows and filtering in Python.
  DB errors now raise 503 instead of silently returning empty data.

[04-1] CloudMessageRequest Pydantic model — messaging.py replaces Dict[str,Any]
  with a typed model (title max 100, description max 500, audience/channels Literal).

[04-3] Literal types on driver actions — drivers.py uses
  Literal["approve","reject","suspend","ban","unban","reactivate"] for
  DriverActionRequest.action and Literal status values for DriverStatusOverride.

[07-2] Next.js security headers — next.config.ts adds headers() with
  X-Frame-Options DENY, X-Content-Type-Options, HSTS, CSP, Referrer-Policy,
  Permissions-Policy applied to all routes.

https://claude.ai/code/session_017BEuKhwtnxtPNzKtjeHwiW

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
