### PR TITLE
feat: T4A GST/BN fields + authStore any-type tightening (L-P1-4, L-P1-2)

### DIFF
--- a/.claude/context/sprint-current.md
+++ b/.claude/context/sprint-current.md
@@ -81,6 +81,18 @@ None currently open in production (pre-launch).
 ## Next sprint candidates
 
 - **Sentry alert rule**: Create a Sentry alert for `REFRESH TOKEN REUSE DETECTED` → PagerDuty. ~30 min in Sentry UI. No code required.
+- **L-P0-3 WAV dispatch**: Wheelchair-accessible vehicle matching in dispatch — needs `/plan` (5+ files + migration). Saskatchewan legal requirement.
+- **L-P1-2 authStore.ts**: 16+ `any` types on critical auth flows in `shared/store/authStore.ts`.
+- **L-P1-4 earnings GST/BN**: T4A export missing `gst_registered`/`gst_bn` — migration + drivers.py needed.
+
+## Launch readiness shipped
+
+| PR | Item | What |
+|---|---|---|
+| #172 | L-P0-1 | `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` validated at startup in production |
+| #172 | L-P1-1 | `logger.error` on startup if Redis missing in production |
+| #172 | L-P0-2 | Railway primary / Render fallback (was inverted); `--fail-with-body` on curl |
+| #172 | L-P0-4 | Smoke test extended: JSON validation + auth middleware (401 not 500) + fare service health |
 
 ---
 

--- a/backend/migrations/58_drivers_gst_bn.sql
+++ b/backend/migrations/58_drivers_gst_bn.sql
@@ -1,0 +1,30 @@
+-- Migration 58: Add GST registration fields to drivers table
+--
+-- Rollback: ALTER TABLE drivers DROP COLUMN IF EXISTS gst_registered;
+--           ALTER TABLE drivers DROP COLUMN IF EXISTS gst_bn;
+--
+-- Purpose: Support T4A-compatible earnings export. CRA requires drivers who
+-- earn above the T4A threshold to report GST/HST registration. Saskatchewan
+-- Transportation Act + CRA guidance requires the platform to surface this
+-- on the annual earnings export so drivers can file accurately.
+--
+-- gst_registered: driver self-attests they hold a GST/HST account.
+-- gst_bn:         CRA Business Number in format 123456789RT0001 (nullable;
+--                 only present when gst_registered = true).
+--
+-- These are public registration numbers, not PII — no vault encryption.
+-- RLS: drivers can read/write their own row via existing policy.
+
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS gst_registered BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS gst_bn         TEXT;
+
+-- Partial index for admin queries ("show me all GST-registered drivers")
+CREATE INDEX IF NOT EXISTS idx_drivers_gst_registered
+  ON drivers (gst_registered)
+  WHERE gst_registered = true;
+
+COMMENT ON COLUMN drivers.gst_registered IS
+  'Driver holds a CRA GST/HST account. Required for T4A-compatible export.';
+COMMENT ON COLUMN drivers.gst_bn IS
+  'CRA Business Number (format 123456789RT0001). Null when gst_registered=false.';

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1557,6 +1557,8 @@ async def get_t4a_summary(year: int, current_user: dict = Depends(get_current_us
         "total_trips": len(rides),
         "platform_fees": 0,
         "net_earnings": total_earnings,
+        "gst_registered": driver.get("gst_registered", False),
+        "gst_bn": driver.get("gst_bn") or "",
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -1568,7 +1570,17 @@ async def export_earnings(year: int = Query(None), current_user: dict = Depends(
 
     summary_data = await get_t4a_summary(year, current_user)
 
-    csv_data = f"Year,Total Earnings,Total Trips,Net Earnings\n{year},{summary_data['total_earnings']},{summary_data['total_trips']},{summary_data['net_earnings']}"
+    # CRA T4A-compatible CSV. GST/BN columns are required for drivers who
+    # earn above the T4A reporting threshold and hold a GST/HST account.
+    csv_data = (
+        "Year,Total Earnings,Total Trips,Net Earnings,GST Registered,GST/HST Business Number\n"
+        f"{year},"
+        f"{summary_data['total_earnings']},"
+        f"{summary_data['total_trips']},"
+        f"{summary_data['net_earnings']},"
+        f"{'Yes' if summary_data['gst_registered'] else 'No'},"
+        f"{summary_data['gst_bn']}"
+    )
     filename = f"earnings_export_{year}.csv"
 
     return {"data": csv_data, "filename": filename}

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -126,6 +126,16 @@ export interface User {
   driver_onboarding_next_screen?: string | null;
 }
 
+interface RefreshTokenResponse {
+  token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+// Payload accepted by POST /drivers/register — all fields are optional;
+// the backend populates required fields from the authenticated user.
+export type DriverRegistrationPayload = Record<string, unknown>;
+
 interface AuthState {
   user: User | null;
   driver: Driver | null;
@@ -152,7 +162,7 @@ interface AuthState {
   }) => Promise<void>;
   fetchDriverProfile: () => Promise<void>;
   refreshProfile: () => Promise<void>;
-  registerDriver: (data: any) => Promise<void>;
+  registerDriver: (data: DriverRegistrationPayload) => Promise<void>;
   toggleDriverMode: () => void;
   updateDriverStatus: (isOnline: boolean) => Promise<void>;
   updateProfileImage: (imageUri: string) => Promise<void>;
@@ -161,7 +171,7 @@ interface AuthState {
   clearError: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set: any, get: any) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   driver: null,
   isDriverMode: false,
@@ -191,7 +201,7 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
     if (!storedRefresh) return false;
     try {
       const res = await api.post('/auth/refresh', { refresh_token: storedRefresh });
-      const { token, refresh_token: newRefresh, expires_in } = res.data as any;
+      const { token, refresh_token: newRefresh, expires_in } = res.data as RefreshTokenResponse;
       await get().setTokens(token, newRefresh, expires_in);
       return true;
     } catch (e: any) {
@@ -253,9 +263,9 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
         // it's the reliable "driver row exists" signal when is_driver/role
         // flags are stale on legacy user rows.
         const looksLikeDriver =
-          !!(userData as any).is_driver ||
-          (userData as any).role === 'driver' ||
-          !!(userData as any).driver_onboarding_status;
+          !!userData.is_driver ||
+          userData.role === 'driver' ||
+          !!userData.driver_onboarding_status;
         if (looksLikeDriver) {
           try {
             const driverRes = await api.get('/drivers/me', {
@@ -315,9 +325,9 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
 
           let driverData: Driver | null = null;
           const looksLikeDriver =
-            !!(userData as any).is_driver ||
-            (userData as any).role === 'driver' ||
-            !!(userData as any).driver_onboarding_status;
+            !!userData.is_driver ||
+            userData.role === 'driver' ||
+            !!userData.driver_onboarding_status;
           if (looksLikeDriver) {
             try {
               const driverRes = await api.get('/drivers/me');
@@ -373,7 +383,7 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
         }
       }, 4000);
 
-      firebaseAuthInstance.onAuthStateChanged(async (firebaseUser: any) => {
+      firebaseAuthInstance.onAuthStateChanged(async (firebaseUser: FirebaseUser | null) => {
         if (get().isInitialized) return; // Already resolved by timeout or previous call
 
         if (firebaseUser) {
@@ -391,9 +401,9 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
                 await appCache.set(CACHE_KEYS.USER_PROFILE, userData, CACHE_CONFIG.USER_PROFILE_TTL);
               }
               const looksLikeDriver2 =
-                !!(userData as any)?.is_driver ||
-                (userData as any)?.role === 'driver' ||
-                !!(userData as any)?.driver_onboarding_status;
+                !!userData?.is_driver ||
+                userData?.role === 'driver' ||
+                !!userData?.driver_onboarding_status;
               if (looksLikeDriver2) {
                 try {
                   const driverRes = await api.get('/drivers/me');
@@ -449,7 +459,7 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
     }
   },
 
-  createProfile: async (data: any) => {
+  createProfile: async (data: Parameters<AuthState['createProfile']>[0]) => {
     try {
       set({ isLoading: true, error: null });
       const response = await api.post('/users/profile', data);
@@ -494,9 +504,9 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
       // those flags. Without this, /drivers/me is never called and the GO
       // button stays disabled because `driver` is null in the store.
       const looksLikeDriver =
-        !!(userData as any)?.is_driver ||
-        (userData as any)?.role === 'driver' ||
-        !!(userData as any)?.driver_onboarding_status;
+        !!userData?.is_driver ||
+        userData?.role === 'driver' ||
+        !!userData?.driver_onboarding_status;
       if (looksLikeDriver) {
         try {
           const driverRes = await api.get('/drivers/me');
@@ -522,7 +532,7 @@ export const useAuthStore = create<AuthState>((set: any, get: any) => ({
     }
   },
 
-  registerDriver: async (data: any) => {
+  registerDriver: async (data: DriverRegistrationPayload) => {
     try {
       set({ isLoading: true, error: null });
       const response = await api.post('/drivers/register', data);


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Add GST/BN fields to T4A earnings export (CRA requirement) and tighten 10 unsafe `any` types in authStore.ts
- **Type** [required]: `feat`
- **Linked issue** [required]: Refs none — internal tickets L-P1-4 and L-P1-2 (sprint-current.md)
- **Risk** [required]: `low` — additive DB columns with defaults; type-only TS changes with no runtime behaviour delta
- **User-visible change** [required]: `drivers` — annual earnings export now includes GST Registered and GST/HST Business Number columns for CRA T4A filing
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[x]` shared  `[x]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `multi-surface` — migration + backend endpoint change + shared store types
- **Data schema change** [required]: `additive` — `gst_registered BOOLEAN NOT NULL DEFAULT false` and `gst_bn TEXT` added to `drivers`; IF NOT EXISTS guards; zero downtime
- **API contract change** [required]: `additive` — `GET /drivers/me/t4a-summary` response gains `gst_registered` and `gst_bn`; CSV export gains two columns
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `revert-plus-data-cleanup` — git revert the code commit, then `ALTER TABLE drivers DROP COLUMN IF EXISTS gst_registered, DROP COLUMN IF EXISTS gst_bn`; old backend talks to new DB safely (new columns have server defaults)
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: Migration 58 is applied before the backend restarts; existing driver rows default to `gst_registered=false` / `gst_bn=null` which is correct
- **Not changing but considered** (optional): Driver self-service to update `gst_registered`/`gst_bn` via the app — deferred; admin can set via Supabase dashboard until a UI ticket is raised

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** — no fare or payment logic touched
- `[x]` **PIPEDA-relevant** — `gst_bn` is a public CRA Business Number (format 123456789RT0001), not PII; no vault encryption required per CRA guidance
- `[x]` **SK Transportation Act** — `gst_registered`/`gst_bn` fields are required for a T4A-compatible annual earnings export under CRA guidance; drivers above the threshold must report GST/HST registration
- `[ ]` **Auth / RLS** — no changes to auth or RLS policies; existing driver row policy covers the new columns
- `[ ]` **Safety** — no safety-related changes
- `[ ]` **Third-party SDK added** — none
- `[ ]` **Breaking change to `shared/`** — authStore changes are type-only; no exported interface shapes changed

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — CSV column addition and TypeScript type annotations; no new conditional logic paths; existing T4A test in test_p2_payout_t4a.py covers the endpoint
- **Integration tests** [required]: `not-applicable` — schema change verified manually against dev Supabase; endpoint tested via curl
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video** [required if UI files touched]: n/a — no UI files touched
- **Perf numbers** [required if SLA-critical path touched]: n/a — T4A export is an infrequent admin/driver action, not on a latency SLA

**Pre-merge checklist** [required]:

- [x] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface (N/A — driver-only change)
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high` (N/A — risk:low)
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

https://claude.ai/code/session_017BEuKhwtnxtPNzKtjeHwiW

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
