### PR TITLE
Claude/fix audit prompt length a jp qn

### DIFF
--- a/backend/routes/admin/maintenance.py
+++ b/backend/routes/admin/maintenance.py
@@ -16,6 +16,35 @@ db = db_supabase  # legacy alias
 
 logger = logging.getLogger(__name__)
 
+
+async def log_audit(
+    action: str,
+    entity_type: str,
+    entity_id: str,
+    actor: str,
+    details: str = "",
+) -> None:
+    """Write a single row to the audit_logs table.
+
+    Non-raising: callers wrap this in try/except so a DB hiccup never
+    blocks the parent operation. Failures are logged at WARNING level.
+    """
+    try:
+        await db_supabase.insert_one(
+            "audit_logs",
+            {
+                "action": action,
+                "entity_type": entity_type,
+                "resource_id": entity_id,
+                "actor_id": actor,
+                "details": details,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except Exception as exc:
+        logger.warning(f"[AUDIT] log_audit({action}, {entity_type}, {entity_id}) failed: {exc}")
+
+
 router = APIRouter()
 
 # ── GPS Location History Cleanup ──

--- a/backend/routes/wallet.py
+++ b/backend/routes/wallet.py
@@ -127,6 +127,9 @@ async def top_up_wallet(
     """Add funds to wallet. In production this would charge via Stripe first."""
     wallet = await get_or_create_wallet(current_user["id"])
 
+    if not wallet.get("is_active", True):
+        raise HTTPException(status_code=403, detail="Your wallet is suspended")
+
     new_balance = await wallet_increment_balance(wallet["id"], _d(req.amount))
 
     txn = await _record_transaction(
@@ -148,6 +151,9 @@ async def top_up_wallet(
 async def wallet_pay(req: WalletPayRequest, current_user: dict = Depends(get_current_user)):
     """Pay for a ride using wallet balance."""
     wallet = await get_or_create_wallet(current_user["id"])
+
+    if not wallet.get("is_active", True):
+        raise HTTPException(status_code=403, detail="Your wallet is suspended")
 
     # R-P1-19: Validate client-supplied amount against the server-stored ride fare
     # to prevent a malicious caller from paying less than the actual fare.

--- a/backend/tests/services/test_dispatch_service.py
+++ b/backend/tests/services/test_dispatch_service.py
@@ -182,32 +182,28 @@ class TestSelectDriverByAlgorithm:
 
 
 def _make_db():
-    """Minimal mock db supporting the find / update_one shapes DispatchService uses."""
+    """Minimal mock db supporting the flat Supabase-style interface DispatchService uses."""
     db = MagicMock()
-    db.service_areas = MagicMock()
-    db.service_areas.find_one = AsyncMock(return_value=None)
-    db.drivers = MagicMock()
-    find_result = MagicMock()
-    find_result.to_list = AsyncMock(return_value=[])
-    db.drivers.find = MagicMock(return_value=find_result)
-    db.drivers.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
-    db.rides = MagicMock()
-    db.rides.find_one = AsyncMock(return_value=None)
-    db.rides.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+    db.find_one = AsyncMock(return_value=None)
+    db.get_rows = AsyncMock(return_value=[])
+    db.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+    db.insert_one = AsyncMock(return_value=None)
     return db
 
 
-@pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
+
+
 class TestDispatchServiceClaim:
     async def test_claim_driver_returns_true_when_row_was_available(self):
         db = _make_db()
-        db.drivers.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
+        db.update_one = AsyncMock(return_value=MagicMock(modified_count=1))
         svc = DispatchService(db)
         assert await svc.claim_driver("d1") is True
 
     async def test_claim_driver_returns_false_when_row_already_taken(self):
         db = _make_db()
-        db.drivers.update_one = AsyncMock(return_value=MagicMock(modified_count=0))
+        db.update_one = AsyncMock(return_value=MagicMock(modified_count=0))
         svc = DispatchService(db)
         assert await svc.claim_driver("d1") is False
 
@@ -215,7 +211,7 @@ class TestDispatchServiceClaim:
         """First driver is taken, second succeeds — walk the list."""
         db = _make_db()
         results = [MagicMock(modified_count=0), MagicMock(modified_count=1)]
-        db.drivers.update_one = AsyncMock(side_effect=results)
+        db.update_one = AsyncMock(side_effect=results)
         svc = DispatchService(db)
 
         ranked = [({"id": "d1"}, 1.0), ({"id": "d2"}, 2.0)]
@@ -224,7 +220,7 @@ class TestDispatchServiceClaim:
 
     async def test_claim_any_driver_returns_none_when_all_taken(self):
         db = _make_db()
-        db.drivers.update_one = AsyncMock(return_value=MagicMock(modified_count=0))
+        db.update_one = AsyncMock(return_value=MagicMock(modified_count=0))
         svc = DispatchService(db)
 
         ranked = [({"id": "d1"}, 1.0), ({"id": "d2"}, 2.0)]
@@ -232,7 +228,6 @@ class TestDispatchServiceClaim:
         assert out is None
 
 
-@pytest.mark.asyncio
 class TestDispatchServiceAssign:
     async def test_assign_driver_flips_ride_to_driver_assigned(self):
         db = _make_db()
@@ -242,49 +237,50 @@ class TestDispatchServiceAssign:
         now = dt.datetime(2026, 1, 1, 12, 0, 0)
         await svc.assign_driver_to_ride("r1", "d1", now)
 
-        db.rides.update_one.assert_awaited_once()
-        call_args = db.rides.update_one.await_args
-        # Filter identifies the ride by id only (business rule)
-        assert call_args.args[0] == {"id": "r1"}
+        db.update_one.assert_awaited_once()
+        call_args = db.update_one.await_args
+        # First positional arg is table name, second is filter, third is update
+        assert call_args.args[0] == "rides"
+        assert call_args.args[1] == {"id": "r1"}
         # Update sets driver_id, status, timestamps
-        update = call_args.args[1]["$set"]
+        update = call_args.args[2]["$set"]
         assert update["driver_id"] == "d1"
         assert update["status"] == "driver_assigned"
         assert update["driver_notified_at"] == now
         assert update["updated_at"] == now
 
 
-@pytest.mark.asyncio
 class TestDispatchServiceLastAssigned:
     async def test_returns_last_assigned_driver_id(self):
         db = _make_db()
-        db.rides.find_one = AsyncMock(return_value={"driver_id": "d_last"})
+        db.get_rows = AsyncMock(return_value=[{"driver_id": "d_last"}])
         svc = DispatchService(db)
         assert await svc.last_assigned_driver_id() == "d_last"
 
     async def test_returns_none_when_no_prior_ride(self):
         db = _make_db()
-        db.rides.find_one = AsyncMock(return_value=None)
+        db.get_rows = AsyncMock(return_value=[])
         svc = DispatchService(db)
         assert await svc.last_assigned_driver_id() is None
 
 
-@pytest.mark.asyncio
 class TestDispatchServiceFindCandidates:
     async def test_queries_online_available_matching_vehicle_type(self):
         db = _make_db()
         rows = [{"id": "d1"}, {"id": "d2"}]
-        find_result = MagicMock()
-        find_result.to_list = AsyncMock(return_value=rows)
-        db.drivers.find = MagicMock(return_value=find_result)
+        db.get_rows = AsyncMock(return_value=rows)
         svc = DispatchService(db)
 
         out = await svc.find_candidate_drivers({"vehicle_type_id": "economy"})
         assert out == rows
-        db.drivers.find.assert_called_once_with(
+        db.get_rows.assert_awaited_once_with(
+            "drivers",
             {
                 "is_online": True,
                 "is_available": True,
+                "is_verified": True,
+                "status": "active",
                 "vehicle_type_id": "economy",
-            }
+            },
+            limit=500,
         )

--- a/backend/tests/services/test_fare_service.py
+++ b/backend/tests/services/test_fare_service.py
@@ -135,23 +135,28 @@ class TestMergeFareConfigs:
 
 
 def _make_db(vehicle_types=None, areas=None, fare_configs=None):
-    """Build a mock db that supports the chain `db.X.find(...).to_list(N)`."""
+    """Build a mock db that supports the flat Supabase-style interface FareService uses."""
     db = MagicMock()
 
-    def make_table(rows):
-        find_result = MagicMock()
-        find_result.to_list = AsyncMock(return_value=rows or [])
-        table = MagicMock()
-        table.find = MagicMock(return_value=find_result)
-        return table
+    # FareService calls db.get_rows(table_name, filters, limit=...) sequentially:
+    # 1st call: vehicle_types, 2nd call: service_areas, 3rd call: fare_configs
+    side_effects = []
+    side_effects.append(vehicle_types if vehicle_types is not None else [])
+    if areas is not None:
+        side_effects.append(areas)
+    if fare_configs is not None:
+        side_effects.append(fare_configs)
 
-    db.vehicle_types = make_table(vehicle_types)
-    db.service_areas = make_table(areas)
-    db.fare_configs = make_table(fare_configs)
+    db.get_rows = AsyncMock(side_effect=side_effects)
+    db.find_one = AsyncMock(return_value=None)
+    db.insert_one = AsyncMock(return_value=None)
+    db.update_one = AsyncMock(return_value=None)
     return db
 
 
-@pytest.mark.asyncio
+pytestmark = pytest.mark.anyio
+
+
 class TestFareService:
     async def test_returns_empty_when_no_vehicle_types(self):
         svc = FareService(_make_db(vehicle_types=[]))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -12,6 +12,25 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# All async tests in this module use anyio (not asyncio).
+pytestmark = pytest.mark.anyio
+
+
+# ---------------------------------------------------------------------------
+# Module-level mock_settings fixture — shared by TestJWTTokenHandling,
+# TestSessionManagement, and TestTokenRefresh.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_settings():
+    """Mock settings with test values matching the JWT_SECRET env var."""
+    with patch("backend.dependencies.settings") as _mock_settings:
+        _mock_settings.JWT_SECRET = "test-secret-key-for-ci-only-32chars!!"
+        _mock_settings.ALGORITHM = "HS256"
+        _mock_settings.ACCESS_TOKEN_EXPIRE_MINUTES = 30
+        yield _mock_settings
+
 
 class TestOTPCreation:
     """Tests for OTP generation and verification."""
@@ -49,15 +68,6 @@ class TestOTPCreation:
 class TestJWTTokenHandling:
     """Tests for JWT token creation and verification."""
 
-    @pytest.fixture
-    def mock_settings(self):
-        """Mock settings with test values."""
-        with patch("backend.dependencies.settings") as mock_settings:
-            mock_settings.SECRET_KEY = "test-secret-key-for-testing-only"
-            mock_settings.ALGORITHM = "HS256"
-            mock_settings.ACCESS_TOKEN_EXPIRE_MINUTES = 30
-            yield mock_settings
-
     def test_create_jwt_token(self, mock_settings):
         """Test JWT token creation."""
         from backend.dependencies import create_jwt_token
@@ -70,13 +80,13 @@ class TestJWTTokenHandling:
 
     def test_create_jwt_token_with_session(self, mock_settings):
         """Test JWT token creation with session ID."""
-        from backend.dependencies import create_jwt_token
+        from backend.dependencies import create_jwt_token, verify_jwt_token
 
         token = create_jwt_token(user_id="user_123", phone="+1234567890", session_id="session_abc")
 
         assert token is not None
-        # Verify token can be decoded
-        decoded = create_jwt_token.verify_jwt_token(token, mock_settings)
+        # Verify token can be decoded and contains session_id
+        decoded = verify_jwt_token(token)
         assert decoded["session_id"] == "session_abc"
 
     def test_verify_jwt_token_valid(self, mock_settings):
@@ -90,7 +100,7 @@ class TestJWTTokenHandling:
         decoded = verify_jwt_token(token)
 
         assert decoded is not None
-        assert decoded["sub"] == "user_123"
+        assert decoded["user_id"] == "user_123"
         assert decoded["phone"] == "+1234567890"
 
     def test_verify_jwt_token_invalid(self, mock_settings):
@@ -101,36 +111,50 @@ class TestJWTTokenHandling:
             verify_jwt_token("invalid.token.here")
 
     def test_verify_jwt_token_expired(self, mock_settings):
-        """Test verifying an expired JWT token."""
+        """Test verifying an expired JWT token raises HTTPException 401."""
         import jwt
+        from fastapi import HTTPException
 
         from backend.dependencies import verify_jwt_token
 
-        # Create expired token
+        # Create expired token using the same secret that verify_jwt_token uses
         payload = {
             "sub": "user_123",
             "phone": "+1234567890",
             "exp": datetime.utcnow() - timedelta(minutes=5),  # Expired 5 minutes ago
         }
 
-        expired_token = jwt.encode(payload, mock_settings.SECRET_KEY, algorithm=mock_settings.ALGORITHM)
+        expired_token = jwt.encode(
+            payload,
+            mock_settings.JWT_SECRET,
+            algorithm=mock_settings.ALGORITHM,
+        )
 
-        with pytest.raises(jwt.ExpiredSignatureError):
+        with pytest.raises(HTTPException) as exc_info:
             verify_jwt_token(expired_token)
 
+        assert exc_info.value.status_code == 401
+
     def test_verify_jwt_token_wrong_algorithm(self, mock_settings):
-        """Test verifying token with wrong algorithm."""
+        """Test verifying token with wrong secret raises HTTPException 401."""
         import jwt
+        from fastapi import HTTPException
 
         from backend.dependencies import verify_jwt_token
 
-        # Create token with different algorithm
-        payload = {"sub": "user_123", "phone": "+1234567890", "exp": datetime.utcnow() + timedelta(minutes=30)}
+        # Create token with a different (wrong) secret key
+        payload = {
+            "sub": "user_123",
+            "phone": "+1234567890",
+            "exp": datetime.utcnow() + timedelta(minutes=30),
+        }
 
         wrong_token = jwt.encode(payload, "wrong-secret-key", algorithm=mock_settings.ALGORITHM)
 
-        with pytest.raises(jwt.InvalidTokenError):
+        with pytest.raises(HTTPException) as exc_info:
             verify_jwt_token(wrong_token)
+
+        assert exc_info.value.status_code == 401
 
 
 class TestGetCurrentUser:
@@ -146,27 +170,36 @@ class TestGetCurrentUser:
             credentials="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyXzEyMyIsInBob25lIjoiKzEyMzQ1Njc4OTAifQ.test_sig",
         )
 
-    @pytest.mark.asyncio
     async def test_get_current_user_valid_token(self, mock_credentials):
         """Test get_current_user with valid token."""
         from backend.dependencies import get_current_user
 
-        with patch("backend.dependencies.verify_jwt_token") as mock_verify:
-            mock_verify.return_value = {"sub": "user_123", "phone": "+1234567890"}
+        mock_user = {"id": "user_123", "phone": "+1234567890", "role": "rider"}
+
+        with (
+            patch("backend.dependencies.firebase_auth.verify_id_token", side_effect=ValueError("not firebase")),
+            patch("backend.dependencies.verify_jwt_token") as mock_verify,
+            patch("backend.dependencies.db_supabase.get_user_by_id", AsyncMock(return_value=mock_user)),
+            patch("backend.dependencies.db_supabase.get_driver_by_user_id_cached", AsyncMock(return_value=None)),
+            patch("backend.dependencies.redis_get", AsyncMock(return_value=None)),
+        ):
+            mock_verify.return_value = {"user_id": "user_123", "phone": "+1234567890"}
 
             user = await get_current_user(mock_credentials)
 
-            assert user["user_id"] == "user_123"
+            assert user["id"] == "user_123"
             assert user["phone"] == "+1234567890"
 
-    @pytest.mark.asyncio
     async def test_get_current_user_invalid_token(self, mock_credentials):
         """Test get_current_user with invalid token."""
         from fastapi import HTTPException
 
         from backend.dependencies import get_current_user
 
-        with patch("backend.dependencies.verify_jwt_token") as mock_verify:
+        with (
+            patch("backend.dependencies.firebase_auth.verify_id_token", side_effect=ValueError("not firebase")),
+            patch("backend.dependencies.verify_jwt_token") as mock_verify,
+        ):
             mock_verify.side_effect = Exception("Invalid token")
 
             with pytest.raises(HTTPException) as exc_info:
@@ -174,7 +207,6 @@ class TestGetCurrentUser:
 
             assert exc_info.value.status_code == 401
 
-    @pytest.mark.asyncio
     async def test_get_current_user_missing_credentials(self):
         """Test get_current_user with missing credentials."""
         from fastapi import HTTPException
@@ -190,82 +222,70 @@ class TestGetCurrentUser:
 class TestAdminUserVerification:
     """Tests for admin user verification."""
 
-    @pytest.mark.asyncio
     async def test_get_admin_user_is_admin(self):
         """Test get_admin_user with admin user."""
         from backend.dependencies import get_admin_user
 
-        admin_user = {"user_id": "admin_123", "phone": "+1234567890", "is_admin": True}
+        admin_user = {"user_id": "admin_123", "phone": "+1234567890", "role": "admin"}
 
         result = await get_admin_user(admin_user)
 
         assert result == admin_user
 
-    @pytest.mark.asyncio
     async def test_get_admin_user_not_admin(self):
         """Test get_admin_user with non-admin user."""
         from fastapi import HTTPException
 
         from backend.dependencies import get_admin_user
 
-        regular_user = {"user_id": "user_123", "phone": "+1234567890", "is_admin": False}
+        regular_user = {"user_id": "user_123", "phone": "+1234567890", "role": "rider"}
 
         with pytest.raises(HTTPException) as exc_info:
             await get_admin_user(regular_user)
 
         assert exc_info.value.status_code == 403
-        assert exc_info.value.detail == "User is not an admin"
+        assert exc_info.value.detail == "Admin access required"
 
 
 class TestFirebaseIntegration:
     """Tests for Firebase authentication integration."""
 
-    @pytest.mark.asyncio
     async def test_firebase_init(self, mock_firebase_admin):
         """Test Firebase initialization."""
         from backend.core.security import init_firebase
 
-        with patch("backend.core.security.firebase") as mock_firebase:
+        # security.py uses firebase_admin directly (not a 'firebase' alias)
+        with patch("backend.core.security.firebase_admin") as mock_fb:
             init_firebase()
-            # Firebase should be initialized
-            assert mock_firebase.initialize_app.called or True  # May be skipped if already init
+            # Firebase should be initialized (or already initialized — both are fine)
+            assert mock_fb.initialize_app.called or True
 
-    @pytest.mark.asyncio
     async def test_create_firebase_user(self, mock_firebase_admin):
         """Test creating user via Firebase."""
         from backend.db_supabase import create_user
 
-        mock_firebase_admin.auth.create_user.return_value = MagicMock(uid="firebase_uid")
+        expected_user = {"id": "user_123", "phone": "+1234567890"}
 
-        with patch("backend.db_supabase.supabase") as mock_supabase:
-            mock_supabase.table.return_value.insert.return_value.execute = AsyncMock(
-                return_value=MagicMock(data=[{"id": "user_123"}])
-            )
+        # Patch at the function level to bypass run_sync/thread-pool complexity
+        with patch("backend.db_supabase.run_sync", new_callable=AsyncMock, return_value=expected_user):
+            result = await create_user({"id": "user_123", "phone": "+1234567890"})
 
-            result = await create_user({"phone": "+1234567890", "email": "test@example.com"})
+        assert result is not None
+        assert result["id"] == "user_123"
 
-            assert result is not None
-
-    @pytest.mark.asyncio
     async def test_get_firebase_user(self, mock_firebase_admin):
         """Test getting user from Firebase."""
         from backend.db_supabase import get_user_by_id
 
-        mock_firebase_admin.auth.get_user.return_value = MagicMock(uid="user_123", phone_number="+1234567890")
+        expected_user = {"id": "user_123", "phone": "+1234567890"}
 
-        with patch("backend.db_supabase.supabase") as mock_supabase:
-            mock_response = MagicMock()
-            mock_response.data = [{"id": "user_123", "phone": "+1234567890"}]
-            mock_supabase.table.return_value.select.return_value.eq.return_value.execute = AsyncMock(
-                return_value=mock_response
-            )
-
+        # Patch at the function level to bypass run_sync/thread-pool complexity
+        with patch("backend.db_supabase.run_sync", new_callable=AsyncMock, return_value=expected_user):
             result = await get_user_by_id("user_123")
 
-            assert result is not None
-            assert result["id"] == "user_123"
+        assert result is not None
+        assert result["id"] == "user_123"
 
-    @pytest.mark.asyncio
     async def test_get_user_by_phone_firebase(self, mock_firebase_admin):
         """Test getting user by phone number."""
         from backend.db_supabase import get_user_by_phone
@@ -310,7 +330,8 @@ class TestAuthEndpoints:
             return_value=MagicMock(data=[{"id": "otp_123"}])
         )
 
-        response = test_client.post("/api/auth/send-otp", json={"phone": "+1234567890"})
+        # Use a valid E.164 phone with at least 12 chars (e.g. +12345678901 = 12 chars)
+        response = test_client.post("/api/auth/send-otp", json={"phone": "+12345678901"})
 
         assert response.status_code == 200
 
@@ -336,7 +357,8 @@ class TestAuthEndpoints:
             return_value=mock_response
         )
 
-        response = test_client.post("/api/auth/verify-otp", json={"phone": "+1234567890", "code": "1234"})
+        # Use a valid E.164 phone with at least 12 chars
+        response = test_client.post("/api/auth/verify-otp", json={"phone": "+12345678901", "code": "1234"})
 
         # OTP lookup returns None via mock chain → invalid code → 400
         assert response.status_code == 400
@@ -345,7 +367,7 @@ class TestAuthEndpoints:
         """Test verifying OTP with missing fields."""
         response = test_client.post(
             "/api/auth/verify-otp",
-            json={"phone": "+1234567890"},  # Missing code
+            json={"phone": "+12345678901"},  # Missing code
         )
 
         assert response.status_code == 422  # Validation error
@@ -364,7 +386,6 @@ class TestSessionManagement:
         decoded = verify_jwt_token(token)
         assert decoded.get("session_id") == session_id
 
-    @pytest.mark.asyncio
     async def test_session_invalidation(self):
         """Test session invalidation logic."""
         # Sessions can be invalidated by checking against a blacklist
@@ -382,16 +403,15 @@ class TestSessionManagement:
 class TestPasswordlessAuth:
     """Tests for passwordless authentication flow."""
 
-    @pytest.mark.asyncio
     async def test_full_auth_flow(self, mock_supabase_client, mock_sms_service):
         """Test complete passwordless auth flow."""
         from backend.dependencies import create_jwt_token, generate_otp
 
         phone = "+1234567890"
 
-        # Step 1: Generate OTP
+        # Step 1: Generate OTP — production generates 4-digit OTPs
         otp = generate_otp()
-        assert len(otp) == 6
+        assert len(otp) == 4
 
         # Step 2: Send OTP (mocked)
         await mock_sms_service.send_otp(phone, otp)
@@ -422,11 +442,11 @@ class TestTokenRefresh:
         original_token = create_jwt_token(user_id="user_123", phone="+1234567890", session_id="session_abc")
 
         decoded = verify_jwt_token(original_token)
-        assert decoded["sub"] == "user_123"
+        assert decoded["user_id"] == "user_123"
 
         # Create refreshed token with same session
         refreshed_token = create_jwt_token(
-            user_id=decoded["sub"], phone=decoded["phone"], session_id=decoded.get("session_id")
+            user_id=decoded["user_id"], phone=decoded["phone"], session_id=decoded.get("session_id")
         )
 
         refreshed_decoded = verify_jwt_token(refreshed_token)
@@ -436,7 +456,6 @@ class TestTokenRefresh:
 # ── 9-9: Token version rotation test ─────────────────────────────────────────
 
 
-@pytest.mark.asyncio
 async def test_old_token_rejected_after_version_rotation():
     """JWT minted with token_version=1 must be rejected 401 after DB rotates to 2."""
     from fastapi import HTTPException

--- a/backend/tests/test_e16_surge_boundary.py
+++ b/backend/tests/test_e16_surge_boundary.py
@@ -27,7 +27,7 @@ Run:
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -64,10 +64,17 @@ def _body(token: str | None = None):
 
 
 def _request():
-    req = MagicMock()
-    req.headers = {}
-    req.client = MagicMock(host="127.0.0.1")
-    return req
+    from starlette.requests import Request as StarletteRequest
+
+    return StarletteRequest(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/rides",
+            "query_string": b"",
+            "headers": [],
+        }
+    )
 
 
 def _sign_token(

--- a/backend/tests/test_e8_duplicate_ride.py
+++ b/backend/tests/test_e8_duplicate_ride.py
@@ -56,9 +56,20 @@ def _body():
 
 
 def _mock_request(idempotency_key: str | None = None):
-    req = MagicMock()
-    req.headers = {"Idempotency-Key": idempotency_key} if idempotency_key else {}
-    return req
+    from starlette.requests import Request as StarletteRequest
+
+    headers = []
+    if idempotency_key:
+        headers = [(b"idempotency-key", idempotency_key.encode())]
+    return StarletteRequest(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/rides",
+            "query_string": b"",
+            "headers": headers,
+        }
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_fare_split.py
+++ b/backend/tests/test_fare_split.py
@@ -17,7 +17,12 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-SAMPLE_USER = {"id": "user_123", "phone": "+1234567890", "role": "rider", "is_driver": False}
+# Phone numbers in +1XXXXXXXXXX format required by the route validator
+PHONE_PARTICIPANT_1 = "+19876543210"
+PHONE_PARTICIPANT_2 = "+11112223333"
+PHONE_PARTICIPANT_3 = "+12223334444"
+
+SAMPLE_USER = {"id": "user_123", "phone": "+12345678901", "role": "rider", "is_driver": False}
 
 SAMPLE_RIDE = {
     "id": "ride_123",
@@ -42,7 +47,7 @@ SAMPLE_PARTICIPANT = {
     "id": "part_1",
     "fare_split_id": "split_1",
     "user_id": "user_456",
-    "phone": "+9876543210",
+    "phone": PHONE_PARTICIPANT_1,
     "share_amount": 15.0,
     "status": "accepted",
     "created_at": "2026-01-01T00:00:00",
@@ -50,14 +55,65 @@ SAMPLE_PARTICIPANT = {
 
 
 def make_mock_db():
+    """Build a mock that mirrors the db_supabase flat-function interface.
+
+    Routes call ``await db.find_one("rides", {...})``, not
+    ``await db.rides.find_one({...})``.  We expose per-table sub-mocks as
+    attributes so individual tests can override them with::
+
+        mock_db.rides.find_one = AsyncMock(return_value=SAMPLE_RIDE)
+
+    The top-level ``find_one`` / ``get_rows`` / ``insert_one`` / ``update_one``
+    AsyncMocks dispatch to the per-table attribute by table name.
+    """
     mock = MagicMock()
-    mock.get_rows = AsyncMock(return_value=[])
-    for col in ("rides", "fare_splits", "fare_split_participants", "users", "wallets", "wallet_transactions"):
+
+    # Per-table sub-mocks (attributes used for per-test overrides)
+    _tables = (
+        "rides",
+        "fare_splits",
+        "fare_split_participants",
+        "users",
+        "wallets",
+        "wallet_transactions",
+    )
+    for tbl in _tables:
         col_mock = MagicMock()
         col_mock.find_one = AsyncMock(return_value=None)
         col_mock.insert_one = AsyncMock(return_value=None)
         col_mock.update_one = AsyncMock(return_value=None)
-        setattr(mock, col, col_mock)
+        setattr(mock, tbl, col_mock)
+
+    # Default get_rows at top level (table-agnostic)
+    mock.get_rows = AsyncMock(return_value=[])
+
+    # Dispatcher: routes call db.find_one("rides", ...) — delegate to per-table mock
+    async def _find_one(table, filters=None, **kwargs):
+        tbl_attr = getattr(mock, table, None)
+        if tbl_attr is not None:
+            return await tbl_attr.find_one(filters, **kwargs)
+        return None
+
+    async def _insert_one(table, doc, **kwargs):
+        tbl_attr = getattr(mock, table, None)
+        if tbl_attr is not None:
+            return await tbl_attr.insert_one(doc, **kwargs)
+        return None
+
+    async def _update_one(table, filters, update, **kwargs):
+        tbl_attr = getattr(mock, table, None)
+        if tbl_attr is not None:
+            return await tbl_attr.update_one(filters, update, **kwargs)
+        return None
+
+    mock.find_one = _find_one
+    mock.insert_one = _insert_one
+    mock.update_one = _update_one
+
+    # RPC stubs used by pay_split_share
+    mock.fare_split_pay_share = AsyncMock(return_value=35.0)
+    mock.wallet_increment_balance = AsyncMock(return_value=None)
+
     return mock
 
 
@@ -78,7 +134,7 @@ class TestCreateFareSplit:
     """POST /api/v1/fare-split"""
 
     def test_create_split_success(self, client):
-        participant_user = {"id": "user_456", "phone": "+9876543210"}
+        participant_user = {"id": "user_456", "phone": PHONE_PARTICIPANT_1}
         mock_db = make_mock_db()
         mock_db.rides.find_one = AsyncMock(return_value=SAMPLE_RIDE)
         mock_db.fare_splits.find_one = AsyncMock(return_value=None)
@@ -87,7 +143,7 @@ class TestCreateFareSplit:
         with patch("routes.fare_split.db", mock_db):
             resp = client.post(
                 "/api/v1/fare-split",
-                json={"ride_id": "ride_123", "participant_phones": ["+9876543210"]},
+                json={"ride_id": "ride_123", "participant_phones": [PHONE_PARTICIPANT_1]},
             )
 
         assert resp.status_code == 200
@@ -105,7 +161,7 @@ class TestCreateFareSplit:
         with patch("routes.fare_split.db", mock_db):
             resp = client.post(
                 "/api/v1/fare-split",
-                json={"ride_id": "bad_ride", "participant_phones": ["+9876543210"]},
+                json={"ride_id": "bad_ride", "participant_phones": [PHONE_PARTICIPANT_1]},
             )
 
         assert resp.status_code == 404
@@ -118,7 +174,7 @@ class TestCreateFareSplit:
         with patch("routes.fare_split.db", mock_db):
             resp = client.post(
                 "/api/v1/fare-split",
-                json={"ride_id": "ride_123", "participant_phones": ["+9876543210"]},
+                json={"ride_id": "ride_123", "participant_phones": [PHONE_PARTICIPANT_1]},
             )
 
         assert resp.status_code == 403
@@ -132,7 +188,7 @@ class TestCreateFareSplit:
         with patch("routes.fare_split.db", mock_db):
             resp = client.post(
                 "/api/v1/fare-split",
-                json={"ride_id": "ride_123", "participant_phones": ["+9876543210"]},
+                json={"ride_id": "ride_123", "participant_phones": [PHONE_PARTICIPANT_1]},
             )
 
         assert resp.status_code == 400
@@ -148,7 +204,7 @@ class TestCreateFareSplit:
         with patch("routes.fare_split.db", mock_db):
             resp = client.post(
                 "/api/v1/fare-split",
-                json={"ride_id": "ride_123", "participant_phones": ["+111", "+222"]},
+                json={"ride_id": "ride_123", "participant_phones": [PHONE_PARTICIPANT_2, PHONE_PARTICIPANT_3]},
             )
 
         assert resp.status_code == 200
@@ -212,7 +268,7 @@ class TestGetFareSplitForRide:
         assert resp.json()["has_split"] is False
 
     def test_existing_split_returned(self, client):
-        participants = [{"id": "p1", "phone": "+9876543210", "share_amount": 15.0, "status": "pending"}]
+        participants = [{"id": "p1", "phone": PHONE_PARTICIPANT_1, "share_amount": 15.0, "status": "pending"}]
         mock_db = make_mock_db()
         mock_db.fare_splits.find_one = AsyncMock(return_value=SAMPLE_SPLIT)
         mock_db.get_rows = AsyncMock(return_value=participants)
@@ -333,6 +389,7 @@ class TestPaySplitShare:
         mock_db = make_mock_db()
         mock_db.fare_split_participants.find_one = AsyncMock(return_value=participant)
         mock_db.wallets.find_one = AsyncMock(return_value=empty_wallet)
+        mock_db.fare_split_pay_share = AsyncMock(side_effect=ValueError("insufficient_funds"))
 
         with patch("routes.fare_split.db", mock_db), patch("routes.wallet.db", mock_db):
             resp = client.post(

--- a/backend/tests/test_loyalty.py
+++ b/backend/tests/test_loyalty.py
@@ -9,6 +9,7 @@ Routes under test (backend/routes/loyalty.py):
 
 import os
 import sys
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -36,14 +37,16 @@ SAMPLE_RIDE = {
 
 
 def make_mock_db():
+    """Build a mock db using the flat Supabase-style interface loyalty routes use.
+
+    loyalty.py calls db.find_one(table, filter), db.insert_one(table, data),
+    db.update_one(table, filter, update), and db.get_rows(table, filter, ...).
+    """
     mock = MagicMock()
+    mock.find_one = AsyncMock(return_value=None)
+    mock.insert_one = AsyncMock(return_value=None)
+    mock.update_one = AsyncMock(return_value=None)
     mock.get_rows = AsyncMock(return_value=[])
-    for col in ("loyalty_accounts", "loyalty_transactions", "rides", "wallets", "wallet_transactions"):
-        col_mock = MagicMock()
-        col_mock.find_one = AsyncMock(return_value=None)
-        col_mock.insert_one = AsyncMock(return_value=None)
-        col_mock.update_one = AsyncMock(return_value=None)
-        setattr(mock, col, col_mock)
     return mock
 
 
@@ -67,7 +70,7 @@ class TestGetLoyaltyStatus:
         """First-time call auto-creates a bronze account."""
         mock_db = make_mock_db()
         # find_one returns None → auto-create path
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=None)
+        mock_db.find_one = AsyncMock(return_value=None)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.get("/api/v1/loyalty")
@@ -83,7 +86,7 @@ class TestGetLoyaltyStatus:
     def test_existing_silver_account(self, client):
         """Existing account data is returned as-is."""
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.get("/api/v1/loyalty")
@@ -110,7 +113,7 @@ class TestGetLoyaltyHistory:
 
     def test_empty_history(self, client):
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
         mock_db.get_rows = AsyncMock(return_value=[])
 
         with patch("routes.loyalty.db", mock_db):
@@ -125,7 +128,7 @@ class TestGetLoyaltyHistory:
             {"id": "t2", "points": -100, "type": "redeemed", "created_at": "2026-01-01T10:00:00"},
         ]
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
         mock_db.get_rows = AsyncMock(return_value=txns)
 
         with patch("routes.loyalty.db", mock_db):
@@ -136,7 +139,7 @@ class TestGetLoyaltyHistory:
 
     def test_limit_validation(self, client):
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
         mock_db.get_rows = AsyncMock(return_value=[])
 
         with patch("routes.loyalty.db", mock_db):
@@ -150,9 +153,8 @@ class TestEarnPoints:
 
     def test_earn_points_for_completed_ride(self, client):
         mock_db = make_mock_db()
-        mock_db.rides.find_one = AsyncMock(return_value=SAMPLE_RIDE)
-        mock_db.loyalty_transactions.find_one = AsyncMock(return_value=None)
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        # find_one called twice: ride lookup, then account lookup
+        mock_db.find_one = AsyncMock(side_effect=[SAMPLE_RIDE, SAMPLE_ACCOUNT])
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/earn?ride_id=ride_123")
@@ -166,9 +168,7 @@ class TestEarnPoints:
     def test_earn_applies_silver_multiplier(self, client):
         """Silver tier (1.25×) earns bonus points."""
         mock_db = make_mock_db()
-        mock_db.rides.find_one = AsyncMock(return_value=SAMPLE_RIDE)  # $20 fare
-        mock_db.loyalty_transactions.find_one = AsyncMock(return_value=None)
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        mock_db.find_one = AsyncMock(side_effect=[SAMPLE_RIDE, SAMPLE_ACCOUNT])  # $20 fare
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/earn?ride_id=ride_123")
@@ -181,7 +181,7 @@ class TestEarnPoints:
 
     def test_ride_not_found_returns_404(self, client):
         mock_db = make_mock_db()
-        mock_db.rides.find_one = AsyncMock(return_value=None)
+        mock_db.find_one = AsyncMock(return_value=None)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/earn?ride_id=bad_ride")
@@ -191,7 +191,7 @@ class TestEarnPoints:
     def test_ride_not_completed_returns_400(self, client):
         pending_ride = {**SAMPLE_RIDE, "status": "in_progress"}
         mock_db = make_mock_db()
-        mock_db.rides.find_one = AsyncMock(return_value=pending_ride)
+        mock_db.find_one = AsyncMock(return_value=pending_ride)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/earn?ride_id=ride_123")
@@ -200,9 +200,12 @@ class TestEarnPoints:
         assert "not completed" in resp.json()["detail"].lower()
 
     def test_already_awarded_returns_idempotent(self, client):
+        """Second call raises DuplicateRecordError on insert → idempotent no-op."""
+        from utils.error_handling import DuplicateRecordError
+
         mock_db = make_mock_db()
-        mock_db.rides.find_one = AsyncMock(return_value=SAMPLE_RIDE)
-        mock_db.loyalty_transactions.find_one = AsyncMock(return_value={"id": "txn_existing", "type": "ride_earned"})
+        mock_db.find_one = AsyncMock(side_effect=[SAMPLE_RIDE, SAMPLE_ACCOUNT])
+        mock_db.insert_one = AsyncMock(side_effect=DuplicateRecordError("ride_earned"))
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/earn?ride_id=ride_123")
@@ -213,7 +216,7 @@ class TestEarnPoints:
     def test_unauthorized_ride_returns_403(self, client):
         other_user_ride = {**SAMPLE_RIDE, "rider_id": "other_user"}
         mock_db = make_mock_db()
-        mock_db.rides.find_one = AsyncMock(return_value=other_user_ride)
+        mock_db.find_one = AsyncMock(return_value=other_user_ride)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/earn?ride_id=ride_123")
@@ -227,11 +230,19 @@ class TestRedeemPoints:
     def test_redeem_points_for_wallet_credit(self, client):
         rich_account = {**SAMPLE_ACCOUNT, "points": 500}
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=rich_account)
+        # find_one called: loyalty_accounts (account), then wallets (wallet via imported helper)
+        mock_db.find_one = AsyncMock(return_value=rich_account)
         sample_wallet = {"id": "wallet_1", "user_id": "user_123", "balance": 10.0, "is_active": True}
-        mock_db.wallets.find_one = AsyncMock(return_value=sample_wallet)
 
-        with patch("routes.loyalty.db", mock_db):
+        with (
+            patch("routes.loyalty.db", mock_db),
+            patch("routes.wallet.db", mock_db),
+            patch(
+                "routes.loyalty.wallet_increment_balance",
+                AsyncMock(return_value=Decimal("11.00")),
+            ),
+        ):
+            mock_db.find_one = AsyncMock(side_effect=[rich_account, sample_wallet])
             resp = client.post("/api/v1/loyalty/redeem", json={"points": 100})
 
         assert resp.status_code == 200
@@ -242,7 +253,7 @@ class TestRedeemPoints:
 
     def test_below_minimum_redemption_returns_400(self, client):
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_ACCOUNT)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/redeem", json={"points": 50})
@@ -253,7 +264,7 @@ class TestRedeemPoints:
     def test_insufficient_points_returns_400(self, client):
         low_balance_account = {**SAMPLE_ACCOUNT, "points": 50}
         mock_db = make_mock_db()
-        mock_db.loyalty_accounts.find_one = AsyncMock(return_value=low_balance_account)
+        mock_db.find_one = AsyncMock(return_value=low_balance_account)
 
         with patch("routes.loyalty.db", mock_db):
             resp = client.post("/api/v1/loyalty/redeem", json={"points": 200})

--- a/backend/tests/test_p0_ship_blockers.py
+++ b/backend/tests/test_p0_ship_blockers.py
@@ -25,6 +25,8 @@ import pytest
 
 from backend.utils.stripe_charge import ChargeOutcome
 
+pytestmark = pytest.mark.anyio
+
 RIDER_ID = "rider_p0"
 DRIVER_USER_ID = "driver_user_p0"
 DRIVER_ID = "driver_row_p0"
@@ -72,7 +74,6 @@ def _driver_row() -> dict:
 
 
 @pytest.mark.e2e
-@pytest.mark.asyncio
 class TestDriverCancelNotifiesRider:
     """When a driver cancels after accepting, the rider's app must learn
     immediately via WebSocket + push — otherwise the rider is stuck on a
@@ -160,7 +161,6 @@ class TestDriverCancelNotifiesRider:
 
 
 @pytest.mark.e2e
-@pytest.mark.asyncio
 class TestNoDriversAvailableTimeout:
     """After ~5 min of searching with no match, the backend auto-cancels
     the ride, WS-notifies the rider, and pushes a notification.
@@ -239,7 +239,6 @@ class TestNoDriversAvailableTimeout:
 
 
 @pytest.mark.e2e
-@pytest.mark.asyncio
 class TestDuplicateRideRequestGuardHandler:
     """Direct handler tests — bypass FastAPI middleware so we can pin the
     actual guard logic regardless of auth/rate-limit config."""
@@ -491,7 +490,6 @@ class TestSurgeBoundaryConsistency:
 
 
 @pytest.mark.e2e
-@pytest.mark.asyncio
 class TestCreateRideHonorsEstimateToken:
     """End-to-end proof that POST /rides uses the token's surge rather
     than re-reading service_area. This is the behaviour the P0-4 gap
@@ -602,7 +600,6 @@ class TestCreateRideHonorsEstimateToken:
 
 
 @pytest.mark.e2e
-@pytest.mark.asyncio
 class TestPaymentFailureAtComplete:
     """When Stripe declines the rider's card at trip completion, the system
     must leave the ride in a recoverable state (rider can re-try or swap
@@ -779,7 +776,6 @@ _BASE_KW = dict(
 # ── E3-1: Happy path — PaymentIntent.confirm succeeds ───────────────────────
 
 
-@pytest.mark.asyncio
 class TestE3HappyPath:
     async def test_confirm_called_instead_of_create(self):
         """When payment_intent_id is supplied, confirm() is called, not create()."""
@@ -821,7 +817,6 @@ class TestE3HappyPath:
 # ── E3-2: Card declined — confirm raises CardError → HTTP 402 ───────────────
 
 
-@pytest.mark.asyncio
 class TestE3CardDecline:
     async def test_card_decline_marks_payment_failed_and_allows_retry(self):
         """stripe.PaymentIntent.confirm raises CardError → declined outcome.
@@ -868,7 +863,6 @@ class TestE3CardDecline:
 # ── E3-3: Stripe unavailable — network / import failure → graceful fallback ─
 
 
-@pytest.mark.asyncio
 class TestE3StripeUnavailable:
     async def test_stripe_base_error_returns_failed(self):
         """Non-card Stripe error (connection, rate-limit) → failed, not 5xx crash."""
@@ -929,6 +923,7 @@ def _make_ride(payment_intent_id: str | None = None) -> dict:
     return {
         "id": "ride_http_1",
         "rider_id": "user_1",
+        "status": "completed",
         "payment_method": "card",
         "payment_method_id": "pm_http",
         "payment_intent_id": payment_intent_id,
@@ -964,7 +959,6 @@ def _app_with_mocked_auth(user_id: str = "user_1"):
     return TestClient(app)
 
 
-@pytest.mark.asyncio
 class TestProcessPaymentHTTP:
     """HTTP surface tests for process_payment — verifies that charge_ride
     outcomes map to the correct HTTP status codes."""

--- a/backend/tests/test_p1_token_refresh.py
+++ b/backend/tests/test_p1_token_refresh.py
@@ -18,9 +18,27 @@ Run:
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from starlette.requests import Request as StarletteRequest
+
+
+def _make_request(user_agent: str = "") -> StarletteRequest:
+    """Return a real Starlette Request so SlowAPI's rate-limit decorator accepts it."""
+    headers = []
+    if user_agent:
+        headers.append((b"user-agent", user_agent.encode()))
+    return StarletteRequest(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/auth/refresh",
+            "query_string": b"",
+            "headers": headers,
+        }
+    )
+
 
 USER_ID = "user_p1_11"
 OLD_REFRESH_ROW_ID = "rtk-row-001"
@@ -65,9 +83,6 @@ class TestRefreshAccessToken:
         new_raw_token = "new-refresh-raw-xyz"
         refresh_expires = datetime.now(timezone.utc) + timedelta(days=30)
 
-        mock_request = MagicMock()
-        mock_request.headers.get = MagicMock(return_value="TestApp/1.0")
-
         with (
             patch("backend.routes.auth.lookup_refresh_token", AsyncMock(return_value=_refresh_row())),
             patch("backend.routes.auth.db.find_one", AsyncMock(return_value=_user_row())),
@@ -83,7 +98,7 @@ class TestRefreshAccessToken:
                 refresh_token = "old-refresh-raw"
 
             result = await auth_mod.refresh_access_token(
-                request=mock_request,
+                request=_make_request(user_agent="TestApp/1.0"),
                 body=_Body(),
             )
 
@@ -97,9 +112,6 @@ class TestRefreshAccessToken:
 
         from backend.routes import auth as auth_mod
 
-        mock_request = MagicMock()
-        mock_request.headers.get = MagicMock(return_value="")
-
         with (
             patch("backend.routes.auth.lookup_refresh_token", AsyncMock(return_value=None)),
             patch("backend.routes.auth.get_remote_address", return_value="127.0.0.1"),
@@ -109,7 +121,7 @@ class TestRefreshAccessToken:
                 refresh_token = "bad-or-revoked-token"
 
             with pytest.raises(HTTPException) as exc_info:
-                await auth_mod.refresh_access_token(request=mock_request, body=_Body())
+                await auth_mod.refresh_access_token(request=_make_request(), body=_Body())
 
         assert exc_info.value.status_code == 401
 
@@ -119,9 +131,6 @@ class TestRefreshAccessToken:
         from fastapi import HTTPException
 
         from backend.routes import auth as auth_mod
-
-        mock_request = MagicMock()
-        mock_request.headers.get = MagicMock(return_value="")
 
         with (
             patch(
@@ -135,7 +144,7 @@ class TestRefreshAccessToken:
                 refresh_token = "admin-refresh-token"
 
             with pytest.raises(HTTPException) as exc_info:
-                await auth_mod.refresh_access_token(request=mock_request, body=_Body())
+                await auth_mod.refresh_access_token(request=_make_request(), body=_Body())
 
         assert exc_info.value.status_code == 401
 
@@ -144,9 +153,6 @@ class TestRefreshAccessToken:
         from fastapi import HTTPException
 
         from backend.routes import auth as auth_mod
-
-        mock_request = MagicMock()
-        mock_request.headers.get = MagicMock(return_value="")
 
         with (
             patch("backend.routes.auth.lookup_refresh_token", AsyncMock(return_value=_refresh_row())),
@@ -158,7 +164,7 @@ class TestRefreshAccessToken:
                 refresh_token = "valid-token-deleted-user"
 
             with pytest.raises(HTTPException) as exc_info:
-                await auth_mod.refresh_access_token(request=mock_request, body=_Body())
+                await auth_mod.refresh_access_token(request=_make_request(), body=_Body())
 
         assert exc_info.value.status_code == 401
 
@@ -173,9 +179,6 @@ class TestRefreshAccessToken:
             issue_calls.append({"replaces": replaces})
             return ("new-raw", "hashed", datetime.now(timezone.utc) + timedelta(days=30))
 
-        mock_request = MagicMock()
-        mock_request.headers.get = MagicMock(return_value="UA")
-
         with (
             patch("backend.routes.auth.lookup_refresh_token", AsyncMock(return_value=_refresh_row())),
             patch("backend.routes.auth.db.find_one", AsyncMock(return_value=_user_row())),
@@ -187,7 +190,7 @@ class TestRefreshAccessToken:
             class _Body:
                 refresh_token = "old-raw"
 
-            await auth_mod.refresh_access_token(request=mock_request, body=_Body())
+            await auth_mod.refresh_access_token(request=_make_request(user_agent="UA"), body=_Body())
 
         assert issue_calls, "issue_refresh_token was not called"
         assert issue_calls[0]["replaces"] == OLD_REFRESH_ROW_ID, (

--- a/backend/tests/test_p2_payout_t4a.py
+++ b/backend/tests/test_p2_payout_t4a.py
@@ -101,11 +101,24 @@ class TestRequestPayout:
     """
 
     async def _request(self, amount: float = 50.00, available_balance: float = 100.00, has_bank_account: bool = True):
+        from starlette.requests import Request as StarletteRequest
+
         from backend.routes.drivers import PayoutRequest, request_payout
 
         req = PayoutRequest(amount=Decimal(str(amount)))
         driver = _driver_row()
         inserted = []
+
+        # Build a real Starlette Request so @idempotent_endpoint can read headers.
+        mock_request = StarletteRequest(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/drivers/payouts",
+                "query_string": b"",
+                "headers": [],
+            }
+        )
 
         # get_driver_balance is called internally and makes multiple get_rows calls.
         # Mock it directly to control the returned balance cleanly.
@@ -119,6 +132,8 @@ class TestRequestPayout:
                 return [_bank_account()] if has_bank_account else []
             return []
 
+        # get_app_settings is imported locally inside request_payout, so patch
+        # it at the settings_loader module level where it's defined.
         with (
             patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(side_effect=_get_rows)),
             patch(
@@ -126,10 +141,11 @@ class TestRequestPayout:
                 AsyncMock(side_effect=lambda t, r: inserted.append(r) or r),
             ),
             patch("backend.routes.drivers.get_driver_balance", AsyncMock(side_effect=_mock_balance)),
-            patch("backend.routes.drivers.get_app_settings", AsyncMock(return_value={})),  # no Stripe key
+            patch("backend.settings_loader.get_app_settings", AsyncMock(return_value={})),  # no Stripe key
         ):
             result = await request_payout(
                 req=req,
+                request=mock_request,
                 current_user={"id": DRIVER_USER_ID},
             )
 
@@ -166,14 +182,24 @@ class TestRequestPayout:
 
     async def test_driver_not_found_raises_404(self):
         from fastapi import HTTPException
+        from starlette.requests import Request as StarletteRequest
 
         from backend.routes.drivers import PayoutRequest, request_payout
 
         req = PayoutRequest(amount=Decimal("50.00"))
+        mock_request = StarletteRequest(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/drivers/payouts",
+                "query_string": b"",
+                "headers": [],
+            }
+        )
 
         with patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[])):
             with pytest.raises(HTTPException) as exc_info:
-                await request_payout(req=req, current_user={"id": "ghost-driver"})
+                await request_payout(req=req, request=mock_request, current_user={"id": "ghost-driver"})
 
         assert exc_info.value.status_code == 404
 
@@ -198,29 +224,27 @@ class TestGetPayoutHistory:
         payouts = [_payout_row(50.00), _payout_row(30.00, "completed")]
         cursor = _SimpleCursor(payouts)
 
-        call_count = [0]
+        # The production code calls get_rows twice with different calling conventions:
+        #   1st call (drivers table): result is awaited  → must return a coroutine
+        #   2nd call (payouts table): result is NOT awaited, used as a cursor object
+        # We use a MagicMock whose __call__ returns the right thing per table.
+        # For the awaited drivers call we wrap the list in a coroutine via
+        # an async helper; for the non-awaited payouts call we return the cursor.
+        async def _awaitable_driver():
+            return [driver]
 
-        def _get_rows(table, query=None, **kwargs):
-            call_count[0] += 1
+        def _sync_get_rows(table, query=None, **kwargs):
             if table == "drivers":
-                return [driver]
-            # Return cursor for payouts (not awaited in the endpoint)
+                return _awaitable_driver()
+            # payouts: not awaited — returned as cursor object
             return cursor
 
-        with patch("backend.routes.drivers.db_supabase.get_rows", MagicMock(side_effect=_get_rows)):
-            # get_rows for drivers is awaited, but for payouts it's not;
-            # wrap driver call in AsyncMock and payouts in sync mock
-            async def _async_get_rows(table, query=None, **kwargs):
-                if table == "drivers":
-                    return [driver]
-                return cursor
-
-            with patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(side_effect=_async_get_rows)):
-                result = await get_payout_history(
-                    limit=20,
-                    offset=0,
-                    current_user={"id": DRIVER_USER_ID},
-                )
+        with patch("backend.routes.drivers.db_supabase.get_rows", side_effect=_sync_get_rows):
+            result = await get_payout_history(
+                limit=20,
+                offset=0,
+                current_user={"id": DRIVER_USER_ID},
+            )
 
         assert result["success"] is True
         assert len(result["payouts"]) == 2

--- a/backend/tests/test_quests.py
+++ b/backend/tests/test_quests.py
@@ -65,14 +65,54 @@ SAMPLE_PROGRESS = {
 
 
 def make_mock_db():
+    """Build a mock that mirrors the db_supabase flat-function interface.
+
+    Routes call ``await db.find_one("drivers", {...})``, not
+    ``await db.drivers.find_one({...})``.  We expose per-table sub-mocks as
+    attributes so individual tests can override them with::
+
+        mock_db.drivers.find_one = AsyncMock(return_value=SAMPLE_DRIVER)
+
+    The top-level ``find_one`` / ``insert_one`` / ``update_one`` AsyncMocks
+    dispatch to the per-table attribute by table name.
+    """
     mock = MagicMock()
-    mock.get_rows = AsyncMock(return_value=[])
-    for col in ("drivers", "quests", "quest_progress", "wallets", "wallet_transactions", "users"):
+
+    # Per-table sub-mocks
+    _tables = ("drivers", "quests", "quest_progress", "wallets", "wallet_transactions", "users")
+    for tbl in _tables:
         col_mock = MagicMock()
         col_mock.find_one = AsyncMock(return_value=None)
         col_mock.insert_one = AsyncMock(return_value=None)
         col_mock.update_one = AsyncMock(return_value=None)
-        setattr(mock, col, col_mock)
+        setattr(mock, tbl, col_mock)
+
+    # Default get_rows at top level (table-agnostic)
+    mock.get_rows = AsyncMock(return_value=[])
+
+    # Dispatcher: routes call db.find_one("drivers", ...) — delegate to per-table mock
+    async def _find_one(table, filters=None, **kwargs):
+        tbl_attr = getattr(mock, table, None)
+        if tbl_attr is not None:
+            return await tbl_attr.find_one(filters, **kwargs)
+        return None
+
+    async def _insert_one(table, doc, **kwargs):
+        tbl_attr = getattr(mock, table, None)
+        if tbl_attr is not None:
+            return await tbl_attr.insert_one(doc, **kwargs)
+        return None
+
+    async def _update_one(table, filters, update, **kwargs):
+        tbl_attr = getattr(mock, table, None)
+        if tbl_attr is not None:
+            return await tbl_attr.update_one(filters, update, **kwargs)
+        return None
+
+    mock.find_one = _find_one
+    mock.insert_one = _insert_one
+    mock.update_one = _update_one
+
     return mock
 
 

--- a/backend/tests/test_wallet.py
+++ b/backend/tests/test_wallet.py
@@ -10,6 +10,7 @@ Routes under test (backend/routes/wallet.py):
 
 import os
 import sys
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -39,16 +40,25 @@ RECIPIENT_WALLET = {
     "updated_at": "2026-01-01T00:00:00",
 }
 
+SAMPLE_RIDE = {
+    "id": "ride_123",
+    "rider_id": "user_123",
+    "status": "completed",
+    "total_fare": 15.0,
+}
+
 
 def make_mock_db():
+    """Build a mock db using the flat Supabase-style interface wallet routes use.
+
+    wallet.py calls db.find_one(table, filter), db.insert_one(table, data),
+    db.update_one(table, filter, update), and db.get_rows(table, filter, ...).
+    """
     mock = MagicMock()
+    mock.find_one = AsyncMock(return_value=None)
+    mock.insert_one = AsyncMock(return_value=None)
+    mock.update_one = AsyncMock(return_value=None)
     mock.get_rows = AsyncMock(return_value=[])
-    for col in ("wallets", "wallet_transactions", "users", "rides"):
-        col_mock = MagicMock()
-        col_mock.find_one = AsyncMock(return_value=None)
-        col_mock.insert_one = AsyncMock(return_value=None)
-        col_mock.update_one = AsyncMock(return_value=None)
-        setattr(mock, col, col_mock)
     return mock
 
 
@@ -70,7 +80,7 @@ class TestGetWallet:
 
     def test_returns_existing_balance(self, client):
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=SAMPLE_WALLET)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_WALLET)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.get("/api/v1/wallet")
@@ -83,7 +93,7 @@ class TestGetWallet:
 
     def test_auto_creates_wallet_for_new_user(self, client):
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=None)
+        mock_db.find_one = AsyncMock(return_value=None)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.get("/api/v1/wallet")
@@ -108,9 +118,12 @@ class TestTopUp:
 
     def test_top_up_increases_balance(self, client):
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=SAMPLE_WALLET)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_WALLET)
 
-        with patch("routes.wallet.db", mock_db):
+        with (
+            patch("routes.wallet.db", mock_db),
+            patch("routes.wallet.wallet_increment_balance", AsyncMock(return_value=Decimal("75.00"))),
+        ):
             resp = client.post("/api/v1/wallet/top-up", json={"amount": 25.0})
 
         assert resp.status_code == 200
@@ -121,7 +134,7 @@ class TestTopUp:
     def test_top_up_suspended_wallet_returns_403(self, client):
         suspended = {**SAMPLE_WALLET, "is_active": False}
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=suspended)
+        mock_db.find_one = AsyncMock(return_value=suspended)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.post("/api/v1/wallet/top-up", json={"amount": 10.0})
@@ -131,7 +144,7 @@ class TestTopUp:
 
     def test_top_up_exceeds_maximum_returns_422(self, client):
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=SAMPLE_WALLET)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_WALLET)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.post("/api/v1/wallet/top-up", json={"amount": 600.0})
@@ -152,10 +165,13 @@ class TestWalletPay:
 
     def test_pay_for_ride_deducts_balance(self, client):
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=SAMPLE_WALLET)
-        mock_db.rides.update_one = AsyncMock(return_value=None)
+        # find_one is called twice: first for wallet, then for ride
+        mock_db.find_one = AsyncMock(side_effect=[SAMPLE_WALLET, SAMPLE_RIDE])
 
-        with patch("routes.wallet.db", mock_db):
+        with (
+            patch("routes.wallet.db", mock_db),
+            patch("routes.wallet.wallet_pay_for_ride", AsyncMock(return_value=Decimal("35.00"))),
+        ):
             resp = client.post("/api/v1/wallet/pay", json={"ride_id": "ride_123", "amount": 15.0})
 
         assert resp.status_code == 200
@@ -166,9 +182,15 @@ class TestWalletPay:
     def test_insufficient_balance_returns_400(self, client):
         low_balance = {**SAMPLE_WALLET, "balance": 5.0}
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=low_balance)
+        mock_db.find_one = AsyncMock(side_effect=[low_balance, SAMPLE_RIDE])
 
-        with patch("routes.wallet.db", mock_db):
+        with (
+            patch("routes.wallet.db", mock_db),
+            patch(
+                "routes.wallet.wallet_pay_for_ride",
+                AsyncMock(side_effect=ValueError("insufficient_funds")),
+            ),
+        ):
             resp = client.post("/api/v1/wallet/pay", json={"ride_id": "ride_123", "amount": 15.0})
 
         assert resp.status_code == 400
@@ -177,7 +199,7 @@ class TestWalletPay:
     def test_pay_from_suspended_wallet_returns_403(self, client):
         suspended = {**SAMPLE_WALLET, "is_active": False}
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=suspended)
+        mock_db.find_one = AsyncMock(return_value=suspended)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.post("/api/v1/wallet/pay", json={"ride_id": "ride_123", "amount": 10.0})
@@ -190,7 +212,7 @@ class TestGetTransactions:
 
     def test_empty_transaction_history(self, client):
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=SAMPLE_WALLET)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_WALLET)
         mock_db.get_rows = AsyncMock(return_value=[])
 
         with patch("routes.wallet.db", mock_db):
@@ -214,7 +236,7 @@ class TestGetTransactions:
             }
         ]
         mock_db = make_mock_db()
-        mock_db.wallets.find_one = AsyncMock(return_value=SAMPLE_WALLET)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_WALLET)
         mock_db.get_rows = AsyncMock(return_value=txns)
 
         with patch("routes.wallet.db", mock_db):
@@ -230,13 +252,19 @@ class TestTransfer:
 
     def test_transfer_to_valid_recipient(self, client):
         mock_db = make_mock_db()
-        mock_db.users.find_one = AsyncMock(return_value=RECIPIENT_USER)
-        mock_db.wallets.find_one = AsyncMock(side_effect=[SAMPLE_WALLET, RECIPIENT_WALLET])
+        # find_one is called: users (recipient lookup), wallets (sender), wallets (recipient)
+        mock_db.find_one = AsyncMock(side_effect=[RECIPIENT_USER, SAMPLE_WALLET, RECIPIENT_WALLET])
 
-        with patch("routes.wallet.db", mock_db):
+        with (
+            patch("routes.wallet.db", mock_db),
+            patch(
+                "routes.wallet._wallet_transfer_rpc",
+                AsyncMock(return_value=(Decimal("40.00"), Decimal("20.00"))),
+            ),
+        ):
             resp = client.post(
                 "/api/v1/wallet/transfer",
-                json={"recipient_phone": "+9876543210", "amount": 10.0},
+                json={"recipient_phone": "+19876543210", "amount": 10.0},
             )
 
         assert resp.status_code == 200
@@ -247,12 +275,12 @@ class TestTransfer:
     def test_transfer_to_self_returns_400(self, client):
         mock_db = make_mock_db()
         # Recipient has same id as sender
-        mock_db.users.find_one = AsyncMock(return_value=SAMPLE_USER)
+        mock_db.find_one = AsyncMock(return_value=SAMPLE_USER)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.post(
                 "/api/v1/wallet/transfer",
-                json={"recipient_phone": "+1234567890", "amount": 10.0},
+                json={"recipient_phone": "+11234567890", "amount": 10.0},
             )
 
         assert resp.status_code == 400
@@ -260,12 +288,12 @@ class TestTransfer:
 
     def test_transfer_recipient_not_found_returns_404(self, client):
         mock_db = make_mock_db()
-        mock_db.users.find_one = AsyncMock(return_value=None)
+        mock_db.find_one = AsyncMock(return_value=None)
 
         with patch("routes.wallet.db", mock_db):
             resp = client.post(
                 "/api/v1/wallet/transfer",
-                json={"recipient_phone": "+0000000000", "amount": 10.0},
+                json={"recipient_phone": "+10000000000", "amount": 10.0},
             )
 
         assert resp.status_code == 404
@@ -273,13 +301,18 @@ class TestTransfer:
     def test_transfer_insufficient_balance_returns_400(self, client):
         empty_wallet = {**SAMPLE_WALLET, "balance": 2.0}
         mock_db = make_mock_db()
-        mock_db.users.find_one = AsyncMock(return_value=RECIPIENT_USER)
-        mock_db.wallets.find_one = AsyncMock(side_effect=[empty_wallet, RECIPIENT_WALLET])
+        mock_db.find_one = AsyncMock(side_effect=[RECIPIENT_USER, empty_wallet, RECIPIENT_WALLET])
 
-        with patch("routes.wallet.db", mock_db):
+        with (
+            patch("routes.wallet.db", mock_db),
+            patch(
+                "routes.wallet._wallet_transfer_rpc",
+                AsyncMock(side_effect=ValueError("insufficient_funds")),
+            ),
+        ):
             resp = client.post(
                 "/api/v1/wallet/transfer",
-                json={"recipient_phone": "+9876543210", "amount": 10.0},
+                json={"recipient_phone": "+19876543210", "amount": 10.0},
             )
 
         assert resp.status_code == 400
@@ -291,7 +324,7 @@ class TestTransfer:
         with patch("routes.wallet.db", mock_db):
             resp = client.post(
                 "/api/v1/wallet/transfer",
-                json={"recipient_phone": "+9876543210", "amount": 300.0},
+                json={"recipient_phone": "+19876543210", "amount": 300.0},
             )
 
         assert resp.status_code == 422


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
