### PR TITLE
fix(p0): double-booking race, SOS fail-open, dev endpoint in prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
   # Deploy Admin Dashboard
   deploy-admin:
     runs-on: ubuntu-latest
-    needs: [admin-test]
+    needs: [admin-test, deploy-backend]
     if: github.ref == 'refs/heads/main'
 
     steps:

--- a/admin-dashboard/sentry.client.config.ts
+++ b/admin-dashboard/sentry.client.config.ts
@@ -19,7 +19,7 @@ function beforeSend(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
 
   // Scrub cookies entirely
   if (event.request?.cookies) {
-    event.request.cookies = '[Filtered]';
+    event.request.cookies = {};
   }
 
   // Remove URL query strings (may contain phone, email, or token params)

--- a/admin-dashboard/sentry.server.config.ts
+++ b/admin-dashboard/sentry.server.config.ts
@@ -14,7 +14,7 @@ function beforeSend(event: Sentry.ErrorEvent): Sentry.ErrorEvent | null {
     }
     event.request.headers = safe;
   }
-  if (event.request?.cookies) event.request.cookies = '[Filtered]';
+  if (event.request?.cookies) event.request.cookies = {};
   if (event.request?.query_string) event.request.query_string = '[Filtered]';
 
   const PII_KEYS = new Set([

--- a/admin-dashboard/src/app/api/admin/auth/login/route.ts
+++ b/admin-dashboard/src/app/api/admin/auth/login/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://127.0.0.1:8000";
+
+const RT_COOKIE = "spinr_admin_rt";
+const RT_MAX_AGE = 30 * 24 * 60 * 60; // 30 days — matches backend refresh token TTL
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${BACKEND_URL}/api/admin/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return NextResponse.json({ detail: "Backend unreachable" }, { status: 502 });
+  }
+
+  const data = await upstream.json();
+
+  if (!upstream.ok) {
+    return NextResponse.json(data, { status: upstream.status });
+  }
+
+  // Strip the refresh token from the response body — it must never reach
+  // the browser's JS context. We store it in an HttpOnly cookie instead.
+  const { refresh_token, refresh_expires_at: _ignored, ...clientData } = data;
+
+  const res = NextResponse.json(clientData, { status: 200 });
+  if (refresh_token) {
+    res.cookies.set(RT_COOKIE, refresh_token, {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: process.env.NODE_ENV === "production",
+      path: "/api/admin/auth",
+      maxAge: RT_MAX_AGE,
+    });
+  }
+  return res;
+}

--- a/admin-dashboard/src/app/api/admin/auth/login/route.ts
+++ b/admin-dashboard/src/app/api/admin/auth/login/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// PIPEDA data residency: pin to Canadian (Toronto) region (F-22).
+export const preferredRegion = "yyz1";
+
 const BACKEND_URL =
   process.env.BACKEND_URL ||
   process.env.NEXT_PUBLIC_API_URL ||

--- a/admin-dashboard/src/app/api/admin/auth/logout/route.ts
+++ b/admin-dashboard/src/app/api/admin/auth/logout/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// PIPEDA data residency: pin to Canadian (Toronto) region (F-22).
+export const preferredRegion = "yyz1";
+
 const BACKEND_URL =
   process.env.BACKEND_URL ||
   process.env.NEXT_PUBLIC_API_URL ||

