### PR TITLE
test(drivers): fix _SimpleCursor await errors in T4A payout tests

### DIFF
--- a/backend/tests/test_p2_payout_t4a.py
+++ b/backend/tests/test_p2_payout_t4a.py
@@ -20,7 +20,7 @@ Run:
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -222,26 +222,13 @@ class TestGetPayoutHistory:
 
         driver = _driver_row()
         payouts = [_payout_row(50.00), _payout_row(30.00, "completed")]
-        cursor = _SimpleCursor(payouts)
 
-        # Production code calls get_rows in two incompatible ways:
-        #   1st call (drivers table): `await get_rows(...)` → needs an awaitable
-        #   2nd call (payouts table): NOT awaited, used as a cursor object
-        #
-        # Strategy: use a plain MagicMock (NOT AsyncMock) so that calling the mock
-        # returns the side_effect value directly. For the awaited "drivers" call,
-        # the side_effect returns a coroutine which `await` will resolve. For the
-        # non-awaited "payouts" call, it returns the cursor object directly.
-        async def _drivers_coro():
-            return [driver]
-
-        def _sync_side_effect(table, query=None, **kwargs):
+        async def _get_rows(table, query=None, **kwargs):
             if table == "drivers":
-                return _drivers_coro()  # coroutine: `await mock(...)` resolves to [driver]
-            return cursor  # cursor object: used without await
+                return [driver]
+            return payouts
 
-        mock_get_rows = MagicMock(side_effect=_sync_side_effect)
-        with patch("backend.routes.drivers.db_supabase.get_rows", mock_get_rows):
+        with patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(side_effect=_get_rows)):
             result = await get_payout_history(
                 limit=20,
                 offset=0,
@@ -285,18 +272,17 @@ class TestGetT4ASummary:
 
         driver = _driver_row()
         rides = [_ride_row(20.00), _ride_row(35.00), _ride_row(15.00)]
-        cursor = _SimpleCursor(rides)
 
         async def _get_rows(table, query=None, **kwargs):
             return [driver]  # for drivers lookup
 
-        def _get_rides_for_driver(drv, **kwargs):
-            return cursor
+        async def _get_rides_for_driver(drv, **kwargs):
+            return rides
 
         with (
             patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(side_effect=_get_rows)),
             patch(
-                "backend.routes.drivers.db_supabase.get_rides_for_driver", MagicMock(side_effect=_get_rides_for_driver)
+                "backend.routes.drivers.db_supabase.get_rides_for_driver", AsyncMock(side_effect=_get_rides_for_driver)
             ),
         ):
             result = await get_t4a_summary(year=2025, current_user={"id": DRIVER_USER_ID})


### PR DESCRIPTION
**Summary**: Fix 2 pre-existing backend-test failures caused by non-awaitable mock objects in the T4A payout test suite.

**Type**: fix
**Linked issue**: none — pre-existing test failures causing noise on every PR CI run
**Risk**: low
**User-visible change**: none
**Scope contract**: [x] This PR matches its stated type (fix — test-only change; no production code modified)

**Surfaces touched**:
  - [x] Backend

**Rollback plan**: git-revert-safe — test-only file; no data or schema side effects.

**Dependencies / coordination**: none

**Assumptions**: `db_supabase.get_rows` and `db_supabase.get_rides_for_driver` are both `async def` functions (verified at lines 1503 and 1527 of `routes/drivers.py`).

**Unit tests**: updated — 2 previously-failing tests now pass; all 8 T4A tests green.

## What changed and why

`test_payout_history_returns_driver_payouts` and `test_t4a_sums_driver_earnings` were failing with `TypeError: object _SimpleCursor can't be used in 'await' expression` because their mock side-effects returned a non-awaitable `_SimpleCursor` object, but the production code (`routes/drivers.py:1508` and `:1527`) `await`s both `get_rows` and `get_rides_for_driver`.

The stale test comments described a "two incompatible ways" pattern that no longer matches production code — both calls are now awaited.

**Fix**: replace `MagicMock` with `AsyncMock` and return the data lists directly from async side-effect functions. Also removes the now-unused `MagicMock` import.

## Pre-merge checklist

- [x] All 8 T4A payout tests pass locally (`pytest tests/test_p2_payout_t4a.py`)
- [x] `ruff check backend/` passes
- [x] No production code modified
- [x] No money arithmetic involved

https://claude.ai/code/session_012vzLtY9ebSY8exwgqCc5qe

---
_Generated by [Claude Code](https://claude.ai/code/session_012vzLtY9ebSY8exwgqCc5qe)_

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
