### PR TITLE
test(contract): money-as-string snapshot + i18n coverage + PaginatedResponse type (Phase 5)

### DIFF
--- a/backend/tests/test_schema_contract.py
+++ b/backend/tests/test_schema_contract.py
@@ -1,0 +1,91 @@
+"""Phase 5 contract test — money fields serialize as Decimal strings.
+
+Regression guard for the Phase 1 wire-format fix (PR #324). Any future
+contributor who removes `class Config: json_encoders = {Decimal: str}`
+from a money-bearing Pydantic model will trip this test.
+"""
+
+import json
+from decimal import Decimal
+
+import pytest
+
+try:
+    from backend.schemas import AppSettings, FareConfig, Ride, RideRatingRequest, ServiceArea
+except ImportError:
+    from schemas import AppSettings, FareConfig, Ride, RideRatingRequest, ServiceArea
+
+
+def _model_to_json_dict(model) -> dict:
+    """Round-trip a Pydantic v1 model through .json() to mirror what FastAPI
+    sends on the wire (jsonable_encoder honours model Config json_encoders)."""
+    return json.loads(model.json())
+
+
+@pytest.mark.unit
+class TestMoneyFieldsSerializeAsString:
+    """Every money field on every response model must serialize as `"X.XX"`,
+    never as a JS-float `X.X`. Float on the wire is the bug Phase 1 fixed."""
+
+    def test_app_settings_money_is_string(self):
+        m = AppSettings()  # uses defaults
+        d = _model_to_json_dict(m)
+        for f in ("cancellation_fee_admin", "cancellation_fee_driver", "platform_fee_percent"):
+            assert isinstance(d[f], str), f"{f!r} should be str, got {type(d[f]).__name__}: {d[f]!r}"
+
+    def test_service_area_airport_fee_is_string(self):
+        m = ServiceArea(name="t", city="t", polygon=[{"lat": 0.0, "lng": 0.0}])
+        d = _model_to_json_dict(m)
+        assert isinstance(d["airport_fee"], str)
+        # surge_multiplier is intentionally float — it's a multiplier, not money
+        assert isinstance(d["surge_multiplier"], float)
+
+    def test_fare_config_money_is_string(self):
+        m = FareConfig(
+            service_area_id="a",
+            vehicle_type_id="b",
+            base_fare=Decimal("3.00"),
+            per_km_rate=Decimal("1.50"),
+            per_minute_rate=Decimal("0.25"),
+            minimum_fare=Decimal("5.00"),
+        )
+        d = _model_to_json_dict(m)
+        for f in ("base_fare", "per_km_rate", "per_minute_rate", "minimum_fare", "booking_fee"):
+            assert isinstance(d[f], str), f"{f!r} should be str, got {type(d[f]).__name__}"
+
+    def test_ride_money_fields_are_strings(self):
+        m = Ride(
+            rider_id="r",
+            vehicle_type_id="v",
+            pickup_address="a",
+            pickup_lat=0.0,
+            pickup_lng=0.0,
+            dropoff_address="b",
+            dropoff_lat=0.0,
+            dropoff_lng=0.0,
+            distance_km=1.0,
+            duration_minutes=1,
+            base_fare=Decimal("3.00"),
+            total_fare=Decimal("10.00"),
+        )
+        d = _model_to_json_dict(m)
+        for f in (
+            "base_fare",
+            "distance_fare",
+            "time_fare",
+            "booking_fee",
+            "total_fare",
+            "tip_amount",
+            "driver_earnings",
+            "admin_earnings",
+            "cancellation_fee_driver",
+            "cancellation_fee_admin",
+        ):
+            assert isinstance(d[f], str), f"{f!r} should be str, got {type(d[f]).__name__}: {d[f]!r}"
+        # surge_multiplier remains float (not money)
+        assert isinstance(d["surge_multiplier"], float)
+
+    def test_ride_rating_tip_is_string(self):
+        m = RideRatingRequest(rating=5, tip_amount=Decimal("2.50"))
+        d = _model_to_json_dict(m)
+        assert isinstance(d["tip_amount"], str)

