### PR TITLE
fix(auth): fix CookieManager import crash — Internal Login Error 500 on OTP verify

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -49,7 +49,7 @@ class Settings(BaseSettings):
     COOKIE_SECURE: bool = True  # HTTPS only in production
     COOKIE_HTTPONLY: bool = True  # JavaScript cannot read
     COOKIE_SAMESITE: str = "Strict"  # Prevent CSRF token leaks
-    COOKIE_DOMAIN: str = ".spinrvm.ca"  # Cross-subdomain support
+    COOKIE_DOMAIN: str = ""  # Set to ".spinrvm.ca" in production env vars for cross-subdomain support
     COOKIE_PATH: str = "/"  # Available to all routes
 
     # CORS settings

--- a/backend/utils/cookie_manager.py
+++ b/backend/utils/cookie_manager.py
@@ -4,7 +4,10 @@ from typing import Optional
 
 from fastapi import Response
 
-from backend.core.config import settings
+try:
+    from ..core.config import settings
+except ImportError:
+    from core.config import settings
 
 
 class CookieManager:


### PR DESCRIPTION
## Root Cause

`backend/utils/cookie_manager.py` used `from backend.core.config import settings` — an **absolute import** that assumes the app runs as a Python package.

Railway builds from `backend/Dockerfile` with `backend/` as the Docker build context, then starts with `uvicorn server:app`. This means the app runs **flat** (all backend files are top-level in `/app`). There is no `backend` package in `sys.path`.

**Crash chain:**
1. `verify_otp` calls `_make_auth_response` after OTP is verified ✅
2. `_make_auth_response` lazy-imports `CookieManager`
3. The relative import (`from ..utils.cookie_manager`) fails (not a package)
4. Falls back to `from utils.cookie_manager import CookieManager`
5. `cookie_manager.py` line 7: `from backend.core.config import settings` → `ModuleNotFoundError`
6. Propagates out of `_make_auth_response` → caught by outer `except Exception as e` in `verify_otp`
7. Returns **500 "Internal Login Error"** on every OTP login attempt

This explains why OTP records were marked `verified=True` (that step succeeded) but login always failed with 500.

## Changes

- `backend/utils/cookie_manager.py` — replace absolute import with dual-import pattern (same as every other module)
- `backend/core/config.py` — change `COOKIE_DOMAIN` default from `.spinrvm.ca` to `""` so cookies are scoped to the Railway host, not the production domain

## Test plan

- [ ] OTP login on physical device (rider-app APK) — expect 200, no 500
- [ ] Subsequent authenticated request (e.g. GET /auth/me) returns user profile
- [ ] Login on driver-app APK same result
- [ ] Admin dashboard login unaffected

AI-assisted — spinr platform (Claude Code)