### PR TITLE
fix(ios): declare camera + photo library purpose strings

### DIFF
--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -42,6 +42,18 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         associatedDomains: [
             'applinks:spinr.app',
         ],
+        // Purpose strings — Apple rejects uploads with ITMS-90683 if any
+        // dependency calls a permission-gated API without a matching string.
+        // Driver app needs camera + photo library for onboarding document
+        // uploads (license, insurance, vehicle registration) per the
+        // Saskatchewan Transportation Act eligibility requirements.
+        // Location strings are supplied by the expo-location plugin block.
+        infoPlist: {
+            NSCameraUsageDescription:
+                'Spinr Driver uses your camera to scan and upload your driver license, vehicle insurance, and vehicle registration documents during onboarding and renewal.',
+            NSPhotoLibraryUsageDescription:
+                'Spinr Driver accesses your photo library so you can upload existing photos of your driver license, vehicle insurance, and vehicle registration.',
+        },
         // Required by Apple for any app using required-reason APIs (enforced from May 2024).
         // Missing this causes App Store / TestFlight rejection at upload time.
         privacyManifests: {

--- a/rider-app/app.config.ts
+++ b/rider-app/app.config.ts
@@ -42,6 +42,16 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             'applinks:spinr.app',
             'applinks:spinr-track.app',
         ],
+        // Purpose strings — Apple rejects uploads with ITMS-90683 if any
+        // dependency calls a permission-gated API without a matching string.
+        // Only declare keys for capabilities actually used; declaring unused
+        // permissions triggers App Review questions.
+        infoPlist: {
+            NSCameraUsageDescription:
+                'Spinr uses your camera so you can take a profile photo for your rider account.',
+            NSPhotoLibraryUsageDescription:
+                'Spinr accesses your photo library so you can choose an existing image as your profile photo.',
+        },
         // Required by Apple for any app using required-reason APIs (enforced from May 2024).
         // Missing this causes App Store / TestFlight rejection at upload time (ITMS-91053).
         privacyManifests: {


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Add `NSCameraUsageDescription` and `NSPhotoLibraryUsageDescription` to both apps' iOS Info.plist via `app.config.ts`. Without these, every TestFlight upload fails preflight with `ITMS-90683`.
- **Type**: `fix`
- **Linked issue**: `none` — PR 3 of 8 in the Expo Build Deployment Readiness plan; no pre-existing ticket.
- **Risk**: `low` — config-only iOS Info.plist change; no JS runtime change, no native module added.
- **User-visible change**: `riders`, `drivers` — iOS permission prompt sheets now display the declared purpose text when the app first asks for camera or photo-library access (instead of empty / Apple-default text).
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[x]` rider-app  `[x]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — single revert removes the `infoPlist` block; the next EAS build then ships without the strings (Apple rejects upload). Reverting only makes sense if the strings are wrong, not as a "safe rollback".
- **Dependencies / coordination**: `none`
- **Assumptions**: `expo-image-picker` is the only library in either app requiring these strings (verified — no audio / contacts / mic libs in deps; location strings are already supplied by the `expo-location` plugin block in driver-app).

## Tier 3 — Compliance flags

- `[x]` **PIPEDA-relevant** — purpose strings are the user-facing PII transparency text shown by Apple's permission framework. They explain what camera and photo-library data the app collects and why. No new log payloads, analytics events, or PII storage paths are introduced.

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — config change. Validation is via `expo prebuild --no-install --platform ios` which emits `ios/<App>/Info.plist`; the strings appear there or they don't.
- **Integration tests**: `not-applicable` — Apple's static analyzer is the integration test (it gates upload).
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: not applicable until on-device test (post-EAS-build).
- **Perf numbers**: not applicable.

**Pre-merge checklist**:

- [ ] Ran the changed code against real Supabase dev — n/a, no backend change.
- [ ] Tested with rider + driver + admin accounts — verified manually post-EAS-build (see Test plan below).
- [ ] Verified the rollback command actually works — n/a, low-risk single-revert.
- [x] Updated CLAUDE.md / `.claude/context/*.md` if a convention changed — no convention change.
- [x] No PII added to logs, Sentry payloads, or analytics.

## Why these specific keys (and no others)

| Key | rider | driver | Reason |
|---|---|---|---|
| `NSCameraUsageDescription` | ✓ | ✓ | `expo-image-picker` |
| `NSPhotoLibraryUsageDescription` | ✓ | ✓ | `expo-image-picker` |
| `NSMicrophoneUsageDescription` | — | — | No audio capture libraries in either app |
| `NSContactsUsageDescription` | — | — | Emergency contacts entered manually; no `expo-contacts` |
| Location strings | — | already in plugin | Driver: supplied via `expo-location` plugin block. Rider: location prompts handled by `expo-location` defaults |

Apple flags **declared but unused** permission keys during App Review. Adding only what we actually use keeps review clean.

## Test plan (post-merge, on next EAS preview build)

- [ ] `cd rider-app && npx expo prebuild --no-install --platform ios --clean && grep -E 'NSCamera|NSPhoto' ios/Spinr/Info.plist` — both keys appear with the declared text.
- [ ] Same for driver-app.
- [ ] `eas build --profile preview --platform ios` — binary uploads to internal distribution without `ITMS-90683`.
- [ ] On device: tap "edit profile photo" (rider) and "upload license" (driver) — purpose-string sheet shows the new text.

https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
