### PR TITLE
fix(ci): fix backend test mocks + admin-test lint crash (ESLint 9 + lockfile)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.12'
-  NODE_VERSION: '20'
+  NODE_VERSION: '22'
 
 jobs:
   # Backend Tests
@@ -279,7 +279,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: admin-dashboard/package-lock.json
 

--- a/backend/tests/test_ride_accept_flow.py
+++ b/backend/tests/test_ride_accept_flow.py
@@ -157,7 +157,7 @@ class TestAcceptRideFlipsStatus:
         assert send_push_mock.await_count >= 1
 
     def test_double_accept_rejected_by_guard(self):
-        """When the atomic guard returns modified_count=0 (ride already taken),
+        """When the atomic guard returns None (ride already taken by concurrent request),
         accept_ride must raise 409 — never return {success: True}."""
         from fastapi import HTTPException
 

--- a/render.yaml
+++ b/render.yaml
@@ -6,13 +6,13 @@ services:
     region: oregon
     buildCommand: |
       cd backend
-      pip install -r requirements.txt
+      pip install --require-hashes -r requirements-locked.txt
     startCommand: |
       cd backend
-      uvicorn backend.server:app --host 0.0.0.0 --port 10000
+      uvicorn server:app --host 0.0.0.0 --port 10000
     envVars:
       - key: PYTHON_VERSION
-        value: 3.9.0
+        value: 3.12.9
       - key: DATABASE_URL
         sync: false
       - key: SUPABASE_URL


### PR DESCRIPTION
## Summary

- **3 backend tests fixed** — `test_double_accept_rejected_by_guard`, `test_two_drivers_accepting_same_ride_one_wins`, `test_no_double_accept` all used a MongoDB-style `modified_count=0` sentinel for the double-accept guard. Production code checks `if guard is None:` (Supabase returns None on no rows matched). Fix: `guard_fail = None` in all three tests.
- **Admin-test lint crash fixed** — `eslint-plugin-react@7.37.5` (bundled inside `eslint-config-next@16.2.4`) calls `context.getFilename()` which was removed in ESLint 10. Its own peer dep caps at `^9.7`. Downgraded `"eslint": "^10"` → `"^9"` (resolves to 9.39.4) which is what `eslint-config-next@16.2.4` was designed for.
- **Lockfile regenerated** — previous lockfile had stale manual edits (axios 1.15.0→1.16.0 changed by hand). `npm ci` in CI installed correct packages from the lockfile, getting the broken `eslint-plugin-react@7.37.5`, while local stale `node_modules` had an older working version — explaining why it worked locally but failed every CI run. Fresh `npm install` fixes the inconsistency.
- **CI upgraded to Node 22** — matches local dev (22.22.2); all packages support it.
- **axios security override** — force `>=1.15.2` via npm overrides; resolves 13 CVEs.
- **Render.yaml aligned** — Python 3.9.0 → 3.12.9, `requirements-locked.txt --require-hashes`, `uvicorn server:app`.

## Root causes fixed

| Job | Failure | Fix |
|-----|---------|-----|
| `backend-test` | 3 concurrency tests: `MagicMock(modified_count=0)` is truthy → `if guard is None:` never fires → 409 never raised | `guard_fail = None` in each test |
| `admin-test` | `eslint-plugin-react@7.37.5` calls `context.getFilename()` removed in ESLint 10 | Downgrade `"eslint": "^10"` → `"^9"` + regenerate lockfile |

## Test plan

- [ ] `backend-test` CI passes — race guard 409 tests correctly mock `db_supabase.update_one` returning `None`
- [ ] `admin-test` CI passes — ESLint 9.39.4 keeps `context.getFilename()` working; lockfile is consistent so `npm ci` installs identical packages locally and in CI
- [ ] All other CI jobs remain green

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew