### PR TITLE
chore(ci): wire expo-doctor into pre-build validation gate

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -102,11 +102,14 @@ jobs:
 
       # Pre-build gate: runs only when a native build is about to happen.
       # Blocks the expensive EAS build credit spend on broken code.
-      - name: Pre-build validation (lint + type-check + tests)
+      # Order matters: expo-doctor first — it surfaces SDK / native-module
+      # mismatches that would otherwise produce confusing tsc / Jest errors.
+      - name: Pre-build validation (doctor + lint + type-check + tests)
         if: |
           (github.event_name == 'push' && contains(github.event.head_commit.message, '[build]')) ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'build')
         run: |
+          yarn doctor
           yarn tsc --noEmit
           yarn lint --max-warnings 0
           yarn test --ci --passWithNoTests
@@ -153,11 +156,12 @@ jobs:
           MESSAGE=$(echo "$MESSAGE" | head -1 | cut -c1-1000)
           eas update --channel "$CHANNEL" --auto --non-interactive --message "$MESSAGE"
 
-      - name: Pre-build validation (lint + type-check + tests)
+      - name: Pre-build validation (doctor + lint + type-check + tests)
         if: |
           (github.event_name == 'push' && contains(github.event.head_commit.message, '[build]')) ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'build')
         run: |
+          yarn doctor
           yarn tsc --noEmit
           yarn lint --max-warnings 0
           yarn test --ci --passWithNoTests

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -122,6 +122,7 @@
     "start": "expo start",
     "web": "expo start --web",
     "build:web": "expo export --platform web",
+    "doctor": "npx --yes expo-doctor",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/rider-app/package.json
+++ b/rider-app/package.json
@@ -8,6 +8,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "lint": "expo lint",
+    "doctor": "npx --yes expo-doctor",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Wire `expo-doctor` as the first step of the EAS pre-build validation gate so SDK / native-module mismatches are caught before tsc / lint / test.
- **Type**: `chore`
- **Linked issue**: `none` — PR 1 of 8 in the Expo Build Deployment Readiness plan (`/root/.claude/plans/yes-and-build-a-lively-whisper.md`); no pre-existing ticket.
- **Risk**: `low` — CI gate only, no app code.
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[x]` rider-app  `[x]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[x]` CI
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — single revert removes the script entries and the workflow step; no runtime state change.
- **Dependencies / coordination**: `none`
- **Assumptions**: EAS workflow image has `npx` available (verified — `actions/setup-node@v6` with Node 20 provides it).

## Tier 3 — Compliance flags

None apply. CI gate only — no money, no PII, no auth, no safety, no new third-party SDK at runtime.

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — CI workflow change; no testable runtime code path.
- **Integration tests**: `not-applicable` — exercise comes from the next `[build]`-tagged commit which runs `yarn doctor` end-to-end.
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: not applicable (no UI).
- **Perf numbers**: not applicable (not on an SLA path).

**Pre-merge checklist**:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — n/a, no backend change.
- [ ] Tested with rider + driver + admin accounts — n/a, no user-facing change.
- [ ] Verified the rollback command actually works — n/a, low-risk single-revert.
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention change; the runbook's Step 0 is now enforced rather than recommended.
- [x] No PII added to logs, Sentry payloads, or analytics.

## Why

`docs/dependency-upgrade-runbook.md` Step 0 already requires `expo-doctor` before any dependency change. It was never wired into CI. The SDK 54 → 55 migration (#639) cost 4 failed EAS builds because async-storage / reanimated / worklets drift produced confusing Gradle errors that masked the root cause; `expo-doctor` would have flagged them at the lockfile stage. This PR makes the gate automatic before any native build is dispatched.

https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg