### PR TITLE
fix: handle ride_status_changed in driver-app WS switch; add driver_u…

### DIFF
--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -198,6 +198,7 @@ async def admin_cancel_ride(
             detail="Cancel did not persist — see backend logs.",
         )
 
+    driver_user_id: str | None = None
     driver_id = ride.get("driver_id")
     if driver_id:
         try:
@@ -207,13 +208,14 @@ async def admin_cancel_ride(
 
         driver = await db_supabase.get_driver_by_id(driver_id)
         if driver and driver.get("user_id"):
+            driver_user_id = driver["user_id"]
             await manager.send_personal_message(
                 {"type": "ride_cancelled", "ride_id": ride_id, "reason": reason},
-                f"driver_{driver['user_id']}",
+                f"driver_{driver_user_id}",
             )
             try:
                 await send_push_notification(
-                    driver["user_id"],
+                    driver_user_id,
                     "Ride Cancelled",
                     reason,
                     {"type": "ride_cancelled", "ride_id": ride_id},
@@ -237,7 +239,14 @@ async def admin_cancel_ride(
         except Exception as e:
             logger.warning(f"admin_cancel_ride: rider push failed: {e}")
 
-    await manager.broadcast_ride_status(ride_id, "cancelled", rider_id=rider_id, reason=reason, source="admin")
+    await manager.broadcast_ride_status(
+        ride_id,
+        "cancelled",
+        rider_id=rider_id,
+        driver_user_id=driver_user_id,
+        reason=reason,
+        source="admin",
+    )
     try:
         await manager.broadcast_to_admins(
             {"type": "ride_cancelled", "ride_id": ride_id, "reason": reason, "source": "admin"}

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -324,21 +324,20 @@ class ConnectionManager:
         ride_id: str,
         status: str,
         rider_id: str | None = None,
+        driver_user_id: str | None = None,
         **extra,
     ):
         """Emit a unified ``ride_status_changed`` event for a ride transition.
 
-        Both the rider app and the admin dashboard listen for this single
+        Rider app, driver app, and admin dashboard all listen for this single
         event type and switch on ``status``. Individual specific events
         (``driver_accepted``, ``ride_started``, …) still fire for
         backward-compat, but every backend state transition should also
-        call this so admin live-monitoring stays consistent without
-        per-event wiring.
+        call this so live-monitoring stays consistent without per-event wiring.
 
-        ``rider_id`` is optional — pass None for transitions that shouldn't
-        fan out to the rider (e.g. the initial driver_assigned pick, which
-        shouldn't trigger a rider UI update until the driver actually
-        accepts).
+        ``rider_id`` and ``driver_user_id`` are optional — pass None for
+        connections that shouldn't receive the event (e.g. driver_user_id=None
+        for transitions the driver triggers themselves and already knows about).
         """
         payload = {"type": "ride_status_changed", "ride_id": ride_id, "status": status, **extra}
         if rider_id:
@@ -346,6 +345,11 @@ class ConnectionManager:
                 await self.send_personal_message(payload, f"rider_{rider_id}")
             except Exception as e:
                 logger.warning(f"broadcast_ride_status: rider send failed for {rider_id}: {e}")
+        if driver_user_id:
+            try:
+                await self.send_personal_message(payload, f"driver_{driver_user_id}")
+            except Exception as e:
+                logger.warning(f"broadcast_ride_status: driver send failed for {driver_user_id}: {e}")
         try:
             await self.broadcast_to_admins(payload)
         except Exception as e:

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -467,6 +467,20 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
         break;
       }
 
+      // Unified status event from socket_manager.broadcast_ride_status().
+      // Currently emitted to drivers on admin-initiated cancellations.
+      // Handlers are idempotent: specific events (ride_cancelled, etc.)
+      // may already have acted; these are reconciliation / catch-up paths.
+      case 'ride_status_changed': {
+        const status = data.status as string | undefined;
+        if (status === 'cancelled') {
+          resetRideState();
+        } else if (status === 'completed' && typeof data.total_fare === 'number') {
+          fetchEarnings('today');
+        }
+        break;
+      }
+
       default:
         console.warn('[WS] Unknown message type received:', data.type);
         break;


### PR DESCRIPTION
…ser_id to broadcast_ride_status

- `socket_manager.broadcast_ride_status` now accepts an optional `driver_user_id` parameter and forwards the unified `ride_status_changed` event to the driver connection alongside the rider and admin fan-out.

- `admin/rides.py` captures the driver's `user_id` before the `broadcast_ride_status` call and passes it, so admin-initiated cancellations now send the unified event to the driver WS in addition to the existing specific `ride_cancelled` message.

- `useDriverDashboard.ts` adds a `case 'ride_status_changed':` handler. On `cancelled` it calls `resetRideState()` (idempotent reconciliation path if the specific `ride_cancelled` event was missed). On `completed` with a `total_fare` it refreshes today's earnings. Previously this type fell through to `default: console.warn`.

https://claude.ai/code/session_0186BYzswgvRZr3MgP41oeAC

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
