### PR TITLE
fix(admin, driver): restore pino dependency and resolve React Server Components issue

### DIFF
--- a/admin-dashboard/src/app/layout.tsx
+++ b/admin-dashboard/src/app/layout.tsx
@@ -5,7 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toaster";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { ThemeProvider } from "@/components/theme-provider";
-import { Analytics } from "@vercel/analytics/next";
+import { AnalyticsWrapper } from "@/components/analytics-wrapper";
 import { AuthInitializer } from "@/components/auth-initializer";
 
 export const metadata: Metadata = {
@@ -38,14 +38,7 @@ export default async function RootLayout({
             </TooltipProvider>
           </SidebarProvider>
         </ThemeProvider>
-        {/* Strip dynamic entity IDs from page paths before they reach Vercel's US
-            edge ingestion — /dashboard/drivers/abc123 → /dashboard/drivers/[id] ([22-3]) */}
-        <Analytics
-          beforeSend={(event) => ({
-            ...event,
-            url: event.url.replace(/\/[0-9a-f-]{8,}(?=\/|$)/gi, '/[id]'),
-          })}
-        />
+        <AnalyticsWrapper />
       </body>
     </html>
   );

--- a/admin-dashboard/src/components/analytics-wrapper.tsx
+++ b/admin-dashboard/src/components/analytics-wrapper.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Analytics } from '@vercel/analytics/next';
+
+export function AnalyticsWrapper() {
+  return (
+    <Analytics
+      beforeSend={(event) => ({
+        ...event,
+        url: event.url.replace(/\/[0-9a-f-]{8,}(?=\/|$)/gi, '/[id]'),
+      })}
+    />
+  );
+}

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -408,6 +408,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           try {
             const token = await firebaseUser.getIdToken();
             if (__DEV__) console.log('[Auth] Got Firebase token');
+            // Set in-memory token immediately so subsequent API calls don't hang on Firebase
+            setInMemoryToken(token);
 
             let userData: User | null = null;
             let driverData: Driver | null = null;


### PR DESCRIPTION
## Summary

Fixes critical admin panel server errors and improves driver onboarding reliability.

### Root Cause
Admin dashboard was failing to load due to two issues:
1. **Missing pino dependency** - Module declared in package.json but not installed after `npm ci`
2. **React Server Components violation** - Vercel Analytics `beforeSend` callback being passed from Server to Client Component

### Changes

#### Admin Dashboard
- Restore `pino` to node_modules via lock file update
- Create `AnalyticsWrapper` client component to properly encapsulate Vercel Analytics with `beforeSend` handler
- Update root layout to use wrapper component

#### Driver App  
- Add auth token guard in vehicle-info form to prevent race condition during onboarding
- Ensures token is available before submitting vehicle update mutation

#### Shared
- Improve auth token initialization timing in Firebase auth flow

### Testing

**Local verification:**
- ✅ Admin dashboard builds successfully: `npm run build` (no TypeScript or module errors)
- ✅ Dev server running: `npm run dev`
- ✅ Login page loads without errors: http://localhost:3000/login
- ✅ No React Server Components violations
- ✅ All pre-commit security checks passing

**Test plan:**
- [ ] Admin login page loads without "server error" message
- [ ] Dashboard pages render after login
- [ ] Driver vehicle-info form submits successfully during onboarding
- [ ] No console errors in browser
- [ ] Production deployment on Vercel succeeds

### Files Changed
- `admin-dashboard/package-lock.json` - Pino dependency lock
- `admin-dashboard/src/app/layout.tsx` - Use AnalyticsWrapper component
- `admin-dashboard/src/components/analytics-wrapper.tsx` - New client component (14 lines)
- `driver-app/app/vehicle-info.tsx` - Add token guard check
- `shared/store/authStore.ts` - Improve token initialization

### Deploy Notes
- Vercel will auto-deploy to production once merged to main (~2-5 min)
- No database migrations needed
- No environment variable changes required
- Safe to deploy during business hours (no breaking changes)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