--- a/admin-dashboard/src/app/api/admin/auth/logout/route.ts
+++ b/admin-dashboard/src/app/api/admin/auth/logout/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://127.0.0.1:8000";
+
+const RT_COOKIE = "spinr_admin_rt";
+
+export async function POST(req: NextRequest) {
+  const refreshToken = req.cookies.get(RT_COOKIE)?.value;
+
+  // Fire revocation at the backend regardless of outcome — best-effort.
+  if (refreshToken) {
+    await fetch(`${BACKEND_URL}/api/admin/auth/logout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    }).catch(() => {});
+  }
+
+  const res = NextResponse.json({ success: true });
+  res.cookies.set(RT_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/api/admin/auth",
+    maxAge: 0,
+  });
+  return res;
+}

--- a/admin-dashboard/src/app/api/admin/auth/refresh/route.ts
+++ b/admin-dashboard/src/app/api/admin/auth/refresh/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
+// PIPEDA data residency: pin to Canadian (Toronto) region (F-22).
+export const preferredRegion = "yyz1";
+
 const BACKEND_URL =
   process.env.BACKEND_URL ||
   process.env.NEXT_PUBLIC_API_URL ||

--- a/admin-dashboard/src/app/api/admin/auth/refresh/route.ts
+++ b/admin-dashboard/src/app/api/admin/auth/refresh/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL =
+  process.env.BACKEND_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  "http://127.0.0.1:8000";
+
+const RT_COOKIE = "spinr_admin_rt";
+const RT_MAX_AGE = 30 * 24 * 60 * 60;
+
+function clearRtCookie(res: NextResponse): void {
+  res.cookies.set(RT_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    path: "/api/admin/auth",
+    maxAge: 0,
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const refreshToken = req.cookies.get(RT_COOKIE)?.value;
+  if (!refreshToken) {
+    return NextResponse.json({ detail: "No refresh token" }, { status: 401 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${BACKEND_URL}/api/admin/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+  } catch {
+    return NextResponse.json({ detail: "Backend unreachable" }, { status: 502 });
+  }
+
+  const data = await upstream.json();
+
+  if (!upstream.ok) {
+    const res = NextResponse.json(data, { status: upstream.status });
+    // On a definitive 401 the token is revoked — clear the cookie.
+    if (upstream.status === 401) clearRtCookie(res);
+    return res;
+  }
+
+  const { refresh_token, refresh_expires_at: _ignored, ...clientData } = data;
+
+  const res = NextResponse.json(clientData, { status: 200 });
+  if (refresh_token) {
+    res.cookies.set(RT_COOKIE, refresh_token, {
+      httpOnly: true,
+      sameSite: "strict",
+      secure: process.env.NODE_ENV === "production",
+      path: "/api/admin/auth",
+      maxAge: RT_MAX_AGE,
+    });
+  }
+  return res;
+}

--- a/admin-dashboard/src/app/login/page.tsx
+++ b/admin-dashboard/src/app/login/page.tsx
@@ -25,7 +25,7 @@ function sanitizeNextPath(next: string | null): string {
 function LoginForm() {
     const router = useRouter();
     const searchParams = useSearchParams();
-    const { setToken, setUser, setRefreshToken, scheduleRefresh } = useAuthStore();
+    const { setToken, setUser, scheduleRefresh } = useAuthStore();
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
@@ -39,10 +39,7 @@ function LoginForm() {
             // Call the admin login API
             const data = await loginAdminSession(email, password);
 
-            // Store token in memory + cookie, refresh token in sessionStorage.
-            // The access JWT is NOT persisted — only the opaque refresh token is.
             setToken(data.token);
-            setRefreshToken(data.refresh_token);
             if (data.access_expires_at) scheduleRefresh(data.access_expires_at);
             setUser({
                 id: data.user.id,

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -28,26 +28,24 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
             // "Invalid credentials" is shown to the user rather than "Unauthorized".
             if (path !== "/api/admin/auth/login") {
                 const store = useAuthStore.getState();
-                // Attempt one silent refresh before giving up. This handles the
-                // case where the access token expired mid-session and the timer
-                // hasn't fired yet (e.g. the tab was backgrounded).
-                if (store.refresh_token) {
-                    await store.silentRefresh();
-                    const newToken = useAuthStore.getState().token;
-                    if (newToken) {
-                        const retryHeaders = { ...headers, Authorization: `Bearer ${newToken}` };
-                        const retryRes = await fetch(url, { ...options, headers: retryHeaders });
-                        if (retryRes.ok) return retryRes.json() as T;
-                        if (retryRes.status !== 401) {
-                            const retryBody = await retryRes.json().catch(() => ({}));
-                            const retryMsg =
-                                retryBody.detail ||
-                                retryBody.error?.detail ||
-                                retryBody.error?.message ||
-                                retryBody.message ||
-                                retryRes.statusText;
-                            throw new Error(retryMsg);
-                        }
+                // Attempt one silent refresh before giving up. The HttpOnly
+                // refresh cookie is sent automatically — no need to check for
+                // a token in JS state.
+                await store.silentRefresh();
+                const newToken = useAuthStore.getState().token;
+                if (newToken) {
+                    const retryHeaders = { ...headers, Authorization: `Bearer ${newToken}` };
+                    const retryRes = await fetch(url, { ...options, headers: retryHeaders });
+                    if (retryRes.ok) return retryRes.json() as T;
+                    if (retryRes.status !== 401) {
+                        const retryBody = await retryRes.json().catch(() => ({}));
+                        const retryMsg =
+                            retryBody.detail ||
+                            retryBody.error?.detail ||
+                            retryBody.error?.message ||
+                            retryBody.message ||
+                            retryRes.statusText;
+                        throw new Error(retryMsg);
                     }
                 }
                 useAuthStore.getState().logout();
@@ -101,9 +99,7 @@ export interface AuthResponse {
 
 export interface AdminLoginResponse {
     token: string;
-    refresh_token: string;
     access_expires_at: string;
-    refresh_expires_at: string;
     user: {
         id: string;
         email: string;

--- a/admin-dashboard/src/middleware.ts
+++ b/admin-dashboard/src/middleware.ts
@@ -1,8 +1,0 @@
-/**
- * Next.js edge middleware — wires up the auth gate from proxy.ts.
- *
- * Next.js requires this file to be named `middleware.ts` and export a
- * function called `middleware` (or a default export). The auth logic lives
- * in proxy.ts so it can be tested independently.
- */
-export { proxy as middleware, config } from './proxy';

--- a/admin-dashboard/src/store/authStore.ts
+++ b/admin-dashboard/src/store/authStore.ts
@@ -105,13 +105,10 @@ interface AuthState {
     user: User | null;
     // Access token lives in memory only — never written to sessionStorage.
     token: string | null;
-    // Refresh token is persisted to sessionStorage (opaque, not a signed JWT).
-    refresh_token: string | null;
     isAuthenticated: boolean;
     isLoading: boolean;
     setUser: (user: User | null) => void;
     setToken: (token: string | null) => void;
-    setRefreshToken: (refreshToken: string | null) => void;
     scheduleRefresh: (accessExpiresAt: string) => void;
     setLoading: (loading: boolean) => void;
     logout: () => void;
@@ -124,7 +121,6 @@ export const useAuthStore = create<AuthState>()(
         (set, get) => ({
             user: null,
             token: null,
-            refresh_token: null,
             isAuthenticated: false,
             isLoading: true,
 
@@ -150,10 +146,6 @@ export const useAuthStore = create<AuthState>()(
                 }
             },
 
-            setRefreshToken: (refreshToken) => {
-                set({ refresh_token: refreshToken });
-            },
-
             scheduleRefresh: (accessExpiresAt) => {
                 scheduleTokenRefresh(accessExpiresAt, get().silentRefresh);
             },
@@ -169,36 +161,31 @@ export const useAuthStore = create<AuthState>()(
                 set({
                     user: null,
                     token: null,
-                    refresh_token: null,
                     isAuthenticated: false,
                     isLoading: false
                 });
+                // Clear the HttpOnly RT cookie server-side (fire-and-forget).
+                fetch("/api/admin/auth/logout", { method: "POST" }).catch(() => {});
             },
 
-            // Exchange the persisted refresh token for a new short-lived access
-            // token. Called proactively by the scheduled timer and on page reload
-            // from onRehydrateStorage. On failure, calls logout() to clear state.
+            // Exchange the HttpOnly refresh cookie for a new short-lived access
+            // token via the /api/admin/auth/refresh Next.js route (which reads the
+            // cookie server-side so JS never sees the token value). Called
+            // proactively by the scheduled timer and on every page reload.
+            // On failure, calls logout() to clear state.
             silentRefresh: async () => {
-                const refreshToken = get().refresh_token;
-                if (!refreshToken) {
-                    get().logout();
-                    return;
-                }
                 try {
                     const res = await fetch(`${API_BASE}/api/admin/auth/refresh`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ refresh_token: refreshToken }),
+                        method: "POST",
                     });
                     if (!res.ok) {
                         get().logout();
                         return;
                     }
-                    const data: { token: string; refresh_token: string; access_expires_at: string } = await res.json();
-                    set({ token: data.token, refresh_token: data.refresh_token });
+                    const data: { token: string; access_expires_at: string } = await res.json();
+                    set({ token: data.token });
                     setAuthCookie(data.token);
                     scheduleTokenRefresh(data.access_expires_at, get().silentRefresh);
-                    // Keep the idle watch alive after a silent token refresh.
                     startIdleWatch(get().logout);
                 } catch {
                     get().logout();
@@ -244,21 +231,20 @@ export const useAuthStore = create<AuthState>()(
         {
             name: 'auth-storage',
             storage: createJSONStorage(() => sessionStorage),
-            // Only persist the refresh token + user profile. The access token
-            // (a signed JWT) is intentionally excluded so XSS cannot steal it
-            // from sessionStorage. On page reload, silentRefresh() re-acquires
-            // a fresh access token from the server before rendering.
+            // Only persist the user profile / auth flag for optimistic rendering.
+            // The access token and refresh token are intentionally NOT stored in
+            // sessionStorage. On page reload, silentRefresh() re-acquires a fresh
+            // access token by presenting the HttpOnly RT cookie to the Next.js
+            // /api/admin/auth/refresh route — JS never sees the RT value.
             partialize: (state) => ({
-                refresh_token: state.refresh_token,
                 user: state.user,
                 isAuthenticated: state.isAuthenticated,
             }),
             onRehydrateStorage: () => (state) => {
                 if (!state) return;
-                if (state.refresh_token) {
-                    // Silently re-acquire an access token, then set isLoading=false.
-                    // silentRefresh calls logout() (which sets isLoading=false) on
-                    // failure, so .then() covers only the success path.
+                if (state.isAuthenticated) {
+                    // Verify the session is still valid and get a fresh access token.
+                    // silentRefresh calls logout() (sets isLoading=false) on failure.
                     state.silentRefresh().then(() => {
                         useAuthStore.getState().setLoading(false);
                     });

--- a/admin-dashboard/vercel.json
+++ b/admin-dashboard/vercel.json
@@ -1,0 +1,4 @@
+{
+  "regions": ["yyz1"],
+  "$schema": "https://openapi.vercel.sh/vercel.json"
+}

--- a/backend/db_supabase.py
+++ b/backend/db_supabase.py
@@ -1063,12 +1063,13 @@ async def get_rows(
     desc: bool = False,
     limit: Optional[int] = None,
     offset: Optional[int] = None,
+    columns: str = "*",
 ):
     if not supabase:
         return []
 
     def _fn():
-        q = supabase.table(table).select("*")
+        q = supabase.table(table).select(columns)
         q = _apply_filters(q, filters)
         if order:
             q = q.order(order, desc=desc)

--- a/backend/migrations/53_rides_one_active_per_rider.sql
+++ b/backend/migrations/53_rides_one_active_per_rider.sql
@@ -1,0 +1,22 @@
+-- 53_rides_one_active_per_rider.sql
+-- Rollback: DROP INDEX IF EXISTS rides_one_active_per_rider;
+--
+-- Enforces the CLAUDE.md invariant at the DB level:
+--   "a rider may have at most one active ride at a time"
+-- Closes the race window between the application-level SELECT check
+-- and the subsequent INSERT in POST /rides (double-booking P0 fix).
+--
+-- Note: CREATE INDEX ... CONCURRENTLY cannot run inside a transaction.
+-- This index is non-concurrent and holds a SHARE lock for its duration.
+-- On a small/medium rides table this is sub-second. If the table exceeds
+-- ~10M rows, run manually outside the migration runner with CONCURRENTLY.
+
+CREATE UNIQUE INDEX IF NOT EXISTS rides_one_active_per_rider
+  ON rides (rider_id)
+  WHERE status IN (
+    'searching',
+    'driver_assigned',
+    'driver_accepted',
+    'driver_arrived',
+    'in_progress'
+  );

--- a/backend/routes/admin/auth.py
+++ b/backend/routes/admin/auth.py
@@ -54,19 +54,31 @@ def _lockout_key(email: str) -> str:
 
 
 async def _is_account_locked(email: str) -> bool:
-    val = await redis_get(_lockout_key(email))
-    return val is not None and int(val) >= _LOGIN_MAX_FAILURES
+    try:
+        val = await redis_get(_lockout_key(email))
+        return val is not None and int(val) >= _LOGIN_MAX_FAILURES
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"[REDIS] _is_account_locked check failed for admin login ({email!r}): {e}")
+        raise HTTPException(status_code=503, detail="ERR_AUTH_UNAVAILABLE") from None
 
 
 async def _record_login_failure(email: str) -> None:
-    key = _lockout_key(email)
-    count = await redis_incr(key)
-    if count == 1:
-        await redis_expire(key, _LOGIN_LOCKOUT_TTL_SECONDS)
+    try:
+        key = _lockout_key(email)
+        count = await redis_incr(key)
+        if count == 1:
+            await redis_expire(key, _LOGIN_LOCKOUT_TTL_SECONDS)
+    except Exception as e:
+        logger.error(f"[REDIS] _record_login_failure could not persist failure count ({email!r}): {e}")
 
 
 async def _clear_login_failures(email: str) -> None:
-    await redis_delete(_lockout_key(email))
+    try:
+        await redis_delete(_lockout_key(email))
+    except Exception as e:
+        logger.error(f"[REDIS] _clear_login_failures could not clear failure count ({email!r}): {e}")
 
 
 # Auth sub-router — mounted at /admin/auth by server.py directly

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -535,6 +535,10 @@ async def admin_get_ride_route_map(
         raise HTTPException(status_code=502, detail="Failed to fetch route map") from e
 
 
+_HEATMAP_MAX_ROWS = 5_000
+_HEATMAP_COLUMNS = "pickup_lat,pickup_lng,dropoff_lat,dropoff_lng,corporate_account_id"
+
+
 @router.get("/rides/heatmap-data")
 async def admin_get_heatmap_data(
     filter: str = Query("all"),
@@ -569,7 +573,17 @@ async def admin_get_heatmap_data(
     if service_area_id:
         query_filters["service_area_id"] = service_area_id
 
-    rides = await db_supabase.get_rows("rides", query_filters, order="created_at", desc=True, limit=10000)
+    # Fetch only the 5 coordinate/billing columns — ride rows carry large JSONB
+    # fields (route_polyline, phase_polylines) that are irrelevant here and
+    # would cause OOM when multiplied across thousands of rows.
+    rides = await db_supabase.get_rows(
+        "rides",
+        query_filters,
+        order="created_at",
+        desc=True,
+        limit=_HEATMAP_MAX_ROWS,
+        columns=_HEATMAP_COLUMNS,
+    )
 
     pickup_points = []
     dropoff_points = []

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -446,7 +446,14 @@ async def get_demand_heatmap(current_user: dict = Depends(get_current_user)):
     query_filters["created_at"] = {"$gte": cutoff}
     query_filters["service_area_id"] = driver["service_area_id"]
 
-    rides = await db_supabase.get_rows("rides", query_filters, order="created_at", desc=True, limit=5000)
+    rides = await db_supabase.get_rows(
+        "rides",
+        query_filters,
+        order="created_at",
+        desc=True,
+        limit=2_000,
+        columns="pickup_lat,pickup_lng",
+    )
 
     points = []
     for r in rides:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -84,6 +84,11 @@ except ImportError:
     from services import corporate_allowance_service, corporate_wallet_service  # type: ignore
     from services.corporate_policy_service import evaluate_policy, evaluate_policy_for_ride  # type: ignore
 
+try:
+    from ..core.config import settings as _settings
+except ImportError:
+    from core.config import settings as _settings  # noqa: F401 — dual-import pattern
+
 db = db_supabase  # legacy alias
 
 
@@ -1026,8 +1031,10 @@ async def create_ride(request: Request, body: CreateRideRequest, current_user: d
                 ride_data.pop("ride_code", None)
                 inserted = await db_supabase.insert_ride(ride_data)
                 break
+            if "rides_one_active_per_rider" in msg:
+                raise HTTPException(status_code=409, detail="You already have an active ride")
             if "unique" in msg or "duplicate" in msg or "23505" in msg:
-                continue  # retry with a new code
+                continue  # retry with a new code for ride_code conflicts
             raise
     else:
         logger.error(f"create_ride: could not allocate unique ride_code after 3 tries: {last_exc}")
@@ -2456,6 +2463,8 @@ async def cancel_scheduled_ride(ride_id: str, current_user: dict = Depends(get_c
 @api_router.post("/{ride_id}/simulate-arrival")
 async def simulate_driver_arrival(ride_id: str, current_user: dict = Depends(get_current_user)):
     """Dev/test only: Simulate driver arriving at pickup, returns OTP."""
+    if _settings.ENV.lower() == "production":
+        raise HTTPException(status_code=403, detail="Not available in production")
     ride = await db_supabase.get_ride(ride_id)
     if not ride:
         raise HTTPException(status_code=404, detail="Ride not found")

--- a/backend/utils/redis_client.py
+++ b/backend/utils/redis_client.py
@@ -95,17 +95,18 @@ async def _get_redis():
 
 async def redis_get(key: str) -> Optional[str]:
     r = await _get_redis()
-    if r:
+    if r is not None:
         try:
             return await r.get(key)
         except Exception as e:
-            logger.warning(f"redis_get error: {e}")
+            logger.error(f"[REDIS] redis_get({key!r}) failed — Redis configured but unavailable: {e}")
+            raise
     return _local_get(key)
 
 
 async def redis_set(key: str, value: str, ttl: Optional[int] = None) -> None:
     r = await _get_redis()
-    if r:
+    if r is not None:
         try:
             if ttl:
                 await r.setex(key, ttl, value)
@@ -113,46 +114,50 @@ async def redis_set(key: str, value: str, ttl: Optional[int] = None) -> None:
                 await r.set(key, value)
             return
         except Exception as e:
-            logger.warning(f"redis_set error: {e}")
+            logger.error(f"[REDIS] redis_set({key!r}) failed — Redis configured but unavailable: {e}")
+            raise
     _local_set(key, value, ttl)
 
 
 async def redis_incr(key: str) -> int:
     r = await _get_redis()
-    if r:
+    if r is not None:
         try:
             return await r.incr(key)
         except Exception as e:
-            logger.warning(f"redis_incr error: {e}")
+            logger.error(f"[REDIS] redis_incr({key!r}) failed — Redis configured but unavailable: {e}")
+            raise
     return _local_incr(key)
 
 
 async def redis_expire(key: str, ttl: int) -> None:
     r = await _get_redis()
-    if r:
+    if r is not None:
         try:
             await r.expire(key, ttl)
             return
         except Exception as e:
-            logger.warning(f"redis_expire error: {e}")
+            logger.error(f"[REDIS] redis_expire({key!r}) failed — Redis configured but unavailable: {e}")
+            raise
     _local_expire(key, ttl)
 
 
 async def redis_delete(key: str) -> None:
     r = await _get_redis()
-    if r:
+    if r is not None:
         try:
             await r.delete(key)
             return
         except Exception as e:
-            logger.warning(f"redis_delete error: {e}")
+            logger.error(f"[REDIS] redis_delete({key!r}) failed — Redis configured but unavailable: {e}")
+            raise
     _local_delete(key)
 
 
 async def redis_delete_pattern(pattern: str) -> int:
     """Delete all keys matching a glob pattern. Returns count deleted."""
     r = await _get_redis()
-    if r:
+    if r is not None:
         try:
             keys = []
             async for key in r.scan_iter(pattern):
@@ -161,8 +166,9 @@ async def redis_delete_pattern(pattern: str) -> int:
                 await r.delete(*keys)
             return len(keys)
         except Exception as e:
-            logger.warning(f"redis_delete_pattern error: {e}")
-    # Fallback
+            logger.error(f"[REDIS] redis_delete_pattern({pattern!r}) failed — Redis configured but unavailable: {e}")
+            raise
+    # Only reached when REDIS_URL is unset (dev mode).
     keys = _local_keys_matching(pattern)
     for k in keys:
         _local_delete(k)

--- a/shared/components/SOSButton.tsx
+++ b/shared/components/SOSButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import {
   View, Text, StyleSheet, TouchableOpacity, Alert, Animated,
-  Linking, Platform, Vibration,
+  Linking, Vibration,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Location from 'expo-location';
@@ -16,27 +16,28 @@ interface SOSButtonProps {
  * SOS Emergency Button — long press to activate.
  * 1. Vibrates device
  * 2. Calls backend emergency endpoint (notifies admin + emergency contacts)
- * 3. Prompts to call 911
- * 4. Shares GPS location
+ * 3. Only shows success + 911 prompt AFTER backend confirms (fail-safe)
+ * 4. On network failure: shows retry dialog, never shows "Alert Sent" falsely
  */
-const SOS_HOLD_MS = 1200; // was 2000
+const SOS_HOLD_MS = 1200;
+const SOS_RETRY_DELAY_MS = 2000;
+const SOS_MAX_ATTEMPTS = 2;
 
 export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps) {
   const [triggered, setTriggered] = useState(false);
+  const [sending, setSending] = useState(false);
   const [pressing, setPressing] = useState(false);
   const pulseAnim = useRef(new Animated.Value(1)).current;
   const pressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const startPress = () => {
     setPressing(true);
-    // Start pulse animation
     Animated.loop(
       Animated.sequence([
         Animated.timing(pulseAnim, { toValue: 1.15, duration: 400, useNativeDriver: true }),
         Animated.timing(pulseAnim, { toValue: 1, duration: 400, useNativeDriver: true }),
       ])
     ).start();
-
     pressTimer.current = setTimeout(() => {
       triggerSOS();
     }, SOS_HOLD_MS);
@@ -52,28 +53,7 @@ export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps)
     }
   };
 
-  const triggerSOS = async () => {
-    setPressing(false);
-    setTriggered(true);
-    Vibration.vibrate([0, 200, 100, 200, 100, 200]); // SOS vibration pattern
-
-    // Get current location
-    let lat: number | undefined;
-    let lng: number | undefined;
-    try {
-      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
-      lat = loc.coords.latitude;
-      lng = loc.coords.longitude;
-    } catch {}
-
-    // Call backend
-    if (rideId) {
-      try {
-        await onTrigger(rideId, lat, lng);
-      } catch {}
-    }
-
-    // Show options
+  const showSuccessAlert = () => {
     Alert.alert(
       '🚨 Emergency Alert Sent',
       'Your location has been shared with Spinr support and your emergency contacts.\n\nDo you want to call 911?',
@@ -84,7 +64,7 @@ export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps)
           onPress: () => Linking.openURL('tel:911'),
         },
         {
-          text: 'I\'m OK',
+          text: "I'm OK",
           style: 'cancel',
           onPress: () => setTriggered(false),
         },
@@ -92,7 +72,66 @@ export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps)
     );
   };
 
+  const showFailureAlert = (retry: () => void) => {
+    Alert.alert(
+      'Alert Not Sent',
+      'Could not reach Spinr. Your device will keep trying. You can call 911 directly.',
+      [
+        {
+          text: 'Call 911',
+          style: 'destructive',
+          onPress: () => Linking.openURL('tel:911'),
+        },
+        {
+          text: 'Retry',
+          onPress: retry,
+        },
+        { text: 'Cancel', style: 'cancel' },
+      ]
+    );
+  };
+
+  const triggerSOS = async () => {
+    setPressing(false);
+    setSending(true);
+    Vibration.vibrate([0, 200, 100, 200, 100, 200]);
+
+    let lat: number | undefined;
+    let lng: number | undefined;
+    try {
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      lat = loc.coords.latitude;
+      lng = loc.coords.longitude;
+    } catch {}
+
+    // Attempt backend call with one retry before declaring failure.
+    let backendOk = !rideId; // no rideId = demo / offline mode, treat as ok
+    if (rideId) {
+      for (let attempt = 0; attempt < SOS_MAX_ATTEMPTS && !backendOk; attempt++) {
+        if (attempt > 0) {
+          await new Promise<void>((r) => setTimeout(r, SOS_RETRY_DELAY_MS));
+        }
+        try {
+          await onTrigger(rideId, lat, lng);
+          backendOk = true;
+        } catch {}
+      }
+    }
+
+    setSending(false);
+
+    if (backendOk) {
+      setTriggered(true);
+      showSuccessAlert();
+    } else {
+      // Do NOT set triggered — the alert was NOT sent.
+      showFailureAlert(triggerSOS);
+    }
+  };
+
   const isLarge = size === 'large';
+  const iconName = triggered ? 'checkmark-circle' : sending ? 'hourglass' : 'shield';
+  const labelText = pressing ? 'Hold...' : sending ? 'Sending…' : triggered ? 'Alert Sent' : 'SOS';
 
   return (
     <Animated.View style={[{ transform: [{ scale: pressing ? pulseAnim : 1 }] }]}>
@@ -101,26 +140,22 @@ export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps)
           styles.btn,
           isLarge ? styles.btnLarge : styles.btnSmall,
           triggered && styles.btnTriggered,
+          sending && styles.btnSending,
           pressing && styles.btnPressing,
         ]}
-        onPressIn={startPress}
-        onPressOut={endPress}
+        onPressIn={sending || triggered ? undefined : startPress}
+        onPressOut={sending || triggered ? undefined : endPress}
         activeOpacity={0.9}
-        accessibilityLabel={triggered ? 'Emergency alert sent' : 'Emergency SOS'}
+        disabled={sending}
+        accessibilityLabel={
+          triggered ? 'Emergency alert sent' : sending ? 'Sending emergency alert' : 'Emergency SOS'
+        }
         accessibilityRole="button"
-        accessibilityHint="Hold for 1.5 seconds to send an emergency alert"
-        accessibilityState={{ selected: triggered }}
+        accessibilityHint="Hold for 1.2 seconds to send an emergency alert"
+        accessibilityState={{ selected: triggered, busy: sending }}
       >
-        <Ionicons
-          name={triggered ? 'checkmark-circle' : 'shield'}
-          size={isLarge ? 28 : 20}
-          color="#FFF"
-        />
-        {isLarge && (
-          <Text style={styles.btnText}>
-            {pressing ? 'Hold...' : triggered ? 'Alert Sent' : 'SOS'}
-          </Text>
-        )}
+        <Ionicons name={iconName} size={isLarge ? 28 : 20} color="#FFF" />
+        {isLarge && <Text style={styles.btnText}>{labelText}</Text>}
       </TouchableOpacity>
       {pressing && (
         <View style={[styles.holdHint, isLarge && { bottom: -24 }]}>
@@ -151,6 +186,9 @@ const styles = StyleSheet.create({
   },
   btnPressing: {
     backgroundColor: '#B91C1C',
+  },
+  btnSending: {
+    backgroundColor: '#D97706',
   },
   btnTriggered: {
     backgroundColor: '#10B981',


### PR DESCRIPTION
- migration 53: partial unique index rides_one_active_per_rider closes
  the race window between the SELECT check and INSERT in POST /rides;
  backend catches the 23505 violation and returns 409 immediately
  instead of retrying as a ride_code conflict

- rides.py: block simulate-arrival endpoint in production (ENV check);
  the endpoint mutated ride state and was accessible to any authenticated
  rider in prod

- SOSButton: never show "Alert Sent" until backend returns 200; amber
  "Sending…" state while in-flight; one automatic retry at 2 s on
  network failure; failure path shows "Alert Not Sent" + Call 911 +
  Retry options instead of silently green-checking

https://claude.ai/code/session_017BEuKhwtnxtPNzKtjeHwiW

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
