### PR TITLE
Fix GST field names in driver profile updates (gst_number → gst_registered/gst_bn)

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -336,7 +336,8 @@ class UpdateDriverProfileRequest(BaseModel):
     """Strict schema for driver profile updates — only whitelisted fields accepted."""
 
     # Safe fields (no re-verification)
-    gst_number: Optional[str] = None
+    gst_registered: Optional[bool] = None
+    gst_bn: Optional[str] = None  # CRA Business Number, format 123456789RT0001
     preferred_language: Optional[str] = None
     photo_url: Optional[str] = None
     is_wav: Optional[bool] = None
@@ -371,7 +372,7 @@ async def update_my_driver(body: UpdateDriverProfileRequest, current_user: dict 
     )
 
     # Fields that always update without affecting verification
-    safe_fields = {"gst_number", "preferred_language", "photo_url", "is_wav"}
+    safe_fields = {"gst_registered", "gst_bn", "preferred_language", "photo_url", "is_wav"}
     # Vehicle/doc fields — changing these on a verified driver triggers re-review
     vehicle_fields = {
         "vehicle_type_id",

--- a/backend/tests/test_p2_payout_t4a.py
+++ b/backend/tests/test_p2_payout_t4a.py
@@ -302,3 +302,119 @@ class TestGetT4ASummary:
                 await get_t4a_summary(year=2025, current_user={"id": "ghost"})
 
         assert exc_info.value.status_code == 404
+
+    async def test_t4a_includes_gst_fields_when_set(self):
+        """gst_registered=True + gst_bn propagate from driver row into summary."""
+        from backend.routes.drivers import get_t4a_summary
+
+        driver = {**_driver_row(), "gst_registered": True, "gst_bn": "123456789RT0001"}
+
+        with (
+            patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[driver])),
+            patch("backend.routes.drivers.db_supabase.get_rides_for_driver", AsyncMock(return_value=[])),
+        ):
+            result = await get_t4a_summary(year=2025, current_user={"id": DRIVER_USER_ID})
+
+        assert result["gst_registered"] is True
+        assert result["gst_bn"] == "123456789RT0001"
+
+    async def test_t4a_gst_fields_default_when_absent(self):
+        """Driver rows without GST columns default to False / empty string."""
+        from backend.routes.drivers import get_t4a_summary
+
+        driver = _driver_row()  # no gst_registered / gst_bn keys
+
+        with (
+            patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[driver])),
+            patch("backend.routes.drivers.db_supabase.get_rides_for_driver", AsyncMock(return_value=[])),
+        ):
+            result = await get_t4a_summary(year=2025, current_user={"id": DRIVER_USER_ID})
+
+        assert result["gst_registered"] is False
+        assert result["gst_bn"] == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PUT /drivers/me — gst_registered + gst_bn field write
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestUpdateDriverGstFields:
+    """Pins that gst_registered and gst_bn reach the DB via PUT /drivers/me.
+
+    L-P1-4: UpdateDriverProfileRequest previously used `gst_number` (wrong
+    column name) and was missing `gst_registered`.  The DB columns are
+    `gst_registered` (bool) and `gst_bn` (text), added in migration 58.
+    """
+
+    def _make_driver(self, **extra) -> dict:
+        return {"id": DRIVER_ID, "user_id": DRIVER_USER_ID, "status": "active", **extra}
+
+    def _patches(self, driver: dict, update_mock: AsyncMock):
+        """Return an ExitStack that covers all DB calls in update_my_driver."""
+        import contextlib
+
+        stack = contextlib.ExitStack()
+        stack.enter_context(patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[driver])))
+        stack.enter_context(patch("backend.routes.drivers.db_supabase.update_one", update_mock))
+        stack.enter_context(
+            patch("backend.routes.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver))
+        )
+        stack.enter_context(patch("backend.routes.drivers._encrypt_driver_pii", AsyncMock(side_effect=lambda d: d)))
+        stack.enter_context(patch("backend.routes.drivers._decrypt_driver_pii", AsyncMock(side_effect=lambda d: d)))
+        return stack
+
+    @pytest.mark.anyio
+    async def test_gst_registered_reaches_db(self):
+        """Setting gst_registered=True via PUT /drivers/me writes to drivers table."""
+        from backend.routes.drivers import UpdateDriverProfileRequest, update_my_driver
+
+        driver = self._make_driver()
+        update_mock = AsyncMock(return_value=None)
+
+        with self._patches(driver, update_mock):
+            await update_my_driver(
+                body=UpdateDriverProfileRequest(gst_registered=True),
+                current_user={"id": DRIVER_USER_ID},
+            )
+
+        update_mock.assert_called_once()
+        _, _filter, updates = update_mock.call_args.args
+        assert updates.get("gst_registered") is True
+        assert "gst_number" not in updates  # old wrong field must not appear
+
+    @pytest.mark.anyio
+    async def test_gst_bn_reaches_db(self):
+        """Setting gst_bn via PUT /drivers/me writes the correct column name."""
+        from backend.routes.drivers import UpdateDriverProfileRequest, update_my_driver
+
+        driver = self._make_driver()
+        update_mock = AsyncMock(return_value=None)
+
+        with self._patches(driver, update_mock):
+            await update_my_driver(
+                body=UpdateDriverProfileRequest(gst_registered=True, gst_bn="123456789RT0001"),
+                current_user={"id": DRIVER_USER_ID},
+            )
+
+        _, _filter, updates = update_mock.call_args.args
+        assert updates.get("gst_bn") == "123456789RT0001"
+        assert "gst_number" not in updates
+
+    @pytest.mark.anyio
+    async def test_omitted_gst_fields_not_written(self):
+        """Omitting GST fields from PUT body leaves driver row unchanged."""
+        from backend.routes.drivers import UpdateDriverProfileRequest, update_my_driver
+
+        driver = self._make_driver()
+        update_mock = AsyncMock(return_value=None)
+
+        with self._patches(driver, update_mock):
+            await update_my_driver(
+                body=UpdateDriverProfileRequest(preferred_language="fr"),
+                current_user={"id": DRIVER_USER_ID},
+            )
+
+        _, _filter, updates = update_mock.call_args.args
+        assert "gst_registered" not in updates
+        assert "gst_bn" not in updates


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Correct `UpdateDriverProfileRequest` to use `gst_registered` (bool) and `gst_bn` (text) instead of the incorrect `gst_number` field, aligning with migration 58 schema and T4A summary logic.
- **Type**: `fix`
- **Linked issue**: Refs #L-P1-4
- **Risk**: `low` — Field rename in request schema only; no data migration needed, no existing clients using `gst_number` yet.
- **User-visible change**: `drivers` — GST registration and business number can now be correctly set via PUT /drivers/me.
- **Scope contract**: `[x]` This PR matches its stated type — schema correction + test coverage only.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend
- **Blast radius**: `isolated`
- **Data schema change**: `none` — DB columns already exist (migration 58); only request schema corrected.
- **API contract change**: `breaking` — `gst_number` field removed, `gst_registered` + `gst_bn` added to `UpdateDriverProfileRequest`.
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — Reverting restores old (broken) field names; no data cleanup needed.
- **Dependencies / coordination**: `none`
- **Assumptions**: Driver app and any other clients calling PUT /drivers/me have not yet adopted the broken `gst_number` field.
- **Not changing but considered**: T4A summary already correctly reads `gst_registered` and `gst_bn` from driver rows; this fix ensures the write path matches.

## Tier 3 — Compliance flags

- `[x]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — GST registration and business number are used in T4A tax reporting for driver payouts.

## Tier 4 — Verification

- **Unit tests**: `added` — 5 new tests covering:
  - T4A summary includes GST fields when set
  - T4A summary defaults GST fields when absent
  - `gst_registered=True` reaches DB via PUT /drivers/me
  - `gst_bn` reaches DB with correct column name
  - Omitted GST fields are not written to DB
- **Integration tests**: `not-applicable` — Schema and request validation are unit-testable.
- **Metrics / logs introduced**: `none`
- **Pre-merge checklist**:
  - [x] Ran against mocked Supabase (unit tests cover DB call paths)
  - [x] No PII added to logs

## Summary of Changes

**backend/routes/drivers.py:**
- `UpdateDriverProfileRequest`: Replaced `gst_number: Optional[str]` with `gst_registered: Optional[bool]` and `gst_bn: Optional[str]` (CRA Business Number format).
- `update_my_driver()`: Updated `safe_fields` set to include `gst_registered` and `gst_bn` instead of `gst_number`.

**backend/tests/test_p2_payout_t4a.py:**
- Added `test_t4a_includes_gst_fields_when_set()`: Verifies T4A summary propagates `gst_registered` and `gst_bn` from driver row.
- Added `test_t4a_gst_fields_default_when_absent()`: Verifies defaults (False / empty string) when fields are missing.
- Added `TestUpdateDriverGstFields` class with three tests:
  - `test_gst_registered_reaches_db()`: Confirms `gst_registered=True` is written and `gst_number` does not appear.
  - `test_gst_bn_reaches_db()`: Confirms `gst_bn` is written with correct column name

https://claude.ai/code/session_01KaKmfdaJGATPYUREemRKaU

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
