### PR TITLE
fix(auth): audit log entries for OTP and auth mutations (S-4)

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -273,6 +273,22 @@ async def send_otp(request: Request, body: SendOTPRequest):
     response = {"success": True, "message": f"OTP sent to ***{phone[-4:]}"}
     # Dev OTP is logged to server console via sms_service.py — never return it
     # in the API response to avoid accidental exposure in client-side logs.
+    import asyncio
+    import hashlib
+
+    _ph = hashlib.sha256(phone.encode()).hexdigest()[:16]
+    try:
+        asyncio.create_task(
+            _audit_log_user(
+                {"id": f"phone_hash:{_ph}", "role": "anonymous"},
+                "otp_sent",
+                "users",
+                _ph,
+                {"phone_last4": phone[-4:]},
+            )
+        )
+    except Exception:
+        logger.error("audit_log write failed for otp_sent", exc_info=True)
 
     return response
 
@@ -430,6 +446,20 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
             set_csrf_cookie(
                 response, csrf, secure=settings.ENV == "production", max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
             )
+            try:
+                import asyncio
+
+                asyncio.create_task(
+                    _audit_log_user(
+                        existing_user,
+                        "otp_verify_success",
+                        "users",
+                        user_id,
+                        {"is_new_user": False},
+                    )
+                )
+            except Exception:
+                logger.error("audit_log write failed for otp_verify_success (returning user)", exc_info=True)
             return _make_auth_response(
                 response,
                 token,
@@ -481,6 +511,20 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
             set_csrf_cookie(
                 response, csrf, secure=settings.ENV == "production", max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
             )
+            try:
+                import asyncio
+
+                asyncio.create_task(
+                    _audit_log_user(
+                        new_user,
+                        "otp_verify_success",
+                        "users",
+                        user_id,
+                        {"is_new_user": True},
+                    )
+                )
+            except Exception:
+                logger.error("audit_log write failed for otp_verify_success (new user)", exc_info=True)
             return _make_auth_response(
                 response,
                 token,
@@ -646,6 +690,20 @@ async def firebase_auth_login(request: Request, response: Response, body: Fireba
     set_csrf_cookie(
         response, csrf, secure=settings.ENV == "production", max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60
     )
+    try:
+        import asyncio
+
+        asyncio.create_task(
+            _audit_log_user(
+                user,
+                "firebase_auth_login",
+                "users",
+                user_id,
+                {"is_new_user": is_new_user},
+            )
+        )
+    except Exception:
+        logger.error("audit_log write failed for firebase_auth_login", exc_info=True)
     return _make_auth_response(
         response,
         token,
@@ -897,7 +955,7 @@ async def logout(
                 )
             )
         except Exception:
-            logger.debug("audit_log write failed for logout event", exc_info=True)
+            logger.error("audit_log write failed for logout event", exc_info=True)
     clear_csrf_cookie(response)
     return {"success": True}
 


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Add fire-and-forget audit log entries at four auth mutation points (OTP send, OTP verify new user, OTP verify returning user, Firebase login) to satisfy security audit finding S-4
- **Type** [required]: `security`
- **Linked issue** [required]: none — security audit finding S-4
- **Risk** [required]: `low` — all audit writes are fire-and-forget wrapped in try/except; auth flow never blocked
- **User-visible change** [required]: `none`
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — removes audit calls; no data cleanup needed
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: `log_user_action` (aliased as `_audit_log_user`) exists in `utils/audit_logger.py` and is safe to call from a background task

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — not applicable
- `[x]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — pre-auth events use sha256[:16] hash of phone; no raw PII in audit entries
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — not applicable
- `[x]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — adds audit trail for OTP and Firebase auth mutations
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — not applicable
- `[ ]` **Third-party SDK added** — not applicable
- `[ ]` **Breaking change to `shared/`** — not applicable

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — audit log calls are fire-and-forget side effects; existing auth tests cover primary response paths
- **Integration tests** [required]: `not-applicable`
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video** [required if UI files touched]: N/A — no UI change
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: N/A

**Pre-merge checklist** [required]:

- [x] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
