### PR TITLE
security(B-P2-8): pin Dockerfile builder + add image-pinning runbook

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,15 @@
-FROM python:3.12-slim
+# B-P2-8: builder stage pinned to a specific Python minor version, matching
+# the runtime stage below. Previously this was `python:3.12-slim` (any 3.12.x),
+# which meant a Docker Hub re-tag of `3.12-slim` could change the build
+# environment between runs without any visible PR diff.
+#
+# NEXT STEP — content-hash pin: add `@sha256:<digest>` after the tag to make
+# the base image bit-for-bit reproducible. This requires a `docker pull` of
+# the current upstream image, which is a manual step performed at the deploy
+# host (Railway / local dev). See `docs/runbooks/docker-image-pinning.md`
+# for the procedure. The digest should be refreshed quarterly or when a
+# Trivy/Grype scan flags the current base.
+FROM python:3.12.9-slim
 
 WORKDIR /build
 

--- a/docs/runbooks/docker-image-pinning.md
+++ b/docs/runbooks/docker-image-pinning.md
@@ -1,0 +1,129 @@
+# Docker Image Pinning — Runbook
+
+**Audience:** anyone who edits `backend/Dockerfile` or rotates the base image.
+
+**Why this exists:** B-P2-8 from the 2026-04-26 backend audit flagged that
+the builder stage used `python:3.12-slim` (any 3.12.x) and the runtime stage
+used `python:3.12.9-slim` — both **mutable tags** with no `@sha256:` content
+hash. A Docker Hub re-tag, a compromised mirror, or a typosquat in a
+multi-platform manifest can replace the bytes behind a tag without any
+diff in our repo.
+
+The Dockerfile in this branch pins both stages to the same minor version
+(`3.12.9-slim`); the **content-hash pin** (the `@sha256:<digest>` suffix)
+is the next layer and is performed manually because it requires a
+`docker pull` against the current upstream image.
+
+---
+
+## Threat model
+
+| Attack | Without digest pin | With digest pin |
+|---|---|---|
+| Docker Hub publishes a re-tag of `python:3.12.9-slim` with malicious bytes | New build runs the malicious base | Build fails with `manifest digest mismatch` until digest is refreshed |
+| Compromised PyPI mirror typosquats a transitive dependency baked into Python's slim image | Captured in next build | Captured in next build (same as without; digest only protects the image, not the runtime install — but our `--require-hashes` lockfile already covers that path) |
+| Insider with Docker Hub push access tampers with the manifest | New build inherits change | Insider must also rotate our pinned digest, which leaves a PR audit trail |
+
+The digest pin is a defense-in-depth layer: it doesn't replace
+`--require-hashes` (which we have for `requirements-locked.txt`) — it
+covers the OS-level layers below the Python install.
+
+---
+
+## Procedure: add or refresh the SHA256 digest
+
+Run on a host with a working `docker` CLI (your laptop, a CI worker, or
+a Railway shell):
+
+```bash
+# 1. Pull the current upstream image. This downloads bytes, not just metadata.
+docker pull python:3.12.9-slim
+
+# 2. Read the manifest digest pinned to that pull.
+docker inspect --format='{{index .RepoDigests 0}}' python:3.12.9-slim
+# → python@sha256:abcd1234...
+```
+
+The output is the form `python@sha256:<digest>`. Copy the digest.
+
+Then edit `backend/Dockerfile`:
+
+```dockerfile
+# Builder stage
+FROM python:3.12.9-slim@sha256:abcd1234efgh5678...
+
+# Runtime stage
+FROM python:3.12.9-slim@sha256:abcd1234efgh5678... AS runtime
+```
+
+Commit on a feature branch:
+
+```bash
+git checkout -b chore/docker-base-pin-YYYYMMDD
+git add backend/Dockerfile
+git commit -m "chore(docker): refresh python:3.12.9-slim digest pin
+
+Re-pinned the builder + runtime base to the current Docker Hub digest
+for python:3.12.9-slim. Verifies via 'docker inspect' on a 2026-MM-DD
+pull. Trivy / Grype image scan should be clean against this digest
+before this PR merges.
+"
+git push -u origin chore/docker-base-pin-YYYYMMDD
+gh pr create --title "chore(docker): refresh python:3.12.9-slim digest pin" \
+             --body "B-P2-8 quarterly digest refresh. See docs/runbooks/docker-image-pinning.md."
+```
+
+CI must pass:
+- The `docker-image-scan` Trivy job builds the image and reports CVE
+  count. A digest refresh that introduces NEW Highs/Criticals must be
+  reverted or scoped (e.g. add an apt-get patch step in the Dockerfile).
+
+---
+
+## Cadence
+
+- **Quarterly**: refresh the digest unconditionally so we're never more
+  than 90 days behind upstream's CVE patches.
+- **On Trivy alert**: if `docker-image-scan` flags a HIGH/CRITICAL CVE in
+  the current base, refresh the digest as soon as Docker Hub publishes
+  a patched build (typically within a week of the upstream Python
+  release).
+- **On Python minor bump**: when bumping `3.12.9` → `3.12.10`, the digest
+  must change too — never carry an old digest into a new minor.
+
+---
+
+## Why we don't pin to the major-only tag
+
+`python:3.12-slim` is a moving alias for the latest 3.12.x. Pinning to it
+gets us "free" patch upgrades but loses build reproducibility — the same
+commit can produce different artifacts on different days. Reproducibility
+beats automatic upgrades for a security-sensitive backend; we pin the
+minor and refresh on a known cadence.
+
+---
+
+## What ELSE the audit (B-P2-8) called for
+
+The audit also flagged "no read-only-root-filesystem in deploy spec".
+Status (2026-04-28):
+
+- **Railway** (primary host): does not expose `read_only: true` for
+  Docker deployments via `railway.toml`. The container's root filesystem
+  is writable by default. Mitigations in place: `USER spinr` (non-root
+  PID), `--require-hashes` lockfile, `--prefix=/install` builder layer.
+  Tracked as a future enhancement; would require migrating to a host
+  that supports the option (Fly.io, K8s, ECS).
+- **Render** (fallback): runtime is `python` (not Docker), so RO-root
+  doesn't apply.
+
+---
+
+## Related
+
+- `backend/Dockerfile` — current pinned state.
+- `backend/requirements-locked.txt` — Python dependency hash pinning
+  (B-P1-10).
+- `docs/runbooks/dependency-update.md` — Python dependency update flow.
+- `.github/workflows/security-gates.yml` — Trivy / Grype image scan
+  job that gates merges.


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Pin `backend/Dockerfile` builder stage to `python:3.12.9-slim` (was `3.12-slim`) so both stages share the same minor; add `docs/runbooks/docker-image-pinning.md` documenting the SHA256 digest refresh procedure (the manual step that can't ship in a PR diff). Closes the documentable half of B-P2-8.
- **Type**: `security`
- **Linked issue**: Refs B-P2-8 from `reports/audits/2026-04-26-backend-verification-rollup.md` ("`Dockerfile:1` is `FROM python:3.12-slim` (no minor pin even); line 19 `FROM python:3.12.9-slim AS runtime` (mutable tag); no `@sha256:` digest; no read-only-root-filesystem in deploy spec").
- **Risk**: `low` — single-line minor-version change on the builder stage; the runtime stage already used the same minor. Existing `--require-hashes` lockfile means the dependency surface is unchanged.
- **User-visible change**: `none`.
- **Scope contract**: `[x]` This PR matches its stated type — security/build-pinning only. No app code, no schema, no CI workflow edits.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `single-surface`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none` (build-time, not runtime).
- **Rollback plan**: `git-revert-safe` — revert the commit. The Dockerfile diff is one line; the runbook is a single new file.
- **Dependencies / coordination**: `none` — branched off `ec363c6` (latest main).
- **Assumptions**: `python:3.12.9-slim` is still available on Docker Hub (it is — used by the runtime stage already).

## Tier 3 — Compliance flags

- `[ ]` **Money-touching**
- `[ ]` **PIPEDA-relevant**
- `[ ]` **SK Transportation Act**
- `[ ]` **Auth / RLS**
- `[ ]` **Safety**
- `[ ]` **Third-party SDK added**
- `[ ]` **Breaking change to `shared/`**

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — Dockerfile + markdown.
- **Integration tests**: `not-applicable` — `docker-image-scan` Trivy job in CI builds the image as part of every PR, which exercises the pin against Docker Hub.
- **Metrics / logs introduced**: `none`.
- **Screenshots / video**: `not-applicable`.
- **Perf numbers**: `not-applicable` — same minor version, same packages, same dependencies. Build artifact bytes may differ if Docker Hub re-tagged 3.12.9-slim between the prior CI run and this one — that's exactly what we want to surface.

**Pre-merge checklist**:

- [x] Ran the changed code against real Supabase dev — N/A; build-time change.
- [ ] Tested with rider + driver + admin accounts — N/A.
- [x] Verified the rollback command actually works — `git revert <commit>`. Reverts to the previous mutable-builder state.
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention change. Runbook is referential.
- [x] No PII added.

---

## What changed

| Commit | Files |
|---|---|
| `1005cc2` | `backend/Dockerfile` (1-line builder pin + 9-line comment block)<br>`docs/runbooks/docker-image-pinning.md` (new, 132 lines) |

## What's IN scope here vs out

**In scope (this PR):**
- Builder stage `FROM python:3.12-slim` → `FROM python:3.12.9-slim` so the build environment is reproducible across re-tags.
- Documentation of the next layer (SHA256 digest pin) including step-by-step `docker pull` + `docker inspect` procedure, quarterly refresh cadence, and Trivy-alert-triggered refresh.
- Status update on the read-only-root-filesystem half of B-P2-8 — Railway doesn't expose `read_only: true` for Docker; documented as a future host-migration item.

**Out of scope (next PRs / follow-ups):**
- Adding the actual `@sha256:<digest>` suffix. This requires `docker pull` against the live upstream image to read the manifest digest; no PR diff can contain a verifiable digest without that pull. The runbook walks the operator through it; expected execution by `devops` on the next quarterly refresh.
- Read-only-root-filesystem enforcement. Tracked as a host-migration item per the runbook; would require Fly.io / K8s / ECS instead of Railway.

## Why a runbook plus a single-line diff (vs everything in one PR)

The audit's B-P2-8 had three sub-items: minor pin, digest pin, RO root. Only the minor pin can land as a PR diff alone; the other two require manual operations or host-level changes. The runbook makes those operations repeatable so the next time someone refreshes the digest, the procedure is in source control rather than tribal knowledge.

## Conflict-safety check

- Branched off latest `origin/main` (`ec363c6`) — verified before write.
- `backend/Dockerfile` change is on a line that no open PR touches (checked `gh pr list --search 'in:diff Dockerfile'` — none).
- New runbook at a path that doesn't exist on main — additive ✓
- No edits to existing runbooks; no edits to CLAUDE.md or sprint-current.md.

https://claude.ai/code/session_01L8Q1kEd7jbNDLkh2ruDsMA

---
_Generated by [Claude Code](https://claude.ai/code/session_01L8Q1kEd7jbNDLkh2ruDsMA)_