--- a/rider-app/__tests__/errorI18nCoverage.test.ts
+++ b/rider-app/__tests__/errorI18nCoverage.test.ts
@@ -1,0 +1,62 @@
+import en from '../i18n/en.json';
+
+describe('rider-app i18n error coverage', () => {
+  // Walk every leaf string under errors.*; collect dotted paths.
+  const collect = (obj: Record<string, unknown>, prefix: string): string[] => {
+    const out: string[] = [];
+    for (const [k, v] of Object.entries(obj)) {
+      const path = prefix ? `${prefix}.${k}` : k;
+      if (typeof v === 'string') out.push(path);
+      else if (v && typeof v === 'object') out.push(...collect(v as Record<string, unknown>, path));
+    }
+    return out;
+  };
+
+  const errorTree = (en as { errors?: Record<string, unknown> }).errors ?? {};
+  const allKeys = collect(errorTree, 'errors');
+
+  it('has at least 28 canonical error keys', () => {
+    expect(allKeys.length).toBeGreaterThanOrEqual(28);
+  });
+
+  it.each([
+    'errors.auth.account_suspended',
+    'errors.auth.otp_invalid',
+    'errors.auth.otp_expired',
+    'errors.auth.otp_locked',
+    'errors.auth.invalid_credentials',
+    'errors.auth.token_expired',
+    'errors.driver.documents_expired',
+    'errors.driver.documents_pending',
+    'errors.driver.documents_rejected',
+    'errors.driver.subscription_required',
+    'errors.driver.not_available',
+    'errors.driver.offline',
+    'errors.ride.not_found',
+    'errors.ride.already_cancelled',
+    'errors.ride.invalid_status',
+    'errors.ride.no_drivers_available',
+    'errors.ride.price_mismatch',
+    'errors.ride.taken',
+    'errors.payment.failed',
+    'errors.payment.method_invalid',
+    'errors.payment.insufficient_funds',
+    'errors.payment.refund_failed',
+    'errors.wallet.transfer_self',
+    'errors.wallet.transfer_recipient_not_found',
+    'errors.system.internal',
+    'errors.system.service_unavailable',
+    'errors.system.rate_limited',
+    'errors.system.database',
+    'errors.unknown',
+  ])('has key %s with non-empty English copy', (key) => {
+    const parts = key.split('.');
+    let node: unknown = en;
+    for (const p of parts) {
+      expect(node).toBeDefined();
+      node = (node as Record<string, unknown>)[p];
+    }
+    expect(typeof node).toBe('string');
+    expect((node as string).length).toBeGreaterThan(0);
+  });
+});

