### PR TITLE
chore(admin): verify all admin API routes require auth — add coverage comment

### DIFF
--- a/backend/routes/admin/__init__.py
+++ b/backend/routes/admin/__init__.py
@@ -18,6 +18,27 @@ could `POST /api/admin/staff` to create themselves as a super-admin.
 ``admin_auth_router`` (login / session / logout) is mounted directly
 by server.py as a separate router and stays public so the dashboard
 can reach /api/admin/auth/login without a token.
+
+Auth coverage audit — 2026-05-06
+----------------------------------
+All admin API endpoints have been audited for authentication gating.
+Coverage is provided by two complementary mechanisms:
+
+1. Router-level dependency (this file):
+   ``admin_router = APIRouter(dependencies=[Depends(get_admin_user)])``
+   covers every sub-router included via ``admin_router.include_router()``.
+   This is the primary gate for all sub-routers in this package.
+
+2. Per-handler ``Depends(get_admin_user)`` in function signatures:
+   Used by ``routes/admin/monitoring.py``, which is mounted directly on
+   ``app`` (not via ``admin_router``) in server.py. Every endpoint in
+   that file carries the dependency individually.
+
+Excluded from ``admin_router`` by design (public):
+   - ``admin_auth_router`` (login, session, logout, MFA, refresh, unlock)
+     — mounted separately by server.py; login must be reachable pre-auth.
+
+No unprotected admin API endpoints exist as of this audit.
 """
 
 from fastapi import APIRouter, Depends


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Post-#310 audit confirms all admin API routes are protected; adds invariant doc comment
- **Type**: `chore`
- **Linked issue**: none — follow-up audit to #310 (admin middleware dead-auth fix)
- **Risk**: `low` — comment-only change, zero behaviour change
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type — comment-only, no logic changes.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — removes the comment; no functional change
- **Dependencies / coordination**: `none`
- **Assumptions**: none

## Tier 3 — Compliance flags

- `[x]` **Auth / RLS** — audit confirms `get_admin_user` dependency covers all 15+ admin sub-routers via router-level `dependencies=[]`; `monitoring.py` covered per-handler; auth routes intentionally public

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — comment-only change
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: N/A
- **Perf numbers**: N/A

**Audit findings summary:**

Two-layer protection confirmed:
1. `admin_router` instantiated with `dependencies=[Depends(get_admin_user)]` — covers all 15+ sub-routers
2. `monitoring.py` (mounted directly on `app`) carries `Depends(get_admin_user)` on all 6 handlers individually
3. `admin_auth_router` (login/refresh/MFA) intentionally public — correct

**Pre-merge checklist**:

- [x] No PII added to logs, Sentry payloads, or analytics
- [x] `CLAUDE.md` / `.claude/context/*.md` unchanged

https://claude.ai/code/session_01WZUd9Gz7jSwkjhezisDLB9