### PR TITLE
fix(rider-app): OTP verify silently skips navigation when token is empty (P3 cookie auth)

### DIFF
--- a/rider-app/app/otp.tsx
+++ b/rider-app/app/otp.tsx
@@ -139,20 +139,20 @@ export default function OtpScreen() {
           code: code,
         });
         const { token, refresh_token, expires_in, user: userData } = response.data;
+        // P3 cookie auth: token is "" when HTTP-only cookies are used
         if (token) {
           await useAuthStore.getState().setTokens(token, refresh_token ?? "", expires_in ?? 900);
-          Analytics.otpVerified();
-
-          if (userData) {
-            useAuthStore.setState({
-              user: userData,
-              isInitialized: true,
-              isLoading: false,
-            });
-            Analytics.login();
-          } else {
-            await initialize();
-          }
+        }
+        Analytics.otpVerified();
+        if (userData) {
+          useAuthStore.setState({
+            user: userData,
+            isInitialized: true,
+            isLoading: false,
+          });
+          Analytics.login();
+        } else {
+          await initialize();
         }
       } else {
         await verifyOTP(verificationId!, code);


### PR DESCRIPTION
## Summary
- After P3, backend returns `token: ""` (tokens in HTTP-only cookies, not response body)
- `otp.tsx` had `if (token)` guard around all post-auth logic — falsy for empty string
- Result: setTokens skipped, user never set in authStore, useEffect navigation never fired, screen stayed frozen
- Fix: move user state setting and initialize() outside the token guard; token storing is still skipped for empty token (correct for cookie mode)

## Test plan
- [ ] Request fresh OTP on device → enter 1234 → should navigate to activity or profile-setup screen

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
