### PR TITLE
fix: resolve all P0 test failures across backend and RN surfaces

### DIFF
--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -143,7 +143,8 @@ async def get_driver_acceptance_rates(
         drivers = await db.get_rows("drivers", {}, limit=500)
     except Exception as e:
         logger.error(f"Failed to fetch drivers: {e}", exc_info=True, extra={"domain": "admin"})
-        drivers = []
+        from fastapi import HTTPException as _HTTPException
+        raise _HTTPException(status_code=503, detail="analytics_unavailable") from e
 
     if service_area_id:
         drivers = [d for d in drivers if d.get("service_area_id") == service_area_id]

--- a/backend/routes/admin/maintenance.py
+++ b/backend/routes/admin/maintenance.py
@@ -72,19 +72,26 @@ async def admin_cleanup_location_history(days: int = Query(30, ge=7, le=1095)):
     deleted_historical = 0
     deleted_idle = 0
     try:
-        # Delete directly — the previous pattern fetched up to 100k rows just
-        # to count them before deleting, which OOMs the process on a busy day.
-        # delete_many is a no-op when nothing matches, so no pre-check needed.
-        await db_supabase.delete_many("driver_location_history", {"timestamp": {"$lt": cutoff_historical}})
-        deleted_historical = -1  # count not fetched; -1 = "deleted (count unknown)"
+        deleted_historical = await db_supabase.count_documents(
+            "driver_location_history", {"timestamp": {"$lt": cutoff_historical}}
+        )
+        if deleted_historical > 0:
+            await db_supabase.delete_many(
+                "driver_location_history", {"timestamp": {"$lt": cutoff_historical}}
+            )
     except Exception as e:
         logger.error(f"Cleanup historical GPS failed: {e}", exc_info=True)
 
     try:
-        await db_supabase.delete_many(
-            "driver_location_history", {"timestamp": {"$lt": cutoff_idle}, "tracking_phase": "online_idle"}
+        deleted_idle = await db_supabase.count_documents(
+            "driver_location_history",
+            {"timestamp": {"$lt": cutoff_idle}, "tracking_phase": "online_idle"},
         )
-        deleted_idle = -1
+        if deleted_idle > 0:
+            await db_supabase.delete_many(
+                "driver_location_history",
+                {"timestamp": {"$lt": cutoff_idle}, "tracking_phase": "online_idle"},
+            )
     except Exception as e:
         logger.error(f"Cleanup idle GPS failed: {e}", exc_info=True)
 
@@ -160,6 +167,7 @@ async def admin_rollup_driver_daily(target_date: Optional[str] = None):
         "driver_location_history",
         {"timestamp": {"$gte": day_start_iso, "$lt": day_end_iso}},
         order="timestamp",
+        columns="driver_id",
         limit=10000,  # enough to identify all active drivers; per-driver aggregation is done in SQL
     )
     drivers_with_gps: set = set()

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1171,6 +1171,7 @@ async def get_ride_history(
         "rides",
         {
             "rider_id": current_user["id"],
+            "status": {"$in": ["completed", "cancelled"]},
         },
         limit=2000,
     )

--- a/backend/tests/test_admin_logout_revocation.py
+++ b/backend/tests/test_admin_logout_revocation.py
@@ -126,7 +126,8 @@ async def test_admin_logout_blacklists_jti():
     redis_set_mock = AsyncMock()
     revoke_mock = AsyncMock()
 
-    request_mock = MagicMock()
+    from starlette.requests import Request as _Request
+    request_mock = MagicMock(spec=_Request)
     request_mock.state = MagicMock()
 
     from backend.routes.admin.auth import LogoutRequest

--- a/backend/tests/test_b_p0_2.py
+++ b/backend/tests/test_b_p0_2.py
@@ -189,9 +189,8 @@ async def test_complete_ride_does_not_overwrite_payment_status():
     with (
         patch(
             "backend.routes.drivers.db_supabase.get_rows",
-            AsyncMock(side_effect=lambda t, *a, **kw: [driver] if t == "drivers" else []),
+            AsyncMock(side_effect=lambda t, *a, **kw: [driver] if t == "drivers" else ([ride] if t == "rides" else [])),
         ),
-        patch("backend.routes.drivers.db_supabase.get_ride", AsyncMock(return_value=ride)),
         patch("backend.routes.drivers.db_supabase.update_one", AsyncMock(side_effect=capture_update_one)),
         patch("backend.routes.drivers.db_supabase.get_user_by_id", AsyncMock(return_value=None)),
         patch("backend.routes.drivers.manager.send_personal_message", AsyncMock()),

--- a/backend/tests/test_p0_ship_blockers.py
+++ b/backend/tests/test_p0_ship_blockers.py
@@ -137,7 +137,7 @@ class TestDriverCancelNotifiesRider:
         that's a safety / fraud vector."""
         from backend.routes import drivers as drv_mod
 
-        in_progress = _ride(status="trip_in_progress", driver_id=DRIVER_ID)
+        in_progress = _ride(status="in_progress", driver_id=DRIVER_ID)
 
         with (
             patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[_driver_row()])),

--- a/driver-app/__mocks__/expo-winter-noop.js
+++ b/driver-app/__mocks__/expo-winter-noop.js
@@ -1,0 +1,4 @@
+// Stubs expo/src/winter/* modules that trigger jest-runtime scope errors (Expo SDK 54).
+// The __ExpoImportMetaRegistry lazy getter calls require('./ImportMetaRegistry') outside
+// the test code scope; returning a safe stub prevents the ReferenceError.
+module.exports = { ImportMetaRegistry: { url: null } };

--- a/driver-app/jest.config.js
+++ b/driver-app/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
     },
   },
   moduleNameMapper: {
+    '^expo/src/winter/ImportMetaRegistry$': '<rootDir>/__mocks__/expo-winter-noop.js',
     '^@shared/api/client$': '<rootDir>/__mocks__/@shared/api/client.js',
     '^@shared/config/spinr\\.config$': '<rootDir>/__mocks__/@shared/config/spinr.config.js',
     '^@shared/(.*)$': '<rootDir>/__mocks__/@shared/$1',

--- a/driver-app/jest.setup.js
+++ b/driver-app/jest.setup.js
@@ -1,3 +1,20 @@
+// Expo SDK 54's runtime.native.ts installs lazy getters for multiple globals via
+// installGlobal.ts. Eagerly trigger them during setupFiles (isInsideTestCode=true)
+// so they cache as static values before test module loading begins.
+const _EXPO_WINTER_GLOBALS = [
+  '__ExpoImportMetaRegistry', 'structuredClone',
+  'TextDecoder', 'TextDecoderStream', 'TextEncoderStream',
+  'URL', 'URLSearchParams',
+];
+for (const _name of _EXPO_WINTER_GLOBALS) {
+  const _desc = Object.getOwnPropertyDescriptor(global, _name);
+  if (_desc && typeof _desc.get === 'function') {
+    try { void global[_name]; } catch (_e) {
+      Object.defineProperty(global, _name, { value: undefined, configurable: true, writable: true });
+    }
+  }
+}
+
 // Mock expo-secure-store
 jest.mock('expo-secure-store', () => ({
   getItemAsync: jest.fn(() => Promise.resolve(null)),

--- a/rider-app/__mocks__/expo-winter-noop.js
+++ b/rider-app/__mocks__/expo-winter-noop.js
@@ -1,0 +1,4 @@
+// Stubs expo/src/winter/* modules that trigger jest-runtime scope errors (Expo SDK 54).
+// The __ExpoImportMetaRegistry lazy getter calls require('./ImportMetaRegistry') outside
+// the test code scope; returning a safe stub prevents the ReferenceError.
+module.exports = { ImportMetaRegistry: { url: null } };

--- a/rider-app/jest-setup-expo.js
+++ b/rider-app/jest-setup-expo.js
@@ -1,0 +1,37 @@
+// Expo SDK 54's runtime.native.ts installs lazy getters for multiple globals
+// (__ExpoImportMetaRegistry, structuredClone, TextDecoder, URL, etc.) via
+// installGlobal.ts. Each getter defers its require() call until first access.
+// If that access happens during test-file module loading (isInsideTestCode=false),
+// jest-runtime throws a scope error.
+//
+// Fix: eagerly trigger every lazy getter here, while we're still inside the
+// setupFiles execution window (isInsideTestCode=true), so the values are
+// cached as plain properties before any test module loads.
+
+const EXPO_WINTER_GLOBALS = [
+  '__ExpoImportMetaRegistry',
+  'structuredClone',
+  'TextDecoder',
+  'TextDecoderStream',
+  'TextEncoderStream',
+  'URL',
+  'URLSearchParams',
+];
+
+for (const name of EXPO_WINTER_GLOBALS) {
+  const desc = Object.getOwnPropertyDescriptor(global, name);
+  if (desc && typeof desc.get === 'function') {
+    try {
+      // eslint-disable-next-line no-unused-expressions
+      void global[name]; // triggers the lazy getter; defineLazyObjectProperty then replaces it with a static value
+    } catch (_e) {
+      // getter resolution failed; install a safe stub so test-module loading won't re-trigger
+      Object.defineProperty(global, name, {
+        value: undefined,
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
+    }
+  }
+}

--- a/rider-app/jest.config.js
+++ b/rider-app/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'jest-expo',
+  setupFiles: ['./jest-setup-expo.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
   testPathIgnorePatterns: [
     '/node_modules/',
@@ -10,6 +11,7 @@ module.exports = {
   ],
   modulePaths: ['<rootDir>/node_modules'],
   moduleNameMapper: {
+    '^expo/src/winter/ImportMetaRegistry$': '<rootDir>/__mocks__/expo-winter-noop.js',
     '^@shared/(.*)$': '<rootDir>/../shared/$1',
   },
   // R-P1-22: Enforce minimum coverage thresholds before merging to main.

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -517,12 +517,9 @@ export const useRideStore = create<RideState>((set, get) => ({
         }
       }
     }
-    // All attempts failed — prompt the user to call 911 directly
-    Alert.alert(
-      'Emergency Alert May Not Have Sent',
-      'Could not reach the server after multiple attempts. Please call 911 directly.',
-      [{ text: 'Call 911', onPress: () => Linking.openURL('tel:911') }]
-    );
+    // All attempts failed — rethrow so SOSButton can set backendOk=false and
+    // show its own "Alert Not Sent" UI with the 911 prompt.
+    throw lastError;
   },
 
   fetchSavedAddresses: async () => {


### PR DESCRIPTION
Backend (production code):
- maintenance.py: use count_documents before delete_many; skip delete when
  count=0; add columns="driver_id" to presence_rows query (GPS OOM fix)
- analytics.py: raise HTTP 503 (detail=analytics_unavailable) on DB error
  instead of silently returning empty driver list
- rides.py: push status=$in[completed,cancelled] filter to DB in
  get_ride_history (avoids full-table scan on busy accounts)

Backend (test fixes):
- test_p0_ship_blockers: correct status string trip_in_progress→in_progress
- test_b_p0_2: patch get_rows for rides table (complete_ride uses get_rows,
  not get_ride)
- test_admin_logout_revocation: use MagicMock(spec=Request) so slowapi's
  isinstance check passes

RN apps (Expo SDK 54 jest env):
- Add jest-setup-expo.js (rider-app) and update jest.setup.js (driver-app)
  to eagerly trigger expo/src/winter lazy globals during setupFiles while
  isInsideTestCode=true, preventing scope errors during test module loading
- Add moduleNameMapper entry for expo-winter-noop.js (belt-and-suspenders)

rider-app / SOS P0:
- rideStore.triggerEmergency: rethrow on all-attempts failure instead of
  calling Alert.alert; SOSButton owns the failure UX and retry loop

https://claude.ai/code/session_01W4CKhhTpY2KmzDYkQTq4Sz

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
