### PR TITLE
[DO NOT MERGE] chore: New Architecture dev-client probe

### DIFF
--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -13,8 +13,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     icon: './assets/images/icon.png',
     scheme: SCHEME,
     userInterfaceStyle: 'automatic',
+    // PROBE BRANCH — DO NOT MERGE. Flipped to true to validate that
+    // Reanimated 4 / LogRocket / gorhom-bottom-sheet / Firebase / expo-location
+    // background tracking all behave correctly under New Architecture before
+    // opening the production-targeted PR (#6). See PR description for matrix.
     // @ts-expect-error newArchEnabled is valid Expo config but not yet typed in ExpoConfig
-    newArchEnabled: false, // disabled: pre-launch stability over perf; re-enable post go-live as a planned migration
+    newArchEnabled: true,
     updates: {
         url: 'https://u.expo.dev/1ed02cf4-97cb-4678-b5a2-0881f89abaa8',
     },

--- a/rider-app/app.config.ts
+++ b/rider-app/app.config.ts
@@ -13,7 +13,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     icon: './assets/images/icon.png',
     scheme: SCHEME,
     userInterfaceStyle: 'automatic',
-    newArchEnabled: false, // disabled: pre-launch stability over perf; re-enable post go-live as a planned migration
+    // PROBE BRANCH — DO NOT MERGE. Flipped to true to validate that
+    // Reanimated 4 / Stripe Payment Sheet / LogRocket / gorhom-bottom-sheet
+    // all behave correctly under New Architecture before opening the
+    // production-targeted PR (#6). See PR description for the validation matrix.
+    newArchEnabled: true,
     updates: {
         url: 'https://u.expo.dev/8f1e4f60-720e-46b0-9b71-33c13d3af043',
     },


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — research / decision-gate branch

PR 5 of 8 in the Expo Build Deployment Readiness plan. **This branch exists to test New Architecture behaviour before flipping the flag in production**, never to merge.

The only diff vs main: `newArchEnabled: true` in both `rider-app/app.config.ts` and `driver-app/app.config.ts`.

## Why this branch exists

`react-native-reanimated@4.3.0` only supports the New Architecture (Software Mansion dropped old-arch support in v4). Today both apps ship with `newArchEnabled: false`, which is mathematically incompatible — animations crash at first transition.

Before flipping the flag in production we need to confirm every native module in the stack works under New Arch. The known unknown is **`@logrocket/react-native@2.3.1`** — LogRocket has historically been the slowest in the RN ecosystem to add Fabric support. Stripe Payment Sheet is a secondary watch item.

## Validation matrix

Run an EAS development build off this branch and execute every row on **both physical iOS and Android, both rider and driver apps**:

| # | Surface | Test | Pass criterion |
|---|---|---|---|
| 1 | Reanimated transitions | Open `app/driver-arriving.tsx` (rider) | Map markers animate smoothly, no console errors |
| 2 | gorhom bottom-sheet | Open ride-options sheet | Open/close gestures responsive |
| 3 | Stripe Payment Sheet | Add card `4242 4242 4242 4242`, run 3DS card `4000 0025 0000 3155`, decline `4000 0000 0000 9995` | All three flows succeed; no "module not found in Fabric registry" errors |
| 4 | LogRocket | Trigger a session, view in dashboard | **Must not crash on app startup**; session captured |
| 5 | Firebase Messaging | Send test push to physical device | Notification delivered, tap routes correctly |

How to run the build:

```bash
cd rider-app
eas build --profile development --platform all --non-interactive
# wait ~20 min, install dev-client APK + IPA on physical devices
cd ../driver-app
eas build --profile development --platform all --non-interactive
```

Document each row's outcome (pass / fail + screenshot or log snippet) in this PR description before deciding the next step.

## Decision rule (read this before merging anything else)

| Probe outcome | Path | Next PR |
|---|---|---|
| All 5 pass on both apps | **Path A** | Open `fix/enable-new-arch` (PR #6) — flip flag on main, change `runtimeVersion` to `{ policy: 'fingerprint' }`, bump app version to 1.0.1, ship |
| Only LogRocket fails | **Path B** | Open `fix/replace-logrocket-with-sentry-replay` (PR #6b) first — remove `@logrocket/react-native`, enable Sentry session replay (gated on PR #4), then Path A |
| Stripe or Reanimated fails | **Path C** | Open `fix/reanimated-3-fallback` (PR #6c) — stay on SDK 55, downgrade `react-native-reanimated 4.3.0 → ~3.18`, remove `react-native-worklets`. Defer New Arch to Q4 2026 |
| 2+ surfaces fail | **Path C** by default | Don't gamble on a fragile flip |

## After running the probe

1. Fill in the validation matrix above with results.
2. Add a "Decision" section to this PR description saying which Path was chosen.
3. **Close this PR without merging.** The chosen Path PR (#6, #6b, or #6c) carries the actual production change.
4. Delete the branch `chore/dev-client-new-arch-probe` after closure.

## Plan context

This is the **single decision gate** that unblocks PR #6 / 6b / 6c. Until it runs, the apps technically crash on production builds because Reanimated 4 isn't compatible with the current `newArchEnabled: false`. PRs #1, #3, #4, #7, #8 can land in parallel without waiting for this probe.

https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg)_