### PR TITLE
fix(auth): use timezone-aware datetime for cookie expires

### DIFF
--- a/backend/utils/cookie_manager.py
+++ b/backend/utils/cookie_manager.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import Response
@@ -34,7 +34,7 @@ class CookieManager:
             key="auth_token",
             value=token,
             max_age=ttl_minutes * 60,
-            expires=datetime.utcnow() + timedelta(minutes=ttl_minutes),
+            expires=datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes),
             httponly=True,
             secure=settings.ENV == "production",
             samesite="Strict",
@@ -61,7 +61,7 @@ class CookieManager:
             key="refresh_token",
             value=token,
             max_age=ttl_days * 86400,
-            expires=datetime.utcnow() + timedelta(days=ttl_days),
+            expires=datetime.now(timezone.utc) + timedelta(days=ttl_days),
             httponly=True,
             secure=settings.ENV == "production",
             samesite="Strict",


### PR DESCRIPTION
## Summary
- `datetime.utcnow()` returns a naive datetime; Starlette's `set_cookie` passes it to `email.utils.format_datetime(usegmt=True)` which requires a timezone-aware UTC datetime → `ValueError: usegmt option requires a UTC datetime` → 500 on every OTP login
- Fix: replace `datetime.utcnow()` with `datetime.now(timezone.utc)` in both `set_auth_cookie` and `set_refresh_cookie`
- Add `timezone` to the `datetime` import

## Root cause chain (full OTP login debug arc)
1. PR #403: CookieManager absolute import crash on Railway flat deploy (fixed)
2. Migration 25: `refresh_tokens` table missing in Supabase (applied manually)
3. **This PR**: naive `datetime.utcnow()` rejected by Starlette cookie serializer

## Test plan
- [ ] Merge and wait for Railway auto-deploy
- [ ] Request fresh OTP on device → enter 1234 → should complete login