--- a/rider-app/i18n/en.json
+++ b/rider-app/i18n/en.json
@@ -78,44 +78,44 @@
   "errors": {
     "auth": {
       "account_suspended": "Your account has been suspended. Please contact support.",
-      "otp_invalid": "The verification code is incorrect. Please try again.",
-      "otp_expired": "Your verification code has expired. Request a new one.",
-      "otp_locked": "Too many failed attempts. Try again in 24 hours.",
-      "invalid_credentials": "Invalid login details. Please try again.",
+      "otp_invalid": "That code didn't match. Check the SMS and try again.",
+      "otp_expired": "That code has expired. Tap Resend to get a new one.",
+      "otp_locked": "Too many failed tries. Please wait a moment before trying again.",
+      "invalid_credentials": "Sign-in details didn't match. Please try again.",
       "token_expired": "Your session has expired. Please sign in again."
     },
     "driver": {
-      "documents_expired": "One or more of your documents have expired.",
-      "documents_pending": "Your documents are still being reviewed.",
-      "documents_rejected": "Your documents were rejected. Please re-upload.",
-      "subscription_required": "An active subscription is required to continue.",
-      "not_available": "No drivers are available right now.",
+      "documents_expired": "Your documents have expired. Please renew them to keep driving.",
+      "documents_pending": "Your documents are still under review. We'll notify you once approved.",
+      "documents_rejected": "Some of your documents were rejected. Please review and resubmit.",
+      "subscription_required": "An active Spinr Pass subscription is required to continue.",
+      "not_available": "This driver isn't available right now.",
       "offline": "The driver is currently offline."
     },
     "ride": {
-      "not_found": "We couldn't find that ride.",
+      "not_found": "We couldn't find that ride. It may have been removed.",
       "already_cancelled": "This ride has already been cancelled.",
-      "invalid_status": "This action is not allowed for the current ride status.",
-      "no_drivers_available": "No drivers are available in your area. Please try again shortly.",
-      "price_mismatch": "The fare has changed. Please review and try again.",
-      "taken": "Another driver accepted this ride first."
+      "invalid_status": "This action isn't allowed for the current ride state.",
+      "no_drivers_available": "No drivers are available right now. Please try again in a few minutes.",
+      "price_mismatch": "The price has changed since you last saw it. Please review and confirm again.",
+      "taken": "Another driver took this ride. We'll find you the next one."
     },
     "payment": {
-      "failed": "Payment failed. Please try again.",
-      "method_invalid": "This payment method is invalid. Choose another.",
-      "insufficient_funds": "Insufficient funds for this transaction.",
-      "refund_failed": "We couldn't process your refund. Please contact support."
+      "failed": "Your payment didn't go through. Please try again or use another method.",
+      "method_invalid": "That payment method isn't valid. Please add a different one.",
+      "insufficient_funds": "Not enough in your wallet. Please top up or use a card.",
+      "refund_failed": "We couldn't process the refund right now. Please contact support."
     },
     "wallet": {
       "transfer_self": "You can't transfer funds to yourself.",
-      "transfer_recipient_not_found": "We couldn't find that recipient."
+      "transfer_recipient_not_found": "We couldn't find that recipient. Please double-check and try again."
     },
     "system": {
       "internal": "Something went wrong on our end. Please try again.",
-      "service_unavailable": "Service is temporarily unavailable. Please try again shortly.",
-      "rate_limited": "You're doing that too often. Please slow down.",
-      "database": "We're having trouble loading your data. Please try again."
+      "service_unavailable": "Spinr is temporarily unavailable. Please try again shortly.",
+      "rate_limited": "You're going a bit fast. Please slow down and try again in a moment.",
+      "database": "We're having trouble reaching our systems. Please try again."
     },
-    "unknown": "An unexpected error occurred. Please try again."
+    "unknown": "Something went wrong. Please try again."
   }
 }

