### PR TITLE
fix(admin): exclude local /api/auth routes from backend rewrite

### DIFF
--- a/admin-dashboard/next.config.ts
+++ b/admin-dashboard/next.config.ts
@@ -69,6 +69,12 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     return [
+      // Local API routes (must be before the catch-all /api rewrite)
+      {
+        source: "/api/auth/:path*",
+        destination: "/api/auth/:path*",
+      },
+      // Proxy everything else to backend
       {
         source: "/api/:path*",
         destination: `${BACKEND_URL}/api/:path*`,


### PR DESCRIPTION
## Summary
Fixes login redirect loop by keeping local /api/auth/* routes from being rewritten to the backend.

## Problem
The rewrite rule in next.config.ts was proxying ALL /api/* requests to the backend, including /api/auth/set-cookie which is a local Next.js API route. When setAuthCookie() tried to call this endpoint, it got rewritten to the backend (which doesn't have it), causing the request to fail silently. The HttpOnly cookie was never set, so the middleware rejected the token and redirected to /login.

## Solution  
Added a rewrite exception for /api/auth/* routes so they stay local and are handled by Next.js.

## Testing
- Build passes
- Local dev verified cookie is now set correctly
- Preview URL should now work without redirect loop

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
