### PR TITLE
test(backend): fix 7 pre-existing test failures (sanitize_string + websocket_auth_ack)

### DIFF
--- a/backend/tests/test_sanitize_string.py
+++ b/backend/tests/test_sanitize_string.py
@@ -47,10 +47,12 @@ class TestHTMLStripping:
         assert val == "bold"
 
     def test_strips_script_tags(self):
-        # After HTML stripping, 'alert' still triggers the suspicious-content check
+        # HTML tags are stripped; the remaining text is logged for security
+        # monitoring but allowed through (suspicious patterns are not rejected —
+        # they are stopped at the parameterised-query layer instead).
         ok, val = sanitize_string('<script>alert("xss")</script>', raise_exception=False)
-        assert ok is False
-        assert val is None
+        assert ok is True
+        assert val is not None
 
     def test_strips_nested_html(self):
         ok, val = sanitize_string("<div><p>text</p></div>")
@@ -121,14 +123,19 @@ class TestNoneAndEmpty:
 
 class TestSuspiciousPatterns:
     def test_sql_injection_still_passes(self):
-        # SQL injection patterns ARE detected and rejected by the implementation
+        # Suspicious patterns are detected and LOGGED for security monitoring
+        # but NOT rejected — parameterised queries in Supabase are the actual
+        # injection defence. User notes may legitimately contain SQL keywords.
         ok, val = sanitize_string("SELECT * FROM users", raise_exception=False)
-        assert ok is False
+        assert ok is True
+        assert val is not None
 
     def test_sql_comment_markers(self):
-        # '--' is flagged as a suspicious SQL comment marker
+        # '--' is detected as suspicious and logged, but the string is allowed
+        # through so legitimate inputs like "call me at 5pm -- thanks" work.
         ok, val = sanitize_string("normal text -- comment", raise_exception=False)
-        assert ok is False
+        assert ok is True
+        assert val is not None
 
     def test_normal_text_not_flagged(self):
         ok, val = sanitize_string("Pick me up at 123 Main St")

--- a/backend/tests/test_websocket_auth_ack.py
+++ b/backend/tests/test_websocket_auth_ack.py
@@ -10,10 +10,15 @@ sends `{"type": "auth_success"}` right after `manager.connect()` to close that
 window. These tests pin that behavior.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+
+# Matches the test value we inject into the settings mock. Any non-empty
+# string works — it just needs to equal payload["aud"] so the audience check
+# passes without touching a real Firebase project.
+_TEST_FIREBASE_APP_ID = "test-firebase-app-id"
 
 
 @pytest.fixture
@@ -50,37 +55,93 @@ def admin_user():
     }
 
 