--- a/rider-app/i18n/en.json
+++ b/rider-app/i18n/en.json
@@ -78,44 +78,44 @@
   "errors": {
     "auth": {
       "account_suspended": "Your account has been suspended. Please contact support.",
-      "otp_invalid": "That code didn't match. Check the SMS and try again.",
-      "otp_expired": "That code has expired. Tap Resend to get a new one.",
-      "otp_locked": "Too many failed tries. Please wait a moment before trying again.",
-      "invalid_credentials": "Sign-in details didn't match. Please try again.",
+      "otp_invalid": "The verification code is incorrect. Please try again.",
+      "otp_expired": "Your verification code has expired. Request a new one.",
+      "otp_locked": "Too many failed attempts. Try again in 24 hours.",
+      "invalid_credentials": "Invalid login details. Please try again.",
       "token_expired": "Your session has expired. Please sign in again."
     },
     "driver": {
-      "documents_expired": "Your documents have expired. Please renew them to keep driving.",
-      "documents_pending": "Your documents are still under review. We'll notify you once approved.",
-      "documents_rejected": "Some of your documents were rejected. Please review and resubmit.",
-      "subscription_required": "An active Spinr Pass subscription is required to continue.",
-      "not_available": "This driver isn't available right now.",
+      "documents_expired": "One or more of your documents have expired.",
+      "documents_pending": "Your documents are still being reviewed.",
+      "documents_rejected": "Your documents were rejected. Please re-upload.",
+      "subscription_required": "An active subscription is required to continue.",
+      "not_available": "No drivers are available right now.",
       "offline": "The driver is currently offline."
     },
     "ride": {
-      "not_found": "We couldn't find that ride. It may have been removed.",
+      "not_found": "We couldn't find that ride.",
       "already_cancelled": "This ride has already been cancelled.",
-      "invalid_status": "This action isn't allowed for the current ride state.",
-      "no_drivers_available": "No drivers are available right now. Please try again in a few minutes.",
-      "price_mismatch": "The price has changed since you last saw it. Please review and confirm again.",
-      "taken": "Another driver took this ride. We'll find you the next one."
+      "invalid_status": "This action is not allowed for the current ride status.",
+      "no_drivers_available": "No drivers are available in your area. Please try again shortly.",
+      "price_mismatch": "The fare has changed. Please review and try again.",
+      "taken": "Another driver accepted this ride first."
     },
     "payment": {
-      "failed": "Your payment didn't go through. Please try again or use another method.",
-      "method_invalid": "That payment method isn't valid. Please add a different one.",
-      "insufficient_funds": "Not enough in your wallet. Please top up or use a card.",
-      "refund_failed": "We couldn't process the refund right now. Please contact support."
+      "failed": "Payment failed. Please try again.",
+      "method_invalid": "This payment method is invalid. Choose another.",
+      "insufficient_funds": "Insufficient funds for this transaction.",
+      "refund_failed": "We couldn't process your refund. Please contact support."
     },
     "wallet": {
       "transfer_self": "You can't transfer funds to yourself.",
-      "transfer_recipient_not_found": "We couldn't find that recipient. Please double-check and try again."
+      "transfer_recipient_not_found": "We couldn't find that recipient."
     },
     "system": {
       "internal": "Something went wrong on our end. Please try again.",
-      "service_unavailable": "Spinr is temporarily unavailable. Please try again shortly.",
-      "rate_limited": "You're going a bit fast. Please slow down and try again in a moment.",
-      "database": "We're having trouble reaching our systems. Please try again."
+      "service_unavailable": "Service is temporarily unavailable. Please try again shortly.",
+      "rate_limited": "You're doing that too often. Please slow down.",
+      "database": "We're having trouble loading your data. Please try again."
     },
-    "unknown": "Something went wrong. Please try again."
+    "unknown": "An unexpected error occurred. Please try again."
   }
 }

