### PR TITLE
feat: P4-7 — T4A annual issuance background job (CRA Feb 28 deadline)

### DIFF
--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -277,6 +277,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning(f"Failed to import Stripe reconciliation loop: {e}")
 
+    # T4A annual issuance — runs on the last day of February each year at
+    # 08:00 UTC. Identifies drivers with ≥ $500 prior-year earnings, sends
+    # each a push notification that their T4A slip is available, and logs
+    # the batch to audit_logs (CRA regulatory requirement, P4-7).
+    try:
+        from utils.t4a_annual_job import t4a_annual_job_loop
+
+        _spawn("t4a_annual_job (yearly Feb 28)", t4a_annual_job_loop)
+    except Exception as e:
+        logger.error(f"Failed to import T4A annual job loop: {e}", exc_info=True)
+
     # Loop watchdog — scans heartbeats every 5 minutes and posts a
     # Slack-compatible alert when any loop has gone stale.  No-op when
     # ALERT_WEBHOOK_URL is unset.
@@ -293,6 +304,7 @@ async def lifespan(app: FastAPI):
             "presence_sweeper (60s)",
             "retention_purge (24h)",
             "stripe_reconcile (24h)",
+            "t4a_annual_job (yearly Feb 28)",
         ]
     )
 

--- a/backend/tests/test_t4a_annual_job.py
+++ b/backend/tests/test_t4a_annual_job.py
@@ -1,0 +1,304 @@
+"""Tests for utils/t4a_annual_job.py — P4-7 CRA T4A annual issuance loop.
+
+Covers:
+- Eligible driver selection (earnings >= $500 threshold)
+- Ineligible drivers are excluded (earnings < $500)
+- Push notification sent per eligible driver
+- Audit log written once per batch
+- Redis leader lock prevents duplicate runs
+- Loop skips when not last day of February
+- Loop skips when hour < 08:00 UTC
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_driver(driver_id: str, user_id: str) -> dict:
+    return {"id": driver_id, "user_id": user_id}
+
+
+def _make_ride(driver_id: str, earnings: str) -> dict:
+    return {
+        "driver_id": driver_id,
+        "status": "completed",
+        "driver_earnings": earnings,
+        "ride_completed_at": "2025-06-15T10:00:00+00:00",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _driver_annual_earnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_driver_annual_earnings_sums_correctly():
+    rides = [_make_ride("d1", "200.00"), _make_ride("d1", "350.50")]
+    with patch("utils.t4a_annual_job.db_supabase") as mock_db:
+        mock_db.get_rows = AsyncMock(return_value=rides)
+        from utils.t4a_annual_job import _driver_annual_earnings
+
+        total = await _driver_annual_earnings("d1", 2025)
+
+    assert total == Decimal("550.50")
+
+
+@pytest.mark.asyncio
+async def test_driver_annual_earnings_empty_rides():
+    with patch("utils.t4a_annual_job.db_supabase") as mock_db:
+        mock_db.get_rows = AsyncMock(return_value=[])
+        from utils.t4a_annual_job import _driver_annual_earnings
+
+        total = await _driver_annual_earnings("d1", 2025)
+
+    assert total == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_driver_annual_earnings_handles_none_earnings():
+    rides = [{"driver_id": "d1", "status": "completed", "driver_earnings": None}]
+    with patch("utils.t4a_annual_job.db_supabase") as mock_db:
+        mock_db.get_rows = AsyncMock(return_value=rides)
+        from utils.t4a_annual_job import _driver_annual_earnings
+
+        total = await _driver_annual_earnings("d1", 2025)
+
+    assert total == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# _run_issuance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_issuance_notifies_eligible_skips_ineligible():
+    """Driver A ($600) notified; driver B ($300) skipped; audit log written."""
+    drivers = [
+        _make_driver("dA", "uA"),
+        _make_driver("dB", "uB"),
+    ]
+
+    async def fake_earnings(driver_id: str, year: int) -> Decimal:
+        return Decimal("600.00") if driver_id == "dA" else Decimal("300.00")
+
+    push_mock = AsyncMock()
+    audit_mock = AsyncMock()
+
+    with (
+        patch("utils.t4a_annual_job.db_supabase") as mock_db,
+        patch("utils.t4a_annual_job._driver_annual_earnings", side_effect=fake_earnings),
+        patch("utils.t4a_annual_job.send_push_notification", push_mock),
+        patch("utils.t4a_annual_job.log_admin_action", audit_mock),
+    ):
+        mock_db.get_rows = AsyncMock(return_value=drivers)
+
+        from utils.t4a_annual_job import _run_issuance
+
+        await _run_issuance(2025)
+
+    # Only driver A gets a push
+    assert push_mock.call_count == 1
+    push_args = push_mock.call_args
+    assert push_args[0][0] == "uA"
+    assert "2025" in push_args[1]["body"] or "2025" in str(push_args)
+
+    # Audit log written once
+    audit_mock.assert_called_once()
+    audit_kwargs = audit_mock.call_args[1]
+    assert audit_kwargs["action"] == "t4a_annual_issuance"
+    assert audit_kwargs["details"]["eligible_count"] == 1
+    assert audit_kwargs["details"]["notified_count"] == 1
+    assert audit_kwargs["details"]["total_drivers"] == 2
+
+
+@pytest.mark.asyncio
+async def test_run_issuance_no_eligible_drivers():
+    """No drivers above threshold — no pushes, audit still written."""
+    drivers = [_make_driver("dA", "uA")]
+
+    push_mock = AsyncMock()
+    audit_mock = AsyncMock()
+
+    with (
+        patch("utils.t4a_annual_job.db_supabase") as mock_db,
+        patch("utils.t4a_annual_job._driver_annual_earnings", AsyncMock(return_value=Decimal("100.00"))),
+        patch("utils.t4a_annual_job.send_push_notification", push_mock),
+        patch("utils.t4a_annual_job.log_admin_action", audit_mock),
+    ):
+        mock_db.get_rows = AsyncMock(return_value=drivers)
+
+        from utils.t4a_annual_job import _run_issuance
+
+        await _run_issuance(2025)
+
+    push_mock.assert_not_called()
+    audit_mock.assert_called_once()
+    assert audit_mock.call_args[1]["details"]["eligible_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_issuance_skips_driver_with_no_user_id():
+    """Drivers missing user_id are skipped silently."""
+    drivers = [{"id": "dA", "user_id": None}]
+
+    push_mock = AsyncMock()
+
+    with (
+        patch("utils.t4a_annual_job.db_supabase") as mock_db,
+        patch("utils.t4a_annual_job._driver_annual_earnings", AsyncMock(return_value=Decimal("999.00"))),
+        patch("utils.t4a_annual_job.send_push_notification", push_mock),
+        patch("utils.t4a_annual_job.log_admin_action", AsyncMock()),
+    ):
+        mock_db.get_rows = AsyncMock(return_value=drivers)
+
+        from utils.t4a_annual_job import _run_issuance
+
+        await _run_issuance(2025)
+
+    push_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_issuance_continues_after_push_failure():
+    """Push failure for one driver doesn't abort the rest."""
+    drivers = [_make_driver("dA", "uA"), _make_driver("dB", "uB")]
+
+    call_count = 0
+
+    async def flaky_push(user_id, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if user_id == "uA":
+            raise RuntimeError("FCM down")
+
+    with (
+        patch("utils.t4a_annual_job.db_supabase") as mock_db,
+        patch("utils.t4a_annual_job._driver_annual_earnings", AsyncMock(return_value=Decimal("600.00"))),
+        patch("utils.t4a_annual_job.send_push_notification", side_effect=flaky_push),
+        patch("utils.t4a_annual_job.log_admin_action", AsyncMock()),
+    ):
+        mock_db.get_rows = AsyncMock(return_value=drivers)
+
+        from utils.t4a_annual_job import _run_issuance
+
+        await _run_issuance(2025)  # must not raise
+
+    assert call_count == 2  # attempted both
+
+
+# ---------------------------------------------------------------------------
+# _maybe_run_tick — date/time guards and Redis lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_tick_skips_when_not_last_day_of_february():
+    """Does nothing on a day that is not last-day-of-February."""
+    from datetime import datetime, timezone
+
+    not_feb_28 = datetime(2025, 3, 1, 10, 0, tzinfo=timezone.utc)
+
+    with (
+        patch("utils.t4a_annual_job.datetime") as mock_dt,
+        patch("utils.t4a_annual_job._run_issuance", AsyncMock()) as mock_issue,
+    ):
+        mock_dt.now.return_value = not_feb_28
+
+        from utils.t4a_annual_job import _maybe_run_tick
+
+        await _maybe_run_tick()
+
+    mock_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_tick_skips_before_run_hour():
+    """Does nothing when it is last-day-of-Feb but hour < 08:00 UTC."""
+    from datetime import datetime, timezone
+
+    early = datetime(2025, 2, 28, 7, 59, tzinfo=timezone.utc)
+
+    with (
+        patch("utils.t4a_annual_job.datetime") as mock_dt,
+        patch("utils.t4a_annual_job._run_issuance", AsyncMock()) as mock_issue,
+    ):
+        mock_dt.now.return_value = early
+
+        from utils.t4a_annual_job import _maybe_run_tick
+
+        await _maybe_run_tick()
+
+    mock_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_tick_redis_lock_prevents_duplicate():
+    """Second call with same lock key is a no-op."""
+    from datetime import datetime, timezone
+
+    feb28 = datetime(2025, 2, 28, 9, 0, tzinfo=timezone.utc)
+
+    with (
+        patch("utils.t4a_annual_job.datetime") as mock_dt,
+        patch("utils.t4a_annual_job.redis_set_nx", AsyncMock(return_value=False)),
+        patch("utils.t4a_annual_job._run_issuance", AsyncMock()) as mock_issue,
+    ):
+        mock_dt.now.return_value = feb28
+
+        from utils.t4a_annual_job import _maybe_run_tick
+
+        await _maybe_run_tick()
+
+    mock_issue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_tick_runs_when_lock_acquired():
+    """Runs issuance exactly once when Redis lock is acquired on Feb 28."""
+    from datetime import datetime, timezone
+
+    feb28 = datetime(2025, 2, 28, 9, 0, tzinfo=timezone.utc)
+
+    with (
+        patch("utils.t4a_annual_job.datetime") as mock_dt,
+        patch("utils.t4a_annual_job.redis_set_nx", AsyncMock(return_value=True)),
+        patch("utils.t4a_annual_job._run_issuance", AsyncMock()) as mock_issue,
+    ):
+        mock_dt.now.return_value = feb28
+
+        from utils.t4a_annual_job import _maybe_run_tick
+
+        await _maybe_run_tick()
+
+    mock_issue.assert_called_once_with(2024)  # prior year
+
+
+@pytest.mark.asyncio
+async def test_maybe_run_tick_leap_year_feb29():
+    """In a leap year the job fires on Feb 29 (last day of Feb)."""
+    from datetime import datetime, timezone
+
+    feb29_leap = datetime(2028, 2, 29, 9, 0, tzinfo=timezone.utc)
+
+    with (
+        patch("utils.t4a_annual_job.datetime") as mock_dt,
+        patch("utils.t4a_annual_job.redis_set_nx", AsyncMock(return_value=True)),
+        patch("utils.t4a_annual_job._run_issuance", AsyncMock()) as mock_issue,
+    ):
+        mock_dt.now.return_value = feb29_leap
+
+        from utils.t4a_annual_job import _maybe_run_tick
+
+        await _maybe_run_tick()
+
+    mock_issue.assert_called_once_with(2027)

--- a/backend/utils/t4a_annual_job.py
+++ b/backend/utils/t4a_annual_job.py
@@ -1,0 +1,177 @@
+"""T4A annual issuance loop — CRA compliance (P4-7).
+
+Runs daily at 08:00 UTC.  On the last day of February each year it identifies
+all drivers who earned ≥ $500 in the prior calendar year, sends each a push
+notification that their T4A slip is ready for download, and logs the batch to
+``audit_logs``.
+
+Replay-safety
+-------------
+A Redis key ``spinr:t4a:issued:{prior_year}`` is claimed via SET NX EX before
+the batch runs.  Only the first replica to acquire the key processes the batch;
+others no-op.  TTL is 400 days — safely beyond one calendar year so the key
+cannot be claimed again in the same year but doesn't accumulate forever.
+
+The in-process ``redis_client`` fallback (when ``REDIS_URL`` is unset) means
+this also behaves correctly in single-replica dev/test mode.
+
+CRA rule
+--------
+T4A (Box 048 – Fees for Services) is required for any person paid ≥ $500 from
+a single payer in a calendar year.  The on-demand endpoint
+``GET /api/v1/drivers/t4a/{year}/pdf`` already generates the PDF; this job
+notifies drivers and records issuance so the audit trail is complete.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import calendar
+import logging
+from datetime import datetime, timezone
+from decimal import Decimal
+
+logger = logging.getLogger(__name__)
+
+# Poll every 60 s so the loop stays responsive to restarts; actual work
+# only happens once per year.
+_LOOP_POLL_SECONDS = 60
+# 400 days > 1 year — key expires well before the next issuance cycle.
+_LOCK_TTL_SECONDS = 400 * 24 * 60 * 60
+# CRA reporting threshold (CAD).
+_T4A_THRESHOLD = Decimal("500.00")
+# Run after 08:00 UTC so nightly retention jobs and reconciliation finish first.
+_RUN_AFTER_HOUR_UTC = 8
+
+try:
+    from ..utils.redis_client import redis_set_nx  # type: ignore
+except ImportError:
+    from utils.redis_client import redis_set_nx  # type: ignore
+
+try:
+    from .. import db_supabase  # type: ignore
+except ImportError:
+    import db_supabase  # type: ignore
+
+try:
+    from ..features import send_push_notification  # type: ignore
+except ImportError:
+    from features import send_push_notification  # type: ignore
+
+try:
+    from ..utils.audit_logger import log_admin_action  # type: ignore
+except ImportError:
+    from utils.audit_logger import log_admin_action  # type: ignore
+
+_SYSTEM_ACTOR = {"id": "system", "role": "system"}
+
+
+async def t4a_annual_job_loop() -> None:
+    """Entry point spawned by lifespan.py. Runs indefinitely."""
+    while True:
+        try:
+            await _maybe_run_tick()
+        except Exception:
+            logger.error("t4a_annual_job tick failed", exc_info=True)
+        await asyncio.sleep(_LOOP_POLL_SECONDS)
+
+
+async def _maybe_run_tick() -> None:
+    """Run the T4A batch only on the last day of February, after 08:00 UTC."""
+    now = datetime.now(timezone.utc)
+    if now.hour < _RUN_AFTER_HOUR_UTC:
+        return
+
+    # Last day of February: calendar.monthrange returns (weekday, days_in_month)
+    _, days_in_feb = calendar.monthrange(now.year, 2)
+    if not (now.month == 2 and now.day == days_in_feb):
+        return
+
+    prior_year = now.year - 1
+    lock_key = f"spinr:t4a:issued:{prior_year}"
+    acquired = await redis_set_nx(lock_key, "1", _LOCK_TTL_SECONDS)
+    if not acquired:
+        logger.info(f"t4a_annual_job: already issued for {prior_year}, skipping")
+        return
+
+    await _run_issuance(prior_year)
+
+
+async def _run_issuance(year: int) -> None:
+    """Identify eligible drivers and notify them that their T4A is ready."""
+    logger.info(f"t4a_annual_job: starting issuance batch for tax year {year}")
+
+    try:
+        drivers = await db_supabase.get_rows("drivers", {}, limit=10000)
+    except Exception:
+        logger.error(f"t4a_annual_job: failed to fetch drivers for {year}", exc_info=True)
+        return
+
+    eligible: list[dict] = []
+    for driver in drivers:
+        try:
+            earnings = await _driver_annual_earnings(driver["id"], year)
+        except Exception:
+            logger.error(f"t4a_annual_job: earnings query failed for driver {driver['id']}", exc_info=True)
+            continue
+        if earnings >= _T4A_THRESHOLD:
+            eligible.append({"driver": driver, "earnings": earnings})
+
+    logger.info(f"t4a_annual_job: {len(eligible)} of {len(drivers)} drivers eligible for {year} T4A")
+
+    notified = 0
+    for item in eligible:
+        driver = item["driver"]
+        earnings = item["earnings"]
+        user_id = driver.get("user_id")
+        if not user_id:
+            continue
+        try:
+            await send_push_notification(
+                user_id,
+                title="Your T4A slip is ready",
+                body=f"Your {year} T4A tax slip (${earnings:.2f} in earnings) is ready to download in the Spinr driver app.",
+                data={"type": "t4a_ready", "year": str(year)},
+            )
+            notified += 1
+        except Exception:
+            logger.error(f"t4a_annual_job: push failed for user {user_id}", exc_info=True)
+
+    # Audit log — one row per batch (not per driver to avoid table bloat).
+    try:
+        await log_admin_action(
+            admin=_SYSTEM_ACTOR,
+            action="t4a_annual_issuance",
+            resource="drivers",
+            resource_id=f"batch_{year}",
+            details={
+                "tax_year": year,
+                "total_drivers": len(drivers),
+                "eligible_count": len(eligible),
+                "notified_count": notified,
+            },
+        )
+    except Exception:
+        logger.error("t4a_annual_job: audit log write failed", exc_info=True)
+
+    logger.info(f"t4a_annual_job: issuance complete for {year} — {notified}/{len(eligible)} notified")
+
+
+async def _driver_annual_earnings(driver_id: str, year: int) -> Decimal:
+    """Sum completed driver_earnings for a driver in a calendar year."""
+    rides = await db_supabase.get_rows(
+        "rides",
+        {
+            "driver_id": driver_id,
+            "status": "completed",
+            "ride_completed_at": {
+                "$gte": f"{year}-01-01T00:00:00+00:00",
+                "$lt": f"{year + 1}-01-01T00:00:00+00:00",
+            },
+        },
+        limit=10000,
+    )
+    return sum(
+        (Decimal(str(r.get("driver_earnings") or "0")) for r in rides),
+        Decimal("0"),
+    )


### PR DESCRIPTION
## Summary

Closes the last open item in P4-7: the CRA-required T4A annual issuance job.

The on-demand PDF endpoint (`GET /api/v1/drivers/t4a/{year}/pdf`) already exists. This PR adds the scheduled background loop that notifies eligible drivers once per year.

## What's added

**`backend/utils/t4a_annual_job.py`** — daily-polling loop that fires on the last day of February:
1. Queries all drivers and sums `driver_earnings` for the prior calendar year
2. Identifies drivers at or above the CRA $500 threshold (Box 048 – Fees for Services)
3. Sends each eligible driver a push notification that their T4A is ready to download
4. Writes a single batch row to `audit_logs` for the regulatory audit trail

**`backend/core/lifespan.py`** — wires the loop into the startup sequence and watchdog list (stale loop triggers `ALERT_WEBHOOK_URL` alert)

**`backend/tests/test_t4a_annual_job.py`** — 12 unit tests

## Replay safety

Redis `SET NX EX 400d` on `spinr:t4a:issued:{prior_year}` ensures exactly one replica per year runs the batch. Falls back to the in-process dict when `REDIS_URL` is unset.

## Test plan

- [x] `ruff check backend/` → clean
- [x] `pytest tests/test_t4a_annual_job.py -v` → 12/12 passed
- [x] Eligible threshold: driver with $600 earnings → notified; driver with $300 → skipped
- [x] Redis lock: second call with `SET NX` returning False → `_run_issuance` not called
- [x] Leap-year Feb 29 fires correctly (2028 test case)
- [x] Push failure for one driver doesn't abort the batch

https://claude.ai/code/session_018hAFyH5yaeNcuH3dFP2cvr

---
_Generated by [Claude Code](https://claude.ai/code/session_018hAFyH5yaeNcuH3dFP2cvr)_

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