-def _patch_auth_and_db(user, driver_profile=None):
-    """Context-manager-ish helper: patch Firebase + db_supabase so the WS
-    endpoint can complete auth without touching real services."""
-    patches = [
-        # Firebase verify → returns a payload carrying the user id
+def _make_settings_mock(client_type: str) -> MagicMock:
+    """Return a settings-shaped mock with the right FIREBASE_*_APP_ID set."""
+    m = MagicMock()
+    m.FIREBASE_DRIVER_APP_ID = _TEST_FIREBASE_APP_ID if client_type == "driver" else ""
+    m.FIREBASE_RIDER_APP_ID = _TEST_FIREBASE_APP_ID if client_type == "rider" else ""
+    return m
+
+
+def _patch_firebase_auth_and_db(user, driver_profile=None, client_type="driver"):
+    """Patches for driver/rider WebSocket auth via Firebase token.
+
+    Since B-P1-1 the endpoint validates payload["aud"] against
+    settings.FIREBASE_{DRIVER,RIDER}_APP_ID. We inject a matching test value
+    via a settings mock and include the same value in the Firebase payload so
+    the audience check passes in test.
+    """
+    firebase_payload = {
+        "uid": user["id"],
+        "phone_number": user.get("phone", ""),
+        "aud": _TEST_FIREBASE_APP_ID,
+    }
+    return [
+        patch("backend.routes.websocket.settings", _make_settings_mock(client_type)),
         patch(
             "backend.routes.websocket.firebase_auth.verify_id_token",
-            return_value={"uid": user["id"], "phone_number": user["phone"]},
+            return_value=firebase_payload,
         ),
-        # db_supabase.get_user_by_id → returns our user fixture
         patch(
             "backend.routes.websocket.db_supabase.get_user_by_id",
             new=AsyncMock(return_value=user),
         ),
-        # For driver client type, the endpoint checks get_rows("drivers", ...)
         patch(
             "backend.routes.websocket.db_supabase.get_rows",
             new=AsyncMock(return_value=[driver_profile] if driver_profile else []),
         ),
-        # Driver online-broadcast path touches db.find_one
         patch(
             "backend.routes.websocket.db.find_one",
             new=AsyncMock(return_value=driver_profile),
         ),
-        # Silence the admin broadcast
         patch(
             "backend.routes.websocket.manager.broadcast_to_admins",
             new=AsyncMock(return_value=None),
         ),
     ]
-    return patches
+
+
+def _patch_jwt_auth_and_db(user, db_user=None):
+    """Patches for admin WebSocket auth via legacy JWT.
+
+    Admin tokens are minted by the backend (not Firebase), so Firebase
+    verify_id_token is forced to raise — this triggers the JWT fallback path
+    in the endpoint. The JWT payload carries role + email so the admin-user
+    shortcut in the fallback applies without a DB lookup.
+    """
+    jwt_payload = {
+        "user_id": user["id"],
+        "role": user.get("role", "rider"),
+        # email is required for the admin-user-from-payload shortcut
+        "email": user.get("email", f"{user['id']}@spinr.test"),
+        "phone": user.get("phone", ""),
+    }
+    return [
+        patch(
+            "backend.routes.websocket.firebase_auth.verify_id_token",
+            side_effect=Exception("firebase not used for admin tokens"),
+        ),
+        patch(
+            "backend.routes.websocket.verify_jwt_token",
+            return_value=jwt_payload,
+        ),
+        patch(
+            "backend.routes.websocket.db_supabase.get_user_by_id",
+            new=AsyncMock(return_value=db_user or user),
+        ),
+        patch(
+            "backend.routes.websocket.db_supabase.get_rows",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "backend.routes.websocket.db.find_one",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "backend.routes.websocket.manager.broadcast_to_admins",
+            new=AsyncMock(return_value=None),
+        ),
+    ]
 
 
 def test_driver_auth_success_is_sent_immediately(app_with_ws, driver_user):
@@ -89,7 +150,7 @@ def test_driver_auth_success_is_sent_immediately(app_with_ws, driver_user):
     flip off the "Connection lost" banner."""
     driver_profile = {"id": "driver_1", "user_id": driver_user["id"], "is_online": True}
 
-    patches = _patch_auth_and_db(driver_user, driver_profile=driver_profile)
+    patches = _patch_firebase_auth_and_db(driver_user, driver_profile=driver_profile, client_type="driver")
     for p in patches:
         p.start()
     try:
@@ -105,14 +166,16 @@ def test_driver_auth_success_is_sent_immediately(app_with_ws, driver_user):
 
 
 def test_admin_auth_success_is_sent_immediately(app_with_ws, admin_user):
-    """Same contract for admin clients — they use the same banner pattern."""
-    patches = _patch_auth_and_db(admin_user, driver_profile=None)
+    """Same contract for admin clients — they use the same banner pattern.
+    Admin tokens go through the legacy JWT path (not Firebase), so Firebase
+    is forced to fail and the JWT fallback is mocked instead."""
+    patches = _patch_jwt_auth_and_db(admin_user)
     for p in patches:
         p.start()
     try:
         client = TestClient(app_with_ws)
         with client.websocket_connect(f"/ws/admin/{admin_user['id']}") as ws:
-            ws.send_json({"type": "auth", "token": "fake-firebase-token"})
+            ws.send_json({"type": "auth", "token": "fake-jwt-token"})
             msg = ws.receive_json()
             assert msg["type"] == "auth_success"
             assert msg["client_type"] == "admin"
@@ -171,8 +234,7 @@ def test_invalid_token_closes_socket_without_ack(app_with_ws):
 def test_driver_without_driver_row_gets_error_not_ack(app_with_ws, driver_user):
     """A user with no drivers-table row cannot connect as a driver — the
     endpoint closes with `user_is_not_a_driver`, NEVER auth_success."""
-    # driver_profile=None → get_rows returns [] so the driver-row check fails
-    patches = _patch_auth_and_db(driver_user, driver_profile=None)
+    patches = _patch_firebase_auth_and_db(driver_user, driver_profile=None, client_type="driver")
     for p in patches:
         p.start()
     try:
@@ -195,7 +257,8 @@ def test_admin_without_admin_role_gets_error_not_ack(app_with_ws):
     """A user with role='rider' cannot connect as admin — closes with
     `admin_access_required`, never auth_success."""
     rider_user = {"id": "user_rider_1", "role": "rider", "phone": "+15551234567"}
-    patches = _patch_auth_and_db(rider_user, driver_profile=None)
+    # JWT path: role='rider' not in admin roles → DB lookup → role check fails
+    patches = _patch_jwt_auth_and_db(rider_user, db_user=rider_user)
     for p in patches:
         p.start()
     try:
@@ -204,7 +267,7 @@ def test_admin_without_admin_role_gets_error_not_ack(app_with_ws):
         client = TestClient(app_with_ws)
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect(f"/ws/admin/{rider_user['id']}") as ws:
-                ws.send_json({"type": "auth", "token": "fake-firebase-token"})
+                ws.send_json({"type": "auth", "token": "fake-jwt-token"})
                 msg = ws.receive_json()
                 assert msg["type"] == "error"
                 assert msg["message"] == "admin_access_required"


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Fixes 7 tests that were failing on `main` before this branch. No production code changed — test fixtures and assertions updated to match the production code's documented behaviour.
- **Type**: `fix`
- **Linked issue**: Pre-existing CI noise on every PR (backend-test job always red on main)
- **Risk**: `low` — tests only; zero production-code changes
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[x]` CI
- **Blast radius**: `tests/` only — `backend/tests/test_sanitize_string.py`, `backend/tests/test_websocket_auth_ack.py`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — test-only changes
- **Dependencies / coordination**: `none`
- **Assumptions**: `none`

## Tier 3 — Compliance flags

_None — no auth, money, or PIPEDA-relevant logic changed._

## Tier 4 — Verification

- **Unit tests**: All 7 previously-failing tests now pass; suite goes from 7 failed → 0 failed on these files.
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: none
- **Screenshots / video**: N/A
- **Perf numbers**: N/A

**Pre-merge checklist**:
- [x] No production code changed — test fixtures only
- [x] CLAUDE.md conventions followed

---

## Changes in detail

### `test_sanitize_string.py` — 3 tests

`sanitize_string()` in `validators.py` intentionally **logs** suspicious patterns (XSS script content, SQL keywords, `--` comment markers) but does NOT reject them. The code comment at line 354 explains the rationale: these patterns appear in legitimate inputs (street addresses, user notes), and injection is stopped at the parameterised-query layer in Supabase rather than the sanitiser layer.

The 3 failing tests were asserting `ok is False` (rejection). Fixed to assert `ok is True` with updated comments documenting the log-not-reject contract.

| Test | Old assertion | New assertion |
|---|---|---|
| `test_strips_script_tags` | `ok is False` | `ok is True` |
| `test_sql_injection_still_passes` | `ok is False` | `ok is True` |
| `test_sql_comment_markers` | `ok is False` | `ok is True` |

### `test_websocket_auth_ack.py` — 4 tests

B-P1-1 added an audience check (`payload["aud"]` must match `settings.FIREBASE_{DRIVER,RIDER}_APP_ID`) after these tests were written. In the test environment `FIREBASE_DRIVER_APP_ID` is unset (empty string), so the check always sent `{"type": "error", "message": "firebase_audience_not_configured"}` before the tests could reach the `auth_success` assertion.

**Driver/rider tests** (`test_driver_auth_success_is_sent_immediately`, `test_driver_without_driver_row_gets_error_not_ack`):
- Added `_make_settings_mock(client_type)` that returns a MagicMock with `FIREBASE_DRIVER_APP_ID = "test-firebase-app-id"`
- Updated Firebase mock payload to include `"aud": "test-firebase-app-id"` so the audience check passes

**Admin tests** (`test_admin_auth_success_is_sent_immediately`, `test_admin_without_admin_role_gets_error_not_ack`):
- Admin tokens are minted by the backend (not Firebase) and carry no Firebase audience claim
- Changed Firebase mock from `return_value={...}` to `side_effect=Exception(...)` so it fails and the JWT fallback path is used
- Added `_patch_jwt_auth_and_db()` helper that mocks `verify_jwt_token` with a payload carrying `role` + `email`

https://claude.ai/code/session_012vzLtY9ebSY8exwgqCc5qe


---
_Generated by [Claude Code](https://claude.ai/code/session_012vzLtY9ebSY8exwgqCc5qe)_

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
