### PR TITLE
fix(ota): runtimeVersion fingerprint policy on both apps

### DIFF
--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -18,12 +18,17 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     updates: {
         url: 'https://u.expo.dev/1ed02cf4-97cb-4678-b5a2-0881f89abaa8',
     },
-    // Bare workflow (after `expo prebuild`) does not support runtime version
-    // policies like { policy: 'appVersion' } — EAS Update requires a literal
-    // string. Bump this manually when you ship native changes that break
-    // JS-bundle compatibility. Keeping it in sync with `version` above is a
-    // reasonable default.
-    runtimeVersion: '1.0.0',
+    // Fingerprint policy: EAS hashes the native source tree on every build
+    // and uses that hash as the runtimeVersion. JS bundles only ship to clients
+    // whose native binary fingerprint matches — eliminating the manual-bump
+    // trap where a forgotten runtimeVersion edit could deliver an OTA update
+    // to clients with incompatible native code.
+    //
+    // Supported in SDK 53+ for the prebuild (CNG) workflow via @expo/fingerprint
+    // (already a transitive dep of expo@~55.0.20). Pre-launch phase: changing
+    // this from a literal '1.0.0' to a fingerprint hash has zero user impact
+    // because no production users exist yet.
+    runtimeVersion: { policy: 'fingerprint' },
     splash: {
         backgroundColor: '#ee2b2b',
         resizeMode: 'contain',

--- a/rider-app/app.config.ts
+++ b/rider-app/app.config.ts
@@ -17,12 +17,17 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     updates: {
         url: 'https://u.expo.dev/8f1e4f60-720e-46b0-9b71-33c13d3af043',
     },
-    // Bare workflow (after `expo prebuild`) does not support runtime version
-    // policies like { policy: 'appVersion' } — EAS Update requires a literal
-    // string. Bump this manually when you ship native changes that break
-    // JS-bundle compatibility. Keeping it in sync with `version` above is a
-    // reasonable default.
-    runtimeVersion: '1.0.0',
+    // Fingerprint policy: EAS hashes the native source tree on every build
+    // and uses that hash as the runtimeVersion. JS bundles only ship to clients
+    // whose native binary fingerprint matches — eliminating the manual-bump
+    // trap where a forgotten runtimeVersion edit could deliver an OTA update
+    // to clients with incompatible native code.
+    //
+    // Supported in SDK 53+ for the prebuild (CNG) workflow via @expo/fingerprint
+    // (already a transitive dep of expo@~55.0.20). Pre-launch phase: changing
+    // this from a literal '1.0.0' to a fingerprint hash has zero user impact
+    // because no production users exist yet.
+    runtimeVersion: { policy: 'fingerprint' },
     splash: {
         backgroundColor: '#ee2b2b',
         resizeMode: 'contain',


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Switch `runtimeVersion` from the literal `'1.0.0'` to `{ policy: 'fingerprint' }` in both mobile `app.config.ts` files to eliminate the manual-bump trap.
- **Type**: `fix`
- **Linked issue**: `none` — extracted from PR #6 in the Expo Build Deployment Readiness plan to ship independently of the New Arch decision.
- **Risk**: `low` — pure config change, pre-launch phase (no production users with `runtimeVersion='1.0.0'` baked in to be stranded).
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[x]` rider-app  `[x]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none` — `@expo/fingerprint@0.16.7` is already a transitive dep of `expo@~55.0.20` (verified resolvable in `rider-app/node_modules/@expo/fingerprint`); no new env var, no new secret.
- **Rollback plan**: `git-revert-safe` — single revert restores `runtimeVersion: '1.0.0'`. Note: any EAS build done between this PR's merge and the revert ships with a fingerprint hash; reverting then publishes builds back at `'1.0.0'` and clients on the fingerprint hash will stop receiving OTA. Pre-launch = nobody to strand.
- **Dependencies / coordination**: `none`
- **Assumptions**: pre-launch — no currently-deployed clients have `runtimeVersion='1.0.0'` baked in; `@expo/fingerprint@0.16.7` is resolvable in both apps' `node_modules`; SDK 55 prebuild workflow honours the fingerprint policy (supported since SDK 53).

## Tier 3 — Compliance flags

None apply.

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — config change. Validation is via the next EAS build's emitted manifest.
- **Integration tests**: `not-applicable` — EAS Update channel matching is the integration test.
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: n/a (no UI).
- **Perf numbers**: n/a (not on an SLA path).

**Pre-merge checklist**:

- [ ] Ran the changed code against real Supabase dev — n/a.
- [ ] Tested with rider + driver + admin accounts — n/a until next EAS build.
- [ ] Verified the rollback command actually works — n/a, low-risk single-revert in pre-launch.
- [x] Updated CLAUDE.md / `.claude/context/*.md` if a convention changed — the misleading inline comment claiming bare/prebuild workflow does not support runtime version policies has been replaced with current SDK 55 facts.
- [x] No PII added to logs, Sentry payloads, or analytics.

## Why this matters

The literal runtimeVersion was a manual-bump trap. Every native change (new dep with native side, plugin change, Info.plist edit, permission addition) had to be paired with a manual `runtimeVersion` bump or the OTA fleet would ship a JS bundle to clients with incompatible native code — silent crash on launch.

In a multi-engineer pre-launch phase where many readiness PRs are flowing (#678 expo-doctor gate, #682 iOS perms, eventual New Arch flip), the chance of forgetting that bump is high. Fingerprint policy makes it impossible to forget — EAS hashes the native source tree on every build and uses the hash as the runtimeVersion. JS bundles only ship to clients whose native fingerprint matches.

## Test plan (post-merge, on next EAS preview build)

- [x] Local: both `app.config.ts` files parse as valid TypeScript; `runtimeVersion: { policy: 'fingerprint' }` is in Expo's typedef.
- [ ] EAS preview build: `eas build --profile preview --platform all` — both apps build; the new build's manifest reports a fingerprint hash, not `"1.0.0"`.
- [ ] EAS Update dry-run: `eas update --branch preview --message "test"` — update publishes under the fingerprint runtimeVersion.
- [ ] Install the new build on a physical device, launch — app pulls the OTA bundle for the fingerprint runtimeVersion, no crash.

https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
