### PR TITLE
chore(ci): add platform input to eas-build workflow_dispatch

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -43,6 +43,12 @@ on:
         default: "production"
         type: choice
         options: [test, preview, production]
+      platform:
+        description: "Native build platform — pick `android` if iOS submission slot / Apple credentials aren't ready yet"
+        required: true
+        default: "all"
+        type: choice
+        options: [all, ios, android]
 
 # Detect which app(s) changed so push-triggered runs only process the affected
 # app. Shared changes hit both.
@@ -122,7 +128,8 @@ jobs:
           (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'build')
         env:
           PROFILE: ${{ github.event.inputs.profile || 'production' }}
-        run: eas build --platform all --non-interactive --profile "$PROFILE"
+          PLATFORM: ${{ github.event.inputs.platform || 'all' }}
+        run: eas build --platform "$PLATFORM" --non-interactive --profile "$PROFILE"
 
   driver:
     needs: detect
@@ -172,4 +179,5 @@ jobs:
           (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'build')
         env:
           PROFILE: ${{ github.event.inputs.profile || 'production' }}
-        run: eas build --platform all --non-interactive --profile "$PROFILE"
+          PLATFORM: ${{ github.event.inputs.platform || 'all' }}
+        run: eas build --platform "$PLATFORM" --non-interactive --profile "$PROFILE"


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Add a `platform` input (`all` | `ios` | `android`, defaults to `all`) to the EAS `workflow_dispatch` trigger so a build can target Android-only or iOS-only when credentials / slots / credits aren't ready for the other.
- **Type**: `chore`
- **Linked issue**: `none` — operational unblock for running the New Arch probe (#684) on Android while iOS submission readiness lags.
- **Risk**: `low` — workflow input addition + parameter substitution; default value preserves existing `--platform all` behaviour for push-triggered builds.
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[x]` CI
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — single revert restores `--platform all`. No state to clean up.
- **Dependencies / coordination**: `none`
- **Assumptions**: EAS CLI accepts `--platform ios` and `--platform android` (it does — documented EAS Build flag, supported since EAS CLI 0.x).

## Tier 3 — Compliance flags

None apply.

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — workflow change.
- **Integration tests**: `not-applicable` — exercise comes from the next manual dispatch with `platform=android`.
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: n/a.
- **Perf numbers**: n/a.

**Pre-merge checklist**:

- [ ] Ran the changed code against real Supabase dev — n/a.
- [ ] Tested with rider + driver + admin accounts — n/a.
- [ ] Verified the rollback command actually works — n/a, low-risk single revert.
- [x] Updated CLAUDE.md / `.claude/context/*.md` if a convention changed — no convention change.
- [x] No PII added to logs, Sentry payloads, or analytics.

## How to use after merge

Go to **Actions → EAS Mobile (Build + Update) → Run workflow** and pick:

- `app`: `rider-app` | `driver-app` | `both`
- `action`: `build` (for native binary) or `update` (for OTA-only — platform input is ignored, OTA is JS-only)
- `profile`: `test` | `preview` | `production`
- `platform`: **`android`** (or `ios` / `all`)
- Branch: pick the branch you want to build (e.g. `chore/dev-client-new-arch-probe` for the New Arch probe)

Or via CLI:

```bash
gh workflow run "EAS Mobile (Build + Update)" \
  --ref chore/dev-client-new-arch-probe \
  -f app=both \
  -f action=build \
  -f profile=preview \
  -f platform=android
```

The push-trigger path (`on.push.paths` for rider/driver/shared edits) is unchanged — it always builds `--platform all` because the input default is `'all'`.

https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7P479V5JMFBe35qw5JeEg)_