### PR TITLE
chore(compliance/B-P3-3): scheduled sub-processor monitor

### DIFF
--- a/.github/workflows/subprocessor-monitor.yml
+++ b/.github/workflows/subprocessor-monitor.yml
@@ -1,0 +1,203 @@
+name: Sub-processor monitor (B-P3-3)
+
+# B-P3-3: ensures docs/vendor-inventory.md gets a scheduled review.
+#
+# Why this exists
+# ---------------
+# PIPEDA s.4.1.3 (cross-border disclosure), SOC 2 CC9.2, and PCI-DSS 12.8
+# require Spinr to maintain an up-to-date inventory of every external
+# vendor that handles user data. The inventory itself lives at
+# docs/vendor-inventory.md and declares a quarterly review cadence — but
+# nothing actually enforced that cadence, so the doc could silently rot.
+#
+# What this workflow does
+# -----------------------
+# Every Monday at 13:00 UTC (≈06:00 PST / 09:00 EST — early-week so a
+# review issue doesn't sit unread over the weekend):
+#
+#   1. Reads the last-modified date of docs/vendor-inventory.md from
+#      git log (most recent non-CI-bot commit; we ignore audit-report
+#      commits to avoid resetting the timer on noise).
+#   2. If that date is older than VENDOR_REVIEW_DAYS (default 90), opens
+#      a GitHub issue tagged `compliance` reminding the owners that the
+#      inventory is due for a quarterly review.
+#   3. Idempotent: if there is already an OPEN issue with the
+#      "subprocessor-review" label, the workflow does nothing — it
+#      will not spam a new issue every week until the existing one is
+#      closed.
+#
+# This is intentionally lightweight. It does NOT scrape vendor
+# sub-processor URLs (those URLs change form, are sometimes auth-gated,
+# and would create a high-noise scrape). It enforces the existing
+# quarterly cadence the doc itself declares; that's the gap the audit
+# (B-P3-3) flagged.
+#
+# Future enhancement: per-vendor sub-processor URL list with hash-diff,
+# tracked separately. See docs/vendor-inventory.md "Future enhancements".
+
+on:
+  schedule:
+    # Weekly Monday 13:00 UTC. cron is in UTC and has no DST handling.
+    - cron: "0 13 * * 1"
+  workflow_dispatch:
+    inputs:
+      force_open_issue:
+        description: "Open a review issue even if the inventory was just updated (manual override)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  VENDOR_REVIEW_DAYS: "90"
+  INVENTORY_FILE: "docs/vendor-inventory.md"
+  ISSUE_LABEL: "subprocessor-review"
+
+jobs:
+  check-and-notify:
+    name: Vendor inventory freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history so `git log` can find the inventory's last
+          # human commit (depth=1 only gives the latest commit overall).
+          fetch-depth: 0
+
+      - name: Compute days since last inventory update
+        id: freshness
+        run: |
+          set -euo pipefail
+          if [ ! -f "${INVENTORY_FILE}" ]; then
+            echo "::error::${INVENTORY_FILE} is missing"
+            exit 1
+          fi
+
+          # Last commit author date for the inventory file. ISO-8601 strict
+          # so `date -d` parses unambiguously. We exclude the CI-audit bot
+          # so a noise commit doesn't reset the timer.
+          last_iso=$(git log -1 \
+            --pretty=format:%aI \
+            --invert-grep \
+            --author='github-actions\[bot\]' \
+            -- "${INVENTORY_FILE}")
+
+          if [ -z "$last_iso" ]; then
+            # No human commits at all (only the bot, or nothing) — treat as
+            # very stale so the issue gets created.
+            last_iso=$(git log -1 --pretty=format:%aI -- "${INVENTORY_FILE}")
+          fi
+
+          last_epoch=$(date -d "${last_iso}" +%s)
+          now_epoch=$(date +%s)
+          age_days=$(( (now_epoch - last_epoch) / 86400 ))
+
+          echo "last_iso=${last_iso}"   >> "$GITHUB_OUTPUT"
+          echo "age_days=${age_days}"   >> "$GITHUB_OUTPUT"
+          echo "Inventory last touched: ${last_iso} (${age_days} days ago)"
+
+      - name: Check for existing open review issue
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # gh issue list returns JSON; use --json to avoid screen-scraping.
+          existing=$(gh issue list \
+            --state open \
+            --label "${ISSUE_LABEL}" \
+            --json number,title \
+            --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            echo "existing=${existing}" >> "$GITHUB_OUTPUT"
+            echo "Found existing open review issue #${existing} — skipping creation."
+          else
+            echo "existing=" >> "$GITHUB_OUTPUT"
+            echo "No existing open review issue."
+          fi
+
+      - name: Decide whether to open issue
+        id: decide
+        run: |
+          set -euo pipefail
+          force="${{ github.event.inputs.force_open_issue || 'false' }}"
+          age="${{ steps.freshness.outputs.age_days }}"
+          existing="${{ steps.existing.outputs.existing }}"
+
+          if [ -n "$existing" ]; then
+            echo "open_issue=false" >> "$GITHUB_OUTPUT"
+            echo "Reason: open issue #${existing} already exists."
+          elif [ "$force" = "true" ]; then
+            echo "open_issue=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: workflow_dispatch with force_open_issue=true."
+          elif [ "$age" -ge "${VENDOR_REVIEW_DAYS}" ]; then
+            echo "open_issue=true" >> "$GITHUB_OUTPUT"
+            echo "Reason: inventory is ${age} days stale (threshold: ${VENDOR_REVIEW_DAYS})."
+          else
+            echo "open_issue=false" >> "$GITHUB_OUTPUT"
+            echo "Reason: inventory is fresh (${age} days, under ${VENDOR_REVIEW_DAYS}d threshold)."
+          fi
+
+      - name: Open vendor-review issue
+        if: steps.decide.outputs.open_issue == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          age="${{ steps.freshness.outputs.age_days }}"
+          last="${{ steps.freshness.outputs.last_iso }}"
+
+          title="Vendor inventory review due — last updated ${age}d ago"
+          body=$(cat <<EOF
+          # Vendor inventory quarterly review
+
+          \`docs/vendor-inventory.md\` was last updated **${last}** — ${age} days ago.
+          The doc declares a quarterly (90-day) review cadence; this issue is
+          this cycle's reminder.
+
+          ## Owners
+
+          \`compliance\` + \`infra\` (per the doc's "Owner" line).
+
+          ## Checklist
+
+          - [ ] Walk every row in **Active Vendors** — confirm vendor still in use.
+          - [ ] For each row: confirm DPA still on file and not expired.
+          - [ ] For each row: confirm vendor's published sub-processor list hasn't changed materially since last review (Stripe, Google, Twilio, Supabase publish these). If it has, update the **Sub-processors** column and disclose the change in the privacy policy within 30 days.
+          - [ ] Confirm hosting region for **Supabase** and **Upstash / Redis Cloud** (still flagged ⚠ VERIFY in the doc).
+          - [ ] Onboarded any new vendors since last review? Run \`Vendor Onboarding Checklist\` from the doc and add rows here.
+          - [ ] Offboarded any vendors? Mark RETIRED and update privacy policy.
+          - [ ] DPIA status updated where relevant.
+          - [ ] Commit the doc changes with message \`chore(compliance): vendor inventory quarterly review YYYY-Q\`. The commit's author timestamp resets this workflow's clock; closing this issue does not.
+
+          ## When to close
+
+          Close this issue once \`docs/vendor-inventory.md\` has been committed
+          with the new review timestamp. The next reminder will fire 90 days
+          after that commit.
+
+          ---
+
+          *Auto-generated by \`.github/workflows/subprocessor-monitor.yml\` (B-P3-3).*
+          EOF
+          )
+
+          gh issue create \
+            --title "${title}" \
+            --body  "${body}" \
+            --label "${ISSUE_LABEL}" \
+            --label "compliance"
+
+      - name: No-op summary
+        if: steps.decide.outputs.open_issue != 'true'
+        run: |
+          echo "✅ No vendor-review issue opened this run."
+          echo "   age_days: ${{ steps.freshness.outputs.age_days }}"
+          echo "   threshold: ${VENDOR_REVIEW_DAYS}"
+          echo "   existing open issue: ${{ steps.existing.outputs.existing }}"

--- a/docs/vendor-inventory.md
+++ b/docs/vendor-inventory.md
@@ -126,10 +126,41 @@ When a vendor relationship ends:
 | Upstash region unknown | Upstash | HIGH | `devops` to verify |
 | Gemini not in privacy policy | Google | MEDIUM | **DV-16 open** |
 | DPIA for Google Maps not filed | Google | MEDIUM | `compliance` to file |
-| No sub-processor monitoring cadence | Multiple | MEDIUM | Add quarterly check to this doc |
+| ~~No sub-processor monitoring cadence~~ | Multiple | RESOLVED | `.github/workflows/subprocessor-monitor.yml` (B-P3-3) opens a `subprocessor-review` issue if this doc hasn't been touched in 90+ days |
 | Email provider not yet selected | — | MEDIUM | `backend` to decide + onboard |
 | PagerDuty/OpsGenie not yet selected | — | HIGH | `devops` to decide |
 | Status page provider not yet selected | — | MEDIUM | `devops` to decide |
+
+---
+
+## Monitoring (B-P3-3)
+
+A scheduled GitHub Action — `.github/workflows/subprocessor-monitor.yml` —
+runs every Monday at 13:00 UTC and:
+
+1. Reads the last commit date for this file (excluding bot-only commits).
+2. If the file is older than 90 days, opens a `subprocessor-review`
+   GitHub issue assigned to the `compliance` label.
+3. The check is idempotent — a single open issue silences the workflow
+   until the issue is closed.
+
+The intent is to enforce the quarterly review cadence the doc itself
+declares. Closing the auto-generated issue does **not** reset the 90-day
+clock; only an actual commit to this file does. The expected close-out
+flow is:
+
+- Owners walk the **Vendor Onboarding** + **Active Vendors** rows.
+- Update the **Change Log** entry with the new review date.
+- Commit with message `chore(compliance): vendor inventory quarterly review YYYY-Q`.
+- Close the GitHub issue once the commit lands.
+
+Manual trigger is also exposed via `workflow_dispatch` with a
+`force_open_issue=true` input for ad-hoc reviews (e.g. mid-cycle vendor
+changes).
+
+Future enhancement: per-vendor sub-processor URL list with hash-diff,
+so material changes to (e.g.) Stripe's published sub-processor page
+auto-flag here. Tracked separately; not in scope for B-P3-3.
 
 ---
 
@@ -138,3 +169,4 @@ When a vendor relationship ends:
 | Date | Change | Author |
 |---|---|---|
 | 2026-04-24 | Initial inventory created | audit-framework |
+| 2026-04-28 | B-P3-3: scheduled `subprocessor-monitor.yml` workflow added; review-cadence gap resolved | session 01L8Q1k |


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Scheduled GitHub Action that opens a `subprocessor-review` issue when `docs/vendor-inventory.md` hasn't been touched in 90+ days. Closes B-P3-3 — the doc declared a quarterly review cadence but nothing enforced it.
- **Type**: `chore`
- **Linked issue**: Refs B-P3-3 from `reports/audits/2026-04-26-backend-verification-rollup.md` ("No `backend/utils/subprocessor_audit.py`; no scheduled GitHub Action / Railway cron diffing `docs/vendor-inventory.md` against vendor sub-processor lists").
- **Risk**: `low` — pure observability/automation; no production code changes; no schema; no API surface. Worst case the workflow misfires and opens a redundant issue, which is idempotent on the second run.
- **User-visible change**: `none`.
- **Scope contract**: `[x]` This PR matches its stated type — chore (compliance + CI). No unrelated refactors.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[x]` CI
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none` (this is a GitHub Actions schedule, not an in-process background loop).
- **Feature flag**: `none`
- **Config / secret change**: `none` — uses the default `github.token` issued to every workflow.
- **Rollback plan**: `git-revert-safe` — delete the workflow file, revert the doc edit. No state lives outside this commit.
- **Dependencies / coordination**: `none` — branched off `ec363c6` (latest main, post-#166).
- **Assumptions**: GitHub Actions is reachable on schedule and `gh issue create` succeeds. If the workflow itself errors, GitHub surfaces the failed run on the Actions tab; an Actions outage just means a delayed reminder, not a security incident.

## Tier 3 — Compliance flags

- `[ ]` **Money-touching**
- `[x]` **PIPEDA-relevant** — directly addresses PIPEDA s.4.1.3 (cross-border disclosure tracking) by enforcing the vendor-inventory review cadence the doc itself declares.
- `[ ]` **SK Transportation Act**
- `[ ]` **Auth / RLS**
- `[ ]` **Safety**
- `[ ]` **Third-party SDK added**
- `[ ]` **Breaking change to `shared/`**

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — workflow is shell + `gh` CLI; the only logic is "compare two timestamps and conditionally call `gh issue create`". All branches are exercised by the workflow_dispatch manual trigger.
- **Integration tests**: `not-applicable`.
- **Metrics / logs introduced**: `none` — workflow output is the GitHub Actions run log.
- **Screenshots / video**: `not-applicable`.
- **Perf numbers**: `not-applicable`.

**Pre-merge checklist**:

- [x] Ran the changed code against real Supabase dev (not just mocks) — N/A; pure CI workflow.
- [ ] Tested with rider + driver + admin accounts — single-surface (CI), not applicable.
- [x] Verified the rollback command actually works — `rm .github/workflows/subprocessor-monitor.yml; git revert <commit>`.
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention change. Inventory doc updated with the new Monitoring section.
- [x] No PII added to logs, Sentry payloads, or analytics. Conversely: this PR enforces vendor-inventory hygiene.

---

## What changed

| Commit | Files |
|---|---|
| `c655658` | `.github/workflows/subprocessor-monitor.yml` (new, 165 lines)<br>`docs/vendor-inventory.md` (+30/-1 — Known Gaps row marked RESOLVED, new "Monitoring" section, Change Log entry) |

## How it works

1. **Trigger**: cron `0 13 * * 1` (Mondays 13:00 UTC ≈ 06:00 PST / 09:00 EST — early-week so a review issue doesn't sit unread over the weekend) + `workflow_dispatch` for manual override.
2. **Freshness check**: `git log -1 --pretty=format:%aI --invert-grep --author='github-actions\[bot\]' -- docs/vendor-inventory.md` → ISO timestamp of the last human commit, ignoring bot commits so audit-report noise can't reset the timer.
3. **Idempotency**: `gh issue list --state open --label subprocessor-review --json number` → if any issue already exists, the workflow skips creation and exits cleanly.
4. **Issue body**: includes the actual age, the doc's owner line (`compliance` + `infra`), a 7-item review checklist, and clear close-out instructions. Closing the issue does NOT reset the workflow's clock — only a commit to the doc does.

## Why a lightweight monitor (not a vendor-page scraper)

The audit's exact wording was "no scheduled GitHub Action / Railway cron diffing `docs/vendor-inventory.md` against vendor sub-processor lists". Two ways to read that:

- **Wide read**: scrape every vendor's sub-processor URL (Stripe, Google, Twilio, Supabase publish these) and hash-diff. **Out of scope** here — vendor pages change form, are sometimes auth-gated, and would create high-noise. Tracked as a future enhancement in the doc.
- **Narrow read**: enforce the quarterly cadence the doc itself declares so the inventory doesn't silently rot. **In scope** — that's the failure mode B-P3-3 actually flagged ("review cadence: quarterly + on any new vendor onboarding" — but nothing made the cadence visible, so it was easy to miss).

This PR ships the narrow read. Once the team has a working review-cadence loop, the wider scraper can layer on top of the same workflow without churn.

## Conflict-safety check

- Branched off latest `origin/main` (`ec363c6`) — verified before write.
- No existing `.github/workflows/subprocessor-monitor.yml` on main — additive ✓
- No existing `Monitoring (B-P3-3)` section in `docs/vendor-inventory.md` — additive ✓
- Known Gaps row updated in place (single line); previous content preserved as strikethrough so the audit history is readable.

https://claude.ai/code/session_01L8Q1kEd7jbNDLkh2ruDsMA

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Q1kEd7jbNDLkh2ruDsMA)_