### PR TITLE
fix(mobile): move reanimated babel plugin to last position (M3)

### DIFF
--- a/driver-app/babel.config.js
+++ b/driver-app/babel.config.js
@@ -3,7 +3,6 @@ module.exports = function (api) {
     return {
         presets: ['babel-preset-expo'],
         plugins: [
-            'react-native-reanimated/plugin',
             [
                 'module-resolver',
                 {
@@ -19,6 +18,8 @@ module.exports = function (api) {
                     extensions: ['.ios.js', '.android.js', '.js', '.ts', '.tsx', '.json'],
                 },
             ],
+            // react-native-reanimated/plugin MUST be last (Babel processes in reverse order)
+            'react-native-reanimated/plugin',
         ],
     };
 };

--- a/rider-app/babel.config.js
+++ b/rider-app/babel.config.js
@@ -3,7 +3,6 @@ module.exports = function (api) {
     return {
         presets: ['babel-preset-expo'],
         plugins: [
-            'react-native-reanimated/plugin',
             [
                 'module-resolver',
                 {
@@ -15,6 +14,8 @@ module.exports = function (api) {
                     extensions: ['.ios.js', '.android.js', '.js', '.ts', '.tsx', '.json'],
                 },
             ],
+            // react-native-reanimated/plugin MUST be last (Babel processes in reverse order)
+            'react-native-reanimated/plugin',
         ],
     };
 };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **M3 (Reanimated plugin order)**: `react-native-reanimated/plugin` was the *first* entry in the `plugins` array in both `rider-app/babel.config.js` and `driver-app/babel.config.js`. The library's documentation requires it to be *last* because Babel processes transforms in reverse order. With it first, animations silently break at runtime with cryptic errors. Fixed in both files; a comment was added to explain the constraint.

- **M5 (react-native-dotenv audit)**: No changes needed. `react-native-dotenv` does not appear as a babel plugin in either app's config. All `process.env.*` references in source files already use the `EXPO_PUBLIC_*` prefix (the native Expo SDK 50+ approach), so the deprecated plugin was never wired up in the first place.

## Files changed

- `rider-app/babel.config.js` — moved `react-native-reanimated/plugin` from position 0 to last
- `driver-app/babel.config.js` — same fix

## Test plan

- [ ] `node -e "require('./rider-app/babel.config.js'); console.log('OK')"` — passes (verified locally)
- [ ] `node -e "require('./driver-app/babel.config.js'); console.log('OK')"` — passes (verified locally)
- [ ] Expo dev build on both apps compiles without Reanimated warnings
- [ ] Animated components (transitions, gestures) behave correctly at runtime

## What was NOT changed

- `package.json` / `yarn.lock` — untouched
- Backend, admin-dashboard, shared — untouched

https://claude.ai/code/session_01Uq5a3iFL8oZ37sE56SUQwH
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq5a3iFL8oZ37sE56SUQwH)_

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
