### PR TITLE
hotfix(rides): remove duplicate requires_wav kwarg breaking import

### DIFF
--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1060,7 +1060,6 @@ async def create_ride(body: CreateRideRequest, request: Request = None, current_
         admin_earnings=_f(admin_earnings),
         payment_method=body.payment_method,
         payment_method_id=body.payment_method_id,
-        requires_wav=body.requires_wav,
         status="searching",
         pickup_otp=hash_otp(pickup_otp_plain),
         ride_requested_at=datetime.now(timezone.utc),


### PR DESCRIPTION
## Summary
- Removes a duplicate `requires_wav=body.requires_wav` kwarg in `routes/rides.py:1063` that was left behind by the PR #558 merge resolution.
- `compile()` reports `SyntaxError: keyword argument repeated: requires_wav` — backend cannot import `routes.rides`, so the server fails to start. (`ast.parse` does **not** flag this, which is how it slipped past the pre-merge syntax check.)

## Cause
The PR #558 conflict resolution kept fields from both branches in `RideEstimateRequest`. The `Ride(...)` constructor below received `requires_wav=body.requires_wav` from each side of the auto-merge. The on-disk fix removed the duplicate, but it was committed without re-staging — the broken staged copy landed in `d0ec6977` and was merged to main as `f29aab82`.

## Test plan
- [x] `python -c "compile(open('backend/routes/rides.py').read(), 'rides.py', 'exec')"` returns clean.
- [x] Full backend pytest: 1906 passed, 5 skipped, 1 xfailed (no regressions).
- [ ] Confirm Railway deploy of main passes startup.

https://claude.ai/code/session_015vEiLwGzEaLTY3C5MFSn4i

---
_Generated by [Claude Code](https://claude.ai/code/session_015vEiLwGzEaLTY3C5MFSn4i)_