### PR TITLE
fix(payments): skip processed_at for unknown Stripe event types (B-P2-2)

### DIFF
--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -230,6 +230,10 @@ async def stripe_webhook(request: Request):
                 "add to dispatch or update Stripe dashboard webhook subscriptions",
                 extra={"domain": "payments", "event_id": event_id},
             )
+        # Leave processed_at NULL for unknown/unhandled events so the nightly
+        # reconciliation job can replay them if they later become actionable.
+        # Return 200 to Stripe so it does not retry indefinitely.
+        return {"received": True, "unhandled": True, "event_id": event_id}
 
     # Success — stamp processed_at. Non-fatal if this fails (we've
     # already finished the side effects, and Stripe won't retry a 2xx).

--- a/backend/tests/test_corporate_webhook.py
+++ b/backend/tests/test_corporate_webhook.py
@@ -111,3 +111,27 @@ def test_non_corporate_topup_passes_through(test_client):
 
     assert resp.status_code == 200, resp.text
     m_apply.assert_not_awaited()
+
+
+def test_unknown_event_type_not_marked_processed(test_client):
+    # B-P2-2: unknown event types must NOT stamp processed_at so the
+    # nightly reconciliation job can replay them if they later become actionable.
+    event = _event(type="customer.subscription.created", id="evt_unknown")
+    event["data"]["object"] = {}
+
+    with (
+        patch(
+            "routes.webhooks.get_app_settings",
+            AsyncMock(return_value={"stripe_webhook_secret": "whsec_x", "stripe_secret_key": "sk_x"}),
+        ),
+        patch("stripe.Webhook.construct_event", return_value=event),
+        patch("routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+        patch("routes.webhooks.mark_stripe_event_processed", AsyncMock()) as m_mark,
+    ):
+        resp = _post(test_client, event)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body.get("unhandled") is True
+    assert body["event_id"] == "evt_unknown"
+    m_mark.assert_not_awaited()


### PR DESCRIPTION
**Summary**: Prevent unknown Stripe event types from being silently marked as processed, preserving them for nightly reconciliation.

**Type**: fix
**Linked issue**: none — B-P2-2 audit finding
**Risk**: low
**User-visible change**: none
**Scope contract**: [x] This PR matches its stated type (fix — corrects a silent data-loss bug in the webhook event lifecycle; no new behaviour for handled event types)

**Surfaces touched**:
  - [x] Backend

**Rollback plan**: git-revert-safe — reverts the early-return addition in the else branch; no data or schema side effects.

**Dependencies / coordination**: none

**Assumptions**: The `stripe_events` table already exists (migration 22) and the nightly reconciliation job queries `WHERE processed_at IS NULL`.

**Unit tests**: added — `test_unknown_event_type_not_marked_processed` asserts `mark_stripe_event_processed` is never awaited for an unknown event type.

## What changed and why

The Stripe webhook handler (`routes/webhooks.py`) called `mark_stripe_event_processed(event_id)` unconditionally at the bottom of the function — including for unknown/unhandled event types that fell into the `else` branch.

**The bug**: if Stripe sends a new event type we haven't implemented yet (e.g. `customer.subscription.created`), we:
1. Claim it in `stripe_events` (correct — prevents double-processing)
2. Log a warning (correct)
3. **Stamp `processed_at`** (wrong — the event was never actioned)

A future replay of the same `event_id` returns `{"duplicate": True}` immediately. The nightly reconciliation job never sees `processed_at IS NULL` so it never replays the event. The unhandled event is silently discarded forever.

**The fix**: add an early `return {"received": True, "unhandled": True}` in the `else` block before `mark_stripe_event_processed` is reached. Stripe still gets a 200 (no infinite retries), but `processed_at` stays NULL so:
- Reconciliation can identify and replay the event
- Engineers can investigate what changed in our Stripe subscription config

## Pre-merge checklist

- [x] All 4 webhook tests pass locally
- [x] `ruff check backend/` passes
- [x] Known event types (`payment_intent.succeeded`, `payment_intent.payment_failed`, `checkout.session.completed`) still reach `mark_stripe_event_processed` unchanged
- [x] No money arithmetic changed — this is a control-flow fix only
- [x] Stripe receives 200 for unknown events (no retry storm)

https://claude.ai/code/session_012vzLtY9ebSY8exwgqCc5qe

---
_Generated by [Claude Code](https://claude.ai/code/session_012vzLtY9ebSY8exwgqCc5qe)_

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
