### PR TITLE
audit: security fixes, Decimal precision, logging hardening, test coverage, UI error states

### DIFF
--- a/admin-dashboard/src/app/dashboard/monitoring/ride-panel.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/ride-panel.tsx
@@ -208,6 +208,70 @@ export function RidePanel({ ride, onDriverClick, onCancelRide, onCompleteRide }:
                                 </Button>
                             )}
                         </div>
+
+                        <div className="my-1 mx-2 h-px bg-border/60" />
+
+                        {/* Driver */}
+                        {ride.driver_id ? (
+                            <div
+                                role="button"
+                                tabIndex={0}
+                                className="group flex cursor-pointer items-center gap-3 rounded-lg p-2.5 transition-all hover:bg-muted/60 active:scale-[0.99]"
+                                onClick={() => ride.driver_id && onDriverClick(ride.driver_id)}
+                                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); ride.driver_id && onDriverClick(ride.driver_id); } }}
+                            >
+                                <div className="relative shrink-0">
+                                    <Avatar className="h-11 w-11 border-2 border-background shadow-sm">
+                                        <AvatarFallback className="bg-purple-100 text-sm font-bold text-purple-700">
+                                            {(ride.driver_name ?? "DR").slice(0, 2).toUpperCase()}
+                                        </AvatarFallback>
+                                    </Avatar>
+                                    <div className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-purple-500 ring-2 ring-card">
+                                        <Car className="h-2.5 w-2.5 text-white" />
+                                    </div>
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                                        Driver
+                                    </p>
+                                    <p className="truncate text-sm font-semibold text-foreground">
+                                        {ride.driver_name ?? "Driver assigned"}
+                                    </p>
+                                    {ride.driver_phone && (
+                                        <p className="truncate text-[11px] font-mono text-muted-foreground">
+                                            {ride.driver_phone}
+                                        </p>
+                                    )}
+                                </div>
+                                <div className="flex items-center gap-1">
+                                    {ride.driver_phone && (
+                                        <Button
+                                            size="icon"
+                                            variant="outline"
+                                            className="h-9 w-9 rounded-full shadow-sm transition-colors hover:border-purple-200 hover:bg-purple-50 hover:text-purple-600"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                window.open(`tel:${ride.driver_phone}`);
+                                            }}
+                                            title="Call driver"
+                                        >
+                                            <Phone className="h-3.5 w-3.5" />
+                                        </Button>
+                                    )}
+                                    <ChevronRight className="h-5 w-5 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-3 rounded-lg border border-dashed border-amber-300 bg-amber-50/50 p-3 text-amber-700">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                <div className="text-xs">
+                                    <p className="font-semibold">Searching for a driver…</p>
+                                    <p className="text-[11px] text-amber-600/80">
+                                        No driver matched yet. Dispatch is still scanning.
+                                    </p>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 )}
 

