### PR TITLE
fix(payments): update Stripe EphemeralKey API version pin to SDK default

### DIFF
--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -540,10 +540,16 @@ async def create_payment_sheet(
         amount_cents = int(Decimal(str(body.amount)).quantize(Decimal("0.01")) * 100)
 
         # EphemeralKey lets the PaymentSheet modal manage the customer's
-        # saved cards. Must match the Stripe API version the SDK expects.
+        # saved cards. api_version must match the version configured on the
+        # Stripe webhook endpoint in the dashboard. We pin it to the version
+        # bundled with the installed SDK (stripe.api_version) so it stays in
+        # sync automatically on SDK upgrades.
+        # Current bundled version: 2026-04-22.dahlia (stripe==15.1.0)
+        # ACTION REQUIRED on SDK upgrade: verify the Stripe dashboard webhook
+        # endpoint API version matches stripe.api_version after upgrading.
         ephemeral_key = stripe.EphemeralKey.create(
             {"customer": customer_id},
-            api_version="2023-10-16",
+            api_version=stripe.api_version,
             api_key=stripe_secret,
         )
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The `stripe.EphemeralKey.create` call in `backend/routes/payments.py` had a hardcoded `api_version="2023-10-16"` that was stale relative to the installed SDK (`stripe==15.1.0`, which bundles `2026-04-22.dahlia`).
- Replaced the literal string with `stripe.api_version` so the pin always matches the installed SDK version, eliminating drift on future SDK upgrades.
- Added an inline comment noting that the **Stripe dashboard webhook endpoint API version** must be kept in sync with `stripe.api_version` whenever the SDK is upgraded.

## Dashboard action required before merging to production

In the [Stripe Dashboard → Developers → Webhooks](https://dashboard.stripe.com/webhooks), update the webhook endpoint's API version from `2023-10-16` to `2026-04-22.dahlia` to match `stripe==15.1.0`. Mismatched versions cause webhook event shapes to differ from what the SDK parses.

## Test plan

- [ ] Confirm `stripe.api_version` resolves to `2026-04-22.dahlia` on the deployed backend (`python3 -c "import stripe; print(stripe.api_version)"`)
- [ ] Manually trigger a PaymentSheet flow in staging and verify EphemeralKey is returned without error
- [ ] Confirm Stripe dashboard webhook endpoint version is updated to `2026-04-22.dahlia`
- [ ] Run `cd backend && pytest -x -q -k "payment or stripe"` in a fully-provisioned environment

https://claude.ai/code/session_01Uq5a3iFL8oZ37sE56SUQwH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq5a3iFL8oZ37sE56SUQwH)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
