### PR TITLE
fix(security): vault_encrypt fail-closed — refuse to store plaintext PII

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -54,25 +54,42 @@ _VAULT_PII_FIELDS: frozenset = frozenset({"license_number", "vehicle_vin"})
 
 
 async def _vault_encrypt(value: str, hint: str = "") -> str:
-    """Encrypt a PII string via Supabase Vault (encrypt_driver_pii RPC)."""
+    """Encrypt a PII string via Supabase Vault (encrypt_driver_pii RPC).
+
+    Fail-closed: any failure raises 503 rather than storing plaintext PII.
+    Storing unencrypted license numbers or VINs is a PIPEDA violation.
+    """
     if not value:
         return value
     try:
         from supabase_client import supabase as _sb  # type: ignore[import]
     except ImportError:
-        return value
+        logger.error(
+            "vault_encrypt: supabase_client unavailable for %s — refusing to store plaintext", hint, exc_info=True
+        )
+        raise HTTPException(status_code=503, detail="Encryption service unavailable")
     if not _sb:
-        return value
+        logger.error("vault_encrypt: Supabase client not initialised for %s — refusing to store plaintext", hint)
+        raise HTTPException(status_code=503, detail="Encryption service unavailable")
     try:
         res = await db_supabase.run_sync(lambda: _sb.rpc("encrypt_driver_pii", {"plaintext": value}).execute())
-        return str(res.data) if res.data else value
-    except Exception as exc:
-        logger.warning("vault encrypt unavailable for %s: %s — storing plaintext", hint, exc)
-        return value
+        if not res.data:
+            logger.error("vault_encrypt: RPC returned no data for %s — refusing to store plaintext", hint)
+            raise HTTPException(status_code=503, detail="Encryption service unavailable")
+        return str(res.data)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("vault_encrypt: RPC failed for %s — refusing to store plaintext", hint, exc_info=True)
+        raise HTTPException(status_code=503, detail="Encryption service unavailable")
 
 
 async def _vault_decrypt(value: str, hint: str = "") -> str:
-    """Decrypt a Vault-encrypted PII token via Supabase RPC (decrypt_driver_pii)."""
+    """Decrypt a Vault-encrypted PII token via Supabase RPC (decrypt_driver_pii).
+
+    On failure, returns the raw token rather than raising — the encrypted token
+    is not PII, so this degrades to unreadable data rather than a privacy leak.
+    """
     if not value:
         return value
     try:
@@ -84,8 +101,8 @@ async def _vault_decrypt(value: str, hint: str = "") -> str:
     try:
         res = await db_supabase.run_sync(lambda: _sb.rpc("decrypt_driver_pii", {"secret_id": value}).execute())
         return str(res.data) if res.data else value
-    except Exception as exc:
-        logger.warning("vault decrypt unavailable for %s: %s — returning raw value", hint, exc)
+    except Exception:
+        logger.error("vault_decrypt: RPC failed for %s — returning raw token", hint, exc_info=True)
         return value
 
 


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Make `_vault_encrypt` fail-closed so driver PII (`license_number`, `vehicle_vin`) is never written to the DB as plaintext when Supabase Vault is unavailable
- **Type** [required]: `security`
- **Linked issue** [required]: none — identified as "vault-encrypt plaintext fallback" next-sprint candidate in sprint-current.md
- **Risk** [required]: `low` — write paths (`register_driver`, `update_driver_profile`) now return 503 on vault unavailability instead of silently persisting plaintext; decrypt path behavior is unchanged
- **User-visible change** [required]: `drivers` — `POST /drivers/register` and `PUT /drivers/profile` return 503 if Supabase Vault is unreachable (previously silently succeeded with unencrypted PII)
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `single-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `additive` — endpoints that previously returned 200 with plaintext PII now return 503 when vault is unreachable; this is a correction not a new contract
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — no schema or data changes; reverting restores silent plaintext fallback (the pre-existing behavior)
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: Supabase Vault is configured and the `encrypt_driver_pii` / `decrypt_driver_pii` RPCs exist in production (added in migration 42). Dev environments without vault will now get 503 on driver create/update with PII fields — intentional.

## Tier 3 — Compliance flags

- `[x]` **PIPEDA-relevant** — `license_number` and `vehicle_vin` are driver PII stored in Supabase; previously a vault outage would silently persist them as plaintext, now it fails closed with 503

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — no tests exercise `_vault_encrypt` directly; driver registration tests use `insert_one` directly, bypassing the route handler and vault path
- **Integration tests** [required]: `not-applicable` — vault RPC is a Supabase-hosted function; not exercised in the test suite
- **Metrics / logs introduced** [required]: `none` — existing `logger.error` calls promoted from `logger.warning`; no new metric names
- **Screenshots / video** [required if UI files touched]: n/a
- **Perf numbers** [required if SLA-critical path touched]: n/a — driver registration is not a SLA-critical path

**Pre-merge checklist** [required]:

- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs — log messages use the field name hint only, never the value
- [x] `except HTTPException: raise` guard prevents inner 503 being swallowed by outer `except Exception`
- [x] `_vault_decrypt` deliberately keeps fallback-to-raw-token behavior — returning an encrypted token on failure is not a PII leak

## Changes

**`_vault_encrypt` (fail-closed on all failure paths):**
- `ImportError` when importing `supabase_client` → `logger.error` + `raise HTTPException(503)`
- `_sb is None` (client not initialised) → `logger.error` + `raise HTTPException(503)`
- RPC exception → `logger.error + exc_info=True` + `raise HTTPException(503)`
- `res.data` is falsy after RPC → also treated as failure, raises 503

**`_vault_decrypt` (logging promoted, behavior unchanged):**
- `logger.warning` → `logger.error + exc_info=True` — decrypt failure surfaces in Sentry
- Fallback to raw encrypted token preserved (not PII, just unreadable data)

## Test plan

- `POST /drivers/register` with vault RPC disabled → confirm 503 returned, no row written to `drivers`
- `PUT /drivers/profile` with `license_number` update and vault unavailable → confirm 503, no DB write
- Normal driver registration with vault available → confirm `license_number` stored as encrypted token, not plaintext
- Check Sentry for any `vault_encrypt` errors that were previously silent warnings

https://claude.ai/code/session_017BEuKhwtnxtPNzKtjeHwiW