### PR TITLE
fix(payments): idempotency check for already-processed payments (C-3)

### DIFF
--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -192,6 +192,20 @@ async def confirm_payment(
         if ride["rider_id"] != current_user["id"]:
             raise HTTPException(status_code=403, detail="forbidden")
 
+        # C-3: Idempotency check — if a prior webhook already settled this payment,
+        # return early with a clear signal rather than re-entering the Stripe flow.
+        # This covers the case where the rider app retries confirm_payment after a
+        # network timeout when the webhook has already processed the payment.
+        # HTTP 200 (not 409) because the payment succeeded — this is not an error.
+        payment_status = ride.get("payment_status")
+        if payment_status in ("paid", "processing"):
+            logger.info(
+                "confirm_payment: ride %s already in payment_status=%s, returning early (C-3 idempotency)",
+                ride_id,
+                payment_status,
+            )
+            return {"status": "already_processed", "payment_status": payment_status}
+
         claimed = await db_supabase.claim_ride_payment_processing(ride_id)
         if not claimed:
             raise HTTPException(status_code=409, detail="payment_already_processing")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Problem**: `confirm_payment()` had no guard against client retries that arrive after a Stripe webhook has already set `payment_status='paid'` on the ride. A retry would re-enter the Stripe `PaymentIntent.retrieve` flow unnecessarily, and in degraded Stripe API conditions could produce confusing or double-confirm behaviour.
- **Fix**: Added an explicit idempotency check (C-3) immediately after the ownership check. If `ride.payment_status` is already `'paid'` or `'processing'`, the handler returns HTTP 200 with `{"status": "already_processed", "payment_status": <current>}` — no Stripe call, no atomic claim, no DB write.
- **No new DB calls**: reuses the `ride` dict already fetched for the ownership check.
- **Relationship to R-1**: The existing `claim_ride_payment_processing()` atomic claim (from PR #598) guards concurrent duplicate requests; this check handles the sequential-retry case where settlement already completed before the retry arrives.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| First call, `payment_status='pending'` | Proceeds normally | Proceeds normally (unchanged) |
| Concurrent duplicate (R-1) | 409 `payment_already_processing` | 409 `payment_already_processing` (unchanged) |
| Retry after webhook settled `'paid'` | Re-enters Stripe flow | 200 `already_processed` (C-3 new) |
| Retry while in-flight `'processing'` | 409 from failed claim | 200 `already_processed` (C-3 new, cleaner signal) |

## Test plan

- [ ] Confirm `payment_status='paid'` on ride → endpoint returns 200 `{"status": "already_processed", "payment_status": "paid"}` without calling Stripe
- [ ] Confirm `payment_status='processing'` on ride → same early return
- [ ] Confirm `payment_status='pending'` ride → flow proceeds to Stripe as before
- [ ] Existing `test_payments.py` tests still pass (no existing behaviour changed for the happy path or the concurrent-race path)
- [ ] Log line `confirm_payment: ride <id> already in payment_status=<status>, returning early (C-3 idempotency)` appears at INFO level in the retry scenario

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
