### PR TITLE
fix: handle ride_status_changed in driver-app WS switch; add driver_user_id to broadcast_ride_status

### DIFF
--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -198,6 +198,7 @@ async def admin_cancel_ride(
             detail="Cancel did not persist — see backend logs.",
         )
 
+    driver_user_id: str | None = None
     driver_id = ride.get("driver_id")
     if driver_id:
         try:
@@ -207,13 +208,14 @@ async def admin_cancel_ride(
 
         driver = await db_supabase.get_driver_by_id(driver_id)
         if driver and driver.get("user_id"):
+            driver_user_id = driver["user_id"]
             await manager.send_personal_message(
                 {"type": "ride_cancelled", "ride_id": ride_id, "reason": reason},
-                f"driver_{driver['user_id']}",
+                f"driver_{driver_user_id}",
             )
             try:
                 await send_push_notification(
-                    driver["user_id"],
+                    driver_user_id,
                     "Ride Cancelled",
                     reason,
                     {"type": "ride_cancelled", "ride_id": ride_id},
@@ -237,7 +239,14 @@ async def admin_cancel_ride(
         except Exception as e:
             logger.warning(f"admin_cancel_ride: rider push failed: {e}")
 
-    await manager.broadcast_ride_status(ride_id, "cancelled", rider_id=rider_id, reason=reason, source="admin")
+    await manager.broadcast_ride_status(
+        ride_id,
+        "cancelled",
+        rider_id=rider_id,
+        driver_user_id=driver_user_id,
+        reason=reason,
+        source="admin",
+    )
     try:
         await manager.broadcast_to_admins(
             {"type": "ride_cancelled", "ride_id": ride_id, "reason": reason, "source": "admin"}

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -324,21 +324,20 @@ class ConnectionManager:
         ride_id: str,
         status: str,
         rider_id: str | None = None,
+        driver_user_id: str | None = None,
         **extra,
     ):
         """Emit a unified ``ride_status_changed`` event for a ride transition.
 
-        Both the rider app and the admin dashboard listen for this single
+        Rider app, driver app, and admin dashboard all listen for this single
         event type and switch on ``status``. Individual specific events
         (``driver_accepted``, ``ride_started``, …) still fire for
         backward-compat, but every backend state transition should also
-        call this so admin live-monitoring stays consistent without
-        per-event wiring.
+        call this so live-monitoring stays consistent without per-event wiring.
 
-        ``rider_id`` is optional — pass None for transitions that shouldn't
-        fan out to the rider (e.g. the initial driver_assigned pick, which
-        shouldn't trigger a rider UI update until the driver actually
-        accepts).
+        ``rider_id`` and ``driver_user_id`` are optional — pass None for
+        connections that shouldn't receive the event (e.g. driver_user_id=None
+        for transitions the driver triggers themselves and already knows about).
         """
         payload = {"type": "ride_status_changed", "ride_id": ride_id, "status": status, **extra}
         if rider_id:
@@ -346,6 +345,11 @@ class ConnectionManager:
                 await self.send_personal_message(payload, f"rider_{rider_id}")
             except Exception as e:
                 logger.warning(f"broadcast_ride_status: rider send failed for {rider_id}: {e}")
+        if driver_user_id:
+            try:
+                await self.send_personal_message(payload, f"driver_{driver_user_id}")
+            except Exception as e:
+                logger.warning(f"broadcast_ride_status: driver send failed for {driver_user_id}: {e}")
         try:
             await self.broadcast_to_admins(payload)
         except Exception as e:

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -460,6 +460,20 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
         break;
       }
 
+      // Unified status event from socket_manager.broadcast_ride_status().
+      // Currently emitted to drivers on admin-initiated cancellations.
+      // Handlers are idempotent: specific events (ride_cancelled, etc.)
+      // may already have acted; these are reconciliation / catch-up paths.
+      case 'ride_status_changed': {
+        const status = data.status as string | undefined;
+        if (status === 'cancelled') {
+          resetRideState();
+        } else if (status === 'completed' && typeof data.total_fare === 'number') {
+          fetchEarnings('today');
+        }
+        break;
+      }
+
       default:
         console.warn('[WS] Unknown message type received:', data.type);
         break;


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Closes driver-app audit gap: adds `case 'ride_status_changed':` to the WS message switch in `useDriverDashboard.ts`. Extends `socket_manager.broadcast_ride_status` with an optional `driver_user_id` parameter so the unified status event can be forwarded to the driver connection. Admin cancellations now pass the driver's `user_id`, making the new handler live code.
- **Type** [required]: `fix`
- **Linked issue** [required]: Refs none — audit gap identified during driver-app verification pass (post-sprint hardening)
- **Risk** [required]: `low` — additive handler; both backend change and driver-app case are idempotent; all existing specific events (`ride_cancelled`, etc.) continue to fire unchanged
- **User-visible change** [required]: `drivers` — on admin-initiated ride cancellations, driver UI now receives a redundant reconciliation signal that ensures `resetRideState()` fires even if the specific `ride_cancelled` event was missed
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.



## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[x]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `multi-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — revert drops the new switch case and the `driver_user_id` param; backend falls back to sending only to rider + admin, driver-app falls back to `default: console.warn`
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: Driver WS connection key is `driver_{user_id}` (confirmed in `socket_manager.py` and `useDriverDashboard.ts`). `resetRideState()` and `fetchEarnings()` are idempotent Zustand actions.
- **Not changing but considered** (optional): rider-app already handles `ride_status_changed` via `applyRideStatusFromWS` + `fetchRide` — no change needed there.

## Tier 3 — Compliance flags

None apply.

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — switch case delegates to already-tested store actions (`resetRideState`, `fetchEarnings`); no new logic branches
- **Integration tests** [required]: `not-applicable`
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video** [required if UI files touched]: N/A — no UI change; handler is a reconciliation path with no new visible state
- **Perf numbers** [required if SLA-critical path touched]: N/A — WS fan-out adds one extra `send_personal_message` call on admin cancellation only; negligible

**Pre-merge checklist** [required]:

- [x] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [x] Verified the rollback command actually works (not just exists) — if `risk:high`
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

https://claude.ai/code/session_0186BYzswgvRZr3MgP41oeAC

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
