### PR TITLE
fix(payments): ownership check and atomic race guard on confirm_payment

### DIFF
--- a/backend/db_supabase.py
+++ b/backend/db_supabase.py
@@ -898,6 +898,30 @@ async def update_ride(ride_id: str, updates: Dict[str, Any]):
     )
 
 
+async def claim_ride_payment_processing(ride_id: str) -> bool:
+    """Atomically transition payment_status from 'pending' to 'processing'.
+
+    Returns True if this caller claimed the row (proceed to call Stripe).
+    Returns False if another concurrent request already claimed it (return 409).
+    Raises if Supabase is unreachable.
+    """
+    if not supabase:
+        raise RuntimeError("Supabase client not configured")
+
+    def _fn() -> bool:
+        res = (
+            supabase.table("rides")
+            .update({"payment_status": "processing"})
+            .eq("id", ride_id)
+            .eq("payment_status", "pending")
+            .execute()
+        )
+        rows = _rows_from_res(res)
+        return len(rows) > 0
+
+    return await run_sync(_fn)
+
+
 async def get_rides_for_user(rider_id: str, limit: int = 100):
     if not supabase:
         return []

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -185,8 +185,18 @@ async def confirm_payment(
     payment_intent_id = body.get("payment_intent_id")
     ride_id = body.get("ride_id")
 
+    if ride_id:
+        ride = await db_supabase.get_ride(ride_id)
+        if not ride:
+            raise HTTPException(status_code=404, detail="Ride not found")
+        if ride["rider_id"] != current_user["id"]:
+            raise HTTPException(status_code=403, detail="forbidden")
+
+        claimed = await db_supabase.claim_ride_payment_processing(ride_id)
+        if not claimed:
+            raise HTTPException(status_code=409, detail="payment_already_processing")
+
     if payment_intent_id and payment_intent_id.startswith("pi_mock_"):
-        # Mock payment
         if ride_id:
             await db_supabase.update_ride(ride_id, {"payment_status": "paid", "payment_intent_id": payment_intent_id})
         return {"status": "succeeded", "mock": True}

--- a/backend/tests/routes/test_payments.py
+++ b/backend/tests/routes/test_payments.py
@@ -1,0 +1,107 @@
+"""Unit tests for POST /payments/confirm security fixes.
+
+S-1: Ownership check — authenticated user must own the ride.
+R-1: Concurrent race guard — atomic DB claim prevents double-charge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_OWNER_ID = "usr-owner"
+_OTHER_ID = "usr-other"
+_RIDE_ID = "ride-xyz"
+
+_RIDE_OWNED = {"id": _RIDE_ID, "rider_id": _OWNER_ID, "payment_status": "pending"}
+_RIDE_OTHER = {"id": _RIDE_ID, "rider_id": _OTHER_ID, "payment_status": "pending"}
+
+_OWNER_USER = {"id": _OWNER_ID}
+_OTHER_USER = {"id": _OTHER_ID}
+
+
+@pytest.mark.anyio
+async def test_confirm_payment_ownership_check_rejects_non_owner():
+    """S-1: a rider who does not own the ride receives 403."""
+    from fastapi import HTTPException
+
+    from backend.routes.payments import confirm_payment
+
+    with patch("backend.routes.payments.db_supabase") as mock_db:
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_OTHER)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await confirm_payment(
+                body={"payment_intent_id": "pi_123", "ride_id": _RIDE_ID},
+                request=None,
+                current_user=_OTHER_USER,
+            )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "forbidden"
+
+
+@pytest.mark.anyio
+async def test_confirm_payment_ownership_check_allows_owner():
+    """S-1: the ride owner passes the ownership check and proceeds normally."""
+    from backend.routes.payments import confirm_payment
+
+    with (
+        patch("backend.routes.payments.db_supabase") as mock_db,
+        patch("backend.routes.payments.get_app_settings", new_callable=AsyncMock, return_value={}),
+    ):
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_OWNED)
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=True)
+        mock_db.update_ride = AsyncMock()
+
+        result = await confirm_payment(
+            body={"payment_intent_id": "pi_mock_abc", "ride_id": _RIDE_ID},
+            request=None,
+            current_user=_OWNER_USER,
+        )
+
+    assert result["status"] == "succeeded"
+    assert result["mock"] is True
+
+
+@pytest.mark.anyio
+async def test_confirm_payment_returns_404_when_ride_missing():
+    """S-1: non-existent ride_id raises 404 before ownership or Stripe call."""
+    from fastapi import HTTPException
+
+    from backend.routes.payments import confirm_payment
+
+    with patch("backend.routes.payments.db_supabase") as mock_db:
+        mock_db.get_ride = AsyncMock(return_value=None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await confirm_payment(
+                body={"payment_intent_id": "pi_123", "ride_id": "nonexistent"},
+                request=None,
+                current_user=_OWNER_USER,
+            )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_confirm_payment_race_guard_returns_409():
+    """R-1: a concurrent second request loses the atomic claim and gets 409."""
+    from fastapi import HTTPException
+
+    from backend.routes.payments import confirm_payment
+
+    with patch("backend.routes.payments.db_supabase") as mock_db:
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_OWNED)
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await confirm_payment(
+                body={"payment_intent_id": "pi_123", "ride_id": _RIDE_ID},
+                request=None,
+                current_user=_OWNER_USER,
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "payment_already_processing"


### PR DESCRIPTION
## Summary

- **S-1 (ownership bypass):** `confirm_payment` now fetches the ride immediately after the `ride_id` is supplied and verifies `ride["rider_id"] == current_user["id"]`. Any mismatch returns `403 forbidden` before any Stripe call is made — previously any authenticated user could trigger a charge on another user's ride.
- **R-1 (concurrent double-charge):** Before reaching Stripe, the endpoint performs an atomic `UPDATE rides SET payment_status='processing' WHERE id=? AND payment_status='pending'`. If 0 rows are updated, a concurrent request already claimed the slot and the caller receives `409 payment_already_processing`. The new `db_supabase.claim_ride_payment_processing()` helper follows the existing `run_sync` / `_rows_from_res` pattern used throughout the file.
- Removes a pre-existing duplicate `except stripe.error.CardError` clause in `add_card` flagged by ruff B025 (would have blocked the commit hook).

## Files changed

- `backend/routes/payments.py` — ownership check + atomic claim in `confirm_payment`; duplicate except removed
- `backend/db_supabase.py` — new `claim_ride_payment_processing()` helper
- `backend/tests/routes/test_payments.py` — four unit tests: 403 on wrong owner, 200 on correct owner (mock path), 404 on missing ride, 409 on lost race
- `backend/tests/routes/__init__.py` — new package marker

## Test plan

- [ ] `pytest backend/tests/routes/test_payments.py -v` — all four cases pass
- [ ] Manually confirm `POST /payments/confirm` with a `ride_id` belonging to a different user returns 403
- [ ] Simulate two concurrent requests with the same `ride_id`; second returns 409
- [ ] Normal happy-path confirm still returns `succeeded`

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