--- a/shared/types/api/pagination.ts
+++ b/shared/types/api/pagination.ts
@@ -1,0 +1,24 @@
+/**
+ * Standard envelope for any paginated list response.
+ *
+ * Cursor-based by default (matches Phase 5 audit recommendation).
+ * Use `next_cursor=null` to signal the last page; clients should not
+ * paginate further. `total` is optional because counting may be
+ * expensive at scale and not all endpoints will populate it.
+ */
+export interface PaginatedResponse<T> {
+  /** Page items in stable order */
+  items: T[];
+  /** Opaque cursor to pass back as ?cursor=... for the next page; null on last page */
+  next_cursor: string | null;
+  /** Convenience: true iff next_cursor !== null */
+  has_more: boolean;
+  /** Optional total — endpoints that can count cheaply may include this */
+  total?: number;
+}
+
+/** Standard query params clients send. `limit` defaults are per-endpoint. */
+export interface PaginationQuery {
+  cursor?: string;
+  limit?: number;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -3,3 +3,4 @@ export * from './api/errors';
 export * from './api/ride';
 export * from './api/user';
 export * from './api/wsEvents';
+export * from './api/pagination';


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Phase 5 of the cross-surface field alignment audit (#316). Adds regression tests so future changes can't quietly re-break the wire-format guarantees Phases 1 and 2 established, and seeds the `PaginatedResponse<T>` shared type that Phase 3b will need. **Tests-and-types only — zero runtime change.**
- **Type**: `chore`
- **Linked issue**: Refs #316
- **Risk**: `low` — no production code touched
- **User-visible change**: `none`
- **Scope contract**: `[x]` regression tests + types only

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend `[x]` rider-app `[ ]` driver-app `[ ]` admin `[x]` shared `[ ]` migrations `[ ]` infra `[ ]` CI
- **Blast radius**: `multi-surface` (test files only)
- **Data schema change**: `none`
- **API contract change**: `none` — defines `PaginatedResponse<T>` for future use; no endpoint adopts it yet
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe`
- **Dependencies / coordination**: independent
- **Assumptions**: Phase 1 (PR #324) keeps `class Config: json_encoders = {Decimal: str}` on the 5 money-bearing Pydantic models. Phase 2B (PR #331) keeps the 28 canonical `errors.*` keys in `rider-app/i18n/en.json`. If a future PR removes either, **this PR's tests will catch it**
- **Not changing but considered**: did NOT migrate any endpoint to `PaginatedResponse<T>` — that's downstream when Phase 3b lands

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** — adds a regression test that verifies money fields stay strings on the wire
- `[ ]` **PIPEDA-relevant** — adds a regression test that verifies all 28 canonical error keys exist in rider-app i18n
- `[ ]` **SK Transportation Act**
- `[ ]` **Auth / RLS**
- `[ ]` **Safety**
- `[ ]` **Third-party SDK added**
- `[ ]` **Breaking change to `shared/`** — adds new exported types only; no removal

## Tier 4 — Verification

- **Unit tests**: `added` —
  - `backend/tests/test_schema_contract.py` — 5 tests, all pass locally (`5 passed in 10.43s`)
  - `rider-app/__tests__/errorI18nCoverage.test.ts` — 30 tests, all pass locally
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: `not-applicable`
- **Perf numbers**: `not-applicable`

**Pre-merge checklist**:

- [x] `pytest backend/tests/test_schema_contract.py` — 5 passed
- [x] `yarn jest __tests__/errorI18nCoverage` — 30 passed
- [x] `tsc --noEmit` clean on `shared/types/api/pagination.ts`
- [x] No production code touched
- [x] No PII added

## What's added

- `backend/tests/test_schema_contract.py` — 5 tests asserting that `AppSettings`, `ServiceArea`, `FareConfig`, `Ride`, and `RideRatingRequest` Pydantic models serialize money fields as `str` (not `float`). Round-trips through `model.json()` to mirror what FastAPI emits on the wire. `surge_multiplier` explicitly asserted to remain `float` (it's a multiplier, not money)
- `rider-app/__tests__/errorI18nCoverage.test.ts` — Walks the `errors.*` tree in `rider-app/i18n/en.json` and asserts every one of the 28 canonical dotted keys (`errors.auth.otp_invalid`, `errors.payment.insufficient_funds`, etc.) maps to a non-empty string. Also asserts the tree contains at least 28 leaf keys
- `shared/types/api/pagination.ts` — `PaginatedResponse<T>` and `PaginationQuery` interfaces. Cursor-based with optional `total`. Re-exported from the `shared/types/index.ts` barrel

## Why this matters

These tests are the kind of guardrail that's invisible until they save you. Phase 1's float-money fix took a multi-PR coordinated change; one inattentive contributor removing `class Config: json_encoders` from a single model would silently regress half of it. The schema-contract test catches that in CI. Same shape for Phase 2B's i18n keys: any backend that adds a new `ErrorCode` and forgets the rider-app key, or any contributor who deletes a key thinking it's unused, trips the coverage test before merge.

https://claude.ai/code/session_01UQ9xbPozFcSwxAue5Y49CE

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
