### PR TITLE
fix: full P0/P1/P2 sprint — safety, payments, mobile crashes, admin polish

### DIFF
--- a/admin-dashboard/src/app/dashboard/analytics/page.tsx
+++ b/admin-dashboard/src/app/dashboard/analytics/page.tsx
@@ -68,7 +68,7 @@ export default function AnalyticsPage() {
         getCancellationBreakdown(dateRange).catch(() => null),
         getDriverAcceptanceRates(dateRange).catch(() => null),
       ]);
-      if (ov === null && cancel === null && drivers === null) {
+      if (ov === null || cancel === null || drivers === null) {
         setFetchError(true);
       }
       setOverview(ov);

--- a/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
+++ b/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { useEffect, useState, useMemo, useCallback } from "react";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -111,6 +116,8 @@ export default function CloudMessagingPage() {
     const [selectedMessage, setSelectedMessage] = useState<CloudMessage | null>(null);
     const [sending, setSending] = useState(false);
     const [activeTab, setActiveTab] = useState<"compose" | "scheduled" | "history">("compose");
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const { toast } = useToast();
 
     // Multi-select user/driver
     const [userOptions, setUserOptions] = useState<UserOption[]>([]);
@@ -222,15 +229,15 @@ export default function CloudMessagingPage() {
     useEffect(() => { setHistoryPage(1); }, [search, statusFilter, audienceFilter, dateFrom, dateTo]);
 
     const handleSend = async () => {
-        if (!form.title.trim() || !form.description.trim()) { alert("Please fill in title and description."); return; }
+        if (!form.title.trim() || !form.description.trim()) { toast({ title: "Missing fields", description: "Please fill in title and description.", variant: "destructive" }); return; }
         const isParticular = form.audience === "particular_customer" || form.audience === "particular_driver";
-        if (isParticular && form.particular_ids.length === 0) { alert("Please select at least one user/driver."); return; }
-        if (form.is_scheduled && !form.scheduled_at) { alert("Please select a date and time."); return; }
+        if (isParticular && form.particular_ids.length === 0) { toast({ title: "No recipients selected", description: "Please select at least one user/driver.", variant: "destructive" }); return; }
+        if (form.is_scheduled && !form.scheduled_at) { toast({ title: "Missing schedule time", description: "Please select a date and time.", variant: "destructive" }); return; }
         const channels: string[] = [];
         if (form.send_push) channels.push("push");
         if (form.send_email) channels.push("email");
         if (form.send_sms) channels.push("sms");
-        if (channels.length === 0) { alert("Please select at least one delivery channel."); return; }
+        if (channels.length === 0) { toast({ title: "No delivery channel", description: "Please select at least one delivery channel.", variant: "destructive" }); return; }
 
         setSending(true);
         try {
@@ -249,7 +256,7 @@ export default function CloudMessagingPage() {
             await fetchData();
             resetForm();
         } catch (error: any) {
-            alert(`Failed to send: ${error.message || "Unknown error"}`);
+            toast({ title: "Failed to send", description: error.message || "Unknown error", variant: "destructive" });
         } finally {
             setSending(false);
         }
@@ -262,10 +269,18 @@ export default function CloudMessagingPage() {
         setUserOptions([]);
     };
 
-    const handleDelete = async (id: string) => {
-        if (!confirm("Cancel this message?")) return;
-        try { await deleteCloudMessage(id); } catch { /* continue */ }
-        setMessages((prev) => prev.filter((m) => m.id !== id));
+    const handleDelete = (id: string) => {
+        setDeleteTarget(id);
+    };
+
+    const confirmDelete = async () => {
+        if (!deleteTarget) return;
+        try { await deleteCloudMessage(deleteTarget); }
+        catch (e: any) { toast({ title: "Failed to cancel message", description: e?.message, variant: "destructive" }); }
+        finally {
+            setMessages((prev) => prev.filter((m) => m.id !== deleteTarget));
+            setDeleteTarget(null);
+        }
     };
 
     const handleExport = () => {
@@ -668,6 +683,19 @@ export default function CloudMessagingPage() {
                     )}
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Cancel this message?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Keep</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Cancel Message</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/allowance-dialog.tsx
+++ b/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/allowance-dialog.tsx
@@ -177,7 +177,10 @@ export default function AllowanceDialog({ companyId, member, onClose, onSaved }:
 
                 <DialogFooter>
                     <Button variant="outline" onClick={onClose}>Cancel</Button>
-                    <Button onClick={save} disabled={saving}>
+                    <Button
+                        onClick={save}
+                        disabled={saving || (type === "fixed_recurring" && (!periodStart || !periodEnd)) || (type !== "unlimited" && !amount)}
+                    >
                         {saving ? "Saving…" : "Save"}
                     </Button>
                 </DialogFooter>

--- a/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/page.tsx
+++ b/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/page.tsx
@@ -54,6 +54,11 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import AllowanceDialog from "./allowance-dialog";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const STATUS_COLORS: Record<CorporateMember["status"], string> = {
     invited: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300",
@@ -145,6 +150,8 @@ function DecisionDialog({ request, approve, onConfirm, onCancel, busy }: Decisio
 export default function CompanyMembersPage() {
     const { id } = useParams<{ id: string }>();
     const companyId = id as string;
+    const { toast } = useToast();
+    const [removeTarget, setRemoveTarget] = useState<string | null>(null);
 
     const [members, setMembers] = useState<CorporateMember[]>([]);
     const [requests, setRequests] = useState<AllowanceRequestRow[]>([]);
@@ -191,19 +198,25 @@ export default function CompanyMembersPage() {
             setInviteUrl(res.invite_url);
             refresh();
         } catch (e: any) {
-            alert(e?.message ?? "Invite failed");
+            toast({ title: "Invite failed", description: e?.message, variant: "destructive" });
         } finally {
             setInviting(false);
         }
     }
 
     async function handleRemove(memberId: string) {
-        if (!window.confirm("Remove this member? Their allowance stops immediately.")) return;
+        setRemoveTarget(memberId);
+    }
+
+    async function confirmRemove() {
+        if (!removeTarget) return;
         try {
-            await removeCompanyMember(companyId, memberId);
+            await removeCompanyMember(companyId, removeTarget);
             refresh();
         } catch (e: any) {
-            alert(e?.message ?? "Remove failed");
+            toast({ title: "Remove failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setRemoveTarget(null);
         }
     }
 
@@ -212,7 +225,7 @@ export default function CompanyMembersPage() {
             await updateCompanyMember(companyId, member.id, { status: newStatus });
             refresh();
         } catch (e: any) {
-            alert(e?.message ?? "Status change failed");
+            toast({ title: "Status change failed", description: e?.message, variant: "destructive" });
         }
     }
 
@@ -227,7 +240,7 @@ export default function CompanyMembersPage() {
             setDecisionTarget(null);
             refresh();
         } catch (e: any) {
-            alert(e?.message ?? "Decision failed");
+            toast({ title: "Decision failed", description: e?.message, variant: "destructive" });
         } finally {
             setDecisionBusy(false);
         }
@@ -542,6 +555,19 @@ export default function CompanyMembersPage() {
                     busy={decisionBusy}
                 />
             )}
+
+            <AlertDialog open={!!removeTarget} onOpenChange={(open) => { if (!open) setRemoveTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Remove member?</AlertDialogTitle>
+                        <AlertDialogDescription>Their allowance stops immediately. This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmRemove} className="bg-red-600 hover:bg-red-700">Remove</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/page.tsx
+++ b/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
     Wallet,
     XCircle,
 } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 
 const STATUS_PILL_CLASSES: Record<CompanyStatus, string> = {
     pending_verification: "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
@@ -100,6 +101,7 @@ function formatDate(iso?: string | null) {
 export default function CompanyDetailPage() {
     const params = useParams<{ id: string }>();
     const id = params?.id;
+    const { toast } = useToast();
 
     const [company, setCompany] = useState<CorporateAccount | null>(null);
     const [loading, setLoading] = useState(true);
@@ -155,7 +157,7 @@ export default function CompanyDetailPage() {
             await walletAdjust(id, { amount, notes: notes.trim() });
             await loadWallet();
         } catch (e: any) {
-            alert(e?.message ?? "Adjustment failed");
+            toast({ title: "Adjustment failed", description: e?.message, variant: "destructive" });
         } finally {
             setWalletBusy(false);
         }
@@ -170,7 +172,7 @@ export default function CompanyDetailPage() {
             });
             await loadWallet();
         } catch (e: any) {
-            alert(e?.message ?? "Failed to toggle auto top-up");
+            toast({ title: "Failed to toggle auto top-up", description: e?.message, variant: "destructive" });
         } finally {
             setWalletBusy(false);
         }
@@ -194,7 +196,7 @@ export default function CompanyDetailPage() {
             setPendingTransition(null);
             setReason("");
         } catch (e: any) {
-            alert(e?.message ?? "Status change failed");
+            toast({ title: "Status change failed", description: e?.message, variant: "destructive" });
         } finally {
             setTransitioning(false);
         }

--- a/admin-dashboard/src/app/dashboard/corporate-accounts/kyb-queue/page.tsx
+++ b/admin-dashboard/src/app/dashboard/corporate-accounts/kyb-queue/page.tsx
@@ -37,8 +37,10 @@ import {
     RefreshCw,
     XCircle,
 } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 
 export default function KybQueuePage() {
+    const { toast } = useToast();
     const [rows, setRows] = useState<CorporateAccount[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -73,7 +75,7 @@ export default function KybQueuePage() {
             await reviewKyb(id, { approve: true });
             await load();
         } catch (e: any) {
-            alert(e?.message ?? "Approval failed");
+            toast({ title: "Approval failed", description: e?.message, variant: "destructive" });
         } finally {
             setBusyId(null);
         }
@@ -92,7 +94,7 @@ export default function KybQueuePage() {
             setRejectNote("");
             await load();
         } catch (e: any) {
-            alert(e?.message ?? "Rejection failed");
+            toast({ title: "Rejection failed", description: e?.message, variant: "destructive" });
         } finally {
             setBusyId(null);
         }

--- a/admin-dashboard/src/app/dashboard/corporate-accounts/page.tsx
+++ b/admin-dashboard/src/app/dashboard/corporate-accounts/page.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/select";
 import { Building2, Plus, Pencil, Trash2, Search, Mail, Phone, RefreshCw, ShieldCheck } from "lucide-react";
 import { useRequireModule } from "@/hooks/useRequireModule";
+import { useToast } from "@/components/ui/use-toast";
 
 const STATUS_PILL_CLASSES: Record<CompanyStatus, string> = {
     pending_verification: "bg-yellow-100 text-yellow-800 hover:bg-yellow-100",
@@ -72,6 +73,7 @@ const PAGE_SIZE = 50;
 
 export default function CorporateAccountsPage() {
     const { allowed } = useRequireModule("corporate_accounts");
+    const { toast } = useToast();
     const [accounts, setAccounts] = useState<CorporateAccount[]>([]);
     const [loading, setLoading] = useState(true);
     const [search, setSearch] = useState("");
@@ -174,7 +176,7 @@ export default function CorporateAccountsPage() {
             fetchAccounts();
         } catch (error) {
             console.error("Failed to save account:", error);
-            alert("Failed to save account. Please try again.");
+            toast({ title: "Failed to save account", description: "Please try again.", variant: "destructive" });
         } finally {
             setFormLoading(false);
         }
@@ -189,7 +191,7 @@ export default function CorporateAccountsPage() {
             fetchAccounts();
         } catch (error) {
             console.error("Failed to delete account:", error);
-            alert("Failed to delete account.");
+            toast({ title: "Failed to delete account", variant: "destructive" });
         } finally {
             setFormLoading(false);
         }

--- a/admin-dashboard/src/app/dashboard/drivers/_components/driver-action-bar.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/_components/driver-action-bar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { driverAction, overrideDriverStatus } from "@/lib/api";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
@@ -33,6 +34,7 @@ const STATUS_CONFIG: Record<DriverStatus, { label: string; color: string; bg: st
 };
 
 export default function DriverActionBar({ driver, onActionComplete }: DriverActionBarProps) {
+    const { toast } = useToast();
     const [actionDialog, setActionDialog] = useState<{ action: string; title: string; description: string; requiresReason: boolean; buttonLabel: string; buttonClass: string } | null>(null);
     const [reason, setReason] = useState("");
     const [loading, setLoading] = useState(false);
@@ -60,7 +62,7 @@ export default function DriverActionBar({ driver, onActionComplete }: DriverActi
             setActionDialog(null);
             onActionComplete();
         } catch (e: any) {
-            alert(e?.message || "Action failed");
+            toast({ title: "Action failed", description: e?.message, variant: "destructive" });
         } finally {
             setLoading(false);
         }

--- a/admin-dashboard/src/app/dashboard/drivers/_components/driver-charts.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/_components/driver-charts.tsx
@@ -65,7 +65,7 @@ export default function DriverCharts({ charts, loading }: { charts: ChartData | 
             {/* Daily Driver Joins */}
             <ChartCard title="Driver Joins" subtitle="New driver registrations per day" icon={UserPlus}>
                 <ResponsiveContainer width="100%" height={200}>
-                    <BarChart data={charts.daily_joins} barSize={18}>
+                    <BarChart data={charts.daily_joins ?? []} barSize={18}>
                         <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
                         <XAxis dataKey="date" tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }} axisLine={false} tickLine={false} />
                         <YAxis tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }} allowDecimals={false} axisLine={false} tickLine={false} />
@@ -78,7 +78,7 @@ export default function DriverCharts({ charts, loading }: { charts: ChartData | 
             {/* Daily Rides */}
             <ChartCard title="Daily Rides" subtitle="Number of rides per day" icon={Car}>
                 <ResponsiveContainer width="100%" height={200}>
-                    <BarChart data={charts.daily_rides} barSize={18}>
+                    <BarChart data={charts.daily_rides ?? []} barSize={18}>
                         <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
                         <XAxis dataKey="date" tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }} axisLine={false} tickLine={false} />
                         <YAxis tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }} allowDecimals={false} axisLine={false} tickLine={false} />
@@ -91,7 +91,7 @@ export default function DriverCharts({ charts, loading }: { charts: ChartData | 
             {/* Daily Earnings */}
             <ChartCard title="Driver Earnings" subtitle="Total driver earnings per day" icon={DollarSign}>
                 <ResponsiveContainer width="100%" height={200}>
-                    <LineChart data={charts.daily_earnings}>
+                    <LineChart data={charts.daily_earnings ?? []}>
                         <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
                         <XAxis dataKey="date" tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }} axisLine={false} tickLine={false} />
                         <YAxis tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }} axisLine={false} tickLine={false}

--- a/admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useState } from "react";
 import { getDriverNotes, addDriverNote, deleteDriverNote } from "@/lib/api";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
     MessageSquare, Plus, Trash2, AlertTriangle, FileText, ShieldCheck,
     Flag, Clock, Loader2, StickyNote,
@@ -27,6 +32,8 @@ function fmtDateTime(d: string) {
 }
 
 export default function DriverNotes({ driverId }: { driverId: string }) {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const [notes, setNotes] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [adding, setAdding] = useState(false);
@@ -56,19 +63,24 @@ export default function DriverNotes({ driverId }: { driverId: string }) {
             setAdding(false);
             loadNotes();
         } catch (e: any) {
-            alert(e?.message || "Failed to add note");
+            toast({ title: "Failed to add note", description: e?.message, variant: "destructive" });
         }
         setSaving(false);
     };
 
-    const handleDelete = async (noteId: string) => {
-        if (!confirm("Delete this note?")) return;
-        setDeleting(noteId);
+    const handleDelete = (noteId: string) => {
+        setDeleteTarget(noteId);
+    };
+
+    const confirmDelete = async () => {
+        if (!deleteTarget) return;
+        setDeleting(deleteTarget);
         try {
-            await deleteDriverNote(noteId);
+            await deleteDriverNote(deleteTarget);
             loadNotes();
         } catch {}
         setDeleting(null);
+        setDeleteTarget(null);
     };
 
     const getCategoryConfig = (cat: string) => CATEGORIES.find(c => c.value === cat) || CATEGORIES[0];
@@ -160,5 +172,18 @@ export default function DriverNotes({ driverId }: { driverId: string }) {
                 </div>
             )}
         </div>
+
+        <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Delete note?</AlertDialogTitle>
+                    <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
     );
 }

--- a/admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx
@@ -86,6 +86,7 @@ export default function DriverNotes({ driverId }: { driverId: string }) {
     const getCategoryConfig = (cat: string) => CATEGORIES.find(c => c.value === cat) || CATEGORIES[0];
 
     return (
+        <>
         <div className="space-y-4">
             <div className="flex items-center justify-between">
                 <div>
@@ -185,5 +186,6 @@ export default function DriverNotes({ driverId }: { driverId: string }) {
                 </AlertDialogFooter>
             </AlertDialogContent>
         </AlertDialog>
+        </>
     );
 }

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -21,6 +21,7 @@ import DriverActionBar from "./_components/driver-action-bar";
 import DriverNotes from "./_components/driver-notes";
 import DriverTimeline from "./_components/driver-timeline";
 import { useRequireModule } from "@/hooks/useRequireModule";
+import { useToast } from "@/components/ui/use-toast";
 
 const STATUS_TABS = [
     { value: "all", label: "All", icon: Users },
@@ -36,6 +37,7 @@ const PAGE_SIZE = 50;
 
 export default function DriversPage() {
     const { allowed } = useRequireModule("drivers");
+    const { toast } = useToast();
     const [data, setData] = useState<any>(null);
     const [drivers, setDrivers] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -160,11 +162,30 @@ export default function DriversPage() {
         return () => document.removeEventListener("keydown", onKey);
     }, [previewUrl]);
 
-    const reloadDriverDocs = async () => { if (!selected?.id) return; try { const d = await getDriverDocuments(selected.id); setDriverDocs(Array.isArray(d) ? d : []); } catch {} };
+    const reloadDriverDocs = async () => {
+        if (!selected?.id) return;
+        try {
+            const d = await getDriverDocuments(selected.id);
+            setDriverDocs(Array.isArray(d) ? d : []);
+        } catch (e: any) {
+            toast({ title: "Could not reload documents", description: e?.message || "Unknown error", variant: "destructive" });
+        }
+    };
 
     const handleReviewDoc = async (docId: string, status: "approved" | "rejected", reason?: string, expiry?: string) => {
         setDocBusy(docId);
-        try { await reviewDocument(docId, status, reason, expiry ? new Date(expiry).toISOString() : undefined); await reloadDriverDocs(); loadData(); loadDrivers(); } catch (e: any) { alert("Could not update document: " + (e?.message || "unknown error")); } finally { setDocBusy(null); }
+        const prevDocs = [...driverDocs];
+        try {
+            await reviewDocument(docId, status, reason, expiry ? new Date(expiry).toISOString() : undefined);
+            await reloadDriverDocs();
+            loadData();
+            loadDrivers();
+        } catch (e: any) {
+            setDriverDocs(prevDocs);
+            toast({ title: "Document review failed", description: e?.message || "Unknown error", variant: "destructive" });
+        } finally {
+            setDocBusy(null);
+        }
     };
 
     const openReviewDialog = (docId: string, action: "approved" | "rejected") => {

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -211,7 +211,7 @@ export default function DriversPage() {
         for (const [k, v] of Object.entries(editForm)) { if (v !== (selected[k] || "")) changes[k] = v; }
         if (Object.keys(changes).length === 0) { setEditing(false); return; }
         setSaving(true);
-        try { await updateDriver(selected.id, changes); const updated = { ...selected, ...changes }; setSelected(updated); setDrivers(prev => prev.map(d => d.id === selected.id ? { ...d, ...changes } : d)); setEditing(false); } catch (e: any) { alert("Failed to save: " + (e?.message || "unknown error")); } finally { setSaving(false); }
+        try { await updateDriver(selected.id, changes); const updated = { ...selected, ...changes }; setSelected(updated); setDrivers(prev => prev.map(d => d.id === selected.id ? { ...d, ...changes } : d)); setEditing(false); } catch (e: any) { toast({ title: "Failed to save driver", description: e?.message || "Unknown error", variant: "destructive" }); } finally { setSaving(false); }
     };
 
     const ef = (field: string) => editForm[field] ?? "";

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -279,6 +279,7 @@ export default function DriversPage() {
                 { key: "is_online", label: "Online" }, { key: "total_rides", label: "Rides" },
                 { key: "created_at", label: "Joined" },
             ]);
+            toast({ title: "Export complete", description: `${res.count ?? res.drivers?.length ?? 0} drivers exported.` });
         } catch (e: any) {
             toast({ title: "Export failed", description: e?.message, variant: "destructive" });
         }

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { getDriverStats, getDrivers, getDriverDocuments, reviewDocument, updateDriver, getServiceAreas, getVehicleTypes, getFareConfigs } from "@/lib/api";
+import { getDriverStats, getDrivers, getDriverDocuments, reviewDocument, updateDriver, getServiceAreas, getVehicleTypes, getFareConfigs, exportDrivers } from "@/lib/api";
 import { Pagination } from "@/components/ui/pagination";
 import { exportToCsv } from "@/lib/export-csv";
 import { formatCurrency } from "@/lib/utils";
@@ -268,7 +268,21 @@ export default function DriversPage() {
     };
     const fmtDate = (d: string) => { if (!d) return "\u2014"; try { return new Date(d).toLocaleDateString("en-CA", { month: "short", day: "numeric", year: "numeric" }); } catch { return d; } };
 
-    const handleExport = () => { exportToCsv("drivers", sorted, [{ key: "id", label: "ID" }, { key: "first_name", label: "First Name" }, { key: "last_name", label: "Last Name" }, { key: "email", label: "Email" }, { key: "phone", label: "Phone" }, { key: "service_area_id", label: "Service Area ID" }, { key: "is_verified", label: "Verified" }, { key: "is_online", label: "Online" }, { key: "rating", label: "Rating" }, { key: "total_rides", label: "Rides" }, { key: "total_earnings", label: "Earnings" }, { key: "vehicle_make", label: "Vehicle Make" }, { key: "vehicle_model", label: "Vehicle Model" }, { key: "license_plate", label: "License Plate" }, { key: "created_at", label: "Joined" }]); };
+    const handleExport = async () => {
+        try {
+            const res = await exportDrivers();
+            exportToCsv("drivers", res.drivers, [
+                { key: "id", label: "ID" }, { key: "name", label: "Name" },
+                { key: "email", label: "Email" }, { key: "phone", label: "Phone" },
+                { key: "vehicle_make", label: "Vehicle Make" }, { key: "vehicle_model", label: "Vehicle Model" },
+                { key: "license_plate", label: "License Plate" }, { key: "is_verified", label: "Verified" },
+                { key: "is_online", label: "Online" }, { key: "total_rides", label: "Rides" },
+                { key: "created_at", label: "Joined" },
+            ]);
+        } catch (e: any) {
+            toast({ title: "Export failed", description: e?.message, variant: "destructive" });
+        }
+    };
 
     const selectedAreaName = serviceAreaId ? serviceAreas.find(a => a.id === serviceAreaId)?.name || "Selected Area" : "All Areas";
     const activeDocs = driverDocs.filter(d => d.status !== "superseded");

--- a/admin-dashboard/src/app/dashboard/heatmap/page.tsx
+++ b/admin-dashboard/src/app/dashboard/heatmap/page.tsx
@@ -43,6 +43,7 @@ export default function HeatMapPage() {
     const [endDate, setEndDate] = useState("");
     const [serviceAreaId, setServiceAreaId] = useState<string>("all");
     const [groupBy, setGroupBy] = useState<"pickup" | "dropoff" | "both">("both");
+    const [dateError, setDateError] = useState("");
 
     // Display toggles
     const [showPickups, setShowPickups] = useState(true);
@@ -103,6 +104,11 @@ export default function HeatMapPage() {
 
     // Fetch heat map data when filters change
     const fetchHeatMapData = useCallback(() => {
+        if (startDate && endDate && startDate > endDate) {
+            setDateError("Start date must be before end date.");
+            return;
+        }
+        setDateError("");
         setLoading(true);
         const { start_date, end_date } = getDateRange();
 
@@ -151,7 +157,7 @@ export default function HeatMapPage() {
                         variant="outline"
                         size="sm"
                         onClick={fetchHeatMapData}
-                        disabled={loading}
+                        disabled={loading || !!dateError}
                     >
                         <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
                         Refresh
@@ -289,6 +295,9 @@ export default function HeatMapPage() {
                             />
                         </div>
                     </div>
+                    {dateError && (
+                        <p className="text-sm text-destructive mt-2">{dateError}</p>
+                    )}
 
                     {/* Display Toggles */}
                     <div className="flex items-center gap-6 mt-4 pt-4 border-t">

--- a/admin-dashboard/src/app/dashboard/heatmap/page.tsx
+++ b/admin-dashboard/src/app/dashboard/heatmap/page.tsx
@@ -106,6 +106,7 @@ export default function HeatMapPage() {
     const fetchHeatMapData = useCallback(() => {
         if (startDate && endDate && startDate > endDate) {
             setDateError("Start date must be before end date.");
+            setLoading(false);
             return;
         }
         setDateError("");

--- a/admin-dashboard/src/app/dashboard/monitoring/driver-panel.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/driver-panel.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { MonitoringDriver } from "./types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ExternalLink, Flag, Phone, Star } from "lucide-react";
@@ -17,6 +18,7 @@ interface DriverPanelProps {
 }
 
 export function DriverPanel({ driver, onRideClick }: DriverPanelProps) {
+    const { toast } = useToast();
     const [rides, setRides] = useState<any[]>([]);
     const [docs, setDocs] = useState<any[]>([]);
     const [tabLoading, setTabLoading] = useState(false);
@@ -154,7 +156,7 @@ export function DriverPanel({ driver, onRideClick }: DriverPanelProps) {
                             size="sm"
                             variant="outline"
                             className="flex-1 gap-1.5 text-xs text-destructive hover:text-destructive"
-                            onClick={() => window.alert(`Flag driver ${driver.name}? Use the full driver profile to submit a formal flag.`)}
+                            onClick={() => toast({ title: "Use driver profile to flag", description: `Open the full profile for ${driver.name} to submit a formal flag.` })}
                         >
                             <Flag className="h-3.5 w-3.5" /> Flag
                         </Button>

--- a/admin-dashboard/src/app/dashboard/monitoring/page.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/page.tsx
@@ -458,6 +458,16 @@ export default function MonitoringPage() {
         wsStatus={wsStatus}
       />
 
+      {/* Stale-data warning banner — visible whenever live feed is interrupted */}
+      {wsStatus !== "connected" && (
+        <div className="flex items-center gap-2 bg-yellow-50 border-b border-yellow-200 px-4 py-2 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:border-yellow-800 dark:text-yellow-300">
+          <span className="font-medium">Live data paused</span>
+          <span className="text-yellow-700 dark:text-yellow-400">
+            — map and ride list may be stale ({wsStatus === "connecting" ? "reconnecting…" : "connection lost"})
+          </span>
+        </div>
+      )}
+
       {/* Main 3-column layout */}
       <div className="flex flex-1 overflow-hidden">
         {/* ── Left: Ride list ─────────────────────────────────────── */}

--- a/admin-dashboard/src/app/dashboard/monitoring/page.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Radio, X } from "lucide-react";
 import { useAuthStore } from "@/store/authStore";
+import { useToast } from "@/components/ui/use-toast";
 
 import { adminCancelRide, getFareConfigs, getMonitoringDrivers, getMonitoringRides, getServiceAreas, getVehicleTypes } from "@/lib/api";
 import { useMonitoringSocket } from "@/hooks/use-monitoring-socket";
@@ -27,6 +28,7 @@ const POLL_INTERVAL_MS = 15_000;
 
 export default function MonitoringPage() {
   const { allowed } = useRequireModule("rides");
+  const { toast } = useToast();
   // ── Refs: source-of-truth maps (never trigger re-renders) ──────────
   const driversMapRef = useRef<Map<string, MonitoringDriver>>(new Map());
   const ridesMapRef = useRef<Map<string, MonitoringRide>>(new Map());
@@ -605,9 +607,7 @@ export default function MonitoringPage() {
                     setSelected(null);
                     setSelectedRide(null);
                   } catch (err: any) {
-                    window.alert(
-                      `Failed to cancel ride: ${err?.message ?? "unknown error"}`,
-                    );
+                    toast({ title: "Failed to cancel ride", description: err?.message ?? "Unknown error", variant: "destructive" });
                   }
                 }}
                 onCompleteRide={async (id) => {

--- a/admin-dashboard/src/app/dashboard/promotions/page.tsx
+++ b/admin-dashboard/src/app/dashboard/promotions/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
+import { useToast } from "@/components/ui/use-toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,6 +14,10 @@ import {
 import {
     Dialog, DialogContent, DialogHeader, DialogTitle,
 } from "@/components/ui/dialog";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
     Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
@@ -103,6 +108,8 @@ function getPromoStatus(p: PromoCode): string {
 
 export default function PromotionsPage() {
     const { allowed } = useRequireModule("promotions");
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const [promos, setPromos] = useState<PromoCode[]>([]);
     const [usage, setUsage] = useState<PromoUsageRecord[]>([]);
     const [stats, setStats] = useState<PromoStatsData | null>(null);
@@ -341,7 +348,10 @@ export default function PromotionsPage() {
     };
 
     const handleSave = async () => {
-        if (!form.code.trim() || !form.discount_value) { alert("Please fill in code and discount value."); return; }
+        if (!form.code.trim() || !form.discount_value) {
+            toast({ title: "Missing required fields", description: "Please fill in code and discount value.", variant: "destructive" });
+            return;
+        }
         setSaving(true);
         try {
             const isPrivateTab = promoTab === "private" || (editingPromo?.promo_type === "private");
@@ -365,7 +375,7 @@ export default function PromotionsPage() {
             resetForm();
             await fetchAll();
         } catch (error: any) {
-            alert(`Failed to save: ${error.message}`);
+            toast({ title: "Failed to save", description: error.message, variant: "destructive" });
         } finally {
             setSaving(false);
         }
@@ -373,13 +383,18 @@ export default function PromotionsPage() {
 
     const toggleActive = async (p: PromoCode) => {
         try { await updatePromotion(p.id, { is_active: !p.is_active }); await fetchAll(); }
-        catch (e: any) { alert(`Failed: ${e.message}`); }
+        catch (e: any) { toast({ title: "Failed to toggle promo", description: e.message, variant: "destructive" }); }
     };
 
     const handleDelete = async (id: string) => {
-        if (!confirm("Delete this promo code?")) return;
-        try { await deletePromotion(id); await fetchAll(); }
-        catch (e: any) { alert(`Failed: ${e.message}`); }
+        setDeleteTarget(id);
+    };
+
+    const confirmDelete = async () => {
+        if (!deleteTarget) return;
+        try { await deletePromotion(deleteTarget); await fetchAll(); }
+        catch (e: any) { toast({ title: "Failed to delete promo", description: e.message, variant: "destructive" }); }
+        finally { setDeleteTarget(null); }
     };
 
     const toggleUserSelection = (opt: UserOption) => {
@@ -707,6 +722,19 @@ export default function PromotionsPage() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete promo code?</AlertDialogTitle>
+                        <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-complaint-form.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-complaint-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { createRideComplaint } from "@/lib/api";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { FileWarning } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 
 const CATEGORIES = [
     { value: "safety", label: "Safety" },
@@ -21,6 +22,7 @@ interface Props {
 }
 
 export default function RideComplaintForm({ open, onClose, rideId, onCreated }: Props) {
+    const { toast } = useToast();
     const [againstType, setAgainstType] = useState<"rider" | "driver">("driver");
     const [category, setCategory] = useState("");
     const [description, setDescription] = useState("");
@@ -31,13 +33,13 @@ export default function RideComplaintForm({ open, onClose, rideId, onCreated }: 
         setLoading(true);
         try {
             await createRideComplaint(rideId, { against_type: againstType, category, description });
-            alert("Complaint created");
+            toast({ title: "Complaint created" });
             onCreated();
             onClose();
             setCategory("");
             setDescription("");
         } catch (e: any) {
-            alert(e.message || "Failed to create complaint");
+            toast({ title: "Failed to create complaint", description: e.message, variant: "destructive" });
         } finally {
             setLoading(false);
         }

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-flag-form.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-flag-form.tsx
@@ -5,6 +5,7 @@ import { flagRideParticipant } from "@/lib/api";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { AlertTriangle } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 
 const FLAG_REASONS = [
     { value: "vomited_in_car", label: "Vomited in car" },
@@ -25,6 +26,7 @@ interface Props {
 }
 
 export default function RideFlagForm({ open, onClose, rideId, targetType, targetName, onFlagged }: Props) {
+    const { toast } = useToast();
     const [reason, setReason] = useState("");
     const [description, setDescription] = useState("");
     const [loading, setLoading] = useState(false);
@@ -35,16 +37,16 @@ export default function RideFlagForm({ open, onClose, rideId, targetType, target
         try {
             const result = await flagRideParticipant(rideId, { target_type: targetType, reason, description: description || undefined });
             if (result.auto_banned) {
-                alert(`${targetType === "rider" ? "Rider" : "Driver"} has been AUTO-BANNED (${result.active_flag_count} flags).`);
+                toast({ title: `${targetType === "rider" ? "Rider" : "Driver"} AUTO-BANNED`, description: `${result.active_flag_count} active flags triggered automatic ban.`, variant: "destructive" });
             } else {
-                alert(`Flag added. Active flags: ${result.active_flag_count}/3`);
+                toast({ title: "Flag added", description: `Active flags: ${result.active_flag_count}/3` });
             }
             onFlagged();
             onClose();
             setReason("");
             setDescription("");
         } catch (e: any) {
-            alert(e.message || "Failed to flag");
+            toast({ title: "Failed to flag", description: e.message, variant: "destructive" });
         } finally {
             setLoading(false);
         }

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { sendRideInvoice, getRideInvoice, getRideRouteMapDataUrl } from "@/lib/api";
 import { Send, Download } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
 import { computePhaseDistances } from "./ride-ui-helpers";
 
 interface Props {
@@ -18,6 +19,7 @@ const fmtMoney = (n: any): string =>
     typeof n === "number" && Number.isFinite(n) ? `$${n.toFixed(2)}` : "—";
 
 export default function RideInvoice({ rideId, status }: Props) {
+    const { toast } = useToast();
     const [sending, setSending] = useState(false);
     const [downloading, setDownloading] = useState(false);
 
@@ -27,9 +29,9 @@ export default function RideInvoice({ rideId, status }: Props) {
         setSending(true);
         try {
             await sendRideInvoice(rideId);
-            alert("Invoice/receipt sent to rider's email");
+            toast({ title: "Invoice sent", description: "Receipt sent to rider's email." });
         } catch {
-            alert("Failed to send invoice");
+            toast({ title: "Failed to send invoice", variant: "destructive" });
         } finally {
             setSending(false);
         }
@@ -353,7 +355,7 @@ export default function RideInvoice({ rideId, status }: Props) {
             doc.save(`spinr-invoice-${data.ride_id?.slice(0, 8) ?? "ride"}.pdf`);
         } catch (e) {
             console.error("Invoice download failed:", e);
-            alert("Failed to download invoice");
+            toast({ title: "Failed to download invoice", variant: "destructive" });
         } finally {
             setDownloading(false);
         }

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-lost-found.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-lost-found.tsx
@@ -5,6 +5,7 @@ import { reportLostItem, resolveLostItem } from "@/lib/api";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { PackageSearch, CheckCircle, Clock, XCircle, Bell } from "lucide-react";
 import { Sec } from "./ride-ui-helpers";
+import { useToast } from "@/components/ui/use-toast";
 
 const STATUS_ICONS: Record<string, { icon: any; color: string }> = {
     reported: { icon: Clock, color: "text-amber-500" },
@@ -20,6 +21,7 @@ interface Props {
 }
 
 export default function RideLostFound({ rideId, items, onRefresh }: Props) {
+    const { toast } = useToast();
     const [showForm, setShowForm] = useState(false);
     const [description, setDescription] = useState("");
     const [loading, setLoading] = useState(false);
@@ -29,12 +31,12 @@ export default function RideLostFound({ rideId, items, onRefresh }: Props) {
         setLoading(true);
         try {
             await reportLostItem(rideId, { item_description: description });
-            alert("Lost item reported. Driver has been notified.");
+            toast({ title: "Lost item reported", description: "Driver has been notified." });
             setShowForm(false);
             setDescription("");
             onRefresh();
         } catch (e: any) {
-            alert(e.message || "Failed to report item");
+            toast({ title: "Failed to report item", description: e.message, variant: "destructive" });
         } finally {
             setLoading(false);
         }
@@ -45,7 +47,7 @@ export default function RideLostFound({ rideId, items, onRefresh }: Props) {
             await resolveLostItem(itemId, { status });
             onRefresh();
         } catch (e: any) {
-            alert(e.message || "Failed to update");
+            toast({ title: "Failed to update item", description: e.message, variant: "destructive" });
         }
     };
 

--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -1084,6 +1084,7 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
     };
 
     return (
+        <>
         <div className="space-y-6">
             {/* SECTION 1: Area Fees */}
             <div>
@@ -1222,6 +1223,7 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
                 </AlertDialogFooter>
             </AlertDialogContent>
         </AlertDialog>
+        </>
     );
 }
 

--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -2,6 +2,11 @@
 
 import { useEffect, useState, lazy, Suspense } from "react";
 import { useRouter } from "next/navigation";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { getServiceAreas, createServiceArea, updateServiceArea, deleteServiceArea, getSubscriptionPlans, createSubscriptionPlan, updateSubscriptionPlan, deleteSubscriptionPlan, getDriverSubscriptions, getAreaFees, createAreaFee, updateAreaFee, deleteAreaFee, getVehicleTypes } from "@/lib/api";
 import { Plus, Trash2, Pencil, MapPin, Settings, DollarSign, Car, CreditCard, ChevronDown, ChevronUp, ToggleLeft, ToggleRight, FileText, Clock, ShieldCheck, ShieldAlert, CheckCircle, Image, Plane, Radar } from "lucide-react";
 import { useRequireModule } from "@/hooks/useRequireModule";
@@ -50,6 +55,8 @@ function getAreaCenter(area: any): { lat: number; lng: number } {
 export default function ServiceAreasPage() {
   const { allowed } = useRequireModule("service_areas");
   const router = useRouter();
+  const { toast } = useToast();
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [areas, setAreas] = useState<any[]>([]);
   const [plans, setPlans] = useState<any[]>([]);
   // Existing vehicle types (from /api/admin/vehicle-types) so the
@@ -136,13 +143,13 @@ export default function ServiceAreasPage() {
       setShowCreate(false);
       setCreateForm({ name: "", city: "", province: "SK", preset: "", polygon: [], polygonText: "", is_active: true, is_airport: false });
       load();
-    } catch (e: any) { alert(e?.message || "Failed to create"); }
+    } catch (e: any) { toast({ title: "Failed to create service area", description: e?.message, variant: "destructive" }); }
   };
 
   const handleCreateAirportSubRegion = async (parentId: string) => {
     const parent = areas.find(a => a.id === parentId);
     if (!airportForm.name || airportForm.polygon.length < 3) {
-      alert("Please enter a name and draw the airport boundary on the map.");
+      toast({ title: "Missing airport boundary", description: "Please enter a name and draw the airport boundary on the map.", variant: "destructive" });
       return;
     }
     try {
@@ -159,7 +166,7 @@ export default function ServiceAreasPage() {
       setAddAirportFor(null);
       setAirportForm({ name: "", airport_fee: 2.0, polygon: [] });
       load();
-    } catch (e: any) { alert(e?.message || "Failed to create airport zone"); }
+    } catch (e: any) { toast({ title: "Failed to create airport zone", description: e?.message, variant: "destructive" }); }
   };
 
   const handleFieldUpdate = async (areaId: string, field: string, value: any) => {
@@ -172,17 +179,22 @@ export default function ServiceAreasPage() {
         }
         return a;
       }));
-    } catch (e: any) { alert("Failed to update: " + (e?.message || "")); }
+    } catch (e: any) { toast({ title: "Failed to update field", description: e?.message, variant: "destructive" }); }
   };
 
   const handleVehiclePricingUpdate = async (areaId: string, pricing: any[]) => {
     await handleFieldUpdate(areaId, 'vehicle_pricing', pricing);
   };
 
-  const handleDelete = async (id: string, name: string) => {
-    if (!confirm(`Delete "${name}"? This cannot be undone.`)) return;
-    await deleteServiceArea(id);
-    load();
+  const handleDelete = (id: string, name: string) => {
+    setDeleteTarget({ id, name });
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try { await deleteServiceArea(deleteTarget.id); load(); }
+    catch (e: any) { toast({ title: "Failed to delete service area", description: e?.message, variant: "destructive" }); }
+    finally { setDeleteTarget(null); }
   };
 
   if (!allowed) return null;
@@ -328,7 +340,7 @@ export default function ServiceAreasPage() {
                           try {
                             await updateServiceArea(area.id, updates);
                             setAreas(prev => prev.map(a => a.id === area.id ? { ...a, ...updates } : a));
-                          } catch (e: any) { alert("Failed to save: " + (e?.message || "")); }
+                          } catch (e: any) { toast({ title: "Failed to save", description: e?.message, variant: "destructive" }); }
                         }} onDelete={() => handleDelete(area.id, area.name)} />
                       )}
 
@@ -489,6 +501,19 @@ export default function ServiceAreasPage() {
           })}
         </div>
       )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{deleteTarget?.name}"?</AlertDialogTitle>
+            <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -1015,6 +1040,8 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
     areaId: string; area: any; fees: any[]; loading: boolean;
     onReload: () => void; onFieldUpdate: (areaId: string, field: string, value: any) => void;
 }) {
+    const { toast } = useToast();
+    const [feeDeleteTarget, setFeeDeleteTarget] = useState<string | null>(null);
     const [editingFee, setEditingFee] = useState<any>(null);
     const [saving, setSaving] = useState(false);
 
@@ -1037,17 +1064,23 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
         try {
             await createAreaFee(areaId, { fee_name: 'New Fee', fee_type: 'custom', calc_mode: 'flat', amount: 0, is_active: true });
             onReload();
-        } catch (e: any) { alert(e?.message || 'Failed'); }
+        } catch (e: any) { toast({ title: "Failed to create fee", description: e?.message, variant: "destructive" }); }
         setSaving(false);
     };
 
     const handleUpdate = async (feeId: string, data: any) => {
-        try { await updateAreaFee(areaId, feeId, data); onReload(); } catch (e: any) { alert(e?.message || 'Failed'); }
+        try { await updateAreaFee(areaId, feeId, data); onReload(); } catch (e: any) { toast({ title: "Failed to update fee", description: e?.message, variant: "destructive" }); }
     };
 
-    const handleDelete = async (feeId: string) => {
-        if (!confirm('Delete this fee?')) return;
-        try { await deleteAreaFee(areaId, feeId); onReload(); } catch (e: any) { alert(e?.message || 'Failed'); }
+    const handleDelete = (feeId: string) => {
+        setFeeDeleteTarget(feeId);
+    };
+
+    const confirmFeeDelete = async () => {
+        if (!feeDeleteTarget) return;
+        try { await deleteAreaFee(areaId, feeDeleteTarget); onReload(); }
+        catch (e: any) { toast({ title: "Failed to delete fee", description: e?.message, variant: "destructive" }); }
+        finally { setFeeDeleteTarget(null); }
     };
 
     return (
@@ -1176,6 +1209,19 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
                 </div>
             </div>
         </div>
+
+        <AlertDialog open={!!feeDeleteTarget} onOpenChange={(open) => { if (!open) setFeeDeleteTarget(null); }}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Delete fee?</AlertDialogTitle>
+                    <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction onClick={confirmFeeDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
     );
 }
 
@@ -1264,6 +1310,8 @@ const DURATION_OPTIONS = [
 function SpinrPassAreaTab({ area, plans, onToggle, onPlansChanged }: {
   area: any; plans: any[]; onToggle: (v: boolean) => void; onPlansChanged: () => void;
 }) {
+  const { toast } = useToast();
+  const [planDeleteTarget, setPlanDeleteTarget] = useState<{ id: string; name: string } | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [subs, setSubs] = useState<any[]>([]);
@@ -1289,7 +1337,7 @@ function SpinrPassAreaTab({ area, plans, onToggle, onPlansChanged }: {
       if (editingId) { await updateSubscriptionPlan(editingId, data); }
       else { await createSubscriptionPlan(data); }
       resetForm(); onPlansChanged();
-    } catch (e: any) { alert(e?.message || "Failed to save plan"); }
+    } catch (e: any) { toast({ title: "Failed to save plan", description: e?.message, variant: "destructive" }); }
   };
 
   const handleEdit = (p: any) => {
@@ -1298,9 +1346,15 @@ function SpinrPassAreaTab({ area, plans, onToggle, onPlansChanged }: {
     setShowForm(true);
   };
 
-  const handleDeletePlan = async (p: any) => {
-    if (!confirm(`Delete "${p.name}" plan?`)) return;
-    await deleteSubscriptionPlan(p.id); onPlansChanged();
+  const handleDeletePlan = (p: any) => {
+    setPlanDeleteTarget({ id: p.id, name: p.name });
+  };
+
+  const confirmPlanDelete = async () => {
+    if (!planDeleteTarget) return;
+    try { await deleteSubscriptionPlan(planDeleteTarget.id); onPlansChanged(); }
+    catch (e: any) { toast({ title: "Failed to delete plan", description: e?.message, variant: "destructive" }); }
+    finally { setPlanDeleteTarget(null); }
   };
 
   const handleTogglePlan = async (p: any) => {
@@ -1458,6 +1512,19 @@ function SpinrPassAreaTab({ area, plans, onToggle, onPlansChanged }: {
           )}
         </div>
       )}
+
+      <AlertDialog open={!!planDeleteTarget} onOpenChange={(open) => { if (!open) setPlanDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete "{planDeleteTarget?.name}" plan?</AlertDialogTitle>
+            <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmPlanDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -81,7 +81,8 @@ export default function SettingsPage() {
             setSettings(updated);
             setSaved(true);
             setTimeout(() => setSaved(false), 2000);
-        } catch {
+        } catch (e: any) {
+            toast({ title: "Failed to save settings", description: e?.message || "Unknown error", variant: "destructive" });
         } finally {
             setSaving(false);
         }

--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -20,6 +20,10 @@ import { Switch } from "@/components/ui/switch";
 import { Save, Check, ShieldCheck, ShieldOff } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { useRequireModule } from "@/hooks/useRequireModule";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 export default function SettingsPage() {
     const { allowed } = useRequireModule("settings");
@@ -28,6 +32,7 @@ export default function SettingsPage() {
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [saved, setSaved] = useState(false);
+    const [confirmSave, setConfirmSave] = useState(false);
 
     const [mfaEnabled, setMfaEnabled] = useState(false);
     const [mfaLoading, setMfaLoading] = useState(true);
@@ -105,7 +110,7 @@ export default function SettingsPage() {
                         Configure platform-wide settings.
                     </p>
                 </div>
-                <Button onClick={handleSave} disabled={saving}>
+                <Button onClick={() => setConfirmSave(true)} disabled={saving}>
                     {saved ? (
                         <>
                             <Check className="mr-2 h-4 w-4" /> Saved!
@@ -470,6 +475,24 @@ export default function SettingsPage() {
                 onOpenChange={setShowEnrollDialog}
                 onEnrolled={() => setMfaEnabled(true)}
             />
+
+            <AlertDialog open={confirmSave} onOpenChange={setConfirmSave}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Save live credentials?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This will overwrite Stripe, Twilio, and other live credentials immediately.
+                            Make sure your values are correct before proceeding.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { setConfirmSave(false); handleSave(); }}>
+                            Save Changes
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/staff/page.tsx
+++ b/admin-dashboard/src/app/dashboard/staff/page.tsx
@@ -5,6 +5,11 @@ import { getStaff, createStaff, updateStaff, deleteStaff } from "@/lib/api";
 import { useAuthStore } from "@/store/authStore";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { Users, Plus, Shield, Eye, EyeOff, Trash2, Edit, Check, X } from "lucide-react";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const ALL_MODULES = [
   { key: "dashboard", label: "Dashboard" },
@@ -57,6 +62,8 @@ interface Staff {
 export default function StaffPage() {
   const { allowed } = useRequireModule("staff");
   const { user } = useAuthStore();
+  const { toast } = useToast();
+  const [deleteTarget, setDeleteTarget] = useState<Staff | null>(null);
   const [staff, setStaff] = useState<Staff[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
@@ -118,7 +125,7 @@ export default function StaffPage() {
       resetForm();
       loadStaff();
     } catch (e: any) {
-      alert(e?.message || "Failed to save staff member");
+      toast({ title: "Failed to save staff member", description: e?.message, variant: "destructive" });
     }
   };
 
@@ -140,10 +147,20 @@ export default function StaffPage() {
     loadStaff();
   };
 
-  const handleDelete = async (s: Staff) => {
-    if (!confirm(`Delete ${s.first_name} ${s.last_name}? This cannot be undone.`)) return;
-    await deleteStaff(s.id);
-    loadStaff();
+  const handleDelete = (s: Staff) => {
+    setDeleteTarget(s);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteStaff(deleteTarget.id);
+      loadStaff();
+    } catch (e: any) {
+      toast({ title: "Failed to delete staff member", description: e?.message, variant: "destructive" });
+    } finally {
+      setDeleteTarget(null);
+    }
   };
 
   const resetForm = () => {
@@ -369,6 +386,19 @@ export default function StaffPage() {
           ))}
         </div>
       )}
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete {deleteTarget?.first_name} {deleteTarget?.last_name}?</AlertDialogTitle>
+            <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/complaints.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/complaints.tsx
@@ -15,6 +15,11 @@ import { Pagination } from "@/components/ui/pagination";
 import { FileWarning, Search, CheckCircle, XCircle, Plus, Trash2, Eye, RefreshCw } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import { useServiceAreas, ServiceAreaFilter, ServiceAreaSelect } from "../_components/service-area-select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const PAGE_SIZE = 50;
 
@@ -27,6 +32,8 @@ const S_CFG: Record<string, { l: string; c: string }> = {
 const CATS = ["rude_behavior", "unsafe_driving", "vehicle_condition", "route_issue", "overcharge", "harassment", "other"];
 
 export default function ComplaintsTab() {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const { areas } = useServiceAreas();
     const [items, setItems] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -70,16 +77,16 @@ export default function ComplaintsTab() {
     const areaName = (id: string) => areas.find((a) => a.id === id)?.name || "";
 
     const handleCreate = async () => {
-        if (!form.ride_id.trim() || !form.description.trim()) { alert("Enter ride ID and description."); return; }
+        if (!form.ride_id.trim() || !form.description.trim()) { toast({ title: "Missing fields", description: "Enter ride ID and description.", variant: "destructive" }); return; }
         setSaving(true);
         try { await createRideComplaint(form.ride_id, { against_type: form.against_type, category: form.category, description: form.description, service_area_id: form.service_area_id || null }); setDialogOpen(false); setForm({ ride_id: "", against_type: "driver", category: "other", description: "", service_area_id: "" }); load(); }
-        catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        catch (e: any) { toast({ title: "Failed to create complaint", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
     const handleResolve = async (status: string) => {
         if (!selected) return;
         try { await resolveComplaint(selected.id, { status, resolution: resolution.trim() || status }); setSelected(null); setResolution(""); load(); }
-        catch (e: any) { alert(e.message); }
+        catch (e: any) { toast({ title: "Failed to resolve complaint", description: e.message, variant: "destructive" }); }
     };
 
     return (
@@ -110,7 +117,7 @@ export default function ComplaintsTab() {
                             <TableCell className="text-[10px] text-muted-foreground">{formatDate(c.created_at)}</TableCell>
                             <TableCell className="text-right"><div className="flex justify-end gap-0.5">
                                 <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); setSelected(c); setResolution(""); }}><Eye className="h-3.5 w-3.5" /></Button>
-                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); if (confirm("Delete?")) deleteComplaint(c.id).then(load); }}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); setDeleteTarget(c.id); }}><Trash2 className="h-3.5 w-3.5" /></Button>
                             </div></TableCell>
                         </TableRow>
                     ))}</TableBody></Table>}
@@ -156,6 +163,19 @@ export default function ComplaintsTab() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete complaint?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { if (deleteTarget) deleteComplaint(deleteTarget).then(load).finally(() => setDeleteTarget(null)); }} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/disputes.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/disputes.tsx
@@ -14,6 +14,11 @@ import { HelpCircle, Search, CheckCircle, XCircle, Clock, Plus, Pencil, Trash2, 
 import { formatDate } from "@/lib/utils";
 import { getDisputes, createDispute, updateDispute, resolveDispute, deleteDispute } from "@/lib/api";
 import { useServiceAreas, ServiceAreaFilter, ServiceAreaSelect } from "../_components/service-area-select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const S_CFG: Record<string, { l: string; i: any; c: string }> = {
     pending: { l: "Pending", i: Clock, c: "bg-amber-500/15 text-amber-600" },
@@ -24,6 +29,8 @@ const S_CFG: Record<string, { l: string; i: any; c: string }> = {
 const TYPES = [{ v: "fare", l: "Fare Dispute" }, { v: "behavior", l: "Behavior Issue" }, { v: "route", l: "Route Issue" }, { v: "safety", l: "Safety Concern" }, { v: "damage", l: "Vehicle Damage" }, { v: "other", l: "Other" }];
 
 export default function DisputesTab() {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const { areas } = useServiceAreas();
     const [disputes, setDisputes] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -57,18 +64,18 @@ export default function DisputesTab() {
     const areaName = (id: string) => areas.find((a) => a.id === id)?.name || "";
 
     const handleSave = async () => {
-        if (!form.description.trim()) { alert("Enter a description."); return; }
+        if (!form.description.trim()) { toast({ title: "Missing description", variant: "destructive" }); return; }
         setSaving(true);
         try {
             if (editing) await updateDispute(editing.id, { reason: form.reason, description: form.description, refund_amount: form.refund_amount ? parseFloat(form.refund_amount) : 0, user_type: form.user_type, service_area_id: form.service_area_id || null });
             else await createDispute({ ride_id: form.ride_id || null, user_name: form.user_name, user_type: form.user_type, reason: form.reason, description: form.description, refund_amount: form.refund_amount ? parseFloat(form.refund_amount) : 0, service_area_id: form.service_area_id || null });
             setDialogOpen(false); reset(); load();
-        } catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        } catch (e: any) { toast({ title: "Failed to save dispute", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
     const handleResolve = async (status: string) => {
-        if (!selected || !resolution.trim()) { alert("Enter resolution notes."); return; }
-        try { await resolveDispute(selected.id, { resolution: status, admin_note: resolution.trim() }); setSelected(null); setResolution(""); load(); } catch (e: any) { alert(e.message); }
+        if (!selected || !resolution.trim()) { toast({ title: "Enter resolution notes before resolving", variant: "destructive" }); return; }
+        try { await resolveDispute(selected.id, { resolution: status, admin_note: resolution.trim() }); setSelected(null); setResolution(""); load(); } catch (e: any) { toast({ title: "Failed to resolve dispute", description: e.message, variant: "destructive" }); }
     };
 
     return (
@@ -108,7 +115,7 @@ export default function DisputesTab() {
                                 <TableCell className="text-right"><div className="flex justify-end gap-0.5">
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); setSelected(d); setResolution(""); }}><Eye className="h-3.5 w-3.5" /></Button>
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); setEditing(d); setForm({ ride_id: d.ride_id || "", user_name: d.user_name || "", user_type: d.user_type || "rider", reason: d.dispute_type || "fare", description: d.description || "", refund_amount: d.refund_amount ? String(d.refund_amount) : "", service_area_id: d.service_area_id || "" }); setDialogOpen(true); }}><Pencil className="h-3.5 w-3.5" /></Button>
-                                    <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); if (confirm("Delete?")) deleteDispute(d.id).then(load); }}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                    <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); setDeleteTarget(d.id); }}><Trash2 className="h-3.5 w-3.5" /></Button>
                                 </div></TableCell>
                             </TableRow>
                         );
@@ -158,6 +165,19 @@ export default function DisputesTab() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete dispute?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { if (deleteTarget) deleteDispute(deleteTarget).then(load).finally(() => setDeleteTarget(null)); }} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/faqs.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/faqs.tsx
@@ -14,6 +14,11 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Search, Plus, Pencil, Trash2, RefreshCw } from "lucide-react";
 import { formatDate } from "@/lib/utils";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const A_CFG: Record<string, { l: string; c: string }> = {
     rider: { l: "Rider", c: "bg-sky-500/15 text-sky-600" },
@@ -25,6 +30,8 @@ type FaqForm = { question: string; answer: string; category: string; audience: s
 const EMPTY: FaqForm = { question: "", answer: "", category: "general", audience: "both", is_active: true };
 
 export default function FaqsTab() {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const [items, setItems] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [search, setSearch] = useState("");
@@ -66,18 +73,23 @@ export default function FaqsTab() {
     };
 
     const handleSave = async () => {
-        if (!form.question.trim() || !form.answer.trim()) { alert("Question and answer are required."); return; }
+        if (!form.question.trim() || !form.answer.trim()) { toast({ title: "Missing fields", description: "Question and answer are required.", variant: "destructive" }); return; }
         setSaving(true);
         try {
             if (editing) await updateFaq(editing.id, form);
             else await createFaq(form);
             setDialogOpen(false); setEditing(null); setForm(EMPTY); load();
-        } catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        } catch (e: any) { toast({ title: "Failed to save FAQ", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
-    const handleDelete = async (id: string) => {
-        if (!confirm("Delete this FAQ?")) return;
-        try { await deleteFaq(id); load(); } catch (e: any) { alert(e.message); }
+    const handleDelete = (id: string) => {
+        setDeleteTarget(id);
+    };
+
+    const confirmDelete = async () => {
+        if (!deleteTarget) return;
+        try { await deleteFaq(deleteTarget); load(); } catch (e: any) { toast({ title: "Failed to delete FAQ", description: e.message, variant: "destructive" }); }
+        finally { setDeleteTarget(null); }
     };
 
     return (
@@ -129,6 +141,19 @@ export default function FaqsTab() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete FAQ?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/flags.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/flags.tsx
@@ -15,11 +15,18 @@ import { Pagination } from "@/components/ui/pagination";
 import { Flag, Search, Plus, Trash2, Eye, RefreshCw, EyeOff, Users, Car } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import { useServiceAreas, ServiceAreaFilter, ServiceAreaSelect } from "../_components/service-area-select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const PAGE_SIZE = 50;
 const REASONS = ["inappropriate_behavior", "safety_concern", "fraud", "policy_violation", "spam", "other"];
 
 export default function FlagsTab() {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const { areas } = useServiceAreas();
     const [flags, setFlags] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -62,10 +69,10 @@ export default function FlagsTab() {
     const areaName = (id: string) => areas.find((a) => a.id === id)?.name || "";
 
     const handleCreate = async () => {
-        if (!form.ride_id.trim()) { alert("Enter a ride ID."); return; }
+        if (!form.ride_id.trim()) { toast({ title: "Missing ride ID", variant: "destructive" }); return; }
         setSaving(true);
         try { await flagRideParticipant(form.ride_id, { target_type: form.target_type, reason: form.reason, description: form.description, service_area_id: form.service_area_id || null }); setDialogOpen(false); setForm({ ride_id: "", target_type: "driver", reason: "other", description: "", service_area_id: "" }); load(); }
-        catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        catch (e: any) { toast({ title: "Failed to create flag", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
     return (
@@ -97,7 +104,7 @@ export default function FlagsTab() {
                             <TableCell className="text-right"><div className="flex justify-end gap-0.5">
                                 <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); setSelected(f); }}><Eye className="h-3.5 w-3.5" /></Button>
                                 {f.is_active !== false && <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); deactivateFlag(f.id).then(load); }} title="Deactivate"><EyeOff className="h-3.5 w-3.5" /></Button>}
-                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); if (confirm("Delete?")) deleteFlag(f.id).then(load); }}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); setDeleteTarget(f.id); }}><Trash2 className="h-3.5 w-3.5" /></Button>
                             </div></TableCell>
                         </TableRow>
                     ))}</TableBody></Table>}
@@ -120,7 +127,7 @@ export default function FlagsTab() {
                         {selected.description && <div><Label className="text-[10px] text-muted-foreground">Description</Label><div className="rounded-lg bg-muted/50 p-2.5 text-xs mt-1">{selected.description}</div></div>}
                         <div className="flex gap-2">
                             {selected.is_active !== false && <Button size="sm" variant="outline" className="flex-1" onClick={() => { deactivateFlag(selected.id).then(() => { setSelected(null); load(); }); }}><EyeOff className="h-3.5 w-3.5 mr-1.5" />Deactivate</Button>}
-                            <Button size="sm" variant="destructive" className="flex-1" onClick={() => { if (confirm("Delete?")) deleteFlag(selected.id).then(() => { setSelected(null); load(); }); }}><Trash2 className="h-3.5 w-3.5 mr-1.5" />Delete</Button>
+                            <Button size="sm" variant="destructive" className="flex-1" onClick={() => setDeleteTarget(selected.id)}><Trash2 className="h-3.5 w-3.5 mr-1.5" />Delete</Button>
                         </div>
                     </div>)}
                 </DialogContent>
@@ -141,6 +148,19 @@ export default function FlagsTab() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete flag?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { if (deleteTarget) deleteFlag(deleteTarget).then(() => { setSelected(null); load(); }).finally(() => setDeleteTarget(null)); }} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/legal-documents.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/legal-documents.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RefreshCw, Save, Check } from "lucide-react";
 import { formatDate } from "@/lib/utils";
+import { useToast } from "@/components/ui/use-toast";
 
 type Audience = "rider" | "driver";
 type DocType = "tos" | "privacy";
@@ -35,6 +36,7 @@ const A_CFG: Record<Audience, { l: string; c: string }> = {
 };
 
 export default function LegalDocumentsTab() {
+    const { toast } = useToast();
     const [rows, setRows] = useState<Record<string, Row>>({});
     const [drafts, setDrafts] = useState<Record<string, string>>({});
     const [loading, setLoading] = useState(true);
@@ -88,7 +90,7 @@ export default function LegalDocumentsTab() {
             setTimeout(() => setSavedKey((cur) => (cur === k ? null : cur)), 1800);
             load();
         } catch (e: any) {
-            alert(e?.message || "Failed to save");
+            toast({ title: "Failed to save document", description: e?.message, variant: "destructive" });
         } finally {
             setSavingKey(null);
         }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/lost-and-found.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/lost-and-found.tsx
@@ -15,6 +15,11 @@ import { Pagination } from "@/components/ui/pagination";
 import { Search, CheckCircle, Plus, Pencil, Trash2, RefreshCw } from "lucide-react";
 import { formatDate } from "@/lib/utils";
 import { useServiceAreas, ServiceAreaFilter, ServiceAreaSelect } from "../_components/service-area-select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const PAGE_SIZE = 50;
 
@@ -26,6 +31,8 @@ const S_CFG: Record<string, { l: string; c: string }> = {
 };
 
 export default function LostAndFoundTab() {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const { areas } = useServiceAreas();
     const [items, setItems] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -69,21 +76,21 @@ export default function LostAndFoundTab() {
     const areaName = (id: string) => areas.find((a) => a.id === id)?.name || "";
 
     const handleCreate = async () => {
-        if (!form.ride_id.trim() || !form.item_description.trim()) { alert("Enter ride ID and item description."); return; }
+        if (!form.ride_id.trim() || !form.item_description.trim()) { toast({ title: "Missing fields", description: "Enter ride ID and item description.", variant: "destructive" }); return; }
         setSaving(true);
         try { await reportLostItem(form.ride_id, { item_description: form.item_description, service_area_id: form.service_area_id || null }); setDialogOpen(false); setForm({ ride_id: "", item_description: "", service_area_id: "" }); load(); }
-        catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        catch (e: any) { toast({ title: "Failed to report item", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
     const handleUpdate = async () => {
         if (!editing) return;
         setSaving(true);
         try { await updateLostItem(editing.id, editForm); setEditDialog(false); setEditing(null); load(); }
-        catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        catch (e: any) { toast({ title: "Failed to update item", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
     const handleResolve = async (id: string, status: string) => {
-        try { await resolveLostItem(id, { status }); load(); } catch (e: any) { alert(e.message); }
+        try { await resolveLostItem(id, { status }); load(); } catch (e: any) { toast({ title: "Failed to update status", description: e.message, variant: "destructive" }); }
     };
 
     return (
@@ -114,7 +121,7 @@ export default function LostAndFoundTab() {
                             <TableCell className="text-right"><div className="flex justify-end gap-0.5">
                                 {item.status !== "resolved" && <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => handleResolve(item.id, "resolved")} title="Resolve"><CheckCircle className="h-3.5 w-3.5 text-emerald-500" /></Button>}
                                 <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => { setEditing(item); setEditForm({ item_description: item.item_description || "", admin_notes: item.admin_notes || "", status: item.status || "reported" }); setEditDialog(true); }}><Pencil className="h-3.5 w-3.5" /></Button>
-                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => { if (confirm("Delete?")) deleteLostItem(item.id).then(load); }}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => setDeleteTarget(item.id)}><Trash2 className="h-3.5 w-3.5" /></Button>
                             </div></TableCell>
                         </TableRow>
                     ))}</TableBody></Table>}
@@ -145,6 +152,19 @@ export default function LostAndFoundTab() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete lost item?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { if (deleteTarget) deleteLostItem(deleteTarget).then(load).finally(() => setDeleteTarget(null)); }} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/support/_tabs/tickets.tsx
+++ b/admin-dashboard/src/app/dashboard/support/_tabs/tickets.tsx
@@ -19,6 +19,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Pagination } from "@/components/ui/pagination";
 import { MessageSquare, CheckCircle, Plus, Trash2, Pencil, Send, Search, RefreshCw, HelpCircle } from "lucide-react";
 import { useServiceAreas, ServiceAreaFilter, ServiceAreaSelect } from "../_components/service-area-select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const PAGE_SIZE = 50;
 
@@ -43,6 +48,8 @@ export default function TicketsTab() {
 }
 
 function TicketsList() {
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const { areas } = useServiceAreas();
     const [tickets, setTickets] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -89,13 +96,13 @@ function TicketsList() {
     const reset = () => { setForm({ subject: "", category: "general", priority: "medium", message: "", user_name: "", user_email: "", service_area_id: "" }); setEditing(null); };
 
     const handleSave = async () => {
-        if (!form.subject.trim()) { alert("Enter a subject."); return; }
+        if (!form.subject.trim()) { toast({ title: "Missing subject", variant: "destructive" }); return; }
         setSaving(true);
         try {
             if (editing) await updateTicket(editing.id, { subject: form.subject, category: form.category, priority: form.priority, service_area_id: form.service_area_id || null });
             else await createTicket({ ...form, service_area_id: form.service_area_id || null });
             setDialogOpen(false); reset(); load();
-        } catch (e: any) { alert(e.message); } finally { setSaving(false); }
+        } catch (e: any) { toast({ title: "Failed to save ticket", description: e.message, variant: "destructive" }); } finally { setSaving(false); }
     };
 
     const areaName = (id: string) => areas.find((a) => a.id === id)?.name || "";
@@ -129,7 +136,7 @@ function TicketsList() {
                                 <TableCell className="text-[10px] text-muted-foreground">{formatDate(t.created_at)}</TableCell>
                                 <TableCell className="text-right"><div className="flex justify-end gap-0.5">
                                     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={(e) => { e.stopPropagation(); setEditing(t); setForm({ subject: t.subject || "", category: t.category || "general", priority: t.priority || "medium", message: t.message || "", user_name: t.user_name || "", user_email: t.user_email || "", service_area_id: t.service_area_id || "" }); setDialogOpen(true); }}><Pencil className="h-3.5 w-3.5" /></Button>
-                                    <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); if (confirm("Delete?")) { deleteTicket(t.id).then(load); if (selected?.id === t.id) setSelected(null); } }}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                    <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={(e) => { e.stopPropagation(); setDeleteTarget(t.id); }}><Trash2 className="h-3.5 w-3.5" /></Button>
                                 </div></TableCell>
                             </TableRow>
                         ))}</TableBody></Table>}
@@ -190,11 +197,25 @@ function TicketsList() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete ticket?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { if (deleteTarget) { deleteTicket(deleteTarget).then(load); if (selected?.id === deleteTarget) setSelected(null); setDeleteTarget(null); } }} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }
 
 function FaqsList() {
+    const [faqDeleteTarget, setFaqDeleteTarget] = useState<string | null>(null);
     const [faqs, setFaqs] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [dialogOpen, setDialogOpen] = useState(false);
@@ -217,7 +238,7 @@ function FaqsList() {
                         <TableRow key={f.id}><TableCell className="font-medium max-w-[280px] truncate text-sm">{f.question}</TableCell><TableCell className="text-xs text-muted-foreground">{f.category || "General"}</TableCell>
                             <TableCell className="text-right"><div className="flex justify-end gap-0.5">
                                 <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => { setEditing(f); setForm({ question: f.question || "", answer: f.answer || "", category: f.category || "" }); setDialogOpen(true); }}><Pencil className="h-3.5 w-3.5" /></Button>
-                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => { if (confirm("Delete?")) deleteFaq(f.id).then(load); }}><Trash2 className="h-3.5 w-3.5" /></Button>
+                                <Button variant="ghost" size="icon" className="h-7 w-7 text-destructive" onClick={() => setFaqDeleteTarget(f.id)}><Trash2 className="h-3.5 w-3.5" /></Button>
                             </div></TableCell>
                         </TableRow>
                     ))}</TableBody></Table>}
@@ -232,6 +253,19 @@ function FaqsList() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!faqDeleteTarget} onOpenChange={(open) => { if (!open) setFaqDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete FAQ?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => { if (faqDeleteTarget) deleteFaq(faqDeleteTarget).then(load).finally(() => setFaqDeleteTarget(null)); }} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/vehicle-types/page.tsx
+++ b/admin-dashboard/src/app/dashboard/vehicle-types/page.tsx
@@ -21,6 +21,11 @@ import {
 } from "@/components/ui/dialog";
 import { Car, Plus, Pencil, Trash2, Users, Image as ImageIcon } from "lucide-react";
 import { useRequireModule } from "@/hooks/useRequireModule";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 interface VehicleType {
     id: string;
@@ -44,6 +49,8 @@ const EMPTY_FORM: Omit<VehicleType, "id" | "created_at"> = {
 
 export default function VehicleTypesPage() {
     const { allowed } = useRequireModule("pricing");
+    const { toast } = useToast();
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
     const [types, setTypes] = useState<VehicleType[]>([]);
     const [loading, setLoading] = useState(true);
     const [dialogOpen, setDialogOpen] = useState(false);
@@ -100,16 +107,19 @@ export default function VehicleTypesPage() {
     };
 
     const handleDelete = async (id: string) => {
-        if (!confirm("Are you sure you want to delete this vehicle type?")) return;
+        setDeleteTarget(id);
+    };
+
+    const confirmDelete = async () => {
+        if (!deleteTarget) return;
         try {
-            await deleteVehicleType(id);
+            await deleteVehicleType(deleteTarget);
             fetchTypes();
         } catch (err: any) {
-            // 409 from the backend means the type is still referenced by a
-            // service area or fare config. Show the message so the operator
-            // knows where to clean up before re-trying the delete.
-            console.error("Error deleting vehicle type:", err);
-            alert(err?.message || "Could not delete vehicle type");
+            // 409 from backend means still referenced by a service area or fare config.
+            toast({ title: "Could not delete vehicle type", description: err?.message, variant: "destructive" });
+        } finally {
+            setDeleteTarget(null);
         }
     };
 
@@ -351,6 +361,19 @@ export default function VehicleTypesPage() {
                     </div>
                 </DialogContent>
             </Dialog>
+
+            <AlertDialog open={!!deleteTarget} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Delete vehicle type?</AlertDialogTitle>
+                        <AlertDialogDescription>This cannot be undone. If this type is referenced by a fare config or service area, deletion will fail.</AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={confirmDelete} className="bg-red-600 hover:bg-red-700">Delete</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </div>
     );
 }

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -1298,6 +1298,9 @@ export const overrideDriverStatus = (driverId: string, status: string, reason?: 
         body: JSON.stringify({ status, reason }),
     });
 
+export const exportDrivers = () =>
+    request<{ drivers: any[]; count: number }>("/api/admin/export/drivers");
+
 export const getDriverNotes = (driverId: string) =>
     request<any[]>(`/api/admin/drivers/${driverId}/notes`);
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1972,7 +1972,10 @@ async def accept_ride(ride_id: str, current_user: dict = Depends(get_current_use
         },
     )
 
-    if hasattr(guard, "modified_count") and guard.modified_count == 0:
+    # update_one returns None when no rows matched the filter (race lost).
+    # The old `hasattr(guard, "modified_count")` check was never true for
+    # Supabase responses, so the double-accept guard was silently disabled.
+    if guard is None:
         diag_logger.info(
             f"[ACCEPT] claim rejected ride_id={ride_id} "
             f"current_status={ride.get('status')} current_driver_id={ride.get('driver_id')}"
@@ -2020,13 +2023,27 @@ async def decline_ride(ride_id: str, current_user: dict = Depends(get_current_us
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    # If assigned, unassign. If searching, just ignore/record decline.
-    await db_supabase.update_ride(
-        ride_id, {"driver_id": None, "status": "searching", "updated_at": datetime.now(timezone.utc)}
+    # Conditional reset: only unassign if this driver is still the assigned one.
+    # An unconditional update_ride() would overwrite a concurrent accept_ride() that
+    # already moved the ride to driver_accepted with a different driver.
+    declined = await db_supabase.update_one(
+        "rides",
+        {"id": ride_id, "driver_id": driver["id"], "status": {"$in": ["searching", "driver_assigned"]}},
+        {
+            "$set": {
+                "driver_id": None,
+                "status": "searching",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        },
     )
-    # M-5: SGI insurance period audit — decline releases the driver from
-    # period 2 back to period 1.
-    await record_period_transition(driver["id"], 1)
+    if declined is None:
+        # Race lost — another driver already accepted; our decline is a no-op.
+        logger.info(f"[DECLINE] ride {ride_id} already claimed by another driver; decline ignored")
+    else:
+        # M-5: SGI insurance period audit — decline releases the driver from
+        # period 2 back to period 1 only when the decline actually took effect.
+        await record_period_transition(driver["id"], 1)
 
     # Record the decline in audit_logs so daily stats can count it
     try:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2109,22 +2109,29 @@ async def arrive_at_pickup(ride_id: str, current_user: dict = Depends(get_curren
                 f"Please move within 200m of the pickup location to mark arrival.",
             )
 
-    await db_supabase.update_ride(
-        ride_id,
+    guard = await db.update_one(
+        "rides",
+        {"id": ride_id, "driver_id": driver["id"], "status": "driver_accepted"},
         {
-            "status": "driver_arrived",
-            "driver_arrived_at": datetime.now(timezone.utc),
-            "updated_at": datetime.now(timezone.utc),
+            "$set": {
+                "status": "driver_arrived",
+                "driver_arrived_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
         },
     )
+    if guard is None:
+        raise HTTPException(status_code=409, detail="Ride is not in driver_accepted state")
 
     if ride.get("rider_id"):
         await manager.send_personal_message({"type": "driver_arrived", "ride_id": ride_id}, f"rider_{ride['rider_id']}")
-        await send_push_notification(
-            ride["rider_id"],
-            "Driver Arrived! 📍",
-            "Your driver has arrived at the pickup location.",
-            data={"type": "driver_arrived", "ride_id": str(ride_id)},
+        asyncio.create_task(
+            send_push_notification(
+                ride["rider_id"],
+                "Driver Arrived! 📍",
+                "Your driver has arrived at the pickup location.",
+                data={"type": "driver_arrived", "ride_id": str(ride_id)},
+            )
         )
     await manager.broadcast_ride_status(ride_id, "driver_arrived", rider_id=ride.get("rider_id"))
 
@@ -2148,26 +2155,33 @@ async def verify_pickup_otp(ride_id: str, request: RideOTPRequest, current_user:
     if not hmac.compare_digest(ride.get("pickup_otp", ""), hash_otp(request.otp)):
         raise HTTPException(status_code=400, detail="Invalid OTP")
 
-    # OTP correct, start ride
-    await db_supabase.update_ride(
-        ride_id,
+    # OTP correct — atomic transition guards against duplicate taps/retries
+    guard = await db.update_one(
+        "rides",
+        {"id": ride_id, "driver_id": driver["id"], "status": "driver_arrived"},
         {
-            "status": "in_progress",
-            "ride_started_at": datetime.now(timezone.utc),
-            "updated_at": datetime.now(timezone.utc),
+            "$set": {
+                "status": "in_progress",
+                "ride_started_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
         },
     )
+    if guard is None:
+        raise HTTPException(status_code=409, detail="Ride is not in driver_arrived state")
     # M-5: SGI insurance period audit — in_progress = period 3 (passenger
-    # aboard, full TNC commercial coverage).
+    # aboard, full TNC commercial coverage). Only record when transition took effect.
     await record_period_transition(driver["id"], 3, ride_id=ride_id)
 
     if ride.get("rider_id"):
         await manager.send_personal_message({"type": "ride_started", "ride_id": ride_id}, f"rider_{ride['rider_id']}")
-        await send_push_notification(
-            ride["rider_id"],
-            "Ride Started! ▶️",
-            "Your ride has started. Have a safe trip!",
-            data={"type": "ride_started", "ride_id": str(ride_id)},
+        asyncio.create_task(
+            send_push_notification(
+                ride["rider_id"],
+                "Ride Started! ▶️",
+                "Your ride has started. Have a safe trip!",
+                data={"type": "ride_started", "ride_id": str(ride_id)},
+            )
         )
     await manager.broadcast_ride_status(ride_id, "in_progress", rider_id=ride.get("rider_id"))
 
@@ -2177,35 +2191,46 @@ async def verify_pickup_otp(ride_id: str, request: RideOTPRequest, current_user:
 @api_router.post("/rides/{ride_id}/start")
 async def start_ride(ride_id: str, current_user: dict = Depends(get_current_user)):
     """Start ride without OTP (if configured) or fallback."""
-    # Logic similar to verify_otp but without check
     driver = (lambda _r: _r[0] if _r else None)(
         await db_supabase.get_rows("drivers", {"user_id": current_user["id"]}, limit=1)
     )
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    await db_supabase.update_ride(
-        ride_id,
+    ride = (lambda _r: _r[0] if _r else None)(
+        await db_supabase.get_rows("rides", {"id": ride_id, "driver_id": driver["id"]}, limit=1)
+    )
+    if not ride:
+        raise HTTPException(status_code=404, detail="Ride not found")
+
+    guard = await db.update_one(
+        "rides",
+        {"id": ride_id, "driver_id": driver["id"], "status": "driver_arrived"},
         {
-            "status": "in_progress",
-            "ride_started_at": datetime.now(timezone.utc),
-            "updated_at": datetime.now(timezone.utc),
+            "$set": {
+                "status": "in_progress",
+                "ride_started_at": datetime.now(timezone.utc),
+                "updated_at": datetime.now(timezone.utc),
+            }
         },
     )
+    if guard is None:
+        raise HTTPException(status_code=409, detail="Ride is not in driver_arrived state")
     # M-5: SGI insurance period audit — in_progress = period 3 (passenger
-    # aboard, full TNC commercial coverage).
+    # aboard, full TNC commercial coverage). Only record when transition took effect.
     await record_period_transition(driver["id"], 3, ride_id=ride_id)
 
-    ride = await db_supabase.get_ride(ride_id)
-    if ride and ride.get("rider_id"):
+    if ride.get("rider_id"):
         await manager.send_personal_message({"type": "ride_started", "ride_id": ride_id}, f"rider_{ride['rider_id']}")
-        await send_push_notification(
-            ride["rider_id"],
-            "Ride Started! ▶️",
-            "Your ride has started. Have a safe trip!",
-            data={"type": "ride_started", "ride_id": str(ride_id)},
+        asyncio.create_task(
+            send_push_notification(
+                ride["rider_id"],
+                "Ride Started! ▶️",
+                "Your ride has started. Have a safe trip!",
+                data={"type": "ride_started", "ride_id": str(ride_id)},
+            )
         )
-    await manager.broadcast_ride_status(ride_id, "in_progress", rider_id=(ride or {}).get("rider_id"))
+    await manager.broadcast_ride_status(ride_id, "in_progress", rider_id=ride.get("rider_id"))
     return {"success": True}
 
 

--- a/backend/routes/fares.py
+++ b/backend/routes/fares.py
@@ -22,7 +22,12 @@ db = db_supabase  # legacy alias
 logger = logging.getLogger(__name__)
 api_router = APIRouter(tags=["Fares"])
 
-# PERF-001: Fare cache TTL in seconds (default 5 min)
+# PERF-001: Fare cache TTL in seconds (default 5 min).
+# WARNING: cached fares embed the surge multiplier at cache-fill time.
+# If surge changes within the TTL window the rider sees a stale estimate;
+# payments.py re-validates the fare at settlement and will reject a mismatch.
+# Set FARE_CACHE_TTL_SECONDS=60 in production to tighten the window during
+# surge events without fully disabling the cache.
 _FARE_CACHE_TTL = int(os.environ.get("FARE_CACHE_TTL_SECONDS", "300"))
 
 # ── Decimal helpers (CQ-009) ──────────────────────────────────────────

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -60,7 +60,6 @@ async def get_or_create_stripe_customer(user_id: str, stripe_secret: str):
     stripe_customer_id = user.get("stripe_customer_id")
 
     if not stripe_customer_id:
-        # Create a new Stripe customer
         customer = stripe.Customer.create(
             email=user.get("email"),
             name=f"{user.get('first_name', '')} {user.get('last_name', '')}".strip(),
@@ -69,6 +68,10 @@ async def get_or_create_stripe_customer(user_id: str, stripe_secret: str):
         )
         stripe_customer_id = customer.id
         await db_supabase.update_one("users", {"id": user_id}, {"stripe_customer_id": stripe_customer_id})
+        # Re-read to use the authoritative value in case a concurrent replica wrote first.
+        # (The loser's Stripe customer is unused but harmless; deduplication can run offline.)
+        fresh = await db_supabase.get_user_by_id(user_id)
+        stripe_customer_id = (fresh or {}).get("stripe_customer_id", stripe_customer_id)
 
     return stripe_customer_id
 
@@ -111,7 +114,7 @@ async def create_payment_intent(
                     action_hint="Refresh the fare estimate",
                 )
 
-        amount = int(body.amount * 100)  # Convert dollars → cents
+        amount = int(Decimal(str(body.amount)).quantize(Decimal("0.01")) * 100)
 
         # Get or create customer for saved payments
         stripe_customer_id = await get_or_create_stripe_customer(current_user["id"], stripe_secret)
@@ -534,7 +537,7 @@ async def create_payment_sheet(
 
     try:
         customer_id = await get_or_create_stripe_customer(current_user["id"], stripe_secret)
-        amount_cents = int(body.amount * 100)
+        amount_cents = int(Decimal(str(body.amount)).quantize(Decimal("0.01")) * 100)
 
         # EphemeralKey lets the PaymentSheet modal manage the customer's
         # saved cards. Must match the Stripe API version the SDK expects.

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2057,6 +2057,9 @@ async def rate_driver(ride_id: str, rating_data: RideRatingRequest, current_user
     if not ride or ride.get("rider_id") != current_user["id"]:
         raise HTTPException(status_code=404, detail="Ride not found or unauthorized")
 
+    if ride.get("status") != "completed":
+        raise HTTPException(status_code=400, detail="Ride must be completed before rating")
+
     # Save rating using existing columns (rider_rating = rating rider gave the driver)
     await db_supabase.update_ride(
         ride_id,
@@ -2081,15 +2084,17 @@ async def rate_driver(ride_id: str, rating_data: RideRatingRequest, current_user
     driver = await db_supabase.get_driver_by_id(driver_id)
     if driver:
         old_count = int(driver.get("total_ratings") or 0)
-        old_avg = float(driver.get("rating") or 0)
+        old_avg = Decimal(str(driver.get("rating") or 0))
         new_count = old_count + 1
-        new_avg = round((old_avg * old_count + float(rating_data.rating)) / new_count, 2)
+        new_avg = ((old_avg * old_count + Decimal(str(rating_data.rating))) / new_count).quantize(
+            Decimal("0.01"), rounding=ROUND_HALF_UP
+        )
         await db_supabase.update_one(
             "drivers",
             {"id": driver_id},
             {
-                "rating": new_avg,
-                "average_rating": new_avg,
+                "rating": float(new_avg),
+                "average_rating": float(new_avg),
                 "total_ratings": new_count,
             },
         )

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -125,7 +125,7 @@ async def stripe_webhook(request: Request):
         payment_intent_id = data_object.get("id")
 
         if ride_id:
-            await db_supabase.update_ride(
+            updated = await db_supabase.update_ride(
                 ride_id,
                 {
                     "payment_status": "paid",
@@ -133,15 +133,23 @@ async def stripe_webhook(request: Request):
                     "paid_at": datetime.now(timezone.utc),
                 },
             )
-            logger.info(f"Payment confirmed via webhook for ride {ride_id}")
+            if updated is None:
+                logger.warning(f"Webhook payment_intent.succeeded: ride {ride_id} not found in DB")
+            else:
+                logger.info(f"Payment confirmed via webhook for ride {ride_id}")
 
         if user_id:
-            await send_push_notification(
-                user_id,
-                "Payment Confirmed ✅",
-                "Your payment has been processed successfully.",
-                {"type": "payment_confirmed", "ride_id": ride_id or ""},
-            )
+            # Wrap push notification so a Firebase outage does not cause Stripe
+            # to retry the webhook for days (which would re-process the payment event).
+            try:
+                await send_push_notification(
+                    user_id,
+                    "Payment Confirmed ✅",
+                    "Your payment has been processed successfully.",
+                    {"type": "payment_confirmed", "ride_id": ride_id or ""},
+                )
+            except Exception as _push_err:
+                logger.error(f"Webhook: push notification failed for user {user_id}: {_push_err}")
 
     elif event_type == "payment_intent.payment_failed":
         ride_id = data_object.get("metadata", {}).get("ride_id")
@@ -161,12 +169,15 @@ async def stripe_webhook(request: Request):
             logger.warning(f"Payment failed for ride {ride_id}: {failure_message}")
 
         if user_id:
-            await send_push_notification(
-                user_id,
-                "Payment Failed ❌",
-                f"Your payment could not be processed: {failure_message}",
-                {"type": "payment_failed", "ride_id": ride_id or ""},
-            )
+            try:
+                await send_push_notification(
+                    user_id,
+                    "Payment Failed ❌",
+                    f"Your payment could not be processed: {failure_message}",
+                    {"type": "payment_failed", "ride_id": ride_id or ""},
+                )
+            except Exception as _push_err:
+                logger.error(f"Webhook: push notification failed for user {user_id}: {_push_err}")
 
         # Notify the driver so they know the rider's payment failed (13-10)
         if ride_id:

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -641,6 +642,31 @@ async def websocket_endpoint(websocket: WebSocket, client_type: str, client_id: 
                 # any client-supplied value.
                 points = data.get("points", [])
                 driver_id = current_driver_id if client_type == "driver" else None
+
+                # Per-connection sliding-window rate limit on total points to
+                # prevent a single connection from flooding driver_location_history
+                # (500-point batches sent every second = 30 000 inserts/min).
+                _BATCH_WINDOW_SECS = 10
+                _BATCH_POINTS_LIMIT = 1000  # max points per 10-second window
+                _now_ts = time.monotonic()
+                if not hasattr(websocket.state, "batch_window_start"):
+                    websocket.state.batch_window_start = _now_ts
+                    websocket.state.batch_points_count = 0
+                if _now_ts - websocket.state.batch_window_start > _BATCH_WINDOW_SECS:
+                    websocket.state.batch_window_start = _now_ts
+                    websocket.state.batch_points_count = 0
+                websocket.state.batch_points_count += len(points)
+                if websocket.state.batch_points_count > _BATCH_POINTS_LIMIT:
+                    await websocket.send_json(
+                        {
+                            "type": "rate_limited",
+                            "scope": "location_batch",
+                            "limit": _BATCH_POINTS_LIMIT,
+                            "window_seconds": _BATCH_WINDOW_SECS,
+                        }
+                    )
+                    continue
+
                 if driver_id and points:
                     docs = []
                     for pt in points[:500]:  # cap at 500 points per batch

--- a/backend/utils/document_expiry.py
+++ b/backend/utils/document_expiry.py
@@ -48,11 +48,21 @@ async def check_expiring_documents():
     now = datetime.now(timezone.utc)
     warning_cutoff = now + timedelta(days=EXPIRY_WARNING_DAYS)
 
-    try:
-        all_drivers = await db.get_rows("drivers", {}, limit=1000)
-    except Exception as e:
-        logger.error(f"Doc expiry: failed to fetch drivers: {e}")
-        return
+    _PAGE_SIZE = 100
+    all_drivers: list = []
+    offset = 0
+    while True:
+        try:
+            page = await db.get_rows("drivers", {}, limit=_PAGE_SIZE, offset=offset)
+        except Exception as e:
+            logger.error(f"Doc expiry: failed to fetch drivers (offset={offset}): {e}")
+            return
+        if not page:
+            break
+        all_drivers.extend(page)
+        if len(page) < _PAGE_SIZE:
+            break
+        offset += _PAGE_SIZE
 
     notified = 0
     for driver in all_drivers:

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -125,14 +125,14 @@ async def retry_failed_payments():
             intent = stripe.PaymentIntent.retrieve(payment_intent_id, api_key=stripe_secret)
 
             if intent.status == "succeeded":
-                # Already succeeded (webhook may have missed it)
+                # Already succeeded (webhook may have missed it) — mark paid but do NOT
+                # increment retry_count to avoid false "payment finally failed" alerts.
                 await db.update_one(
                     "rides",
                     {"id": ride_id},
                     {
                         "$set": {
                             "payment_status": "paid",
-                            "payment_retry_count": retry_count + 1,
                             "updated_at": datetime.now(timezone.utc).isoformat(),
                         }
                     },
@@ -140,8 +140,13 @@ async def retry_failed_payments():
                 logger.info(f"Payment retry: ride {ride_id} already paid (intent succeeded)")
 
             elif intent.status in ("requires_payment_method", "requires_confirmation"):
-                # Try to confirm again
-                stripe.PaymentIntent.confirm(payment_intent_id, api_key=stripe_secret)
+                # Idempotency key prevents duplicate charges when two replicas both pick
+                # up the same failed ride in the same retry loop tick.
+                stripe.PaymentIntent.confirm(
+                    payment_intent_id,
+                    api_key=stripe_secret,
+                    idempotency_key=f"retry-confirm-{ride_id}-{retry_count}",
+                )
                 attempt = retry_count + 1
                 await db.update_one(
                     "rides",

--- a/backend/utils/safety_checkin_loop.py
+++ b/backend/utils/safety_checkin_loop.py
@@ -142,7 +142,16 @@ async def _tick() -> None:
             continue  # still within the response window
 
         # Escalate: insert an open safety incident for the ops team.
-        await _escalate(ride, now)
+        try:
+            await _escalate(ride, now)
+        except Exception:
+            # _escalate already logged the error. The _escalated_key is NOT set,
+            # so the next tick will retry. Log ride_id here for ops correlation.
+            logger.error(
+                f"[SAFETY_CHECKIN] Escalation failed for ride {ride_id}; "
+                "will retry on next tick. Check DB/Redis connectivity.",
+                exc_info=False,
+            )
 
 
 async def _escalate(ride: dict, now: datetime) -> None:
@@ -166,11 +175,15 @@ async def _escalate(ride: dict, now: datetime) -> None:
             "created_at": now.isoformat(),
         }
         await _supabase_db.insert_one("safety_incidents", incident)
-        # Mark escalated so we don't create duplicate incidents.
+        # Mark escalated only after a successful insert so a DB failure does
+        # not silently suppress future escalation attempts.
         await redis_set(_escalated_key(ride_id), "1", ttl=4 * 3600)
         logger.warning(f"[SAFETY_CHECKIN] No response from rider {rider_id} on ride {ride_id}; safety incident opened.")
     except Exception:
         logger.error(
-            f"[SAFETY_CHECKIN] Failed to escalate ride {ride_id}",
+            f"[SAFETY_CHECKIN] Failed to escalate ride {ride_id} — will retry next tick",
             exc_info=True,
         )
+        # Re-raise so the caller (_tick) knows escalation failed and can log
+        # context. The _escalated_key is NOT set, so the next tick will retry.
+        raise

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -14,6 +14,7 @@ SplashScreen.preventAutoHideAsync().catch(() => {});
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useAuthStore } from '@shared/store/authStore';
 import { useLocationStore } from '@shared/store/locationStore';
+import { useDriverStore } from '../store/driverStore';
 import SpinrConfig from '@shared/config/spinr.config';
 import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import { OfflineBanner } from '@shared/components/OfflineBanner';
@@ -142,6 +143,16 @@ export default function RootLayout() {
   const [isOffline, setIsOffline] = useState(false);
   // Guard so we only register the FCM token once per auth session.
   const fcmRegisteredRef = useRef(false);
+  const prevAuthTokenRef = useRef(authToken);
+
+  // Clear driver ride state on logout so a re-login doesn't see the
+  // previous session's in-progress offer / active ride.
+  useEffect(() => {
+    if (prevAuthTokenRef.current && !authToken) {
+      useDriverStore.getState().resetRideState();
+    }
+    prevAuthTokenRef.current = authToken;
+  }, [authToken]);
 
   // ── LogRocket session recording ──
   // Guard against Expo Go — @logrocket/react-native ships a native module

--- a/driver-app/app/otp.tsx
+++ b/driver-app/app/otp.tsx
@@ -73,6 +73,12 @@ export default function OtpScreen() {
     variant: 'info' | 'warning' | 'danger' | 'success';
   }>({ visible: false, title: '', message: '', variant: 'info' });
 
+  useEffect(() => {
+    if (!phoneNumber) {
+      router.back();
+    }
+  }, []);
+
   // Animate dots as user types
   useEffect(() => {
     dotAnims.forEach((anim, i) => {
@@ -147,6 +153,7 @@ export default function OtpScreen() {
           phone: phoneNumber,
           code: code,
         });
+        if (!response.data) throw new Error('Empty response from auth server');
         const { token, refresh_token, expires_in, user: userData } = response.data;
         if (token) {
           await useAuthStore.getState().setTokens(token, refresh_token ?? '', expires_in ?? 900);

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -386,6 +386,16 @@ export default function RootLayout() {
     })();
   }, [isAuthInitialized]);
 
+  // Clear ride session data when the user logs out so a subsequent login
+  // doesn't show the previous session's ride, driver, or chat state.
+  const prevAuthTokenRef = useRef(authToken);
+  useEffect(() => {
+    if (prevAuthTokenRef.current && !authToken) {
+      useRideStore.getState().clearRide();
+    }
+    prevAuthTokenRef.current = authToken;
+  }, [authToken]);
+
   // ── Network connectivity monitoring for offline sync ──
   useEffect(() => {
     const unsubscribe = NetInfo.addEventListener(state => {

--- a/rider-app/app/chat-driver.tsx
+++ b/rider-app/app/chat-driver.tsx
@@ -38,7 +38,7 @@ export default function ChatDriverScreen() {
 
   // Load chat history from the backend on mount.
   useEffect(() => {
-    if (!rideId) return;
+    if (!rideId) { router.replace('/(tabs)' as any); return; }
     (async () => {
       try {
         const res = await api.get(`/rides/${rideId}/messages`);

--- a/rider-app/app/driver-arriving.tsx
+++ b/rider-app/app/driver-arriving.tsx
@@ -125,6 +125,7 @@ function DriverArrivingScreenContent() {
   }, [rideId, currentRide?.status, wsConnected]);
 
   useEffect(() => {
+    if (!rideId) return;
     if (currentRide?.status === RideStatus.DRIVER_ARRIVED) {
       router.replace({ pathname: '/driver-arrived', params: { rideId } });
     } else if (currentRide?.status === RideStatus.IN_PROGRESS) {

--- a/rider-app/app/driver-arriving.tsx
+++ b/rider-app/app/driver-arriving.tsx
@@ -111,7 +111,7 @@ function DriverArrivingScreenContent() {
   }, [currentRide?.pickup_lat, currentRide?.pickup_lng, currentDriver?.lat, currentDriver?.lng]);
 
   useEffect(() => {
-    if (!rideId) return;
+    if (!rideId) { router.replace('/(tabs)' as any); return; }
     fetchRide(rideId);
     // Suspend fallback poll when WebSocket is healthy — saves battery/bandwidth.
     // Keep a fast 3 s poll during driver assignment negotiation in case a

--- a/rider-app/app/otp.tsx
+++ b/rider-app/app/otp.tsx
@@ -68,6 +68,12 @@ export default function OtpScreen() {
   }>({ visible: false, title: '', message: '', variant: 'info' });
 
   useEffect(() => {
+    if (!phoneNumber) {
+      router.back();
+    }
+  }, []);
+
+  useEffect(() => {
     dotAnims.forEach((anim, i) => {
       Animated.spring(anim, {
         toValue: i < code.length ? 1 : 0,
@@ -138,6 +144,7 @@ export default function OtpScreen() {
           phone: phoneNumber,
           code: code,
         });
+        if (!response.data) throw new Error('Empty response from auth server');
         const { token, refresh_token, expires_in, user: userData } = response.data;
         // P3 cookie auth: token is "" when HTTP-only cookies are used
         if (token) {

--- a/rider-app/app/otp.tsx
+++ b/rider-app/app/otp.tsx
@@ -71,6 +71,7 @@ export default function OtpScreen() {
     if (!phoneNumber) {
       router.back();
     }
+    return () => { resendInFlight.current = false; };
   }, []);
 
   useEffect(() => {

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -61,7 +61,8 @@ function RideCompletedScreenContent() {
   const distance = currentRide?.distance_km || 0;
 
   useEffect(() => {
-    if (rideId) fetchRide(rideId);
+    if (!rideId) { router.replace('/(tabs)' as any); return; }
+    fetchRide(rideId);
   }, [rideId]);
 
   // Check if ride was already paid (e.g. coming back to this screen)

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -78,7 +78,7 @@ function RideCompletedScreenContent() {
   }, []);
 
   const buildReceiptText = () => {
-    const tipAmount = selectedTip || (customTip ? parseFloat(customTip) || 0 : 0);
+    const tipAmount = selectedTip !== null ? selectedTip : (customTip ? parseFloat(customTip) || 0 : 0);
     const total = fare + tipAmount;
     const rideDate = currentRide?.ride_completed_at
       ? new Date(currentRide.ride_completed_at).toLocaleString('en-CA', {

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -167,7 +167,7 @@ function RideCompletedScreenContent() {
     if (isSubmitting) return; // prevent double tap
     setIsSubmitting(true);
     try {
-      const tipAmount = selectedTip || (customTip ? parseFloat(customTip) : 0);
+      const tipAmount = selectedTip !== null ? selectedTip : (customTip ? parseFloat(customTip) || 0 : 0);
 
       // 1. Rate the driver first — this is fire-and-forget because
       //    rating may fail if already rated (idempotent upstream).
@@ -227,7 +227,7 @@ function RideCompletedScreenContent() {
   // Android (Apple Pay uses the same sheet on iOS via handleSubmit in future).
   const handleGooglePay = async () => {
     if (isSubmitting || sheetLoading || alreadyPaid) return;
-    const tipAmount = selectedTip || (customTip ? parseFloat(customTip) : 0);
+    const tipAmount = selectedTip !== null ? selectedTip : (customTip ? parseFloat(customTip) || 0 : 0);
     const result = await presentSheet({
       rideId: rideId as string,
       amount: parseFloat(currentRide?.total_fare || '0'),

--- a/rider-app/app/ride-in-progress.tsx
+++ b/rider-app/app/ride-in-progress.tsx
@@ -104,7 +104,7 @@ function RideInProgressScreenContent() {
   }, [currentRide, currentDriver?.lat, currentDriver?.lng]);
 
   useEffect(() => {
-    if (!rideId) return;
+    if (!rideId) { router.replace('/(tabs)' as any); return; }
     fetchRide(rideId);
     // Suspend fallback poll while WebSocket is delivering updates in real-time.
     if (wsConnected) return;

--- a/rider-app/app/ride-in-progress.tsx
+++ b/rider-app/app/ride-in-progress.tsx
@@ -120,7 +120,7 @@ function RideInProgressScreenContent() {
   }, [eta]);
 
   useEffect(() => {
-    if (currentRide?.status === RideStatus.COMPLETED) {
+    if (currentRide?.status === RideStatus.COMPLETED && rideId) {
       router.replace({ pathname: '/ride-completed', params: { rideId } });
     }
   }, [currentRide?.status]);

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -181,7 +181,10 @@ function RideOptionsScreenContent() {
   };
 
   const handleSelect = (index: number) => {
-    if (!estimates[index].available) return;
+    if (!estimates[index]?.available) {
+      setAlertState({ visible: true, title: 'Unavailable', message: 'This vehicle type is not available right now. Please choose another.', variant: 'warning' });
+      return;
+    }
     setSelectedIndex(index);
     selectVehicle(estimates[index].vehicle_type);
     // Re-fetch nearby drivers filtered by this vehicle type

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -190,7 +190,7 @@ function RideOptionsScreenContent() {
     // Re-fetch nearby drivers filtered by this vehicle type
     setTimeout(() => fetchNearbyDrivers(), 100);
     // Re-calculate promo discount for new fare
-    fetchAvailablePromos(parseFloat(estimates[index].total_fare));
+    fetchAvailablePromos(parseFloat(estimates[index].total_fare || '0'));
   };
 
   const handleConfirm = () => {
@@ -201,7 +201,7 @@ function RideOptionsScreenContent() {
     }
     if (workModeEnabled && activeCompanyId && selectedEstimate) {
       const when = isScheduling && scheduledTime ? scheduledTime : undefined;
-      const check = checkRide(parseFloat(selectedEstimate.total_fare), when);
+      const check = checkRide(parseFloat(selectedEstimate.total_fare || '0'), when);
       if (!check.ok) {
         setAlertState({
           visible: true,
@@ -579,13 +579,13 @@ function RideOptionsScreenContent() {
                 <View style={[styles.optionPriceContainer, !isAvailable && { opacity: 0.4 }]}>
                   {appliedPromo && appliedPromo.discount_amount > 0 && isSelected ? (
                     <View style={{ alignItems: 'flex-end' }}>
-                      <Text style={styles.optionPriceStruck} allowFontScaling={false}>${parseFloat(estimate.total_fare).toFixed(2)}</Text>
+                      <Text style={styles.optionPriceStruck} allowFontScaling={false}>${parseFloat(estimate.total_fare || '0').toFixed(2)}</Text>
                       <Text style={styles.optionPriceDiscounted} allowFontScaling={false}>
-                        ${Math.max(0, parseFloat(estimate.total_fare) - appliedPromo.discount_amount).toFixed(2)}
+                        ${Math.max(0, parseFloat(estimate.total_fare || '0') - appliedPromo.discount_amount).toFixed(2)}
                       </Text>
                     </View>
                   ) : (
-                    <Text style={styles.optionPrice} allowFontScaling={false}>${parseFloat(estimate.total_fare).toFixed(2)}</Text>
+                    <Text style={styles.optionPrice} allowFontScaling={false}>${parseFloat(estimate.total_fare || '0').toFixed(2)}</Text>
                   )}
                   {isSelected && isAvailable && (
                     <View style={styles.selectedCheck}>

--- a/rider-app/app/wallet.tsx
+++ b/rider-app/app/wallet.tsx
@@ -156,7 +156,13 @@ export default function WalletScreen() {
       <View style={styles.balanceCard}>
         <Text style={styles.balanceLabel}>Available Balance</Text>
         {storeError ? (
-          <Text style={[styles.balanceAmount, { fontSize: 20 }]}>Balance unavailable</Text>
+          <TouchableOpacity onPress={() => {
+            clearError();
+            Promise.all([fetchWallet(), fetchTransactions(30)]);
+          }}>
+            <Text style={[styles.balanceAmount, { fontSize: 18 }]}>Balance unavailable</Text>
+            <Text style={{ color: '#FFF', opacity: 0.8, textAlign: 'center', marginTop: 4 }}>Tap to retry</Text>
+          </TouchableOpacity>
         ) : (
           <Text style={styles.balanceAmount}>
             ${parseFloat(wallet?.balance ?? '0').toFixed(2)}

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -690,8 +690,9 @@ export const useRideStore = create<RideState>((set, get) => ({
     // while the next poll (reduced to 15 s via the WS fallback) fills
     // in any remaining details the WS message doesn't carry.
     const updated = { ...currentRide, status, ...(extra || {}) };
-    set({ currentRide: updated });
-    _persistRide(updated, currentDriver);
+    const isTerminal = TERMINAL_STATUSES.has(status);
+    set({ currentRide: updated, ...(isTerminal ? { currentDriver: null } : {}) });
+    _persistRide(updated, isTerminal ? null : currentDriver);
   },
 
   // ── Offline hydration ────────────────────────────────────────────

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -690,9 +690,10 @@ export const useRideStore = create<RideState>((set, get) => ({
     // while the next poll (reduced to 15 s via the WS fallback) fills
     // in any remaining details the WS message doesn't carry.
     const updated = { ...currentRide, status, ...(extra || {}) };
-    const isTerminal = TERMINAL_STATUSES.has(status);
-    set({ currentRide: updated, ...(isTerminal ? { currentDriver: null } : {}) });
-    _persistRide(updated, isTerminal ? null : currentDriver);
+    // Keep currentDriver so the ride-completed receipt screen can still show
+    // driver name/vehicle until the user taps Done. clearRide() will null it.
+    set({ currentRide: updated });
+    _persistRide(updated, currentDriver);
   },
 
   // ── Offline hydration ────────────────────────────────────────────

--- a/shared/components/SOSButton.tsx
+++ b/shared/components/SOSButton.tsx
@@ -116,7 +116,9 @@ export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps)
     } catch {}
 
     // Attempt backend call with one retry before declaring failure.
-    let backendOk = !rideId; // no rideId = demo / offline mode, treat as ok
+    // Never treat missing rideId as success — that would show "Alert Sent"
+    // without any backend notification going out.
+    let backendOk = false;
     if (rideId) {
       for (let attempt = 0; attempt < SOS_MAX_ATTEMPTS && !backendOk; attempt++) {
         if (attempt > 0) {
@@ -131,7 +133,17 @@ export function SOSButton({ rideId, onTrigger, size = 'small' }: SOSButtonProps)
 
     setSending(false);
 
-    if (backendOk) {
+    if (!rideId) {
+      // No active ride context — direct user to call 911 immediately.
+      Alert.alert(
+        'No Active Ride',
+        'Emergency alert requires an active ride. Call 911 directly for immediate help.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Call 911', style: 'destructive', onPress: () => Linking.openURL('tel:911') },
+        ],
+      );
+    } else if (backendOk) {
       setTriggered(true);
       showSuccessAlert();
     } else {


### PR DESCRIPTION
## Summary

Full sprint closing all P0 safety/security findings, P1 logic bugs, and P2 polish items across backend, rider-app, driver-app, and admin-dashboard.

### Backend

- **Atomic ride state transitions** — `arrive_at_pickup`, `verify_pickup_otp`, `start_ride` now use conditional `UPDATE … WHERE status = expected` so duplicate taps / network retries return 409 instead of re-transitioning
- **Accept/decline race condition** — `accept_ride` relies solely on atomic Supabase update return; `decline_ride` uses conditional UPDATE to prevent overwriting a concurrent accept
- **Rating guard** — `rate_driver` blocked on non-completed rides; float rolling average replaced with Decimal accumulation
- **Stripe idempotency** — `payment_retry.py` adds `idempotency_key` to `PaymentIntent.confirm()`; skips `retry_count` increment on already-succeeded intents
- **Stripe customer race** — `get_or_create_stripe_customer` uses upsert pattern to prevent orphaned Stripe customers under concurrent requests
- **Decimal money arithmetic** — `int(body.amount * 100)` float replaced with `Decimal`-based conversion in `payments.py`
- **Safety incident durability** — `safety.py` returns 503 on insert failure instead of silently succeeding; escalation failures logged as error and retried
- **Webhook reliability** — Stripe webhook wraps `send_push_notification` in try/except so FCM outages don't trigger 3-day Stripe retries; logs warning when ride not found after payment update
- **Push notification latency** — `send_push_notification` calls in `arrive_at_pickup`, `verify_pickup_otp`, `start_ride` moved into `asyncio.create_task()` to remove FCM round-trip from HTTP response time
- **Document expiry pagination** — replaced `limit=1000` with paginated 100-row loop
- **Location batch rate limit** — per-connection sliding window (1 000 pts / 10 s) prevents DoS via large batch floods
- **Fare cache surge annotation** — TTL configurable via `FARE_CACHE_TTL_SECONDS`; warning comment that surge is baked into cached value

### Mobile (rider-app / driver-app)

- **SOS false positive** — `SOSButton` guarded when `rideId` undefined; shows error instead of fake "Alert Sent"
- **Navigation param crashes** — `ride-completed`, `driver-arriving`, `ride-in-progress`, `chat-driver` redirect to home when `rideId` missing instead of crashing
- **OTP null crash** — guards `response.data` before destructure; redirects back when `phoneNumber` missing
- **`resendInFlight` leak** — reset on unmount in rider-app OTP screen
- **Logout ghost state** — `logout()` calls `resetRideState()` on driver store; prevents stale ride appearing on re-login
- **Fare NaN safety** — `parseFloat(estimate.total_fare || '0')` guards throughout `ride-options`; interval cleared on unmount
- **Tip = 0 falsy bug** — `selectedTip !== null ? … : …` replaces `selectedTip || …` so zero-tip is valid

### Admin Dashboard

- **`alert()`/`confirm()` eliminated** — all 20+ native browser dialogs replaced with `toast` + `AlertDialog` across monitoring, promotions, corporate accounts, support, vehicle types, drivers, and service areas
- **Document review error handling** — optimistic rollback + toast on `reviewDocument` / `reloadDriverDocs` failure
- **WebSocket stale-data banner** — "Live data paused — reconnecting…" shown when monitoring socket is down
- **Settings save confirmation** — AlertDialog gate before writing live Stripe/Twilio credentials; save errors now surface via destructive toast instead of being swallowed
- **Allowance dialog validation** — Save disabled when `fixed_recurring` type selected but date fields empty
- **Analytics partial failure** — error banner triggers when any (not all) sub-fetch fails
- **Heatmap date validation** — blocks refresh and shows inline error when start > end date
- **Driver chart null guards** — `data={charts.daily_joins ?? []}` prevents crash on empty dataset
- **CSV export** — calls backend `/admin/export/drivers` instead of exporting client-filtered rows; shows success toast with row count
- **Error boundary** — app-level `error.tsx` prevents blank screen on unhandled page crashes

## Test plan

- [ ] Backend: `pytest -m unit` — no regressions
- [ ] Rider-app: `yarn test` — 157 tests pass
- [ ] Admin: `npm run build` — clean TypeScript compile
- [ ] Smoke: OTP → book ride → driver accepts → arrive → OTP verify → complete → rate
- [ ] Smoke: SOS button with and without active ride
- [ ] Smoke: Admin document review approve/reject with network error simulation
- [ ] Smoke: Admin monitoring page with WebSocket disconnect

https://claude.ai/code/session_01FCEXpGu3c1PTmrDWUDvD2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCEXpGu3c1PTmrDWUDvD2E)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
