### PR TITLE
fix(dispatch): Redis leader lock on scheduled-rides tick (R-2)

### DIFF
--- a/backend/utils/scheduled_rides.py
+++ b/backend/utils/scheduled_rides.py
@@ -25,6 +25,7 @@ try:
     from ..db import db
     from ..features import send_push_notification
     from .datetime_utils import parse_iso_utc
+    from .redis_client import redis_set_nx
 except ImportError:
     from db import db
     from features import send_push_notification
@@ -112,6 +113,12 @@ async def _send_reminder(ride: dict):
 
 async def check_scheduled_rides():
     """Check for scheduled rides that need dispatching or reminders."""
+    try:
+        if not await redis_set_nx("spinr:scheduled_rides:lock", "1", ttl=90):
+            return
+    except Exception as _lock_err:
+        logger.warning(f"scheduled_rides: Redis leader lock unavailable ({_lock_err}), proceeding without lock")
+
     now = datetime.now(timezone.utc)
     ten_min_from_now = now + timedelta(minutes=10)
 


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Add a per-tick Redis `SET NX EX 90` leader lock to `check_scheduled_rides()` so only one replica processes scheduled rides per 60 s cycle, preventing duplicate reminders and double-dispatch
- **Type** [required]: `fix`
- **Linked issue** [required]: none — reliability audit finding R-2
- **Risk** [required]: `low` — Redis unavailability degrades gracefully; per-ride flags still provide replay safety
- **User-visible change** [required]: `none`
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `modified` — adds leader lock to `scheduled_ride_dispatcher_loop` tick
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — removes leader lock; `reminder_sent` and `scheduled_dispatched` flags still prevent double-processing
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: `redis_set_nx` returns False (not raises) when the key already exists; raises only on Redis unavailability

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — not applicable
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — not applicable
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — not applicable
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — not applicable
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — not applicable
- `[ ]` **Third-party SDK added** — not applicable
- `[ ]` **Breaking change to `shared/`** — not applicable

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — leader lock behaviour requires multi-replica integration testing; existing tick logic tests unaffected
- **Integration tests** [required]: `not-applicable`
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video** [required if UI files touched]: N/A — no UI change
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: N/A

**Pre-merge checklist** [required]:

- [x] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

https://claude.ai/code/session_01WsRNJXwu21To1wyvohMVew

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
