### PR TITLE
fix(tests): unblock backend-test — repair broken-import / undefined-name failures on main

### DIFF
--- a/backend/tests/routes/test_payments.py
+++ b/backend/tests/routes/test_payments.py
@@ -15,7 +15,6 @@ _OTHER_ID = "usr-other"
 _RIDE_ID = "ride-xyz"
 
 _RIDE_OWNED = {"id": _RIDE_ID, "rider_id": _OWNER_ID, "payment_status": "pending"}
-_RIDE_OTHER = {"id": _RIDE_ID, "rider_id": _OTHER_ID, "payment_status": "pending"}
 
 _OWNER_USER = {"id": _OWNER_ID}
 _OTHER_USER = {"id": _OTHER_ID}
@@ -29,7 +28,7 @@ async def test_confirm_payment_ownership_check_rejects_non_owner():
     from backend.routes.payments import confirm_payment
 
     with patch("backend.routes.payments.db_supabase") as mock_db:
-        mock_db.get_ride = AsyncMock(return_value=_RIDE_OTHER)
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_OWNED)
 
         with pytest.raises(HTTPException) as exc_info:
             await confirm_payment(

--- a/backend/tests/test_corporate_company_routes.py
+++ b/backend/tests/test_corporate_company_routes.py
@@ -5,9 +5,17 @@ fake `current_user`. Guard behaviour is still exercised because the
 guard's `list_active_memberships_for_user` call is mocked per-test.
 """
 
+from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+
+def _money(v):
+    """Compare API money values regardless of whether they are returned as
+    str (post Decimal-stringification) or float (legacy)."""
+    return Decimal(str(v))
+
 
 _FAKE_USER = {"id": "u_admin", "phone": "+15550001111"}
 
@@ -370,15 +378,15 @@ def test_billing_summary_aggregates_rows(test_client, rider_override):
     body = resp.json()
     assert body["month"] == "2026-04"
     assert body["ride_count"] == 3
-    assert body["allowance_total"] == 35.0
+    assert _money(body["allowance_total"]) == Decimal("35.0")
     # master_total: 5.0 + 0.0 + 45.0 = 50.0
-    assert body["master_total"] == 50.0
+    assert _money(body["master_total"]) == Decimal("50.0")
     # total: allowance + master = 35.0 + 50.0 = 85.0
-    assert body["total"] == 85.0
-    assert body["wallet_balance"] == 120.0
+    assert _money(body["total"]) == Decimal("85.0")
+    assert _money(body["wallet_balance"]) == Decimal("120.0")
     # by_member sorted by total desc — m2 (45.0) beats m1 (40.0) unambiguously
     assert body["by_member"][0]["member_id"] == "m2"
-    assert body["by_member"][0]["total"] == 45.0
+    assert _money(body["by_member"][0]["total"]) == Decimal("45.0")
     assert body["by_member"][1]["member_id"] == "m1"
     assert body["by_member"][1]["ride_count"] == 2
 
@@ -431,8 +439,8 @@ def test_billing_statement_returns_line_items(test_client, rider_override):
     body = resp.json()
     assert len(body["line_items"]) == 3
     # total: 35.0 (allowance) + 50.0 (master) = 85.0
-    assert body["summary"]["total"] == 85.0
-    assert body["summary"]["avg_fare"] == round(85.0 / 3, 2)
+    assert _money(body["summary"]["total"]) == Decimal("85.0")
+    assert _money(body["summary"]["avg_fare"]) == _money(round(85.0 / 3, 2))
 
 
 def test_billing_statement_rejects_bad_month(test_client, rider_override):
@@ -463,7 +471,7 @@ def test_billing_transactions_returns_paged_ledger(test_client, rider_override):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["wallet_id"] == "w1"
-    assert body["balance"] == 250.0
+    assert _money(body["balance"]) == Decimal("250.0")
     assert len(body["transactions"]) == 1
     m_list.assert_awaited_once_with(wallet_id="w1", skip=0, limit=25)
 

--- a/backend/tests/test_coverage_payments.py
+++ b/backend/tests/test_coverage_payments.py
@@ -279,8 +279,12 @@ async def test_confirm_payment_mock():
 
     with patch("backend.routes.payments.db_supabase") as mock_db:
         mock_db.update_ride = AsyncMock()
+        mock_db.get_ride = AsyncMock(
+            return_value={"id": "ride-1", "rider_id": _USER["id"], "payment_status": "pending"}
+        )
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=True)
         result = await confirm_payment(
-            request={"payment_intent_id": "pi_mock_test", "ride_id": "ride-1"},
+            body={"payment_intent_id": "pi_mock_test", "ride_id": "ride-1"},
             current_user=_USER,
         )
 
@@ -293,7 +297,7 @@ async def test_confirm_payment_mock_no_ride_id():
     from backend.routes.payments import confirm_payment
 
     result = await confirm_payment(
-        request={"payment_intent_id": "pi_mock_xyz"},
+        body={"payment_intent_id": "pi_mock_xyz"},
         current_user=_USER,
     )
     assert result["status"] == "succeeded"
@@ -305,7 +309,7 @@ async def test_confirm_payment_no_stripe_key():
 
     with patch("backend.routes.payments.get_app_settings", new_callable=AsyncMock, return_value=_settings(False)):
         result = await confirm_payment(
-            request={"payment_intent_id": "pi_real_001"},
+            body={"payment_intent_id": "pi_real_001"},
             current_user=_USER,
         )
     assert result["status"] == "unknown"
@@ -318,6 +322,7 @@ async def test_confirm_payment_real_stripe():
 
     mock_intent = MagicMock()
     mock_intent.status = "succeeded"
+    mock_intent.metadata = {"user_id": str(_USER["id"])}
 
     with (
         patch("backend.routes.payments.get_app_settings", new_callable=AsyncMock, return_value=_settings()),
@@ -325,8 +330,12 @@ async def test_confirm_payment_real_stripe():
         patch("backend.routes.payments.db_supabase") as mock_db,
     ):
         mock_db.update_ride = AsyncMock()
+        mock_db.get_ride = AsyncMock(
+            return_value={"id": "ride-1", "rider_id": _USER["id"], "payment_status": "pending"}
+        )
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=True)
         result = await confirm_payment(
-            request={"payment_intent_id": "pi_real_001", "ride_id": "ride-1"},
+            body={"payment_intent_id": "pi_real_001", "ride_id": "ride-1"},
             current_user=_USER,
         )
 
@@ -717,7 +726,7 @@ async def test_payment_sheet_ride_idempotency_key():
         patch("backend.routes.payments.stripe.EphemeralKey.create", return_value=mock_ephemeral),
         patch("backend.routes.payments.stripe.PaymentIntent.create", create_spy),
     ):
-        mock_db.get_ride = AsyncMock(return_value={"id": "ride-ps", "total_fare": "12.00"})
+        mock_db.get_ride = AsyncMock(return_value={"id": "ride-ps", "total_fare": "12.00", "rider_id": _USER["id"]})
         mock_db.get_user_by_id = AsyncMock(return_value=_USER)
         mock_db.update_one = AsyncMock()
 
@@ -808,7 +817,7 @@ async def test_confirm_payment_stripe_error():
     ):
         with pytest.raises(HTTPException) as exc:
             await confirm_payment(
-                request={"payment_intent_id": "pi_real_err"},
+                body={"payment_intent_id": "pi_real_err"},
                 current_user=_USER,
             )
     assert exc.value.status_code == 500

--- a/backend/tests/test_coverage_rides.py
+++ b/backend/tests/test_coverage_rides.py
@@ -168,7 +168,7 @@ async def test_estimate_ride_returns_estimates():
         mock_db.get_rows = AsyncMock(return_value=[])
 
         result = await estimate_ride(
-            request=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
+            body=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
             current_user=_USER,
         )
 
@@ -211,7 +211,7 @@ async def test_estimate_ride_includes_nearby_drivers():
         mock_db.get_rows = AsyncMock(return_value=[nearby_driver])
 
         result = await estimate_ride(
-            request=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
+            body=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
             current_user=_USER,
         )
 
@@ -289,8 +289,9 @@ async def test_get_ride_history_returns_completed_rides():
 
     with patch("backend.routes.rides.db_supabase") as mock_db:
         mock_db.get_rows = AsyncMock(return_value=completed)
+        mock_db.find_one = AsyncMock(return_value=None)
 
-        result = await get_ride_history(request=req, limit=3, current_user=_USER)
+        result = await get_ride_history(request=req, limit=3, before=None, current_user=_USER)
 
     assert len(result["rides"]) == 3
     assert result["next_cursor"] is not None
@@ -301,10 +302,13 @@ async def test_get_ride_history_cursor_pagination():
     from backend.routes.rides import get_ride_history
 
     req = _starlette_request()
-    rides = [{"id": f"r-{i}", "status": "completed", "driver_id": _DRIVER_ID} for i in range(5)]
+    # The DB layer applies the `created_at < cursor_ts` filter, so the mock
+    # simulates that by returning only rides older than the cursor.
+    rides_after_cursor = [{"id": f"r-{i}", "status": "completed", "driver_id": _DRIVER_ID} for i in range(2, 5)]
 
     with patch("backend.routes.rides.db_supabase") as mock_db:
-        mock_db.get_rows = AsyncMock(return_value=rides)
+        mock_db.get_rows = AsyncMock(return_value=rides_after_cursor)
+        mock_db.find_one = AsyncMock(return_value={"id": "r-1", "created_at": "2024-01-02T00:00:00Z"})
 
         result = await get_ride_history(request=req, limit=20, before="r-1", current_user=_USER)
 
@@ -327,8 +331,9 @@ async def test_get_ride_history_filters_cancelled_without_driver():
 
     with patch("backend.routes.rides.db_supabase") as mock_db:
         mock_db.get_rows = AsyncMock(return_value=rides)
+        mock_db.find_one = AsyncMock(return_value=None)
 
-        result = await get_ride_history(request=req, limit=20, current_user=_USER)
+        result = await get_ride_history(request=req, limit=20, before=None, current_user=_USER)
 
     ids = [r["id"] for r in result["rides"]]
     assert "r-1" not in ids
@@ -449,7 +454,7 @@ async def test_add_tip_success():
             )
 
     assert result["success"] is True
-    assert result["tip_amount"] == 2.00
+    assert Decimal(str(result["tip_amount"])) == Decimal("2.00")
 
 
 @pytest.mark.anyio
@@ -1891,7 +1896,7 @@ async def test_trigger_emergency_not_found():
         with pytest.raises(HTTPException) as exc:
             await trigger_emergency(
                 ride_id=_RIDE_ID,
-                request=EmergencyRequest(),
+                body=EmergencyRequest(),
                 current_user=_USER,
             )
     assert exc.value.status_code == 404
@@ -1910,7 +1915,7 @@ async def test_trigger_emergency_not_authorized():
         with pytest.raises(HTTPException) as exc:
             await trigger_emergency(
                 ride_id=_RIDE_ID,
-                request=EmergencyRequest(),
+                body=EmergencyRequest(),
                 current_user=_USER,
             )
     assert exc.value.status_code == 403
@@ -1939,7 +1944,7 @@ async def test_trigger_emergency_success():
         mock_manager.broadcast_to_admins = AsyncMock()
         result = await trigger_emergency(
             ride_id=_RIDE_ID,
-            request=EmergencyRequest(latitude=52.1, longitude=-106.6),
+            body=EmergencyRequest(latitude=52.1, longitude=-106.6),
             current_user=_USER,
         )
     assert result["success"] is True
@@ -2243,9 +2248,12 @@ async def test_get_ride_history_with_cursor():
     """Cursor pagination should skip rides up to and including the cursor id."""
     from backend.routes.rides import get_ride_history
 
-    rides = [_ride(status="completed", **{"id": f"r-{i}", "driver_id": _DRIVER_ID}) for i in range(5)]
+    # The DB layer applies the `created_at < cursor_ts` filter, so the mock
+    # simulates that by returning only rides older than the cursor.
+    rides_after_cursor = [_ride(status="completed", **{"id": f"r-{i}", "driver_id": _DRIVER_ID}) for i in range(2, 5)]
     with patch("backend.routes.rides.db_supabase") as mock_db:
-        mock_db.get_rows = AsyncMock(return_value=rides)
+        mock_db.get_rows = AsyncMock(return_value=rides_after_cursor)
+        mock_db.find_one = AsyncMock(return_value={"id": "r-1", "created_at": "2024-01-02T00:00:00Z"})
         result = await get_ride_history(
             request=_starlette_request(),
             limit=10,

--- a/backend/tests/test_p0_ship_blockers.py
+++ b/backend/tests/test_p0_ship_blockers.py
@@ -19,6 +19,7 @@ Run as:
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -644,7 +645,7 @@ class TestPaymentFailureAtComplete:
             result = await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
 
         assert result["success"] is True
-        assert result["charged_amount"] == 20.5  # 18.5 + 2.0 tip
+        assert Decimal(str(result["charged_amount"])) == Decimal("20.5")  # 18.5 + 2.0 tip
 
     async def test_wallet_rejects_insufficient_balance(self):
         """If the wallet can't cover fare + tip, payment returns 400 and

--- a/backend/tests/test_process_payment_card.py
+++ b/backend/tests/test_process_payment_card.py
@@ -116,7 +116,7 @@ class TestCardSuccess:
             result = await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
 
         assert result["success"] is True
-        assert result["charged_amount"] == 18.5
+        assert Decimal(str(result["charged_amount"])) == Decimal("18.5")
 
         # The last write to payment_status must be "paid"
         assert _last_payment_status_write(updates) == "paid"
@@ -142,10 +142,10 @@ class TestCardSuccess:
             result = await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
 
         # Fare was 18.5, tip 2 → 20.5
-        assert result["charged_amount"] == 20.5
+        assert Decimal(str(result["charged_amount"])) == Decimal("20.5")
         # tip_amount must be persisted on the ride
         paid_write = next(u for u in updates if u.get("payment_status") == "paid")
-        assert paid_write.get("tip_amount") == 2.0
+        assert Decimal(str(paid_write.get("tip_amount"))) == Decimal("2.0")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_promo_rate_limit.py
+++ b/backend/tests/test_promo_rate_limit.py
@@ -82,6 +82,22 @@ def _build_promo_app() -> FastAPI:
 # ── /promo/validate (10 per minute) ──────────────────────────────────────────
 
 
+@pytest.fixture(autouse=True)
+def _enable_real_limiter():
+    """The global conftest disables `default_limiter` (so most tests don't trip
+    rate-limits incidentally). These tests need the real limiter ON to verify
+    enforcement, so locally re-enable + reset its storage before each test."""
+    from utils.rate_limiter import default_limiter
+
+    default_limiter.enabled = True
+    inner = getattr(default_limiter, "_limiter", None)
+    storage = getattr(inner, "storage", None) if inner is not None else None
+    if storage is not None and callable(getattr(storage, "reset", None)):
+        storage.reset()
+    yield
+    default_limiter.enabled = False
+
+
 class TestPromoValidateRateLimit:
     """Rate-limit enforcement for POST /promo/validate (promo_validate_limit: 10/min)."""
 

--- a/backend/tests/test_surge_engine.py
+++ b/backend/tests/test_surge_engine.py
@@ -426,12 +426,6 @@ async def test_recalculate_inserts_surge_pricing_history_row():
     assert table == "surge_pricing"
     assert payload["service_area_id"] == "a1"
     assert payload["source"] == "auto"
-    # The manual area was skipped → calculate_surge_for_area never called
-    mock_calc.assert_not_called()
-    # No DB update should have been written for the manual area
-    mock_db_update.assert_not_called()
-    # No results returned (nothing was auto-processed)
-    assert results == []
 
 
 @pytest.mark.anyio
@@ -484,6 +478,8 @@ def test_manual_override_value_above_auto_cap_is_valid() -> None:
     confirms that SURGE_CAP is a ceiling only for the auto tier function —
     a stored value of 3.0 returned directly (simulating a DB read) is valid.
     """
+    from utils.surge_engine import SURGE_CAP
+
     # Simulate what the admin dashboard would store and what the DB returns.
     # The auto function is bypassed for manual areas, so the stored value is
     # returned verbatim.


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Fix 29 of 40 broken backend tests on main (test-only diff). Backend-test failure count drops from 40 → 11; remaining 11 are blocked on a single production bug documented for follow-up.
- **Type** [required]: `fix`
- **Linked issue** [required]: Refs #555, #663, #664, #672 (every recent PR's `backend-test` job has been failing on these inherited bugs)
- **Risk** [required]: `low` — pure test-only diff, no production code touched, no schema/API changes.
- **User-visible change** [required]: `none`
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `single-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — pure test-file diff; reverting drops the test fixes but cannot break production.
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: The 11 remaining backend-test failures are caused by a single production bug (`_amount` undefined in `utils/stripe_charge.py:234`) outside this PR's test-only scope.

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** — touches money-test assertions but not money logic.
- `[ ]` **PIPEDA-relevant**
- `[ ]` **SK Transportation Act**
- `[ ]` **Auth / RLS**
- `[ ]` **Safety**
- `[ ]` **Third-party SDK added**
- `[ ]` **Breaking change to `shared/`**

## Tier 4 — Verification

- **Unit tests** [required]: `updated` — 29 test fixes across 8 files. Failure count: 40 → 11. Pass count: 2,182 → 2,211. Coverage 63.80% (≥ 60% threshold).
- **Integration tests** [required]: `not-applicable`
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video** [required if UI files touched]: not applicable.
- **Perf numbers** [required if SLA-critical path touched]: not applicable.

**Pre-merge checklist** [required]:

- [x] Ran the changed code against real Supabase dev (not just mocks) — n/a, test-only diff
- [x] Tested with rider + driver + admin accounts — n/a, no UX surface
- [x] Verified the rollback command actually works — `git revert` is mechanical
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention change
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

---

## Test fix table

| Test file | Root cause | Fix |
|---|---|---|
| `tests/test_surge_engine.py` (2) | `SURGE_CAP` not imported at call site; stale leftover refs to undefined `mock_calc`/`mock_db_update`/`results` | Hoist `SURGE_CAP` import; drop dead lines from a deleted predecessor test |
| `tests/test_coverage_payments.py` (6) | `confirm_payment(...)` kwarg renamed `request → body`; missing AsyncMocks for `get_ride`/`claim_ride_payment_processing` and `intent.metadata` for the new ownership/claim path | Rename kwarg, add the missing AsyncMocks |
| `tests/test_coverage_rides.py` (10) | Multiple kwarg renames (`estimate_ride`, `trigger_emergency`); `get_ride_history` cursor moved to DB layer; `add_tip` returns money as string post Decimal-stringification | Rename kwargs, mock `find_one`, simulate DB-side cursor filtering, compare via `Decimal(str(...))` |
| `tests/routes/test_payments.py` (1) | `_RIDE_OTHER` had `rider_id == _OTHER_USER.id`, so the ownership check legitimately passed | Use `_RIDE_OWNED` for the rejection scenario |
| `tests/test_corporate_company_routes.py` (3) | Money fields serialized as strings (`'35.00'`) post commit `b2090b9` | Add `_money()` Decimal-coercing helper |
| `tests/test_promo_rate_limit.py` (4) | Autouse `reset_rate_limiters` fixture set `default_limiter.enabled = False`, masking the very behaviour these tests pin | Local autouse fixture re-enables the limiter for this module only |
| `tests/test_process_payment_card.py` (2) | `result["charged_amount"]` is a string post-stringification | Compare via `Decimal(str(...))` |
| `tests/test_p0_ship_blockers.py` (1) | Same money-stringification | Compare via `Decimal(str(...))`; add `Decimal` import |

## Out of scope: 11 remaining failures (single production bug)

All 11 remaining backend-test failures share one root cause: `utils/stripe_charge.py:234` references undefined local `_amount` (very likely a stale rename — should be `total_amount`). Per the test-only scope, production code under `utils/` was not touched.

```
File "utils/stripe_charge.py", line 234, in charge_ride
    charged_amount=float(_amount),
                         ^^^^^^^
NameError: name '_amount' is not defined
```

Affected tests (all blocked on the same line):
- `tests/test_stripe_charge.py::TestSuccess` (2) and `::TestIdempotencyKey` (1)
- `tests/test_p0_ship_blockers.py::TestE3HappyPath` (2)
- `tests/test_e4_d10_payment_3ds_quests.py::TestPayment3DSRetry` (3)
- `tests/test_payment_retry.py` (3)

Recommended follow-up: a one-line production fix renaming `_amount → total_amount` will likely clear all 11.

https://claude.ai/code/session_01UQ9xbPozFcSwxAue5Y49CE

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
