### PR TITLE
fix(backend): logging safety — PII removal, bare excepts, exc_info

### DIFF
--- a/backend/db_supabase.py
+++ b/backend/db_supabase.py
@@ -453,8 +453,9 @@ async def _read_cached_row(key: str) -> Optional[Dict[str, Any]]:
         _metric_inc("spinr_cache_error_total", {"prefix": prefix, "op": "decode"})
         try:
             await redis_delete(key)
-        except Exception:  # noqa: S110
-            pass
+        except Exception:
+            # Non-fatal: best-effort eviction of corrupt cache entry; miss is acceptable
+            logger.warning("Failed to evict corrupt cache key %s", key, exc_info=True)
         return None
 
 

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -322,8 +322,9 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
     if datetime.now(timezone.utc) > expires_at:
         try:
             await db_supabase.delete_otp_record(otp_record["id"])
-        except Exception:  # noqa: S110
-            pass
+        except Exception:
+            # Non-fatal: OTP expiry cleanup failure does not block the error response
+            logger.warning("Failed to delete expired OTP record %s", otp_record["id"], exc_info=True)
         raise SpinrException(
             message="ERR_OTP_EXPIRED",
             error_code=ErrorCode.AUTH_OTP_EXPIRED,
@@ -334,8 +335,9 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
 
     try:
         await db_supabase.update_one("otp_records", {"id": otp_record["id"]}, {"verified": True})
-    except Exception:  # noqa: S110
-        pass
+    except Exception:
+        # Non-fatal: marking OTP as verified is best-effort; verification already succeeded
+        logger.warning("Failed to mark OTP record %s as verified", otp_record["id"], exc_info=True)
 
     # SEC-008: Clear failure counter + lockout on successful verification
     await _clear_otp_failures(phone)
@@ -827,7 +829,10 @@ async def refresh_access_token(request: Request, response: Response, body: Optio
 @api_router.post("/logout")
 @limiter.limit("3/minute")
 async def logout(
-    request: Request, response: Response, body: Optional[LogoutRequest] = None, current_user: dict = Depends(get_current_user)
+    request: Request,
+    response: Response,
+    body: Optional[LogoutRequest] = None,
+    current_user: dict = Depends(get_current_user),
 ):
     """Revoke the presented refresh token.
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1803,7 +1803,7 @@ async def _build_and_email_data_export(user_id: str, email: str) -> None:
         )
 
         await send_email(to=email, subject=subject, body=body)
-        logger.info("Data export emailed to %s for user %s", email, user_id)
+        logger.info("Data export emailed for user %s", user_id)
         logger.info(
             "dsar_export_completed",
             extra={"user_id": user_id, "domain": "privacy", "metric": "dsar_export_completed"},
@@ -2443,7 +2443,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
     # Post-ride receipt notification stub
     rider = await db_supabase.get_user_by_id(ride.get("rider_id"))
     if rider and rider.get("email"):
-        logger.info(f"Sending email receipt for ride {ride_id} to {rider['email']}")
+        logger.info(f"Sending email receipt for ride {ride_id} to user {rider['id']}")
 
     # Fire-and-forget: render the route PNG from phase_polylines and
     # upload to Cloudinary so the admin drawer + email receipt can

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -154,7 +154,7 @@ async def create_payment_intent(
 
         return {"client_secret": intent.client_secret, "payment_intent_id": intent.id, "mock": False}
     except Exception as e:
-        logger.error(f"Stripe error: {e}")
+        logger.error(f"Stripe error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
 
@@ -184,7 +184,7 @@ async def confirm_payment(request: Dict[str, Any], current_user: dict = Depends(
 
             return {"status": intent.status, "mock": False}
         except Exception as e:
-            logger.error(f"Stripe error: {e}")
+            logger.error(f"Stripe error: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
     return {"status": "unknown", "mock": True}
@@ -218,7 +218,7 @@ async def create_setup_intent(current_user: dict = Depends(get_current_user)):
             "mock": False,
         }
     except Exception as e:
-        logger.error(f"Stripe error: {e}")
+        logger.error(f"Stripe error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
 
@@ -258,7 +258,7 @@ async def get_payment_methods(current_user: dict = Depends(get_current_user)):
             "mock": False,
         }
     except Exception as e:
-        logger.error(f"Stripe error: {e}")
+        logger.error(f"Stripe error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
 
@@ -292,7 +292,7 @@ async def get_cards(current_user: dict = Depends(get_current_user)):
             for m in methods.data
         ]
     except Exception as e:
-        logger.error(f"Get cards error: {e}")
+        logger.error(f"Get cards error: {e}", exc_info=True)
         return []
 
 
@@ -451,7 +451,7 @@ async def add_card(request: Request, current_user: dict = Depends(get_current_us
             action_hint="Add a different card",
         ) from e
     except Exception as e:
-        logger.error(f"Add card error: {e}")
+        logger.error(f"Add card error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
 

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1310,8 +1310,9 @@ async def get_ride(request: Request, ride_id: str, current_user: dict = Depends(
             settings = await get_app_settings()
             free_cancel_window = int(settings.get("free_cancel_window_seconds", 120))
             cancellation_fee_amount = float(settings.get("cancellation_fee", 3.0))
-        except Exception:  # noqa: S110
-            pass
+        except Exception:
+            # Non-fatal: fall back to hardcoded defaults if settings fetch fails
+            logger.error("Failed to fetch app settings for cancellation config", exc_info=True)
 
     driver_accepted_at = ride.get("driver_accepted_at")
     if driver_accepted_at:
@@ -1344,8 +1345,9 @@ async def get_ride(request: Request, ride_id: str, current_user: dict = Depends(
             try:
                 settings = await get_app_settings()
                 offer_timeout_seconds = int(settings.get("ride_offer_timeout_seconds", 15))
-            except Exception:  # noqa: S110
-                pass
+            except Exception:
+                # Non-fatal: fall back to hardcoded default if settings fetch fails
+                logger.error("Failed to fetch app settings for offer timeout config", exc_info=True)
         ride["offer_timeout_seconds"] = offer_timeout_seconds
         if driver_notified_at:
             try:

--- a/backend/sms_service.py
+++ b/backend/sms_service.py
@@ -32,7 +32,7 @@ async def send_sms(
         logger.info(f"SMS sent to {to_phone} via Twilio (SID: {sms.sid})")
         return {"success": True, "provider": "twilio", "sid": sms.sid}
     except Exception as e:
-        logger.error(f"Failed to send SMS to {to_phone}: {e}")
+        logger.error(f"Failed to send SMS to ...{to_phone[-4:]}: {e}")
         return {"success": False, "provider": "twilio", "error": str(e)}
 
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **S-2 PII removal**: phone numbers in SMS failure logs now masked to last-4; email addresses in data export and receipt dispatch logs replaced with `user_id`
- **C-4 bare excepts**: all 5 `except Exception: pass` blocks replaced — non-fatal OTP cleanup and cache eviction use `logger.warning(..., exc_info=True)` and continue; settings-fetch failures in ride flow use `logger.error(..., exc_info=True)` and fall back to hardcoded defaults
- **C-5 exc_info**: all 6 `logger.error` calls in `payments.py` (lines 157, 187, 221, 261, 295, 454) now include `exc_info=True` so stack traces appear in Sentry/logs

## Files changed

| File | Change |
|------|--------|
| `backend/sms_service.py` | `to_phone` → `...{to_phone[-4:]}` in error log |
| `backend/routes/drivers.py` | Remove email from data-export log; use `rider['id']` in receipt log |
| `backend/routes/rides.py` | `except Exception: pass` → `logger.error(..., exc_info=True)` (×2, settings fetch) |
| `backend/routes/auth.py` | `except Exception: pass` → `logger.warning(..., exc_info=True)` (×2, OTP cleanup) |
| `backend/db_supabase.py` | `except Exception: pass` → `logger.warning(..., exc_info=True)` (cache eviction) |
| `backend/routes/payments.py` | Add `exc_info=True` to 6 `logger.error` calls |

## Test plan

- [ ] Trigger an SMS send failure in dev and confirm log shows `...1234` not full phone
- [ ] Trigger data export flow and confirm log shows only `user_id`
- [ ] Confirm `ruff check` passes on all changed files (verified in CI)
- [ ] Confirm no new lint errors introduced

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
