### PR TITLE
refactor(shared): eliminate final any types in logger, cache, AppMap, SupportScreen, ErrorScreen

### DIFF
--- a/shared/cache/index.ts
+++ b/shared/cache/index.ts
@@ -85,7 +85,7 @@ export const CACHE_KEYS = {
 
 // Main cache class
 class AppCache {
-    private memoryCache: Map<string, { data: any; expiry: number }> = new Map();
+    private memoryCache: Map<string, { data: unknown; expiry: number }> = new Map();
 
     /**
      * Get data from cache

--- a/shared/components/AppMap.tsx
+++ b/shared/components/AppMap.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, Platform } from 'react-native';
 
 const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY || '';
 
-const AppMap = React.forwardRef((props: any, ref: any) => {
+const AppMap = React.forwardRef<MapView, React.ComponentProps<typeof MapView>>((props, ref) => {
     const provider = Platform.OS === 'android'
         ? (GOOGLE_MAPS_API_KEY ? PROVIDER_GOOGLE : undefined)
         : undefined;

--- a/shared/components/AppMap.web.tsx
+++ b/shared/components/AppMap.web.tsx
@@ -1,9 +1,9 @@
 import React, { useMemo } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, ViewProps } from 'react-native';
 import { useTheme } from '../theme/ThemeContext';
 import type { ThemeColors } from '../theme/index';
 
-const AppMap = React.forwardRef((props: any, ref: any) => {
+const AppMap = React.forwardRef<View, ViewProps>((props, ref) => {
     const { colors } = useTheme();
     const styles = useMemo(() => createStyles(colors), [colors]);
 

--- a/shared/components/ErrorScreen.tsx
+++ b/shared/components/ErrorScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image, Platform } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useRouter, type Href } from 'expo-router';
 import { useTheme } from '../theme/ThemeContext';
 import type { ThemeColors } from '../theme/index';
 
@@ -143,7 +143,7 @@ export function UnauthorizedScreen({ onLogin }: { onLogin?: () => void }) {
     if (onLogin) {
       onLogin();
     } else {
-      router.push('/login' as any);
+      router.push('/login' as Href);
     }
   };
 

--- a/shared/components/SupportScreen.tsx
+++ b/shared/components/SupportScreen.tsx
@@ -15,6 +15,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 import api from '@shared/api/client';
 import CustomAlert from '@shared/components/CustomAlert';
 import { useTheme } from '@shared/theme/ThemeContext';
@@ -305,7 +306,7 @@ export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
             { key: 'faq', label: 'FAQ', icon: 'help-circle-outline' },
             { key: 'chat', label: 'AI Chat', icon: 'sparkles-outline' },
             { key: 'contact', label: 'Contact', icon: 'mail-outline' },
-          ] as { key: Tab; label: string; icon: string }[]
+          ] as { key: Tab; label: string; icon: IoniconName }[]
         ).map((tab) => (
           <TouchableOpacity
             key={tab.key}
@@ -313,7 +314,7 @@ export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
             onPress={() => setActiveTab(tab.key)}
           >
             <Ionicons
-              name={tab.icon as any}
+              name={tab.icon}
               size={16}
               color={activeTab === tab.key ? colors.primary : colors.textDim}
             />
@@ -544,7 +545,7 @@ export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
               <Text style={styles.companyTitle}>
                 {companyInfo.name || 'SPINR TECHNOLOGIES INC.'}
               </Text>
-              {[
+              {([
                 {
                   icon: 'location-outline',
                   text: companyInfo.address || 'Saskatoon, SK, Canada',
@@ -555,9 +556,9 @@ export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
                   text: companyInfo.phone || SUPPORT_PHONE_DISPLAY,
                 },
                 { icon: 'globe-outline', text: companyInfo.website || 'www.spinr.ca' },
-              ].map((row) => (
-                <View key={row.icon} style={styles.companyRow}>
-                  <Ionicons name={row.icon as any} size={16} color={colors.textDim} />
+              ] as { icon: IoniconName; text: string }[]).map((row) => (
+                <View key={String(row.icon)} style={styles.companyRow}>
+                  <Ionicons name={row.icon} size={16} color={colors.textDim} />
                   <Text style={styles.companyText}>{row.text}</Text>
                 </View>
               ))}

--- a/shared/utils/logger.ts
+++ b/shared/utils/logger.ts
@@ -23,9 +23,9 @@
 const isDev = typeof __DEV__ !== 'undefined' ? __DEV__ : process.env.NODE_ENV !== 'production';
 
 export interface Logger {
-  info: (...args: any[]) => void;
-  warn: (...args: any[]) => void;
-  error: (...args: any[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
 }
 
 export function createLogger(tag: string): Logger {
@@ -36,13 +36,13 @@ export function createLogger(tag: string): Logger {
     return {
       info: () => {},
       warn: () => {},
-      error: (...args: any[]) => console.error(prefix, ...args),
+      error: (...args: unknown[]) => console.error(prefix, ...args),
     };
   }
 
   return {
-    info: (...args: any[]) => console.log(prefix, ...args),
-    warn: (...args: any[]) => console.warn(prefix, ...args),
-    error: (...args: any[]) => console.error(prefix, ...args),
+    info: (...args: unknown[]) => console.log(prefix, ...args),
+    warn: (...args: unknown[]) => console.warn(prefix, ...args),
+    error: (...args: unknown[]) => console.error(prefix, ...args),
   };
 }


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Eliminate the final 15 `any` type occurrences in `shared/` — logger variadic args, cache entry type, AppMap forwardRef generics, SupportScreen Ionicons name casts, and ErrorScreen router push.
- **Type**: `refactor`
- **Linked issue**: none — final installment of the any-type sweep (follows #313, #551)
- **Risk**: `low` — compile-time types only; zero runtime behaviour change
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[x]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `single-surface` — all changes in `shared/`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe`
- **Dependencies / coordination**: `none`
- **Assumptions**: Consumers of `Logger` already pass values compatible with `unknown[]`; `AppMap` callers already pass `MapView`-compatible props

## Tier 3 — Compliance flags

- `[ ]` Money-touching
- `[ ]` PIPEDA-relevant
- `[ ]` SK Transportation Act
- `[ ]` Auth / RLS
- `[ ]` Safety
- `[ ]` Third-party SDK added
- `[ ]` Breaking change to `shared/`

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — type-only changes
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: N/A
- **Perf numbers**: N/A

**Pre-merge checklist**:

- [x] Tested with rider + driver + admin accounts — N/A (type changes only)
- [x] No PII added to logs, Sentry payloads, or analytics

---

### Changes

| File | Hits | Fix |
|---|---|---|
| `shared/utils/logger.ts` | 7 | `...args: any[]` → `...args: unknown[]` on all 3 Logger methods |
| `shared/cache/index.ts` | 1 | `Map<string, { data: any }>` → `{ data: unknown }` |
| `shared/components/AppMap.tsx` | 2 | `forwardRef<MapView, ComponentProps<typeof MapView>>` |
| `shared/components/AppMap.web.tsx` | 2 | `forwardRef<View, ViewProps>` |
| `shared/components/SupportScreen.tsx` | 2 | `IoniconName` alias (`ComponentProps<typeof Ionicons>['name']`) replaces `as any` casts on both icon arrays |
| `shared/components/ErrorScreen.tsx` | 1 | Import `Href` from `expo-router`; `'/login' as Href` replaces `as any` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01KaKmfdaJGATPYUREemRKaU)_