### PR TITLE
fix(frontend): auth security — remove sessionStorage token, handle cookie failure

### DIFF
--- a/admin-dashboard/src/app/login/page.tsx
+++ b/admin-dashboard/src/app/login/page.tsx
@@ -50,11 +50,16 @@ function LoginForm() {
         // Await the HttpOnly admin_token cookie being written before navigating.
         // router.push triggers middleware immediately; if the cookie isn't committed
         // yet the middleware redirects back to /login, causing an instant logout loop.
-        await fetch('/api/auth/set-cookie', {
+        // If the cookie write fails, surface an error instead of redirecting into a
+        // broken session — auth succeeded but the session cannot be persisted.
+        const cookieRes = await fetch('/api/auth/set-cookie', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ token: data.token }),
-        }).catch(() => {});
+        });
+        if (!cookieRes.ok) {
+            throw new Error('Login succeeded but session could not be saved. Please try again.');
+        }
         const next = sanitizeNextPath(searchParams.get("next"));
         router.push(next);
     };

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -246,89 +246,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (__DEV__) console.log("Auth initializing...");
     set({ isLoading: true });
 
-    // Strategy:
-    //   1. ALWAYS check for a stored backend JWT first.
-    //   2. Only fall through to Firebase if there's no stored token.
-    //   This prevents Firebase onAuthStateChanged (which fires with null
-    //   when no Firebase phone-auth session exists) from deleting a
-    //   perfectly valid backend JWT.
+    // Strategy: access tokens are memory-only (never persisted).
+    // On cold start, go straight to the refresh token path.
+    // The refresh token flow re-hydrates the session without forcing
+    // the user back to the OTP screen.
 
-    const storedToken = await storage.getItem('auth_token');
-    if (__DEV__) console.log('[Auth] Stored token:', storedToken ? 'EXISTS' : 'NULL');
-
-    if (storedToken) {
-      // ── Stored backend JWT path ──
-      try {
-        const response = await api.get('/auth/me', {
-          headers: { Authorization: `Bearer ${storedToken}` }
-        });
-        const userData = response.data as User;
-
-        if (__DEV__) console.log('[Auth] /auth/me →', {
-          phone: userData?.phone,
-          first_name: userData?.first_name,
-          last_name: userData?.last_name,
-          email: userData?.email,
-          profile_complete: userData?.profile_complete,
-          is_driver: userData?.is_driver,
-          driver_onboarding_status: userData?.driver_onboarding_status,
-          driver_onboarding_next_screen: userData?.driver_onboarding_next_screen,
-        });
-
-        await appCache.set(CACHE_KEYS.USER_PROFILE, userData, CACHE_CONFIG.USER_PROFILE_TTL);
-
-        let driverData: Driver | null = null;
-        // See refreshProfile for why we also gate on driver_onboarding_status:
-        // it's the reliable "driver row exists" signal when is_driver/role
-        // flags are stale on legacy user rows.
-        const looksLikeDriver =
-          !!userData.is_driver ||
-          userData.role === 'driver' ||
-          !!userData.driver_onboarding_status;
-        if (looksLikeDriver) {
-          try {
-            const driverRes = await api.get('/drivers/me', {
-              headers: { Authorization: `Bearer ${storedToken}` }
-            });
-            driverData = driverRes.data as Driver;
-            await appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverData, CACHE_CONFIG.USER_PROFILE_TTL);
-          } catch (e: unknown) {
-            if (isApiError(e) && e.response?.status === 404) {
-              // No driver row — auto-create one from the user's profile.
-              // The backend fills all required fields from the authenticated user.
-              if (__DEV__) console.log('[Auth] No driver row on init — auto-registering');
-              try {
-                const regRes = await api.post('/drivers/register', {}, {
-                  headers: { Authorization: `Bearer ${storedToken}` }
-                });
-                driverData = regRes.data as Driver;
-                await appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverData, CACHE_CONFIG.USER_PROFILE_TTL);
-              } catch (regErr) {
-                if (__DEV__) console.log('[Auth] Auto-register failed on init:', regErr);
-              }
-            } else {
-              if (__DEV__) console.log('Failed to fetch driver data on init');
-            }
-          }
-        }
-
-        setInMemoryToken(storedToken);
-        set({
-          user: userData,
-          driver: driverData,
-          token: storedToken,
-          isInitialized: true,
-          isLoading: false
-        });
-        return; // Done — valid session restored
-      } catch (error: unknown) {
-        if (__DEV__) console.log('[Auth] Stored token invalid or expired:', isApiError(error) ? error.message : String(error));
-        await storage.deleteItem('auth_token');
-        // Fall through to no-session state below
-      }
-    }
-
-    // ── No valid stored access token — try silent refresh ──
+    // ── No stored access token — try silent refresh ──
     // setTokens() keeps the access token in memory only but persists the
     // refresh token. On cold start (memory wiped), this is the normal path
     // to restore a session without forcing the user back to the OTP screen.
@@ -435,7 +358,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
                 }
               }
               set({ user: userData, driver: driverData, token, isInitialized: true, isLoading: false });
-              await storage.setItem('auth_token', token);
             } catch (err) {
               if (__DEV__) console.log('[Auth] Firebase user but backend fetch failed');
               set({ isLoading: false, isInitialized: true, error: 'Failed to sync user' });


### PR DESCRIPTION
## Summary

- **S-5** (`shared/store/authStore.ts`): Access tokens must never be persisted. Removes the `storage.setItem('auth_token', token)` call from the Firebase `onAuthStateChanged` path and eliminates the entire `storedToken` read-back block from `initialize()`. Cold-start session hydration now goes exclusively through the refresh token path (which was already the documented and correct flow).
- **S-6** (`admin-dashboard/src/app/login/page.tsx`): The cookie-write call (`/api/auth/set-cookie`) was silently swallowed with `.catch(()=>{})` and the redirect always proceeded. Now checks `cookieRes.ok`; on failure throws an error that the existing `catch` blocks surface as a user-visible message: "Login succeeded but session could not be saved. Please try again."

## Test plan

- [ ] Mobile (web): log in → verify `auth_token` is NOT written to `sessionStorage`; verify `refresh_token` IS written; verify app works after tab close + reopen (refresh path re-hydrates)
- [ ] Mobile (cold start): confirm session restores via refresh token without OTP re-prompt
- [ ] Admin login: simulate `/api/auth/set-cookie` returning a non-2xx (e.g. mock a 500) — expect error banner, no redirect
- [ ] Admin login happy path: cookie write succeeds → redirect to `/dashboard` unchanged
- [ ] Admin MFA flow: same cookie-write error path via `handleMfaSubmit`

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew)_

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
