### PR TITLE
fix(ci-audit): fix empty job logs due to Authorization header on S3 r…

### DIFF
--- a/scripts/ci-audit/error_classifier.py
+++ b/scripts/ci-audit/error_classifier.py
@@ -33,12 +33,18 @@ CATEGORY_RULES: list[tuple[str, str, str]] = [
     # (category, pattern_in_log, description_template)
     # ── Test failures ─────────────────────────────────────────────────────
     ("test",     r"FAILED\s+tests/",               "pytest test failure"),
+    ("test",     r"FAILED\s+backend/tests/",        "pytest test failure (backend prefix)"),
+    ("test",     r"= \d+ failed",                   "pytest: N tests failed"),
+    ("test",     r"= \d+ error",                    "pytest: collection/fixture errors"),
+    ("test",     r"ERROR\s+collecting",              "pytest collection error"),
+    ("test",     r"ERROR\s+tests/",                 "pytest fixture/setup error"),
     ("test",     r"AssertionError",                 "assertion error in test"),
     ("test",     r"FAIL\s+.*\.(test|spec)\.[tj]sx?", "Jest/Vitest test failure"),
     ("test",     r"●\s+.*\s+›",                     "Jest describe block failure"),
     ("test",     r"TimeoutError:",                  "test timeout"),
     ("test",     r"Error: expect\(",                "expect assertion failure"),
-    ("test",     r"short test summary info",          "pytest summary (failures present)"),
+    ("test",     r"short test summary info",         "pytest summary (failures present)"),
+    ("test",     r"Tests\s+\d+\s+failed",           "Vitest/Jest failure summary"),
     ("coverage", r"FAIL\s+Required test coverage",  "coverage threshold not met"),
     ("coverage", r"Coverage\s+.*below\s+threshold", "coverage threshold not met"),
     # ── Lint / type errors ────────────────────────────────────────────────
@@ -57,7 +63,7 @@ CATEGORY_RULES: list[tuple[str, str, str]] = [
     ("security", r"HIGH.*vulnerability",            "Trivy HIGH vulnerability"),
     ("security", r"EXPO_PUBLIC_.*SECRET",           "exposed secret in public env var"),
     # ── Build failures ────────────────────────────────────────────────────
-    ("build",    r"ModuleNotFoundError",            "Python module not found"),
+    ("build",    r"ModuleNotFoundError:\s+No module named", "Python module not found"),
     ("build",    r"ImportError",                    "Python import error"),
     ("build",    r"SyntaxError",                    "syntax error"),
     ("build",    r"Cannot find module",             "Node module not found"),

--- a/scripts/ci-audit/fetch_run_data.py
+++ b/scripts/ci-audit/fetch_run_data.py
@@ -17,7 +17,22 @@ from pathlib import Path
 from typing import Any
 
 API_BASE = "https://api.github.com"
-MAX_LOG_CHARS = 10_000  # Keep last N chars of each job log (errors usually tail)
+MAX_LOG_CHARS = 20_000  # Keep last N chars of each job log (errors usually tail)
+
+
+class _NoAuthOnRedirect(urllib.request.HTTPRedirectHandler):
+    """Strip Authorization header when following GitHub's 302 redirect to presigned
+    storage URLs.  Python's default urllib handler forwards ALL original headers,
+    including Authorization.  S3 presigned URLs embed their own auth signature;
+    receiving a conflicting Authorization header causes a 403 SignatureDoesNotMatch
+    error, making every log fetch silently return "".
+    """
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        new_req = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if new_req:
+            new_req.remove_header("Authorization")
+        return new_req
 
 
 def _get(url: str, token: str) -> Any:
@@ -46,15 +61,23 @@ def _get(url: str, token: str) -> Any:
 
 
 def _get_text(url: str, token: str) -> str:
+    """Fetch job log text from GitHub Actions API.
+
+    GitHub returns a 302 redirect to a presigned storage URL.  We use a custom
+    opener that strips the Authorization header on redirect so that the S3/Azure
+    presigned URL isn't rejected due to conflicting auth signatures.
+    """
     req = urllib.request.Request(
         url,
         headers={
             "Authorization": f"Bearer {token}",
-            "Accept": "application/vnd.github.v3.raw",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
         },
     )
+    opener = urllib.request.build_opener(_NoAuthOnRedirect())
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with opener.open(req, timeout=60) as resp:
             text = resp.read().decode("utf-8", errors="replace")
             return text[-MAX_LOG_CHARS:]  # Errors are usually at the end
     except (urllib.error.HTTPError, urllib.error.URLError):


### PR DESCRIPTION
…edirect

GitHub's job log API returns a 302 redirect to a presigned storage URL (S3/Azure).  Python's urllib follows the redirect and forwards all original headers including Authorization.  S3 presigned URLs embed their own auth signature; receiving a conflicting Authorization header causes a 403 SignatureDoesNotMatch, making every log fetch silently return "". The result: all CI audit reports showed 0 errors even for failing runs.

Fix:
- Add _NoAuthOnRedirect handler that strips Authorization before following GitHub's 302 redirect to the presigned log URL
- Switch Accept header to application/vnd.github+json (correct for the jobs API; vnd.github.v3.raw is for raw file content only)
- Increase log fetch timeout 30s → 60s (log files can be large)
- Double MAX_LOG_CHARS 10k → 20k (captures more of the test output)

Also improve error_classifier.py patterns to catch:
- "= N failed" (pytest summary line, always present when tests fail)
- "= N error" (pytest collection/fixture errors)
- "ERROR collecting" (import/syntax errors in test files)
- "ERROR tests/" (fixture setup errors)
- "Tests N failed" (Vitest/Jest failure summary)
- More specific ModuleNotFoundError pattern

https://claude.ai/code/session_01KaKmfdaJGATPYUREemRKaU

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