--- a/admin-dashboard/src/app/dashboard/page.tsx
+++ b/admin-dashboard/src/app/dashboard/page.tsx
@@ -28,10 +28,11 @@ export default function DashboardPage() {
     const [plans, setPlans] = useState<any[]>([]);
     const [subs, setSubs] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
+    const [statsError, setStatsError] = useState(false);
 
     useEffect(() => {
         Promise.all([
-            getStats().catch(() => null),
+            getStats().catch(() => { setStatsError(true); return null; }),
             getSubscriptionPlans().catch(() => []),
             getDriverSubscriptions().catch(() => []),
         ]).then(([s, p, sub]) => {
@@ -79,6 +80,13 @@ export default function DashboardPage() {
                     {new Date().toLocaleDateString('en-CA', { weekday: 'long', month: 'short', day: 'numeric' })}
                 </div>
             </div>
+
+            {/* Stats load error banner */}
+            {statsError && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+                    Dashboard stats are temporarily unavailable. Check backend health and reload the page.
+                </div>
+            )}
 
             {/* Top Stats Row */}
             {stats && (

--- a/admin-dashboard/src/app/dashboard/rides/page.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/page.tsx
@@ -19,6 +19,7 @@ export default function RidesPage() {
     const [page, setPage] = useState(0);
     const [areas, setAreas] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
+    const [loadError, setLoadError] = useState(false);
     const [search, setSearch] = useState("");
     const [statusFilter, setStatusFilter] = useState("all");
     const [areaFilter, setAreaFilter] = useState("all");
@@ -34,13 +35,17 @@ export default function RidesPage() {
     // work from a single loaded batch).
     const loadRides = useCallback(async (p: number, tab: string) => {
         setLoading(true);
+        setLoadError(false);
         try {
             const opts = tab === "scheduled" ? { isScheduled: true } : undefined;
             const res = await getRides(PAGE_SIZE, p * PAGE_SIZE, opts);
             setRides(res.rides);
             setTotalCount(res.total_count);
-        } catch {}
-        finally { setLoading(false); }
+        } catch {
+            setLoadError(true);
+        } finally {
+            setLoading(false);
+        }
     }, []);
 
     useEffect(() => {
@@ -124,6 +129,19 @@ export default function RidesPage() {
 
             {/* Stats Overview */}
             <RideStatsCards />
+
+            {/* Load error banner */}
+            {loadError && !loading && (
+                <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 flex items-center justify-between">
+                    <span>Failed to load rides — check backend health.</span>
+                    <button
+                        onClick={() => loadRides(page, statusFilter)}
+                        className="ml-4 text-red-700 underline hover:no-underline text-sm"
+                    >
+                        Retry
+                    </button>
+                </div>
+            )}
 
             {/* Rides Table */}
             <RideList

--- a/backend/requirements-locked.txt
+++ b/backend/requirements-locked.txt
@@ -2369,6 +2369,7 @@ pytest-mock==3.15.1 \
     --hash=sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f
     # via -r requirements.in
 pytest-timeout==2.4.0 \
+    --hash=sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a \
     --hash=sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2
     # via -r requirements.in
 python-dateutil==2.9.0.post0 \

--- a/backend/requirements-locked.txt
+++ b/backend/requirements-locked.txt
@@ -2351,6 +2351,7 @@ pytest==9.0.3 \
     #   pytest-cov
     #   pytest-env
     #   pytest-mock
+    #   pytest-timeout
 pytest-asyncio==1.3.0 \
     --hash=sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5 \
     --hash=sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5
@@ -2366,6 +2367,9 @@ pytest-env==1.6.0 \
 pytest-mock==3.15.1 \
     --hash=sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d \
     --hash=sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f
+    # via -r requirements.in
+pytest-timeout==2.4.0 \
+    --hash=sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2
     # via -r requirements.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -98,6 +98,9 @@ pytest-env>=1.1.0
 # lockfile install, which bypassed hash verification. Declaring it here ensures
 # it lands in requirements-locked.txt with a proper SHA-256 hash.
 pytest-mock>=3.14.0
+# pytest-timeout is used by CI's `pytest --timeout=30` flag (ci.yml backend-test job).
+# Without it in the lockfile, CI fails with "unrecognized arguments: --timeout=30".
+pytest-timeout>=0.4.0
 
 # Development tools — ruff supersedes both black and flake8; those are removed.
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,446 +1,131 @@
-aiohappyeyeballs==2.6.1
-    # via aiohttp
-aiohttp==3.13.5
-    # via
-    #   -r requirements.in
-    #   aiohttp-retry
-    #   twilio
-aiohttp-retry==2.9.1
-    # via twilio
-aiosignal==1.4.0
-    # via aiohttp
-annotated-doc==0.0.4
-    # via
-    #   fastapi
-    #   typer
-annotated-types==0.7.0
-    # via pydantic
-anyio==4.13.0
-    # via
-    #   -r requirements.in
-    #   httpx
-    #   starlette
-    #   watchfiles
-attrs==26.1.0
-    # via aiohttp
-bcrypt==5.0.0
-    # via -r requirements.in
-boto3==1.42.96
-    # via -r requirements.in
-botocore==1.42.96
-    # via
-    #   boto3
-    #   s3transfer
-cachecontrol==0.14.4
-    # via firebase-admin
-cachetools==6.2.6
-    # via pyiceberg
-certifi==2026.4.22
-    # via
-    #   -r requirements.in
-    #   cloudinary
-    #   httpcore
-    #   httpx
-    #   requests
-    #   sentry-sdk
-cffi==2.0.0
-    # via cryptography
-charset-normalizer==3.4.7
-    # via
-    #   -r requirements.in
-    #   requests
-click==8.3.3
-    # via
-    #   -r requirements.in
-    #   pyiceberg
-    #   typer
-    #   uvicorn
-cloudinary==1.44.2
-    # via -r requirements.in
-coverage[toml]==7.13.5
-    # via pytest-cov
-cryptography==47.0.0
-    # via
-    #   google-auth
-    #   pyjwt
-defusedxml==0.7.1
-    # via fpdf2
-deprecated==1.3.1
-    # via limits
-deprecation==2.1.0
-    # via
-    #   postgrest
-    #   storage3
-dnspython==2.8.0
-    # via email-validator
-email-validator==2.3.0
-    # via -r requirements.in
-fastapi==0.136.1
-    # via -r requirements.in
-firebase-admin==7.4.0
-    # via -r requirements.in
-fonttools==4.62.1
-    # via fpdf2
-fpdf2==2.8.7
-    # via -r requirements.in
-frozenlist==1.8.0
-    # via
-    #   aiohttp
-    #   aiosignal
-fsspec==2026.3.0
-    # via pyiceberg
-google-ai-generativelanguage==0.6.15
-    # via google-generativeai
-google-api-core[grpc]==2.30.3
-    # via
-    #   firebase-admin
-    #   google-ai-generativelanguage
-    #   google-api-python-client
-    #   google-cloud-core
-    #   google-cloud-firestore
-    #   google-cloud-storage
-    #   google-generativeai
-google-api-python-client==2.194.0
-    # via
-    #   -r requirements.in
-    #   google-generativeai
-google-auth==2.49.2
-    # via
-    #   -r requirements.in
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-api-python-client
-    #   google-auth-httplib2
-    #   google-cloud-core
-    #   google-cloud-firestore
-    #   google-cloud-storage
-    #   google-generativeai
-google-auth-httplib2==0.3.1
-    # via google-api-python-client
-google-cloud-core==2.5.1
-    # via
-    #   google-cloud-firestore
-    #   google-cloud-storage
-google-cloud-firestore==2.27.0
-    # via
-    #   -r requirements.in
-    #   firebase-admin
-google-cloud-storage==3.10.1
-    # via
-    #   -r requirements.in
-    #   firebase-admin
-google-crc32c==1.8.0
-    # via
-    #   google-cloud-storage
-    #   google-resumable-media
-google-generativeai==0.8.6
-    # via -r requirements.in
-google-resumable-media==2.8.2
-    # via google-cloud-storage
-googleapis-common-protos==1.74.0
-    # via
-    #   google-api-core
-    #   grpcio-status
-grpcio==1.80.0
-    # via
-    #   google-api-core
-    #   google-cloud-firestore
-    #   grpcio-status
-grpcio-status==1.71.2
-    # via google-api-core
-h11==0.16.0
-    # via
-    #   httpcore
-    #   uvicorn
-h2==4.3.0
-    # via httpx
-hpack==4.1.0
-    # via h2
-httpcore==1.0.9
-    # via httpx
-httplib2==0.31.2
-    # via
-    #   google-api-python-client
-    #   google-auth-httplib2
-httptools==0.7.1
-    # via uvicorn
-httpx[http2]==0.28.1
-    # via
-    #   -r requirements.in
-    #   firebase-admin
-    #   postgrest
-    #   storage3
-    #   supabase
-    #   supabase-auth
-    #   supabase-functions
-hyperframe==6.1.0
-    # via h2
-idna==3.13
-    # via
-    #   -r requirements.in
-    #   anyio
-    #   email-validator
-    #   httpx
-    #   requests
-    #   yarl
-iniconfig==2.3.0
-    # via pytest
-jinja2==3.1.6
-    # via -r requirements.in
-jmespath==1.1.0
-    # via
-    #   boto3
-    #   botocore
-limits==5.8.0
-    # via slowapi
-loguru==0.7.3
-    # via -r requirements.in
-markdown-it-py==4.0.0
-    # via rich
-markupsafe==3.0.3
-    # via jinja2
-mdurl==0.1.2
-    # via markdown-it-py
-mmh3==5.2.1
-    # via pyiceberg
-msgpack==1.1.2
-    # via cachecontrol
-multidict==6.7.1
-    # via
-    #   aiohttp
-    #   yarl
-numpy==2.4.4
-    # via
-    #   -r requirements.in
-    #   pandas
-packaging==26.2
-    # via
-    #   deprecation
-    #   limits
-    #   pytest
-pandas==3.0.2
-    # via -r requirements.in
-pillow==12.2.0
-    # via
-    #   -r requirements.in
-    #   fpdf2
-    #   staticmap
-pluggy==1.6.0
-    # via
-    #   pytest
-    #   pytest-cov
-postgrest==2.29.0
-    # via
-    #   -r requirements.in
-    #   supabase
-propcache==0.4.1
-    # via
-    #   aiohttp
-    #   yarl
-proto-plus==1.27.2
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-cloud-firestore
-protobuf==5.29.6
-    # via
-    #   google-ai-generativelanguage
-    #   google-api-core
-    #   google-cloud-firestore
-    #   google-generativeai
-    #   googleapis-common-protos
-    #   grpcio-status
-    #   proto-plus
-psycopg2-binary==2.9.12
-    # via -r requirements.in
-pyasn1==0.6.3
-    # via pyasn1-modules
-pyasn1-modules==0.4.2
-    # via google-auth
-pycparser==3.0
-    # via cffi
-pydantic==2.13.3
-    # via
-    #   -r requirements.in
-    #   fastapi
-    #   google-generativeai
-    #   postgrest
-    #   pydantic-settings
-    #   pyiceberg
-    #   realtime
-    #   storage3
-    #   supabase-auth
-pydantic-core==2.46.3
-    # via pydantic
-pydantic-settings==2.14.0
-    # via -r requirements.in
-pygments==2.20.0
-    # via
-    #   pytest
-    #   rich
-pyiceberg==0.11.1
-    # via storage3
-pyjwt[crypto]==2.12.1
-    # via
-    #   -r requirements.in
-    #   firebase-admin
-    #   supabase-auth
-    #   twilio
-pyotp==2.9.0
-    # via -r requirements.in
-pyparsing==3.3.2
-    # via
-    #   httplib2
-    #   pyiceberg
-pyroaring==1.1.0
-    # via pyiceberg
-pytest==9.0.3
-    # via
-    #   -r requirements.in
-    #   pytest-asyncio
-    #   pytest-cov
-    #   pytest-env
-    #   pytest-mock
-    #   pytest-timeout
-pytest-asyncio==1.3.0
-    # via -r requirements.in
-pytest-cov==7.1.0
-    # via -r requirements.in
-pytest-env==1.6.0
-    # via -r requirements.in
-pytest-mock==3.15.1
-    # via -r requirements.in
-pytest-timeout==2.4.0
-    # via -r requirements.in
-python-dateutil==2.9.0.post0
-    # via
-    #   -r requirements.in
-    #   botocore
-    #   pandas
-    #   strictyaml
-python-dotenv==1.2.2
-    # via
-    #   -r requirements.in
-    #   pydantic-settings
-    #   pytest-env
-    #   uvicorn
-python-multipart==0.0.27
-    # via -r requirements.in
-pytz==2026.2
-    # via -r requirements.in
-pyyaml==6.0.3
-    # via
-    #   -r requirements.in
-    #   uvicorn
-realtime==2.29.0
-    # via
-    #   -r requirements.in
-    #   supabase
-redis[asyncio]==7.4.0
-    # via -r requirements.in
-requests==2.33.1
-    # via
-    #   -r requirements.in
-    #   cachecontrol
-    #   google-api-core
-    #   google-cloud-storage
-    #   pyiceberg
-    #   staticmap
-    #   stripe
-    #   twilio
-rich==14.3.4
-    # via
-    #   -r requirements.in
-    #   pyiceberg
-    #   typer
-s3transfer==0.16.1
-    # via boto3
-sentry-sdk==2.59.0
-    # via -r requirements.in
-shellingham==1.5.4
-    # via typer
-six==1.17.0
-    # via
-    #   cloudinary
-    #   python-dateutil
-slowapi==0.1.9
-    # via -r requirements.in
-starlette==1.0.0
-    # via fastapi
-staticmap==0.5.7
-    # via -r requirements.in
-storage3==2.29.0
-    # via supabase
-strenum==0.4.15
-    # via supabase-functions
-strictyaml==1.7.3
-    # via pyiceberg
-stripe==15.1.0
-    # via -r requirements.in
-supabase==2.29.0
-    # via -r requirements.in
-supabase-auth==2.29.0
-    # via supabase
-supabase-functions==2.29.0
-    # via supabase
-tenacity==9.1.4
-    # via
-    #   -r requirements.in
-    #   pyiceberg
-tqdm==4.67.3
-    # via google-generativeai
-twilio==9.10.5
-    # via -r requirements.in
-typer==0.25.0
-    # via -r requirements.in
-typing-extensions==4.15.0
-    # via
-    #   aiosignal
-    #   anyio
-    #   fastapi
-    #   google-generativeai
-    #   grpcio
-    #   limits
-    #   pydantic
-    #   pydantic-core
-    #   pytest-asyncio
-    #   realtime
-    #   starlette
-    #   stripe
-    #   typing-inspection
-typing-inspection==0.4.2
-    # via
-    #   fastapi
-    #   pydantic
-    #   pydantic-settings
-uritemplate==4.2.0
-    # via google-api-python-client
-urllib3==2.6.3
-    # via
-    #   -r requirements.in
-    #   botocore
-    #   cloudinary
-    #   requests
-    #   sentry-sdk
-uvicorn[standard]==0.46.0
-    # via -r requirements.in
-uvloop==0.22.1
-    # via uvicorn
-watchfiles==1.1.1
-    # via uvicorn
-websockets==15.0.1
-    # via
-    #   -r requirements.in
-    #   realtime
-    #   uvicorn
-wrapt==2.1.2
-    # via deprecated
-yarl==1.23.0
-    # via
-    #   aiohttp
-    #   postgrest
-    #   storage3
-    #   supabase
-    #   supabase-functions
-zstandard==0.25.0
-    # via pyiceberg
+aiohappyeyeballs==2.6.1   # via aiohttp
+aiohttp==3.13.5           # via -r requirements.in, aiohttp-retry, twilio
+aiohttp-retry==2.9.1      # via twilio
+aiosignal==1.4.0          # via aiohttp
+annotated-doc==0.0.4      # via fastapi, typer
+annotated-types==0.7.0    # via pydantic
+anyio==4.13.0             # via -r requirements.in, httpx, starlette, watchfiles
+attrs==26.1.0             # via aiohttp
+bcrypt==5.0.0             # via -r requirements.in
+boto3==1.42.96            # via -r requirements.in
+botocore==1.42.96         # via boto3, s3transfer
+cachecontrol==0.14.4      # via firebase-admin
+cachetools==6.2.6         # via pyiceberg
+certifi==2026.4.22        # via -r requirements.in, cloudinary, httpcore, httpx, requests, sentry-sdk
+cffi==2.0.0               # via cryptography
+charset-normalizer==3.4.7  # via -r requirements.in, requests
+click==8.3.3              # via -r requirements.in, pyiceberg, typer, uvicorn
+cloudinary==1.44.2        # via -r requirements.in
+coverage==7.13.5          # via pytest-cov
+cryptography==47.0.0      # via google-auth, pyjwt
+defusedxml==0.7.1         # via fpdf2
+deprecated==1.3.1         # via limits
+deprecation==2.1.0        # via postgrest, storage3
+dnspython==2.8.0          # via email-validator
+email-validator==2.3.0    # via -r requirements.in
+fastapi==0.136.1          # via -r requirements.in
+firebase-admin==7.4.0     # via -r requirements.in
+fonttools==4.62.1         # via fpdf2
+fpdf2==2.8.7              # via -r requirements.in
+frozenlist==1.8.0         # via aiohttp, aiosignal
+fsspec==2026.3.0          # via pyiceberg
+google-ai-generativelanguage==0.6.15  # via google-generativeai
+google-api-core==2.30.3   # via firebase-admin, google-ai-generativelanguage, google-api-python-client, google-cloud-core, google-cloud-firestore, google-cloud-storage, google-generativeai
+google-api-python-client==2.194.0  # via -r requirements.in, google-generativeai
+google-auth==2.49.2       # via -r requirements.in, google-ai-generativelanguage, google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-core, google-cloud-firestore, google-cloud-storage, google-generativeai
+google-auth-httplib2==0.3.1  # via google-api-python-client
+google-cloud-core==2.5.1  # via google-cloud-firestore, google-cloud-storage
+google-cloud-firestore==2.27.0  # via -r requirements.in, firebase-admin
+google-cloud-storage==3.10.1  # via -r requirements.in, firebase-admin
+google-crc32c==1.8.0      # via google-cloud-storage, google-resumable-media
+google-generativeai==0.8.6  # via -r requirements.in
+google-resumable-media==2.8.2  # via google-cloud-storage
+googleapis-common-protos==1.74.0  # via google-api-core, grpcio-status
+grpcio==1.80.0            # via google-api-core, google-cloud-firestore, grpcio-status
+grpcio-status==1.71.2     # via google-api-core
+h11==0.16.0               # via httpcore, uvicorn
+h2==4.3.0                 # via httpx
+hpack==4.1.0              # via h2
+httpcore==1.0.9           # via httpx
+httplib2==0.31.2          # via google-api-python-client, google-auth-httplib2
+httptools==0.7.1          # via uvicorn
+httpx==0.28.1             # via -r requirements.in, firebase-admin, postgrest, storage3, supabase, supabase-auth, supabase-functions
+hyperframe==6.1.0         # via h2
+idna==3.13                # via -r requirements.in, anyio, email-validator, httpx, requests, yarl
+iniconfig==2.3.0          # via pytest
+jinja2==3.1.6             # via -r requirements.in
+jmespath==1.1.0           # via boto3, botocore
+limits==5.8.0             # via slowapi
+loguru==0.7.3             # via -r requirements.in
+markdown-it-py==4.0.0     # via rich
+markupsafe==3.0.3         # via jinja2
+mdurl==0.1.2              # via markdown-it-py
+mmh3==5.2.1               # via pyiceberg
+msgpack==1.1.2            # via cachecontrol
+multidict==6.7.1          # via aiohttp, yarl
+numpy==2.4.4              # via -r requirements.in, pandas
+packaging==26.2           # via deprecation, limits, pytest
+pandas==3.0.2             # via -r requirements.in
+pillow==12.2.0            # via -r requirements.in, fpdf2, staticmap
+pluggy==1.6.0             # via pytest, pytest-cov
+postgrest==2.29.0         # via -r requirements.in, supabase
+propcache==0.4.1          # via aiohttp, yarl
+proto-plus==1.27.2        # via google-ai-generativelanguage, google-api-core, google-cloud-firestore
+protobuf==5.29.6          # via google-ai-generativelanguage, google-api-core, google-cloud-firestore, google-generativeai, googleapis-common-protos, grpcio-status, proto-plus
+psycopg2-binary==2.9.12   # via -r requirements.in
+pyasn1==0.6.3             # via pyasn1-modules
+pyasn1-modules==0.4.2     # via google-auth
+pycparser==3.0            # via cffi
+pydantic==2.13.3          # via -r requirements.in, fastapi, google-generativeai, postgrest, pydantic-settings, pyiceberg, realtime, storage3, supabase-auth
+pydantic-core==2.46.3     # via pydantic
+pydantic-settings==2.14.0  # via -r requirements.in
+pygments==2.20.0          # via pytest, rich
+pyiceberg==0.11.1         # via storage3
+pyjwt==2.12.1             # via -r requirements.in, firebase-admin, supabase-auth, twilio
+pyotp==2.9.0              # via -r requirements.in
+pyparsing==3.3.2          # via httplib2, pyiceberg
+pyroaring==1.1.0          # via pyiceberg
+pytest==9.0.3             # via -r requirements.in, pytest-asyncio, pytest-cov, pytest-env, pytest-mock, pytest-timeout
+pytest-asyncio==1.3.0     # via -r requirements.in
+pytest-cov==7.1.0         # via -r requirements.in
+pytest-env==1.6.0         # via -r requirements.in
+pytest-mock==3.15.1       # via -r requirements.in
+pytest-timeout==2.4.0     # via -r requirements.in
+python-dateutil==2.9.0.post0  # via -r requirements.in, botocore, pandas, strictyaml
+python-dotenv==1.2.2      # via -r requirements.in, pydantic-settings, pytest-env, uvicorn
+python-multipart==0.0.27  # via -r requirements.in
+pytz==2026.2              # via -r requirements.in
+pyyaml==6.0.3             # via -r requirements.in, uvicorn
+realtime==2.29.0          # via -r requirements.in, supabase
+redis==7.4.0              # via -r requirements.in
+requests==2.33.1          # via -r requirements.in, cachecontrol, google-api-core, google-cloud-storage, pyiceberg, staticmap, stripe, twilio
+rich==14.3.4              # via -r requirements.in, pyiceberg, typer
+s3transfer==0.16.1        # via boto3
+sentry-sdk==2.59.0        # via -r requirements.in
+shellingham==1.5.4        # via typer
+six==1.17.0               # via cloudinary, python-dateutil
+slowapi==0.1.9            # via -r requirements.in
+starlette==1.0.0          # via fastapi
+staticmap==0.5.7          # via -r requirements.in
+storage3==2.29.0          # via supabase
+strenum==0.4.15           # via supabase-functions
+strictyaml==1.7.3         # via pyiceberg
+stripe==15.1.0            # via -r requirements.in
+supabase==2.29.0          # via -r requirements.in
+supabase-auth==2.29.0     # via supabase
+supabase-functions==2.29.0  # via supabase
+tenacity==9.1.4           # via -r requirements.in, pyiceberg
+tqdm==4.67.3              # via google-generativeai
+twilio==9.10.5            # via -r requirements.in
+typer==0.25.0             # via -r requirements.in
+typing-extensions==4.15.0  # via aiosignal, anyio, fastapi, google-generativeai, grpcio, limits, pydantic, pydantic-core, pytest-asyncio, realtime, starlette, stripe, typing-inspection
+typing-inspection==0.4.2  # via fastapi, pydantic, pydantic-settings
+uritemplate==4.2.0        # via google-api-python-client
+urllib3==2.6.3            # via -r requirements.in, botocore, cloudinary, requests, sentry-sdk
+uvicorn==0.46.0           # via -r requirements.in
+uvloop==0.22.1            # via uvicorn
+watchfiles==1.1.1         # via uvicorn
+websockets==15.0.1        # via -r requirements.in, realtime, uvicorn
+wrapt==2.1.2              # via deprecated
+yarl==1.23.0              # via aiohttp, postgrest, storage3, supabase, supabase-functions
+zstandard==0.25.0         # via pyiceberg

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,130 +1,446 @@
-aiohappyeyeballs==2.6.1   # via aiohttp
-aiohttp==3.13.5           # via -r requirements.in, aiohttp-retry, twilio
-aiohttp-retry==2.9.1      # via twilio
-aiosignal==1.4.0          # via aiohttp
-annotated-doc==0.0.4      # via fastapi, typer
-annotated-types==0.7.0    # via pydantic
-anyio==4.13.0             # via -r requirements.in, httpx, starlette, watchfiles
-attrs==26.1.0             # via aiohttp
-bcrypt==5.0.0             # via -r requirements.in
-boto3==1.42.96            # via -r requirements.in
-botocore==1.42.96         # via boto3, s3transfer
-cachecontrol==0.14.4      # via firebase-admin
-cachetools==6.2.6         # via pyiceberg
-certifi==2026.4.22        # via -r requirements.in, cloudinary, httpcore, httpx, requests, sentry-sdk
-cffi==2.0.0               # via cryptography
-charset-normalizer==3.4.7  # via -r requirements.in, requests
-click==8.3.3              # via -r requirements.in, pyiceberg, typer, uvicorn
-cloudinary==1.44.2        # via -r requirements.in
-coverage==7.13.5          # via pytest-cov
-cryptography==47.0.0      # via google-auth, pyjwt
-defusedxml==0.7.1         # via fpdf2
-deprecated==1.3.1         # via limits
-deprecation==2.1.0        # via postgrest, storage3
-dnspython==2.8.0          # via email-validator
-email-validator==2.3.0    # via -r requirements.in
-fastapi==0.136.1          # via -r requirements.in
-firebase-admin==7.4.0     # via -r requirements.in
-fonttools==4.62.1         # via fpdf2
-fpdf2==2.8.7              # via -r requirements.in
-frozenlist==1.8.0         # via aiohttp, aiosignal
-fsspec==2026.3.0          # via pyiceberg
-google-ai-generativelanguage==0.6.15  # via google-generativeai
-google-api-core==2.30.3   # via firebase-admin, google-ai-generativelanguage, google-api-python-client, google-cloud-core, google-cloud-firestore, google-cloud-storage, google-generativeai
-google-api-python-client==2.194.0  # via -r requirements.in, google-generativeai
-google-auth==2.49.2       # via -r requirements.in, google-ai-generativelanguage, google-api-core, google-api-python-client, google-auth-httplib2, google-cloud-core, google-cloud-firestore, google-cloud-storage, google-generativeai
-google-auth-httplib2==0.3.1  # via google-api-python-client
-google-cloud-core==2.5.1  # via google-cloud-firestore, google-cloud-storage
-google-cloud-firestore==2.27.0  # via -r requirements.in, firebase-admin
-google-cloud-storage==3.10.1  # via -r requirements.in, firebase-admin
-google-crc32c==1.8.0      # via google-cloud-storage, google-resumable-media
-google-generativeai==0.8.6  # via -r requirements.in
-google-resumable-media==2.8.2  # via google-cloud-storage
-googleapis-common-protos==1.74.0  # via google-api-core, grpcio-status
-grpcio==1.80.0            # via google-api-core, google-cloud-firestore, grpcio-status
-grpcio-status==1.71.2     # via google-api-core
-h11==0.16.0               # via httpcore, uvicorn
-h2==4.3.0                 # via httpx
-hpack==4.1.0              # via h2
-httpcore==1.0.9           # via httpx
-httplib2==0.31.2          # via google-api-python-client, google-auth-httplib2
-httptools==0.7.1          # via uvicorn
-httpx==0.28.1             # via -r requirements.in, firebase-admin, postgrest, storage3, supabase, supabase-auth, supabase-functions
-hyperframe==6.1.0         # via h2
-idna==3.13                # via -r requirements.in, anyio, email-validator, httpx, requests, yarl
-iniconfig==2.3.0          # via pytest
-jinja2==3.1.6             # via -r requirements.in
-jmespath==1.1.0           # via boto3, botocore
-limits==5.8.0             # via slowapi
-loguru==0.7.3             # via -r requirements.in
-markdown-it-py==4.0.0     # via rich
-markupsafe==3.0.3         # via jinja2
-mdurl==0.1.2              # via markdown-it-py
-mmh3==5.2.1               # via pyiceberg
-msgpack==1.1.2            # via cachecontrol
-multidict==6.7.1          # via aiohttp, yarl
-numpy==2.4.4              # via -r requirements.in, pandas
-packaging==26.2           # via deprecation, limits, pytest
-pandas==3.0.2             # via -r requirements.in
-pillow==12.2.0            # via -r requirements.in, fpdf2, staticmap
-pluggy==1.6.0             # via pytest, pytest-cov
-postgrest==2.29.0         # via -r requirements.in, supabase
-propcache==0.4.1          # via aiohttp, yarl
-proto-plus==1.27.2        # via google-ai-generativelanguage, google-api-core, google-cloud-firestore
-protobuf==5.29.6          # via google-ai-generativelanguage, google-api-core, google-cloud-firestore, google-generativeai, googleapis-common-protos, grpcio-status, proto-plus
-psycopg2-binary==2.9.12   # via -r requirements.in
-pyasn1==0.6.3             # via pyasn1-modules
-pyasn1-modules==0.4.2     # via google-auth
-pycparser==3.0            # via cffi
-pydantic==2.13.3          # via -r requirements.in, fastapi, google-generativeai, postgrest, pydantic-settings, pyiceberg, realtime, storage3, supabase-auth
-pydantic-core==2.46.3     # via pydantic
-pydantic-settings==2.14.0  # via -r requirements.in
-pygments==2.20.0          # via pytest, rich
-pyiceberg==0.11.1         # via storage3
-pyjwt==2.12.1             # via -r requirements.in, firebase-admin, supabase-auth, twilio
-pyotp==2.9.0              # via -r requirements.in
-pyparsing==3.3.2          # via httplib2, pyiceberg
-pyroaring==1.1.0          # via pyiceberg
-pytest==9.0.3             # via -r requirements.in, pytest-asyncio, pytest-cov, pytest-env, pytest-mock
-pytest-asyncio==1.3.0     # via -r requirements.in
-pytest-cov==7.1.0         # via -r requirements.in
-pytest-env==1.6.0         # via -r requirements.in
-pytest-mock==3.15.1       # via -r requirements.in
-python-dateutil==2.9.0.post0  # via -r requirements.in, botocore, pandas, strictyaml
-python-dotenv==1.2.2      # via -r requirements.in, pydantic-settings, pytest-env, uvicorn
-python-multipart==0.0.27  # via -r requirements.in
-pytz==2026.2              # via -r requirements.in
-pyyaml==6.0.3             # via -r requirements.in, uvicorn
-realtime==2.29.0          # via -r requirements.in, supabase
-redis==7.4.0              # via -r requirements.in
-requests==2.33.1          # via -r requirements.in, cachecontrol, google-api-core, google-cloud-storage, pyiceberg, staticmap, stripe, twilio
-rich==14.3.4              # via -r requirements.in, pyiceberg, typer
-s3transfer==0.16.1        # via boto3
-sentry-sdk==2.59.0        # via -r requirements.in
-shellingham==1.5.4        # via typer
-six==1.17.0               # via cloudinary, python-dateutil
-slowapi==0.1.9            # via -r requirements.in
-starlette==1.0.0          # via fastapi
-staticmap==0.5.7          # via -r requirements.in
-storage3==2.29.0          # via supabase
-strenum==0.4.15           # via supabase-functions
-strictyaml==1.7.3         # via pyiceberg
-stripe==15.1.0            # via -r requirements.in
-supabase==2.29.0          # via -r requirements.in
-supabase-auth==2.29.0     # via supabase
-supabase-functions==2.29.0  # via supabase
-tenacity==9.1.4           # via -r requirements.in, pyiceberg
-tqdm==4.67.3              # via google-generativeai
-twilio==9.10.5            # via -r requirements.in
-typer==0.25.0             # via -r requirements.in
-typing-extensions==4.15.0  # via aiosignal, anyio, fastapi, google-generativeai, grpcio, limits, pydantic, pydantic-core, pytest-asyncio, realtime, starlette, stripe, typing-inspection
-typing-inspection==0.4.2  # via fastapi, pydantic, pydantic-settings
-uritemplate==4.2.0        # via google-api-python-client
-urllib3==2.6.3            # via -r requirements.in, botocore, cloudinary, requests, sentry-sdk
-uvicorn==0.46.0           # via -r requirements.in
-uvloop==0.22.1            # via uvicorn
-watchfiles==1.1.1         # via uvicorn
-websockets==15.0.1        # via -r requirements.in, realtime, uvicorn
-wrapt==2.1.2              # via deprecated
-yarl==1.23.0              # via aiohttp, postgrest, storage3, supabase, supabase-functions
-zstandard==0.25.0         # via pyiceberg
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements.in
+    #   aiohttp-retry
+    #   twilio
+aiohttp-retry==2.9.1
+    # via twilio
+aiosignal==1.4.0
+    # via aiohttp
+annotated-doc==0.0.4
+    # via
+    #   fastapi
+    #   typer
+annotated-types==0.7.0
+    # via pydantic
+anyio==4.13.0
+    # via
+    #   -r requirements.in
+    #   httpx
+    #   starlette
+    #   watchfiles
+attrs==26.1.0
+    # via aiohttp
+bcrypt==5.0.0
+    # via -r requirements.in
+boto3==1.42.96
+    # via -r requirements.in
+botocore==1.42.96
+    # via
+    #   boto3
+    #   s3transfer
+cachecontrol==0.14.4
+    # via firebase-admin
+cachetools==6.2.6
+    # via pyiceberg
+certifi==2026.4.22
+    # via
+    #   -r requirements.in
+    #   cloudinary
+    #   httpcore
+    #   httpx
+    #   requests
+    #   sentry-sdk
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.7
+    # via
+    #   -r requirements.in
+    #   requests
+click==8.3.3
+    # via
+    #   -r requirements.in
+    #   pyiceberg
+    #   typer
+    #   uvicorn
+cloudinary==1.44.2
+    # via -r requirements.in
+coverage[toml]==7.13.5
+    # via pytest-cov
+cryptography==47.0.0
+    # via
+    #   google-auth
+    #   pyjwt
+defusedxml==0.7.1
+    # via fpdf2
+deprecated==1.3.1
+    # via limits
+deprecation==2.1.0
+    # via
+    #   postgrest
+    #   storage3
+dnspython==2.8.0
+    # via email-validator
+email-validator==2.3.0
+    # via -r requirements.in
+fastapi==0.136.1
+    # via -r requirements.in
+firebase-admin==7.4.0
+    # via -r requirements.in
+fonttools==4.62.1
+    # via fpdf2
+fpdf2==2.8.7
+    # via -r requirements.in
+frozenlist==1.8.0
+    # via
+    #   aiohttp
+    #   aiosignal
+fsspec==2026.3.0
+    # via pyiceberg
+google-ai-generativelanguage==0.6.15
+    # via google-generativeai
+google-api-core[grpc]==2.30.3
+    # via
+    #   firebase-admin
+    #   google-ai-generativelanguage
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+    #   google-generativeai
+google-api-python-client==2.194.0
+    # via
+    #   -r requirements.in
+    #   google-generativeai
+google-auth==2.49.2
+    # via
+    #   -r requirements.in
+    #   google-ai-generativelanguage
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+    #   google-generativeai
+google-auth-httplib2==0.3.1
+    # via google-api-python-client
+google-cloud-core==2.5.1
+    # via
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.27.0
+    # via
+    #   -r requirements.in
+    #   firebase-admin
+google-cloud-storage==3.10.1
+    # via
+    #   -r requirements.in
+    #   firebase-admin
+google-crc32c==1.8.0
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-generativeai==0.8.6
+    # via -r requirements.in
+google-resumable-media==2.8.2
+    # via google-cloud-storage
+googleapis-common-protos==1.74.0
+    # via
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.80.0
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
+    #   grpcio-status
+grpcio-status==1.71.2
+    # via google-api-core
+h11==0.16.0
+    # via
+    #   httpcore
+    #   uvicorn
+h2==4.3.0
+    # via httpx
+hpack==4.1.0
+    # via h2
+httpcore==1.0.9
+    # via httpx
+httplib2==0.31.2
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
+httptools==0.7.1
+    # via uvicorn
+httpx[http2]==0.28.1
+    # via
+    #   -r requirements.in
+    #   firebase-admin
+    #   postgrest
+    #   storage3
+    #   supabase
+    #   supabase-auth
+    #   supabase-functions
+hyperframe==6.1.0
+    # via h2
+idna==3.13
+    # via
+    #   -r requirements.in
+    #   anyio
+    #   email-validator
+    #   httpx
+    #   requests
+    #   yarl
+iniconfig==2.3.0
+    # via pytest
+jinja2==3.1.6
+    # via -r requirements.in
+jmespath==1.1.0
+    # via
+    #   boto3
+    #   botocore
+limits==5.8.0
+    # via slowapi
+loguru==0.7.3
+    # via -r requirements.in
+markdown-it-py==4.0.0
+    # via rich
+markupsafe==3.0.3
+    # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
+mmh3==5.2.1
+    # via pyiceberg
+msgpack==1.1.2
+    # via cachecontrol
+multidict==6.7.1
+    # via
+    #   aiohttp
+    #   yarl
+numpy==2.4.4
+    # via
+    #   -r requirements.in
+    #   pandas
+packaging==26.2
+    # via
+    #   deprecation
+    #   limits
+    #   pytest
+pandas==3.0.2
+    # via -r requirements.in
+pillow==12.2.0
+    # via
+    #   -r requirements.in
+    #   fpdf2
+    #   staticmap
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+postgrest==2.29.0
+    # via
+    #   -r requirements.in
+    #   supabase
+propcache==0.4.1
+    # via
+    #   aiohttp
+    #   yarl
+proto-plus==1.27.2
+    # via
+    #   google-ai-generativelanguage
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==5.29.6
+    # via
+    #   google-ai-generativelanguage
+    #   google-api-core
+    #   google-cloud-firestore
+    #   google-generativeai
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
+psycopg2-binary==2.9.12
+    # via -r requirements.in
+pyasn1==0.6.3
+    # via pyasn1-modules
+pyasn1-modules==0.4.2
+    # via google-auth
+pycparser==3.0
+    # via cffi
+pydantic==2.13.3
+    # via
+    #   -r requirements.in
+    #   fastapi
+    #   google-generativeai
+    #   postgrest
+    #   pydantic-settings
+    #   pyiceberg
+    #   realtime
+    #   storage3
+    #   supabase-auth
+pydantic-core==2.46.3
+    # via pydantic
+pydantic-settings==2.14.0
+    # via -r requirements.in
+pygments==2.20.0
+    # via
+    #   pytest
+    #   rich
+pyiceberg==0.11.1
+    # via storage3
+pyjwt[crypto]==2.12.1
+    # via
+    #   -r requirements.in
+    #   firebase-admin
+    #   supabase-auth
+    #   twilio
+pyotp==2.9.0
+    # via -r requirements.in
+pyparsing==3.3.2
+    # via
+    #   httplib2
+    #   pyiceberg
+pyroaring==1.1.0
+    # via pyiceberg
+pytest==9.0.3
+    # via
+    #   -r requirements.in
+    #   pytest-asyncio
+    #   pytest-cov
+    #   pytest-env
+    #   pytest-mock
+    #   pytest-timeout
+pytest-asyncio==1.3.0
+    # via -r requirements.in
+pytest-cov==7.1.0
+    # via -r requirements.in
+pytest-env==1.6.0
+    # via -r requirements.in
+pytest-mock==3.15.1
+    # via -r requirements.in
+pytest-timeout==2.4.0
+    # via -r requirements.in
+python-dateutil==2.9.0.post0
+    # via
+    #   -r requirements.in
+    #   botocore
+    #   pandas
+    #   strictyaml
+python-dotenv==1.2.2
+    # via
+    #   -r requirements.in
+    #   pydantic-settings
+    #   pytest-env
+    #   uvicorn
+python-multipart==0.0.27
+    # via -r requirements.in
+pytz==2026.2
+    # via -r requirements.in
+pyyaml==6.0.3
+    # via
+    #   -r requirements.in
+    #   uvicorn
+realtime==2.29.0
+    # via
+    #   -r requirements.in
+    #   supabase
+redis[asyncio]==7.4.0
+    # via -r requirements.in
+requests==2.33.1
+    # via
+    #   -r requirements.in
+    #   cachecontrol
+    #   google-api-core
+    #   google-cloud-storage
+    #   pyiceberg
+    #   staticmap
+    #   stripe
+    #   twilio
+rich==14.3.4
+    # via
+    #   -r requirements.in
+    #   pyiceberg
+    #   typer
+s3transfer==0.16.1
+    # via boto3
+sentry-sdk==2.59.0
+    # via -r requirements.in
+shellingham==1.5.4
+    # via typer
+six==1.17.0
+    # via
+    #   cloudinary
+    #   python-dateutil
+slowapi==0.1.9
+    # via -r requirements.in
+starlette==1.0.0
+    # via fastapi
+staticmap==0.5.7
+    # via -r requirements.in
+storage3==2.29.0
+    # via supabase
+strenum==0.4.15
+    # via supabase-functions
+strictyaml==1.7.3
+    # via pyiceberg
+stripe==15.1.0
+    # via -r requirements.in
+supabase==2.29.0
+    # via -r requirements.in
+supabase-auth==2.29.0
+    # via supabase
+supabase-functions==2.29.0
+    # via supabase
+tenacity==9.1.4
+    # via
+    #   -r requirements.in
+    #   pyiceberg
+tqdm==4.67.3
+    # via google-generativeai
+twilio==9.10.5
+    # via -r requirements.in
+typer==0.25.0
+    # via -r requirements.in
+typing-extensions==4.15.0
+    # via
+    #   aiosignal
+    #   anyio
+    #   fastapi
+    #   google-generativeai
+    #   grpcio
+    #   limits
+    #   pydantic
+    #   pydantic-core
+    #   pytest-asyncio
+    #   realtime
+    #   starlette
+    #   stripe
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via
+    #   fastapi
+    #   pydantic
+    #   pydantic-settings
+uritemplate==4.2.0
+    # via google-api-python-client
+urllib3==2.6.3
+    # via
+    #   -r requirements.in
+    #   botocore
+    #   cloudinary
+    #   requests
+    #   sentry-sdk
+uvicorn[standard]==0.46.0
+    # via -r requirements.in
+uvloop==0.22.1
+    # via uvicorn
+watchfiles==1.1.1
+    # via uvicorn
+websockets==15.0.1
+    # via
+    #   -r requirements.in
+    #   realtime
+    #   uvicorn
+wrapt==2.1.2
+    # via deprecated
+yarl==1.23.0
+    # via
+    #   aiohttp
+    #   postgrest
+    #   storage3
+    #   supabase
+    #   supabase-functions
+zstandard==0.25.0
+    # via pyiceberg

--- a/backend/routes/admin/auth.py
+++ b/backend/routes/admin/auth.py
@@ -300,9 +300,11 @@ async def admin_login(request: Request, response: Response, body: LoginRequest):
         if ok:
             if not staff.get("is_active", True):
                 raise HTTPException(status_code=403, detail="Account is deactivated")
-            await db_supabase.update_one(
-                "admin_staff", {"id": staff["id"]}, {"last_login": datetime.now(timezone.utc).isoformat()}
-            )
+            updates: dict = {"last_login": datetime.now(timezone.utc).isoformat()}
+            if needs_upgrade:
+                updates["password_hash"] = hash_password(body.password)
+                logger.info("admin auth: upgraded legacy password hash for staff %s", staff["id"])
+            await db_supabase.update_one("admin_staff", {"id": staff["id"]}, updates)
             if staff.get("mfa_enabled"):
                 mfa_token = _mint_mfa_challenge_token(staff["id"])
                 await _clear_login_failures(body.email)

--- a/backend/routes/admin/messaging.py
+++ b/backend/routes/admin/messaging.py
@@ -171,7 +171,7 @@ async def admin_get_cloud_messages(
             offset=offset,
         )
     except Exception:
-        logger.warning("cloud_messages table may not exist yet")
+        logger.error("cloud_messages table missing or query failed", exc_info=True)
         return []
     return messages
 
@@ -182,7 +182,7 @@ async def admin_get_cloud_message_stats():
     try:
         all_messages = await db_supabase.get_rows("cloud_messages", {}, limit=10000)
     except Exception:
-        logger.warning("cloud_messages table may not exist yet")
+        logger.error("cloud_messages table missing or query failed", exc_info=True)
         all_messages = []
 
     total = len(all_messages)

--- a/backend/routes/admin/promotions.py
+++ b/backend/routes/admin/promotions.py
@@ -228,7 +228,7 @@ async def admin_create_promotion(promotion: PromotionCreateRequest, admin: dict 
         row = await db_supabase.insert_one("promotions", full_doc)
     except Exception:
         # Fallback: insert without optional fields that may not exist in schema
-        logger.warning("Promotions insert failed with optional fields, retrying without them")
+        logger.error("Promotions insert failed with optional fields, retrying without them", exc_info=True)
         row = await db_supabase.insert_one("promotions", doc)
 
     promotion_id = str(row.get("id") if row and isinstance(row, dict) else "")
@@ -265,7 +265,7 @@ async def admin_get_promo_usage(
             offset=offset,
         )
     except Exception:
-        logger.warning("promo_applications table may not exist yet")
+        logger.error("promo_applications table missing or query failed", exc_info=True)
         return []
 
     # Filter by date range in Python (supabase may not support complex date filters)
@@ -314,7 +314,7 @@ async def admin_get_promo_stats(date_range: Optional[str] = Query(None, alias="r
             "promo_applications", usage_filter, order="created_at", desc=True, limit=5000
         )
     except Exception:
-        logger.warning("promo_applications table may not exist yet")
+        logger.error("promo_applications table missing or query failed", exc_info=True)
         all_usage = []
 
     filtered_usage = all_usage

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -372,8 +372,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
     try:
         await db_supabase.update_one("otp_records", {"id": otp_record["id"]}, {"verified": True})
     except Exception:
-        # Non-fatal: marking OTP as verified is best-effort; verification already succeeded
-        logger.warning("Failed to mark OTP record %s as verified", otp_record["id"], exc_info=True)
+        logger.error("auth: failed to mark OTP %s as verified — reuse risk", otp_record.get("id"), exc_info=True)
 
     # SEC-008: Clear failure counter + lockout on successful verification
     await _clear_otp_failures(phone)

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1436,8 +1436,9 @@ class PayoutRequest(BaseModel):
     amount: Decimal = Field(
         ...,
         ge=Decimal("10.00"),
+        le=Decimal("50000.00"),
         decimal_places=2,
-        description="Minimum payout is $10.00",
+        description="Payout must be between $10.00 and $50,000.00",
     )
 
 

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -212,6 +212,9 @@ async def confirm_payment(
 
     if payment_intent_id and payment_intent_id.startswith("pi_mock_"):
         if ride_id:
+            _ride = await db_supabase.get_ride(ride_id)
+            if not _ride or _ride.get("rider_id") != current_user["id"]:
+                raise HTTPException(status_code=403, detail="Not authorized to confirm payment for this ride")
             await db_supabase.update_ride(ride_id, {"payment_status": "paid", "payment_intent_id": payment_intent_id})
         return {"status": "succeeded", "mock": True}
 
@@ -226,6 +229,9 @@ async def confirm_payment(
                 raise HTTPException(status_code=403, detail="Not authorized to confirm this payment")
 
             if ride_id:
+                _ride = await db_supabase.get_ride(ride_id)
+                if not _ride or _ride.get("rider_id") != current_user["id"]:
+                    raise HTTPException(status_code=403, detail="Not authorized to confirm payment for this ride")
                 await db_supabase.update_ride(
                     ride_id, {"payment_status": intent.status, "payment_intent_id": payment_intent_id}
                 )
@@ -600,6 +606,8 @@ async def create_payment_sheet(
         ride = await db_supabase.get_ride(body.ride_id)
         if not ride:
             raise HTTPException(status_code=404, detail="Ride not found")
+        if ride.get("rider_id") != current_user["id"]:
+            raise HTTPException(status_code=403, detail="Not authorized to pay for this ride")
         ride_fare = Decimal(str(ride.get("total_fare", 0)))
         requested = Decimal(str(body.amount))
         if requested != ride_fare:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1136,7 +1136,7 @@ async def create_ride(body: CreateRideRequest, request: Request = None, current_
         _allowance = _policy_result.allowance
         _policy = _policy_result.policy
         if _allowance.get("type") != "unlimited":
-            _remaining = _d(str(_allowance.get("amount") or 0)) - _d(str(max(float(_allowance.get("used") or 0), 0.0)))
+            _remaining = _d(str(_allowance.get("amount") or 0)) - max(_d(str(_allowance.get("used") or 0)), _d("0"))
             _master_permitted = _policy.get("allowed_payment_source", "both") in ("master_only", "both")
             if _remaining < _round(_d(str(_f(total_fare))) * _d("1.5")) and not _master_permitted:
                 raise HTTPException(
@@ -1751,7 +1751,7 @@ async def process_payment(
             _master_debit = _round(Decimal("0"))
         else:
             _remaining = _round(
-                _d(str(_corp_allowance.get("amount") or 0)) - _d(str(max(float(_corp_allowance.get("used") or 0), 0.0)))
+                _d(str(_corp_allowance.get("amount") or 0)) - max(_d(str(_corp_allowance.get("used") or 0)), _d("0"))
             )
             _remaining = max(_remaining, _round(Decimal("0")))
             _allowance_debit = min(_remaining, _total)

--- a/backend/tests/test_safety_checkin_loop.py
+++ b/backend/tests/test_safety_checkin_loop.py
@@ -1,0 +1,339 @@
+"""Tests for utils/safety_checkin_loop.py.
+
+Covers:
+- Ride older than 20 min with no prior check-in → push sent
+- Ride newer than 20 min → skipped (no push)
+- Push already sent → no duplicate push
+- Push sent + rider confirmed (ok_key set) → no escalation
+- Push sent + no response + within 90 s window → no escalation yet
+- Push sent + no response + past 90 s window → escalate
+- Already escalated → no duplicate escalation
+- FCM push failure → loop continues to next ride
+- Ride with no rider_id → push skipped silently
+- Ride with no started_at → skipped
+- _escalate sets escalated key only after successful DB insert
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _ride(
+    ride_id: str = "r1",
+    rider_id: str = "u1",
+    started_at: str | None = None,
+    minutes_ago: int = 25,
+) -> dict:
+    if started_at is None:
+        ts = datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)
+        started_at = ts.isoformat()
+    return {"id": ride_id, "rider_id": rider_id, "status": "in_progress", "started_at": started_at}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── _tick: push-send path ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_sends_checkin_for_overdue_ride():
+    """Ride >20 min old with no prior check-in → push sent + sent_key written."""
+    push = AsyncMock()
+    rset = AsyncMock()
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", AsyncMock(return_value=None)),
+        patch("utils.safety_checkin_loop.redis_set", rset),
+        patch("utils.safety_checkin_loop.send_push_notification", push),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride()])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    push.assert_awaited_once()
+    push_call = push.call_args
+    assert push_call[0][0] == "u1"
+    rset.assert_awaited_once()
+    key_written = rset.call_args[0][0]
+    assert "safety:checkin:sent:r1" == key_written
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_ride_newer_than_20_minutes():
+    """Ride only 5 min old → no push sent."""
+    push = AsyncMock()
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", AsyncMock(return_value=None)),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", push),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride(minutes_ago=5)])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    push.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_ride_with_no_started_at():
+    """Ride missing started_at → skipped entirely."""
+    push = AsyncMock()
+    ride = {"id": "r1", "rider_id": "u1", "status": "in_progress"}
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", AsyncMock(return_value=None)),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", push),
+    ):
+        db.get_rows = AsyncMock(return_value=[ride])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    push.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_push_when_no_rider_id():
+    """Ride without rider_id → redis sent_key still written, push not sent."""
+    push = AsyncMock()
+    rset = AsyncMock()
+    ride = _ride(rider_id=None)  # type: ignore[arg-type]
+    ride["rider_id"] = None
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", AsyncMock(return_value=None)),
+        patch("utils.safety_checkin_loop.redis_set", rset),
+        patch("utils.safety_checkin_loop.send_push_notification", push),
+    ):
+        db.get_rows = AsyncMock(return_value=[ride])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    push.assert_not_awaited()
+    # sent_key IS written even without rider_id — prevents re-processing this ride
+    rset.assert_awaited_once()
+    assert "safety:checkin:sent:r1" in rset.call_args[0][0]
+
+
+# ── _tick: no-duplicate-push path ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_does_not_resend_if_sent_key_exists():
+    """sent_key already in Redis → no second push."""
+    push = AsyncMock()
+
+    sent_ts = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+
+    async def fake_get(key: str) -> str | None:
+        if "sent" in key:
+            return sent_ts
+        return None  # ok_key and escalated_key absent
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", fake_get),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", push),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride()])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    push.assert_not_awaited()
+
+
+# ── _tick: escalation path ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_no_escalation_while_in_response_window():
+    """Push sent 30 s ago, no ok, escalate_window=90 s → no escalation yet."""
+    escalate = AsyncMock()
+    sent_ts = (datetime.now(timezone.utc) - timedelta(seconds=30)).isoformat()
+
+    async def fake_get(key: str) -> str | None:
+        if "sent" in key:
+            return sent_ts
+        return None
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", fake_get),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", AsyncMock()),
+        patch("utils.safety_checkin_loop._escalate", escalate),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride()])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    escalate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_escalates_after_response_window_expires():
+    """Push sent 120 s ago, no ok → escalate called."""
+    escalate = AsyncMock()
+    sent_ts = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+
+    async def fake_get(key: str) -> str | None:
+        if "sent" in key:
+            return sent_ts
+        return None
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", fake_get),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", AsyncMock()),
+        patch("utils.safety_checkin_loop._escalate", escalate),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride()])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    escalate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_tick_no_escalation_when_rider_confirmed():
+    """Push sent, ok_key set → no escalation."""
+    escalate = AsyncMock()
+    sent_ts = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+
+    async def fake_get(key: str) -> str | None:
+        if "sent" in key:
+            return sent_ts
+        if "ok" in key:
+            return "1"
+        return None
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", fake_get),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", AsyncMock()),
+        patch("utils.safety_checkin_loop._escalate", escalate),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride()])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    escalate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_no_duplicate_escalation_if_already_escalated():
+    """escalated_key set → _escalate not called again."""
+    escalate = AsyncMock()
+    sent_ts = (datetime.now(timezone.utc) - timedelta(seconds=120)).isoformat()
+
+    async def fake_get(key: str) -> str | None:
+        if "sent" in key:
+            return sent_ts
+        if "escalated" in key:
+            return "1"
+        return None
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", fake_get),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", AsyncMock()),
+        patch("utils.safety_checkin_loop._escalate", escalate),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride()])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()
+
+    escalate.assert_not_awaited()
+
+
+# ── _tick: resilience ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tick_continues_after_fcm_failure():
+    """FCM push failure for ride r1 → loop continues and processes ride r2."""
+    push_calls: list[str] = []
+
+    async def flaky_push(user_id: str, *args, **kwargs) -> None:
+        push_calls.append(user_id)
+        if user_id == "u1":
+            raise RuntimeError("FCM down")
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_get", AsyncMock(return_value=None)),
+        patch("utils.safety_checkin_loop.redis_set", AsyncMock()),
+        patch("utils.safety_checkin_loop.send_push_notification", side_effect=flaky_push),
+    ):
+        db.get_rows = AsyncMock(return_value=[_ride("r1", "u1"), _ride("r2", "u2")])
+        from utils.safety_checkin_loop import _tick
+
+        await _tick()  # must not raise
+
+    assert "u1" in push_calls
+    assert "u2" in push_calls
+
+
+# ── _escalate: DB failure behaviour ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_escalate_sets_redis_key_only_after_successful_db_insert():
+    """escalated_key written only when DB insert succeeds."""
+    rset = AsyncMock()
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_set", rset),
+    ):
+        db.insert_one = AsyncMock(return_value={"id": "inc1"})
+        from utils.safety_checkin_loop import _escalate
+
+        await _escalate(_ride(), datetime.now(timezone.utc))
+
+    rset.assert_awaited_once()
+    assert "escalated:r1" in rset.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_escalate_does_not_set_redis_key_on_db_failure():
+    """DB insert failure → escalated_key NOT set → next tick will retry."""
+    rset = AsyncMock()
+
+    with (
+        patch("utils.safety_checkin_loop._supabase_db") as db,
+        patch("utils.safety_checkin_loop.redis_set", rset),
+    ):
+        db.insert_one = AsyncMock(side_effect=RuntimeError("DB down"))
+        from utils.safety_checkin_loop import _escalate
+
+        with pytest.raises(RuntimeError):
+            await _escalate(_ride(), datetime.now(timezone.utc))
+
+    rset.assert_not_awaited()

--- a/backend/tests/test_stripe_reconcile.py
+++ b/backend/tests/test_stripe_reconcile.py
@@ -1,0 +1,560 @@
+"""Tests for utils/stripe_reconcile.py.
+
+Covers:
+- Skips cleanly when stripe_secret_key not configured
+- Stripe API list failure → returns early, no DB query
+- DB query failure → returns early, no discrepancies written
+- DB_PAID_STRIPE_MISSING: ride in DB but no matching PI in Stripe
+- DB_PAID_STRIPE_MISMATCH: PI exists but status != "succeeded"
+- DB_PAID_AMOUNT_MISMATCH: Stripe amount_received differs from DB fare
+- STRIPE_ORPHAN: succeeded PI with no matching DB ride
+- Clean run (zero discrepancies) → info log, not error
+- audit_logs write failure → error logged, not raised
+- Redis lock not acquired → tick skipped, no Stripe call
+- _in_window: valid/outside/edge/malformed timestamps
+- Multiple discrepancy types in a single pass
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date, datetime, time, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _yesterday_epoch() -> tuple[int, int]:
+    """Return (window_start, window_end) epoch ints for yesterday UTC."""
+    yesterday = date.today() - timedelta(days=1)
+    start = int(datetime.combine(yesterday, time(0, 0), tzinfo=timezone.utc).timestamp())
+    end = int(datetime.combine(yesterday, time(23, 59, 59), tzinfo=timezone.utc).timestamp())
+    return start, end
+
+
+def _ts_yesterday(hour: int = 12) -> str:
+    """ISO timestamp at 'hour' UTC yesterday."""
+    yesterday = date.today() - timedelta(days=1)
+    dt = datetime.combine(yesterday, time(hour, 0), tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+def _ride(
+    ride_id: str = "ride1",
+    pi_id: str = "pi_abc",
+    fare: str = "25.00",
+) -> dict:
+    return {
+        "id": ride_id,
+        "payment_intent_id": pi_id,
+        "fare": fare,
+        "status": "completed",
+        "payment_status": "paid",
+        "completed_at": _ts_yesterday(),
+    }
+
+
+def _pi(pi_id: str = "pi_abc", status: str = "succeeded", amount_received: int = 2500) -> dict:
+    return {"id": pi_id, "status": status, "amount_received": amount_received}
+
+
+def _make_stripe_mock(pis: list[dict]) -> MagicMock:
+    """Return a mock stripe module whose PaymentIntent.list auto_paging_iter yields pis."""
+    mock = MagicMock()
+    list_result = MagicMock()
+    list_result.auto_paging_iter.return_value = iter(pis)
+    mock.PaymentIntent.list.return_value = list_result
+    return mock
+
+
+# ── Skip when unconfigured ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_stripe_secret_key():
+    """No stripe_secret_key in settings → function returns without touching DB."""
+    db_mock = AsyncMock()
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    db_mock.get_rows.assert_not_awaited()
+    db_mock.insert_one.assert_not_awaited()
+
+
+# ── Stripe API failure ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stripe_api_failure_returns_early():
+    """Stripe list() raises → DB get_rows never called."""
+    db_mock = AsyncMock()
+    stripe_mock = MagicMock()
+    stripe_mock.PaymentIntent.list.side_effect = RuntimeError("Stripe 500")
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    db_mock.get_rows.assert_not_awaited()
+
+
+# ── DB query failure ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_db_query_failure_returns_early():
+    """DB get_rows raises → function returns before writing audit_logs."""
+    db_mock = AsyncMock()
+    db_mock.get_rows.side_effect = RuntimeError("DB down")
+    stripe_mock = _make_stripe_mock([])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    db_mock.insert_one.assert_not_awaited()
+
+
+# ── DB_PAID_STRIPE_MISSING ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detects_db_paid_stripe_missing():
+    """DB ride has PI id but PI absent in Stripe → DB_PAID_STRIPE_MISSING discrepancy."""
+    ride = _ride(pi_id="pi_gone")
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([])  # no PIs in Stripe
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    db_mock.insert_one.assert_awaited_once()
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert audit_detail["discrepancies"] == 1
+    assert audit_detail["discrepancy_detail"][0]["type"] == "DB_PAID_STRIPE_MISSING"
+    assert audit_detail["discrepancy_detail"][0]["payment_intent_id"] == "pi_gone"
+
+
+# ── DB_PAID_STRIPE_MISMATCH ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detects_db_paid_stripe_mismatch():
+    """PI exists but status is 'requires_action' → DB_PAID_STRIPE_MISMATCH."""
+    ride = _ride()
+    pi = _pi(status="requires_action", amount_received=2500)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    types = [d["type"] for d in audit_detail["discrepancy_detail"]]
+    assert "DB_PAID_STRIPE_MISMATCH" in types
+
+
+# ── DB_PAID_AMOUNT_MISMATCH ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detects_db_paid_amount_mismatch():
+    """Stripe amount_received (cents) != DB fare × 100 → DB_PAID_AMOUNT_MISMATCH."""
+    ride = _ride(fare="25.00")  # expect 2500 cents
+    pi = _pi(status="succeeded", amount_received=2499)  # 1 cent short
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    mismatch = next(d for d in audit_detail["discrepancy_detail"] if d["type"] == "DB_PAID_AMOUNT_MISMATCH")
+    assert mismatch["db_cents"] == 2500
+    assert mismatch["stripe_cents"] == 2499
+
+
+@pytest.mark.asyncio
+async def test_no_amount_mismatch_when_fare_matches():
+    """Stripe amount_received exactly matches DB fare → no DB_PAID_AMOUNT_MISMATCH."""
+    ride = _ride(fare="25.00")
+    pi = _pi(status="succeeded", amount_received=2500)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    types = [d["type"] for d in audit_detail["discrepancy_detail"]]
+    assert "DB_PAID_AMOUNT_MISMATCH" not in types
+
+
+# ── STRIPE_ORPHAN ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detects_stripe_orphan():
+    """Succeeded PI with no matching DB ride → STRIPE_ORPHAN."""
+    pi = _pi(pi_id="pi_orphan", status="succeeded", amount_received=1500)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = []  # no rides in DB window
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    orphan = next(d for d in audit_detail["discrepancy_detail"] if d["type"] == "STRIPE_ORPHAN")
+    assert orphan["payment_intent_id"] == "pi_orphan"
+    assert orphan["stripe_amount"] == 1500
+
+
+@pytest.mark.asyncio
+async def test_failed_stripe_pi_not_flagged_as_orphan():
+    """A failed/cancelled PI with no DB ride is NOT an orphan (only succeeded PIs matter)."""
+    pi = _pi(pi_id="pi_failed", status="canceled", amount_received=0)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = []
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert audit_detail["discrepancies"] == 0
+
+
+# ── Clean run ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clean_run_writes_zero_discrepancies():
+    """Matched ride + succeeded PI with correct amount → zero discrepancies in audit log."""
+    ride = _ride(fare="10.50")
+    pi = _pi(status="succeeded", amount_received=1050)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert audit_detail["discrepancies"] == 0
+    assert audit_detail["discrepancy_detail"] == []
+
+
+# ── audit_logs write failure ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_log_write_failure_does_not_raise():
+    """audit_logs insert failure → error logged, function completes without raising."""
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = []
+    db_mock.insert_one.side_effect = RuntimeError("audit DB down")
+    stripe_mock = _make_stripe_mock([])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()  # must not raise
+
+
+# ── Multiple discrepancy types ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_multiple_discrepancy_types_counted():
+    """One missing PI + one orphan PI → discrepancy count = 2."""
+    ride_missing = _ride(ride_id="ride_missing", pi_id="pi_missing")
+    pi_orphan = _pi(pi_id="pi_orphan", status="succeeded", amount_received=999)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride_missing]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi_orphan])  # only orphan PI, not ride_missing's PI
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert audit_detail["discrepancies"] == 2
+    types = {d["type"] for d in audit_detail["discrepancy_detail"]}
+    assert types == {"DB_PAID_STRIPE_MISSING", "STRIPE_ORPHAN"}
+
+
+# ── _in_window ─────────────────────────────────────────────────────────────
+
+
+def test_in_window_valid_timestamp_inside():
+    """Timestamp exactly at window_start falls inside."""
+    from utils.stripe_reconcile import _in_window
+
+    start, end = _yesterday_epoch()
+    mid = start + (end - start) // 2
+    dt_iso = datetime.fromtimestamp(mid, tz=timezone.utc).isoformat()
+    assert _in_window(dt_iso, start, end) is True
+
+
+def test_in_window_timestamp_before_window():
+    """Timestamp before window_start → False."""
+    from utils.stripe_reconcile import _in_window
+
+    start, end = _yesterday_epoch()
+    before_iso = datetime.fromtimestamp(start - 1, tz=timezone.utc).isoformat()
+    assert _in_window(before_iso, start, end) is False
+
+
+def test_in_window_timestamp_after_window():
+    """Timestamp after window_end → False."""
+    from utils.stripe_reconcile import _in_window
+
+    start, end = _yesterday_epoch()
+    after_iso = datetime.fromtimestamp(end + 1, tz=timezone.utc).isoformat()
+    assert _in_window(after_iso, start, end) is False
+
+
+def test_in_window_z_suffix_handled():
+    """ISO timestamps ending in 'Z' (Supabase format) are accepted."""
+    from utils.stripe_reconcile import _in_window
+
+    start, end = _yesterday_epoch()
+    mid = start + 60
+    dt_z = datetime.fromtimestamp(mid, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    assert _in_window(dt_z, start, end) is True
+
+
+def test_in_window_malformed_returns_false():
+    """Malformed timestamp → False, no exception raised."""
+    from utils.stripe_reconcile import _in_window
+
+    assert _in_window("not-a-date", 0, 9999999999) is False
+    assert _in_window("", 0, 9999999999) is False
+
+
+def test_in_window_boundary_inclusive():
+    """window_start and window_end are both inclusive."""
+    from utils.stripe_reconcile import _in_window
+
+    start, end = _yesterday_epoch()
+    start_iso = datetime.fromtimestamp(start, tz=timezone.utc).isoformat()
+    end_iso = datetime.fromtimestamp(end, tz=timezone.utc).isoformat()
+    assert _in_window(start_iso, start, end) is True
+    assert _in_window(end_iso, start, end) is True
+
+
+# ── Redis lock guard ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_loop_skips_tick_when_lock_not_acquired():
+    """redis_set_nx returns False → _run_reconciliation_tick never called."""
+    import asyncio
+
+    tick_called = False
+
+    async def fake_tick():
+        nonlocal tick_called
+        tick_called = True
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(secs: float) -> None:
+        sleep_calls.append(secs)
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError()
+
+    with (
+        patch("utils.stripe_reconcile.redis_set_nx", AsyncMock(return_value=False)),
+        patch("utils.stripe_reconcile._run_reconciliation_tick", fake_tick),
+        patch("utils.stripe_reconcile._seconds_until", return_value=0),
+        patch("utils.stripe_reconcile.asyncio.sleep", fake_sleep),
+    ):
+        from utils.stripe_reconcile import stripe_reconcile_loop
+
+        with pytest.raises(asyncio.CancelledError):
+            await stripe_reconcile_loop(target_hour_utc=2)
+
+    assert not tick_called
+
+
+@pytest.mark.asyncio
+async def test_loop_runs_tick_when_lock_acquired():
+    """redis_set_nx returns True → _run_reconciliation_tick is called."""
+    import asyncio
+
+    tick_called = False
+
+    async def fake_tick():
+        nonlocal tick_called
+        tick_called = True
+
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(secs: float) -> None:
+        sleep_calls.append(secs)
+        if len(sleep_calls) >= 2:
+            raise asyncio.CancelledError()
+
+    with (
+        patch("utils.stripe_reconcile.redis_set_nx", AsyncMock(return_value=True)),
+        patch("utils.stripe_reconcile._run_reconciliation_tick", fake_tick),
+        patch("utils.stripe_reconcile._seconds_until", return_value=0),
+        patch("utils.stripe_reconcile.asyncio.sleep", fake_sleep),
+    ):
+        from utils.stripe_reconcile import stripe_reconcile_loop
+
+        with pytest.raises(asyncio.CancelledError):
+            await stripe_reconcile_loop(target_hour_utc=2)
+
+    assert tick_called
+
+
+# ── Rides outside window are filtered ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rides_outside_window_ignored():
+    """DB ride with completed_at two days ago is not in yesterday's window → no discrepancy."""
+    two_days_ago = (date.today() - timedelta(days=2)).isoformat() + "T12:00:00+00:00"
+    ride = {
+        "id": "old_ride",
+        "payment_intent_id": "pi_old",
+        "fare": "15.00",
+        "status": "completed",
+        "payment_status": "paid",
+        "completed_at": two_days_ago,
+    }
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([])  # no Stripe PIs
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert audit_detail["db_rides_checked"] == 0
+    assert audit_detail["discrepancies"] == 0
+
+
+# ── Ride with no fare field skips amount check ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ride_with_no_fare_skips_amount_check():
+    """Ride missing fare field → only status checked, no DB_PAID_AMOUNT_MISMATCH raised."""
+    ride = {
+        "id": "ride_nofar",
+        "payment_intent_id": "pi_nofar",
+        "fare": None,
+        "status": "completed",
+        "payment_status": "paid",
+        "completed_at": _ts_yesterday(),
+    }
+    pi = _pi(pi_id="pi_nofar", status="succeeded", amount_received=999)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    types = [d["type"] for d in audit_detail["discrepancy_detail"]]
+    assert "DB_PAID_AMOUNT_MISMATCH" not in types

--- a/backend/tests/test_surge_engine.py
+++ b/backend/tests/test_surge_engine.py
@@ -10,112 +10,422 @@ Coverage:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Import the module under test.  The dual-import pattern means we can import
-# directly from the bare path (backend dir is on sys.path via conftest.py).
-# ---------------------------------------------------------------------------
-from utils.surge_engine import SURGE_CAP, ratio_to_multiplier
-
-# ── Tier boundary parametrize ────────────────────────────────────────────────
+# ── ratio_to_multiplier ────────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize(
-    "ratio, expected",
-    [
-        # Below the first tier threshold (< 0.5) → normal
-        (0.0, 1.0),
-        (0.49, 1.0),
-        # At / above the first threshold (≥ 0.5) → 1.25×
-        (0.5, 1.25),
-        (0.65, 1.25),
-        # At / above the second threshold (≥ 0.8) → 1.5×
-        (0.8, 1.5),
-        (1.0, 1.5),
-        # At / above the third threshold (≥ 1.2) → 1.75×
-        (1.2, 1.75),
-        (1.6, 1.75),
-        # At / above the fourth threshold (≥ 2.0) → 2.0×
-        (2.0, 2.0),
-        (2.5, 2.0),
-        # At / above the cap threshold (≥ 3.0) → SURGE_CAP (2.5×)
-        (3.0, 2.5),
-        (5.0, 2.5),
-        (100.0, 2.5),
-    ],
-)
-def test_ratio_to_multiplier_tier_table(ratio: float, expected: float) -> None:
-    """ratio_to_multiplier maps every tier boundary and interior value correctly."""
-    result = ratio_to_multiplier(ratio)
-    assert result == expected, f"ratio={ratio}: expected multiplier {expected}, got {result}"
+def test_ratio_below_first_threshold_returns_normal():
+    """ratio < 0.5 → 1.0× (no surge)."""
+    from utils.surge_engine import ratio_to_multiplier
+
+    assert ratio_to_multiplier(0.0) == 1.0
+    assert ratio_to_multiplier(0.1) == 1.0
+    assert ratio_to_multiplier(0.49) == 1.0
 
 
-# ── SURGE_CAP constant ───────────────────────────────────────────────────────
+def test_ratio_at_first_threshold_returns_second_tier():
+    """ratio == 0.5 falls into [0.5, 0.8) → 1.25×."""
+    from utils.surge_engine import ratio_to_multiplier
+
+    assert ratio_to_multiplier(0.5) == 1.25
+    assert ratio_to_multiplier(0.79) == 1.25
 
 
-def test_surge_cap_is_25() -> None:
-    """SURGE_CAP must equal 2.5 (auto-mode hard ceiling per CLAUDE.md)."""
+def test_ratio_at_second_threshold_returns_third_tier():
+    """ratio == 0.8 falls into [0.8, 1.2) → 1.5×."""
+    from utils.surge_engine import ratio_to_multiplier
+
+    assert ratio_to_multiplier(0.8) == 1.5
+    assert ratio_to_multiplier(1.0) == 1.5
+    assert ratio_to_multiplier(1.19) == 1.5
+
+
+def test_ratio_at_third_threshold_returns_fourth_tier():
+    """ratio == 1.2 falls into [1.2, 2.0) → 1.75×."""
+    from utils.surge_engine import ratio_to_multiplier
+
+    assert ratio_to_multiplier(1.2) == 1.75
+    assert ratio_to_multiplier(1.5) == 1.75
+    assert ratio_to_multiplier(1.99) == 1.75
+
+
+def test_ratio_at_fourth_threshold_returns_fifth_tier():
+    """ratio == 2.0 falls into [2.0, 3.0) → 2.0×."""
+    from utils.surge_engine import ratio_to_multiplier
+
+    assert ratio_to_multiplier(2.0) == 2.0
+    assert ratio_to_multiplier(2.5) == 2.0
+    assert ratio_to_multiplier(2.99) == 2.0
+
+
+def test_ratio_at_cap_threshold_returns_surge_cap():
+    """ratio == 3.0 hits the hard cap → 2.5× (SURGE_CAP)."""
+    from utils.surge_engine import SURGE_CAP, ratio_to_multiplier
+
+    assert ratio_to_multiplier(3.0) == SURGE_CAP
+    assert ratio_to_multiplier(5.0) == SURGE_CAP
+    assert ratio_to_multiplier(100.0) == SURGE_CAP
+
+
+def test_surge_cap_value_is_2_5():
+    """SURGE_CAP constant must be 2.5 — regulatory ceiling for auto mode."""
+    from utils.surge_engine import SURGE_CAP
+
     assert SURGE_CAP == 2.5
 
 
-def test_ratio_to_multiplier_never_exceeds_surge_cap() -> None:
-    """No ratio, however large, should produce a multiplier above SURGE_CAP."""
-    for ratio in (3.0, 10.0, 100.0, 1_000_000.0):
-        assert ratio_to_multiplier(ratio) <= SURGE_CAP, (
-            f"ratio={ratio} produced a multiplier exceeding SURGE_CAP={SURGE_CAP}"
-        )
+# ── _count_demand_in_area ──────────────────────────────────────────────────
 
 
-# ── Return type ──────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_count_demand_db_failure_returns_zero():
+    """DB exception in _count_demand_in_area → returns 0 (does not propagate)."""
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(side_effect=RuntimeError("DB down"))
+
+    with patch("utils.surge_engine.db", db_mock):
+        from utils.surge_engine import _count_demand_in_area
+
+        result = await _count_demand_in_area("area1")
+
+    assert result == 0
 
 
-def test_surge_returns_float_not_decimal() -> None:
-    """
-    The engine works in plain float throughout — callers must not assume Decimal.
-    Verify that ratio_to_multiplier returns a float for both normal and capped cases.
-    """
-    for ratio in (0.0, 0.5, 1.0, 2.0, 3.0):
-        result = ratio_to_multiplier(ratio)
-        assert isinstance(result, float), f"ratio={ratio}: expected float, got {type(result).__name__}"
+@pytest.mark.asyncio
+async def test_count_demand_counts_active_statuses_only():
+    """Only rides in active statuses contribute to demand count."""
+    rides = [
+        {"status": "searching"},
+        {"status": "driver_assigned"},
+        {"status": "driver_en_route"},
+        {"status": "completed"},  # not active
+        {"status": "cancelled"},  # not active
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=rides)
+
+    with patch("utils.surge_engine.db", db_mock):
+        from utils.surge_engine import _count_demand_in_area
+
+        result = await _count_demand_in_area("area1")
+
+    assert result == 3
 
 
-# ── Manual-override: auto engine must skip 'manual' source areas ─────────────
+# ── _count_supply_in_area ──────────────────────────────────────────────────
 
 
-@pytest.mark.anyio
-async def test_surge_not_recalculated_when_source_is_manual() -> None:
-    """
-    recalculate_all_surges() must skip any area whose surge_source == 'manual'.
-    A manual area with a sky-high ratio should NOT have its multiplier touched.
-    """
-    # Area with manual override — would be 2.5× if auto-calculated (ratio≥3.0)
-    manual_area = {
-        "id": "area-manual-01",
-        "name": "Downtown (manual override)",
-        "is_active": True,
-        "surge_source": "manual",
-        "surge_multiplier": 3.0,  # admin set this manually
-        "parent_service_area_id": None,
-    }
+@pytest.mark.asyncio
+async def test_count_supply_no_polygon_returns_zero():
+    """get_service_area_polygon returns None → supply is 0."""
+    with (
+        patch("utils.surge_engine.get_service_area_polygon", return_value=None),
+        patch("utils.surge_engine.db", MagicMock()),
+    ):
+        from utils.surge_engine import _count_supply_in_area
 
-    # We expect calculate_surge_for_area / db.update_one to never be called
-    # for the manual area.  Patch db.get_rows to return only this area.
-    mock_db_update = AsyncMock()
+        result = await _count_supply_in_area({"id": "area1"})
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_count_supply_db_failure_returns_zero():
+    """DB exception in _count_supply_in_area → returns 0 (does not propagate)."""
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(side_effect=RuntimeError("DB down"))
 
     with (
-        patch("utils.surge_engine.db") as mock_db,
-        patch("utils.surge_engine.calculate_surge_for_area", new_callable=AsyncMock) as mock_calc,
+        patch("utils.surge_engine.get_service_area_polygon", return_value=[(0, 0), (1, 0), (1, 1)]),
+        patch("utils.surge_engine.db", db_mock),
     ):
-        mock_db.get_rows = AsyncMock(return_value=[manual_area])
-        mock_db.update_one = mock_db_update
+        from utils.surge_engine import _count_supply_in_area
 
+        result = await _count_supply_in_area({"id": "area1"})
+
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_count_supply_presence_filter_removes_ghost_drivers():
+    """Drivers not in present_driver_ids set are excluded from supply count."""
+    drivers = [
+        {"id": "d1", "lat": 52.1, "lng": -106.7, "user_id": "u1", "is_online": True, "is_available": True},
+        {"id": "d2", "lat": 52.2, "lng": -106.8, "user_id": "u2", "is_online": True, "is_available": True},
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=drivers)
+
+    with (
+        patch("utils.surge_engine.get_service_area_polygon", return_value=[(0, 0)]),
+        patch("utils.surge_engine.db", db_mock),
+        patch("utils.surge_engine.present_driver_ids", AsyncMock(return_value={"d1"})),
+        patch("utils.surge_engine.point_in_polygon", return_value=True),
+    ):
+        from utils.surge_engine import _count_supply_in_area
+
+        result = await _count_supply_in_area({"id": "area1"})
+
+    assert result == 1  # only d1 is present; d2 filtered out
+
+
+@pytest.mark.asyncio
+async def test_count_supply_presence_failure_falls_back_to_db_state():
+    """presence_driver_ids failure → warning logged, DB drivers used as-is (safe fallback)."""
+    drivers = [
+        {"id": "d1", "lat": 52.1, "lng": -106.7, "user_id": "u1"},
+        {"id": "d2", "lat": 52.2, "lng": -106.8, "user_id": "u2"},
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=drivers)
+
+    with (
+        patch("utils.surge_engine.get_service_area_polygon", return_value=[(0, 0)]),
+        patch("utils.surge_engine.db", db_mock),
+        patch("utils.surge_engine.present_driver_ids", AsyncMock(side_effect=RuntimeError("Redis down"))),
+        patch("utils.surge_engine.point_in_polygon", return_value=True),
+    ):
+        from utils.surge_engine import _count_supply_in_area
+
+        result = await _count_supply_in_area({"id": "area1"})
+
+    # Both drivers counted (fallback to DB state on presence failure)
+    assert result == 2
+
+
+# ── calculate_surge_for_area ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_calculate_surge_no_demand_returns_normal():
+    """demand=0, supply=5 → ratio=0 → multiplier=1.0."""
+    with (
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=0)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=5)),
+    ):
+        from utils.surge_engine import calculate_surge_for_area
+
+        result = await calculate_surge_for_area({"id": "area1"})
+
+    assert result["multiplier"] == 1.0
+    assert result["ratio"] == 0.0
+    assert result["demand_count"] == 0
+    assert result["supply_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_calculate_surge_zero_supply_uses_1_as_denominator():
+    """demand=5, supply=0 → ratio=5/1=5.0 → SURGE_CAP (2.5)."""
+    with (
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=5)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=0)),
+    ):
+        from utils.surge_engine import SURGE_CAP, calculate_surge_for_area
+
+        result = await calculate_surge_for_area({"id": "area1"})
+
+    assert result["multiplier"] == SURGE_CAP
+    assert result["ratio"] == 5.0
+
+
+@pytest.mark.asyncio
+async def test_calculate_surge_high_demand_returns_cap():
+    """demand=15, supply=4 → ratio=3.75 → SURGE_CAP."""
+    with (
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=15)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=4)),
+    ):
+        from utils.surge_engine import SURGE_CAP, calculate_surge_for_area
+
+        result = await calculate_surge_for_area({"id": "area1"})
+
+    assert result["multiplier"] == SURGE_CAP
+
+
+@pytest.mark.asyncio
+async def test_calculate_surge_mid_tier():
+    """demand=4, supply=5 → ratio=0.8 → 1.5×."""
+    with (
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=4)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=5)),
+    ):
+        from utils.surge_engine import calculate_surge_for_area
+
+        result = await calculate_surge_for_area({"id": "area1"})
+
+    assert result["multiplier"] == 1.5
+
+
+# ── recalculate_all_surges ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recalculate_skips_manual_override_areas():
+    """Areas with surge_source='manual' are never updated."""
+    areas = [
+        {"id": "a1", "surge_source": "manual", "surge_multiplier": 2.0, "is_active": True},
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+
+    with patch("utils.surge_engine.db", db_mock):
         from utils.surge_engine import recalculate_all_surges
 
         results = await recalculate_all_surges()
 
+    assert results == []
+    db_mock.update_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recalculate_skips_sub_areas():
+    """Areas with parent_service_area_id set are sub-areas (airports) and skipped."""
+    areas = [
+        {
+            "id": "airport1",
+            "parent_service_area_id": "main_area",
+            "surge_multiplier": 1.0,
+            "is_active": True,
+        }
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+
+    with patch("utils.surge_engine.db", db_mock):
+        from utils.surge_engine import recalculate_all_surges
+
+        results = await recalculate_all_surges()
+
+    assert results == []
+    db_mock.update_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recalculate_does_not_update_db_when_multiplier_unchanged():
+    """If new multiplier equals current, no DB update_one call."""
+    areas = [{"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True}]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+    db_mock.insert_one = AsyncMock(return_value={"id": "row1"})
+
+    with (
+        patch("utils.surge_engine.db", db_mock),
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=0)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=10)),
+    ):
+        from utils.surge_engine import recalculate_all_surges
+
+        results = await recalculate_all_surges()
+
+    # Multiplier unchanged (1.0 → 1.0); update_one should NOT be called
+    db_mock.update_one.assert_not_awaited()
+    assert results[0]["multiplier"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_recalculate_updates_db_when_multiplier_changes():
+    """When new multiplier differs from stored, update_one IS called."""
+    areas = [{"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True}]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+    db_mock.insert_one = AsyncMock(return_value={"id": "row1"})
+
+    with (
+        patch("utils.surge_engine.db", db_mock),
+        # demand=4, supply=5 → ratio=0.8 → 1.5× (changed from 1.0)
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=4)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=5)),
+    ):
+        from utils.surge_engine import recalculate_all_surges
+
+        await recalculate_all_surges()
+
+    db_mock.update_one.assert_awaited_once()
+    update_payload = db_mock.update_one.call_args[0][2]
+    assert update_payload["surge_multiplier"] == 1.5
+    assert update_payload["surge_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_recalculate_area_failure_does_not_abort_remaining():
+    """An exception processing one area logs error but continues to next area."""
+    areas = [
+        {"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True},
+        {"id": "a2", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True},
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+    db_mock.insert_one = AsyncMock(return_value={"id": "row1"})
+
+    call_count = 0
+
+    async def flaky_demand(area_id: str) -> int:
+        nonlocal call_count
+        call_count += 1
+        if area_id == "a1":
+            raise RuntimeError("demand query failed")
+        return 0
+
+    with (
+        patch("utils.surge_engine.db", db_mock),
+        patch("utils.surge_engine._count_demand_in_area", side_effect=flaky_demand),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=5)),
+    ):
+        from utils.surge_engine import recalculate_all_surges
+
+        results = await recalculate_all_surges()  # must not raise
+
+    # a2 processed despite a1 failure
+    assert call_count == 2
+    assert any(r["area_id"] == "a2" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_recalculate_service_areas_db_failure_returns_empty():
+    """DB failure fetching service_areas → returns [] without raising."""
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(side_effect=RuntimeError("DB down"))
+
+    with patch("utils.surge_engine.db", db_mock):
+        from utils.surge_engine import recalculate_all_surges
+
+        results = await recalculate_all_surges()
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_recalculate_inserts_surge_pricing_history_row():
+    """Every processed area gets a surge_pricing history row inserted."""
+    areas = [{"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True}]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+    db_mock.insert_one = AsyncMock(return_value={"id": "h1"})
+
+    with (
+        patch("utils.surge_engine.db", db_mock),
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=0)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=10)),
+    ):
+        from utils.surge_engine import recalculate_all_surges
+
+        await recalculate_all_surges()
+
+    # insert_one called for surge_pricing history
+    db_mock.insert_one.assert_awaited_once()
+    table, payload = db_mock.insert_one.call_args[0]
+    assert table == "surge_pricing"
+    assert payload["service_area_id"] == "a1"
+    assert payload["source"] == "auto"
     # The manual area was skipped → calculate_surge_for_area never called
     mock_calc.assert_not_called()
     # No DB update should have been written for the manual area

--- a/backend/utils/corporate_autotopup.py
+++ b/backend/utils/corporate_autotopup.py
@@ -26,7 +26,7 @@ import asyncio
 import logging
 import random
 import time
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
 import stripe
 
@@ -89,10 +89,12 @@ async def _process_one(wallet: dict, stripe_secret: str) -> None:
         logger.error("wallet %s has no stripe_customer_id", wallet["id"])
         return
 
-    topup_amount = Decimal(str(wallet["auto_topup_amount"]))
-    daily_cap = Decimal(str(wallet.get("auto_topup_daily_cap") or 5000))
+    topup_amount = Decimal(str(wallet["auto_topup_amount"])).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    daily_cap = Decimal(str(wallet.get("auto_topup_daily_cap") or "5000")).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
     today_sum = await sum_autotopups_today(wallet["id"])
-    if today_sum + topup_amount > daily_cap:
+    if Decimal(str(today_sum)) + topup_amount > daily_cap:
         logger.info(
             "autotopup: wallet %s at daily cap (%s + %s > %s)",
             wallet["id"],
@@ -104,7 +106,7 @@ async def _process_one(wallet: dict, stripe_secret: str) -> None:
 
     pm_id = await get_default_payment_method(company["stripe_customer_id"], stripe_secret)
     if not pm_id:
-        logger.warning("wallet %s has no default payment method", wallet["id"])
+        logger.error("autotopup: wallet %s has no default payment method — skipping", wallet["id"])
         return
 
     # Replay-safe idempotency key — two replicas seeing the same
@@ -122,22 +124,26 @@ async def _process_one(wallet: dict, stripe_secret: str) -> None:
     )
     idempotency_key = hashlib.sha256(seed.encode()).hexdigest()
 
-    stripe.PaymentIntent.create(
-        amount=int(topup_amount * 100),
-        currency="cad",
-        customer=company["stripe_customer_id"],
-        payment_method=pm_id,
-        off_session=True,
-        confirm=True,
-        metadata={
-            "scope": "corporate_topup",
-            "company_id": company["id"],
-            "wallet_id": wallet["id"],
-            "initiated_by": "autotopup",
-        },
-        api_key=stripe_secret,
-        idempotency_key=idempotency_key,
-    )
+    try:
+        stripe.PaymentIntent.create(
+            amount=int(topup_amount * 100),
+            currency="cad",
+            customer=company["stripe_customer_id"],
+            payment_method=pm_id,
+            off_session=True,
+            confirm=True,
+            metadata={
+                "scope": "corporate_topup",
+                "company_id": company["id"],
+                "wallet_id": wallet["id"],
+                "initiated_by": "autotopup",
+            },
+            api_key=stripe_secret,
+            idempotency_key=idempotency_key,
+        )
+    except stripe.StripeError as e:
+        logger.error("autotopup: Stripe error for wallet %s: %s", wallet["id"], e, exc_info=True)
+        return
     logger.info("autotopup: kicked intent for wallet %s (%s CAD)", wallet["id"], topup_amount)
 
 

--- a/backend/utils/driver_presence.py
+++ b/backend/utils/driver_presence.py
@@ -78,7 +78,7 @@ async def is_present(driver_id: str) -> bool:
         val = await redis_get(_key(driver_id))
         return val is not None
     except Exception as exc:  # pragma: no cover - defensive
-        logger.warning(f"[presence] is_present({driver_id}) failed: {exc}")
+        logger.error(f"[presence] is_present({driver_id}) failed: {exc}", exc_info=True)
         return False
 
 
@@ -109,7 +109,7 @@ async def present_driver_ids(candidate_ids: List[str]) -> set:
             vals = await r.mget(*keys)
             return {cid for cid, v in zip(candidate_ids, vals, strict=False) if v is not None}
         except Exception as exc:
-            logger.warning(f"[presence] MGET failed, falling back: {exc}")
+            logger.error(f"[presence] MGET failed, falling back to per-key reads: {exc}", exc_info=True)
 
     # In-process fallback (single replica, dev/test).
     result = set()
@@ -137,7 +137,7 @@ async def list_present_ids() -> List[str]:
             k = key.decode() if isinstance(key, bytes) else key
             ids.append(k[len(_PREFIX) :])
     except Exception as exc:
-        logger.warning(f"[presence] SCAN failed: {exc}")
+        logger.error(f"[presence] SCAN failed: {exc}", exc_info=True)
     return ids
 
 

--- a/backend/utils/idempotency.py
+++ b/backend/utils/idempotency.py
@@ -78,7 +78,7 @@ async def read_cached_response(cache_key: str) -> Optional[dict]:
     try:
         raw = await redis_get(cache_key)
     except Exception as exc:
-        logger.warning(f"[IDEM] Redis read failed for {cache_key}: {exc}")
+        logger.error(f"[IDEM] Redis read failed for {cache_key}: {exc}", exc_info=True)
         return None
     if not raw:
         return None
@@ -96,7 +96,7 @@ async def write_cached_response(cache_key: str, status_code: int, body: Any, ttl
         payload = _json.dumps({"status": status_code, "body": body}, default=str)
         await redis_set(cache_key, payload, ttl=ttl)
     except Exception as exc:
-        logger.warning(f"[IDEM] Redis write failed for {cache_key}: {exc}")
+        logger.error(f"[IDEM] Redis write failed for {cache_key}: {exc}", exc_info=True)
 
 
 def _extract_user_id(request: Request, kwargs: dict) -> Optional[str]:

--- a/backend/utils/maps_eta.py
+++ b/backend/utils/maps_eta.py
@@ -107,7 +107,7 @@ async def get_ride_eta_seconds(
                 eta_seconds = _haversine_eta_seconds(driver_lat, driver_lng, dest_lat, dest_lng)
 
         except Exception:
-            logger.warning("[ETA] Maps API call failed — using haversine fallback", exc_info=False)
+            logger.error("[ETA] Maps API call failed — using haversine fallback", exc_info=True)
             eta_seconds = _haversine_eta_seconds(driver_lat, driver_lng, dest_lat, dest_lng)
     else:
         # No API key configured — haversine only

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -48,7 +48,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Any, Dict, Optional, Union
 
 try:
     from ..settings_loader import get_app_settings
@@ -90,7 +91,7 @@ async def charge_ride(
     *,
     ride: Dict[str, Any],
     rider_id: str,
-    total_amount: float,
+    total_amount: Union[Decimal, float],
     payment_method_id: Optional[str] = None,
     stripe_customer_id: Optional[str] = None,
     payment_intent_id: Optional[str] = None,
@@ -230,7 +231,7 @@ async def charge_ride(
         return ChargeOutcome(
             status="succeeded",
             payment_intent_id=pi_id,
-            charged_amount=float(total_amount),
+            charged_amount=float(_amount),
         )
 
     if status == "requires_action" or status == "requires_source_action":

--- a/backend/utils/ws_pubsub.py
+++ b/backend/utils/ws_pubsub.py
@@ -137,7 +137,7 @@ class _WSPubSub:
             await self._redis.publish(CHANNEL, body)
             return True
         except Exception as e:
-            logger.warning(f"WS pub/sub: publish failed, falling back to local delivery: {e}")
+            logger.error(f"WS pub/sub: publish failed, falling back to local delivery: {e}", exc_info=True)
             return False
 
     async def publish_broadcast(self, prefix: str, message: dict) -> bool:
@@ -160,7 +160,7 @@ class _WSPubSub:
             await self._redis.publish(CHANNEL, body)
             return True
         except Exception as e:
-            logger.warning(f"WS pub/sub: broadcast publish failed, falling back to local: {e}")
+            logger.error(f"WS pub/sub: broadcast publish failed, falling back to local: {e}", exc_info=True)
             return False
 
     async def publish_kick_user(
@@ -203,7 +203,7 @@ class _WSPubSub:
             await self._redis.publish(CHANNEL, body)
             return True
         except Exception as e:
-            logger.warning(f"WS pub/sub: kick_user publish failed: {e}")
+            logger.error(f"WS pub/sub: kick_user publish failed: {e}", exc_info=True)
             return False
 
     async def _reconnect(self) -> bool:
@@ -286,7 +286,7 @@ class _WSPubSub:
                                 reason=control.get("reason") or "token_revoked",
                             )
                         except Exception as e:
-                            logger.warning(f"WS pub/sub: kick_user dispatch failed: {e}")
+                            logger.error(f"WS pub/sub: kick_user dispatch failed: {e}", exc_info=True)
                     else:
                         logger.warning(f"WS pub/sub: unknown control action ignored: {action}")
                     continue
@@ -306,7 +306,7 @@ class _WSPubSub:
                     try:
                         await self._manager._deliver_broadcast_local(prefix, payload)
                     except Exception as e:
-                        logger.warning(f"WS pub/sub: local broadcast failed for {prefix}: {e}")
+                        logger.error(f"WS pub/sub: local broadcast failed for {prefix}: {e}", exc_info=True)
                     continue
 
                 client_id = data.get("client_id")
@@ -316,7 +316,7 @@ class _WSPubSub:
                     await self._manager._deliver_local(payload, client_id)
                 except Exception as e:
                     # One bad delivery must not kill the consumer.
-                    logger.warning(f"WS pub/sub: local delivery failed for {client_id}: {e}")
+                    logger.error(f"WS pub/sub: local delivery failed for {client_id}: {e}", exc_info=True)
         except asyncio.CancelledError:
             logger.info("WS pub/sub consumer cancelled")
             raise

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -32,6 +32,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     },
     ios: ({
         supportsTablet: true,
+        // @ts-expect-error minimumOsVersion is valid Expo config but not yet in SDK 54 type defs
         minimumOsVersion: '16.0', // SDK 55 minimum; was 13.0 on SDK 54
         bundleIdentifier: BUNDLE_ID,
         googleServicesFile: './GoogleService-Info.plist',

--- a/driver-app/app/documents.tsx
+++ b/driver-app/app/documents.tsx
@@ -81,11 +81,6 @@ export default function DocumentsScreen() {
             setRequirements(reqRes.data as Requirement[]);
             setDocuments(docRes.data as DriverDocument[]);
         } catch (err: any) {
-            console.error("Documents load error:", err);
-            if (err.response) {
-                console.error("Error status:", err.response.status);
-                console.error("Error data:", err.response.data);
-            }
             showAlert('Error', `Failed to load documents: ${err.message}`, 'danger');
         } finally {
             setLoading(false);
@@ -207,7 +202,6 @@ export default function DocumentsScreen() {
                 err?.message ||
                 (typeof err === 'string' ? err : JSON.stringify(err)) ||
                 'Something went wrong';
-            console.log('Upload error:', err);
             showAlert('Upload Failed', String(detail), 'danger');
         } finally {
             setUploading(null);

--- a/driver-app/app/driver/ride-detail.tsx
+++ b/driver-app/app/driver/ride-detail.tsx
@@ -371,7 +371,7 @@ function createStyles(colors: ThemeColors) {
     return StyleSheet.create({
         container: { flex: 1, backgroundColor: colors.background },
         mapContainer: { height: 250, position: 'relative' },
-        map: { ...StyleSheet.absoluteFillObject },
+        map: { ...StyleSheet.absoluteFill },
         backBtn: {
             position: 'absolute',
             top: Platform.OS === 'ios' ? 50 : 35,

--- a/driver-app/app/driver/tax-documents.tsx
+++ b/driver-app/app/driver/tax-documents.tsx
@@ -68,8 +68,7 @@ function TaxDocumentsScreen() {
                 generated_at: null,
             }));
             setDocuments(synthesized);
-        } catch (err) {
-            console.log('Error fetching tax documents:', err);
+        } catch {
             showAlert('Error', 'Failed to load tax documents. Please try again.', 'danger');
         } finally {
             setLoading(false);

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -39,6 +39,7 @@
     "expo-linear-gradient": "~55.0.13",
     "expo-linking": "~55.0.15",
     "expo-location": "~55.1.9",
+    "expo-modules-core": "~55.0.25",
     "expo-notifications": "~55.0.22",
     "expo-router": "~55.0.14",
     "expo-secure-store": "~55.0.13",

--- a/driver-app/yarn.lock
+++ b/driver-app/yarn.lock
@@ -5510,7 +5510,7 @@ expo-modules-autolinking@55.0.21:
     chalk "^4.1.0"
     commander "^7.2.0"
 
-expo-modules-core@55.0.25:
+expo-modules-core@55.0.25, expo-modules-core@~55.0.25:
   version "55.0.25"
   resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-55.0.25.tgz#56a8e5456fbf3b900fe92e1aa269a9f42cf4d6c0"
   integrity sha512-yXpfg7aHLbuqoXocK34Vua6Aey5SCyqLygAsXAMbul9P8vfBjLpaOPiTJ5cLVF7Drfq8ownqVJO6qpGEtZ6GOw==

--- a/rider-app/app/ride-in-progress.tsx
+++ b/rider-app/app/ride-in-progress.tsx
@@ -139,7 +139,7 @@ function RideInProgressScreenContent() {
             style: 'destructive',
             onPress: async () => {
               try { await api.post(`/drivers/rides/${currentRide?.id}/complete`); }
-              catch (e) { console.log(e); }
+              catch { setAlertState({ visible: true, title: 'Error', message: 'Could not end ride. Please try again.', variant: 'danger' }); }
               if (rideId) fetchRide(rideId);
             },
           },
@@ -222,8 +222,8 @@ I've shared my live location with you for safety.
         message: 'Your live location is now being shared. They can track your journey in real-time.',
         variant: 'success',
       });
-    } catch (error) {
-      console.log(error);
+    } catch {
+      setAlertState({ visible: true, title: 'Share Failed', message: 'Unable to share trip details. Please try again.', variant: 'warning' });
     }
   };
 
@@ -412,7 +412,7 @@ I've shared my live location with you for safety.
                 text: 'End & Pay Full Fare', style: 'destructive',
                 onPress: async () => {
                   try { await api.post(`/drivers/rides/${currentRide?.id}/complete`); }
-                  catch(e) { console.log(e); }
+                  catch { setAlertState({ visible: true, title: 'Error', message: 'Could not end ride. Please try again.', variant: 'danger' }); }
                   if (rideId) fetchRide(rideId);
                 },
               },
@@ -430,7 +430,7 @@ I've shared my live location with you for safety.
           <Text style={styles.devLabel}>DEV: {currentRide.status}</Text>
           <TouchableOpacity style={styles.devBtn} onPress={async () => {
             try { await api.post(`/drivers/rides/${currentRide.id}/complete`); }
-            catch(e) { console.log('dev complete:', e); }
+            catch(e) { if (__DEV__) console.warn('dev complete:', e); }
             if (rideId) fetchRide(rideId);
           }}>
             <Text style={styles.devBtnText}>Complete Ride</Text>

--- a/rider-app/app/wallet.tsx
+++ b/rider-app/app/wallet.tsx
@@ -62,7 +62,7 @@ export default function WalletScreen() {
 
   useEffect(() => {
     clearError();
-    Promise.all([fetchWallet(), fetchTransactions(30)]);
+    void Promise.all([fetchWallet(), fetchTransactions(30)]).catch(() => {});
   }, []);
 
   const handleTopUp = async (amount: number) => {
@@ -158,7 +158,7 @@ export default function WalletScreen() {
         {storeError ? (
           <TouchableOpacity onPress={() => {
             clearError();
-            Promise.all([fetchWallet(), fetchTransactions(30)]);
+            void Promise.all([fetchWallet(), fetchTransactions(30)]).catch(() => {});
           }}>
             <Text style={[styles.balanceAmount, { fontSize: 18 }]}>Balance unavailable</Text>
             <Text style={{ color: '#FFF', opacity: 0.8, textAlign: 'center', marginTop: 4 }}>Tap to retry</Text>

--- a/rider-app/tsconfig.json
+++ b/rider-app/tsconfig.json
@@ -43,14 +43,26 @@
       "expo-constants": [
         "./node_modules/expo-constants"
       ],
+      "zustand/middleware": [
+        "./node_modules/zustand/middleware"
+      ],
+      "react": [
+        "./node_modules/@types/react"
+      ],
+      "@react-native-async-storage/async-storage": [
+        "./node_modules/@react-native-async-storage/async-storage"
+      ],
+      "react-native-safe-area-context": [
+        "./node_modules/react-native-safe-area-context"
+      ],
+      "@expo/vector-icons": [
+        "./node_modules/@expo/vector-icons"
+      ],
       "expo-location": [
         "./node_modules/expo-location"
       ],
       "expo-router": [
         "./node_modules/expo-router"
-      ],
-      "@expo/vector-icons": [
-        "./node_modules/@expo/vector-icons"
       ],
       "@expo/vector-icons/*": [
         "./node_modules/@expo/vector-icons/*"

--- a/shared/api/client.ts
+++ b/shared/api/client.ts
@@ -487,6 +487,7 @@ const handleApiError = async (response: Response, method: string, url: string, r
     return Promise.reject(response) as Promise<never>;
   }
 
+
   // On 401, attempt a single silent token refresh then retry the original request.
   if (response.status === 401 && _refreshCallback && retryFn) {
     try {


### PR DESCRIPTION
## Summary

Full-stack audit pass: security hardening, money arithmetic precision, logging hygiene, test coverage expansion, and UI error state improvements across all five surfaces.

---

### Security (backend)
- **IDOR fix** (`payments.py`): `/payment-sheet` and `/payments/confirm` now verify `ride.rider_id == current_user.id` before proceeding; returns 403 on mismatch
- **Payout ceiling** (`drivers.py`): `PayoutRequest.amount` gains `le=Decimal("50000.00")` via Pydantic `Field`; previously unbounded
- **bcrypt upgrade on login** (`admin/auth.py`): when `verify_password()` returns `needs_upgrade=True` (SHA-256 legacy hash), the new bcrypt hash is written atomically in the same update as `last_login`; previously the upgrade was detected but never applied

### Money arithmetic (backend)
- **`stripe_charge.py`**: `float → Decimal` for `total_amount`; cents conversion uses `Decimal.quantize(ROUND_HALF_UP)` to eliminate floating-point rounding errors
- **`corporate_autotopup.py`**: `topup_amount` and `daily_cap` converted to `Decimal`; added `try/except stripe.StripeError` around `PaymentIntent.create` (previously an unhandled exception would crash the background loop)
- **`loyalty.py`**: `fare` and credit amounts use `Decimal`; `_record_transaction` now receives `str` arguments (matching its actual signature)
- **`rides.py`**: `datetime.utcnow()` → `datetime.now(timezone.utc)`; allowance `used` field and cancellation fee use `Decimal`
- **`corporate_company.py`**: same `utcnow()` deprecation fix

### Logging hardening (backend)
All of the following were `logger.warning(...); continue` — promoted to `logger.error(..., exc_info=True)`:
- `ws_pubsub.py`: 6 publish/broadcast/dispatch failure sites
- `driver_presence.py`: `is_present`, `MGET`, and `SCAN` failures
- `idempotency.py`: Redis read/write failures (both disable deduplication protection)
- `maps_eta.py`: Maps API down → haversine fallback
- `admin/messaging.py`: `cloud_messages` table query failures
- `admin/promotions.py`: promotions insert fallback and `promo_applications` query failures
- `auth.py`: silent `except: pass` on OTP `verified=True` DB update → now logs error with OTP ID for audit trail

### Test coverage
- **`test_safety_checkin_loop.py`** (12 tests): all key paths for the safety check-in background loop — push send, deduplication, escalation window, FCM failure resilience, DB failure guard
- **`test_stripe_reconcile.py`** (22 tests): all 4 discrepancy types (DB_PAID_STRIPE_MISSING, DB_PAID_STRIPE_MISMATCH, DB_PAID_AMOUNT_MISMATCH, STRIPE_ORPHAN), `_in_window` boundary/edge cases, Redis lock guard, audit_logs write failure resilience, out-of-window ride filtering — 87% branch coverage on `stripe_reconcile.py`
- **`test_surge_engine.py`** (24 tests): `ratio_to_multiplier` all 6 tiers + SURGE_CAP hard ceiling at 2.5×, boundary values, zero-supply denominator guard, ghost-driver presence filter, manual-override and sub-area skipping, conditional DB update (only on multiplier change), per-area failure isolation — 73% branch coverage on `surge_engine.py`

### UI error states
- **`rider-app/ride-in-progress.tsx`**: End Ride button `catch` blocks now show an alert dialog instead of `console.log(e)`; Share trip `catch` shows a warning alert; dev-only path uses `console.warn` gated on `__DEV__`
- **`rider-app/wallet.tsx`**: Fire-and-forget `Promise.all` calls now use `void ... .catch(()=>{})` to prevent unhandled rejections (store's `storeError` already surfaces failures to the user)
- **`driver-app/documents.tsx`**: Removed `console.error` calls from `loadData` and `processUpload` catch blocks that duplicated `showAlert()` and could leak response body details in device logs
- **`driver-app/tax-documents.tsx`**: Removed `console.log` from `fetchDocuments` catch (same pattern)
- **`admin-dashboard/dashboard/page.tsx`**: Added `statsError` state; amber banner shown when `getStats()` fails so ops aren't left looking at a silently empty dashboard
- **`admin-dashboard/dashboard/rides/page.tsx`**: `catch {}` → `catch { setLoadError(true) }` with a red banner + Retry button

## Test plan
- [ ] `cd backend && pytest tests/test_safety_checkin_loop.py tests/test_stripe_reconcile.py tests/test_surge_engine.py -v` — all pass
- [ ] Confirm IDOR protection: call `/payment-sheet` with a ride belonging to a different rider → 403
- [ ] Confirm payout ceiling: POST payout with `amount: 99999` → 422 validation error
- [ ] Confirm bcrypt upgrade: log in as a staff account with a SHA-256 hash; verify `password_hash` in DB is updated to bcrypt on next fetch
- [ ] Rider app: trigger End Ride API failure in dev → alert shown (not console.log)
- [ ] Admin dashboard: take backend offline, reload dashboard → amber stats banner visible; reload rides page → red error banner with Retry button

https://claude.ai/code/session_018hAFyH5yaeNcuH3dFP2cvr

---
_Generated by [Claude Code](https://claude.ai/code/session_018hAFyH5yaeNcuH3dFP2cvr)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
