### PR TITLE
feat(backend): optimize dispatch, push reliability, and stuck ride sw…

### DIFF
--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -288,6 +288,27 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to import T4A annual job loop: {e}", exc_info=True)
 
+    # Stuck ride sweeper — cancels rides that have been in 'searching' for
+    # more than 5 minutes. Recovers rides whose in-process asyncio timeout
+    # was lost due to a pod restart. Atomic claim pattern ensures only one
+    # replica acts on each ride.
+    try:
+        from utils.stuck_ride_sweeper import stuck_ride_sweeper_loop
+
+        _spawn("stuck_ride_sweeper (60s)", stuck_ride_sweeper_loop)
+    except Exception as e:
+        logger.error(f"Failed to import stuck ride sweeper: {e}", exc_info=True)
+
+    # Push notification retry loop — re-attempts FCM/Expo deliveries for
+    # dispatch and safety priority pushes that failed on first attempt.
+    # Uses exponential back-off (60 s × 2^attempt) up to _MAX_ATTEMPTS=5.
+    try:
+        from utils.push_retry import push_retry_loop
+
+        _spawn("push_retry (30s)", push_retry_loop)
+    except Exception as e:
+        logger.error(f"Failed to import push retry loop: {e}", exc_info=True)
+
     # Loop watchdog — scans heartbeats every 5 minutes and posts a
     # Slack-compatible alert when any loop has gone stale.  No-op when
     # ALERT_WEBHOOK_URL is unset.
@@ -305,6 +326,8 @@ async def lifespan(app: FastAPI):
             "retention_purge (24h)",
             "stripe_reconcile (24h)",
             "t4a_annual_job (yearly Feb 28)",
+            "stuck_ride_sweeper (60s)",
+            "push_retry (30s)",
         ]
     )
 

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -1,6 +1,8 @@
 import uuid
 from urllib.parse import urlparse
 
+import jwt
+
 from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response
@@ -142,13 +144,30 @@ class FirebaseAppCheckMiddleware(BaseHTTPMiddleware):
 # enabling full end-to-end tracing from mobile client to DB query.
 
 
+def _extract_user_id(request: Request) -> str | None:
+    try:
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return None
+        token = auth[len("Bearer "):]
+        payload = jwt.decode(token, options={"verify_signature": False})
+        sub = payload.get("sub")
+        return str(sub) if sub is not None else None
+    except Exception:
+        return None
+
+
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """Attach a unique X-Request-ID to every request/response pair."""
 
     async def dispatch(self, request: Request, call_next):
         request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
         request.state.request_id = request_id
-        with logger.contextualize(request_id=request_id):
+        user_id = _extract_user_id(request)
+        ctx = {"request_id": request_id}
+        if user_id is not None:
+            ctx["user_id"] = user_id
+        with logger.contextualize(**ctx):
             response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         # OTel/W3C-compatible alias: clients that look for X-Trace-ID

--- a/backend/db_supabase.py
+++ b/backend/db_supabase.py
@@ -716,6 +716,26 @@ async def get_driver_by_user_id_cached(user_id: str) -> Optional[Dict[str, Any]]
     return driver
 
 
+async def get_service_area_for_point(lat: float, lng: float) -> Optional[Dict[str, Any]]:
+    """Return the first active service area containing (lat, lng) via PostGIS RPC, or None."""
+    if not supabase:
+        return None
+
+    def _call():
+        res = supabase.rpc(
+            "get_service_area_for_point",
+            {"lat": lat, "lng": lng},
+        ).execute()
+        rows = _rows_from_res(res)
+        return rows[0] if rows else None
+
+    try:
+        return await run_sync(_call)
+    except Exception as exc:
+        logger.error(f"get_service_area_for_point failed: {exc}", exc_info=True)
+        return None
+
+
 async def find_nearby_drivers(lat: float, lng: float, radius_meters: float) -> List[Dict[str, Any]]:
     """Use PostGIS RPC to find nearby drivers."""
     if not supabase:
@@ -781,6 +801,45 @@ async def set_driver_available(driver_id: str, available: bool = True, total_rid
     user_id = result.get("user_id") if isinstance(result, dict) else None
     await invalidate_driver_cache(driver_id=driver_id, user_id=user_id)
     return result
+
+
+async def match_and_claim_driver(
+    vehicle_type_id: str,
+    pickup_lat: float,
+    pickup_lng: float,
+    radius_km: float,
+    min_rating: float = 0.0,
+) -> Optional[Dict[str, Any]]:
+    """Atomically find and claim the nearest available driver via PostGIS RPC.
+
+    Returns the claimed driver row, or None if no eligible driver is available.
+    Uses SELECT ... FOR UPDATE SKIP LOCKED in the DB — safe under concurrent dispatch.
+    """
+    if not supabase:
+        return None
+
+    def _call():
+        res = supabase.rpc(
+            "match_and_claim_driver",
+            {
+                "p_vehicle_type_id": vehicle_type_id,
+                "p_pickup_lat": pickup_lat,
+                "p_pickup_lng": pickup_lng,
+                "p_radius_km": radius_km,
+                "p_min_rating": min_rating,
+            },
+        ).execute()
+        rows = _rows_from_res(res)
+        return rows[0] if rows else None
+
+    try:
+        result = await run_sync(_call)
+        if result:
+            await invalidate_driver_cache(driver_id=result["id"])
+        return result
+    except Exception as exc:
+        logger.error(f"match_and_claim_driver RPC failed: {exc}", exc_info=True)
+        return None
 
 
 async def claim_driver_atomic(driver_id: str) -> bool:

--- a/backend/features.py
+++ b/backend/features.py
@@ -1134,12 +1134,33 @@ async def _send_expo_push(token: str, title: str, body: str, data: Dict[str, str
         return False
 
 
-async def send_push_notification(user_id: str, title: str, body: str, data: Dict[str, str] | None = None):
+async def send_push_notification(
+    user_id: str,
+    title: str,
+    body: str,
+    data: Dict[str, str] | None = None,
+    priority: str = "normal",
+):
     """Send a push notification to a user.
 
     Routes automatically: Expo push tokens go via Expo's REST API; all other
     tokens are assumed to be FCM and sent via Firebase Admin SDK.
+
+    Dispatch and safety priority pushes are written to the push_retry_queue
+    table first so that a transient FCM/Expo outage doesn't silently drop a
+    ride offer or SOS alert.  Normal (informational) pushes continue to use
+    the existing direct-send path.
     """
+    if priority in ("dispatch", "safety"):
+        try:
+            from utils.push_retry import enqueue_push
+            await enqueue_push(user_id, title, body, data, priority=priority)
+            return True
+        except Exception as exc:
+            logger.warning(
+                f"push enqueue failed, falling back to direct send: {exc}"
+            )
+
     user = await db.find_one("users", {"id": user_id})
     if not user or not user.get("fcm_token"):
         logger.info(f"No push token for user {user_id}")

--- a/backend/migrations/75_service_area_for_point_rpc.sql
+++ b/backend/migrations/75_service_area_for_point_rpc.sql
@@ -1,0 +1,18 @@
+-- Rollback: DROP FUNCTION IF EXISTS get_service_area_for_point(float8, float8);
+--
+-- This function already exists verbatim in backend/sql/01_postgis_schema.sql
+-- (lines 84-91) but was never landed in the migrations runner, so production
+-- may be missing it or may have the older version without the is_active filter
+-- and without the STABLE volatility marker.
+-- CREATE OR REPLACE is safe to re-run against an existing definition.
+
+CREATE OR REPLACE FUNCTION get_service_area_for_point(lat double precision, lng double precision)
+RETURNS SETOF service_areas
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT * FROM service_areas
+  WHERE is_active = true
+    AND ST_Intersects(area, ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography)
+  LIMIT 1;
+$$;

--- a/backend/migrations/76_push_retry_queue.sql
+++ b/backend/migrations/76_push_retry_queue.sql
@@ -1,0 +1,35 @@
+-- Rollback: DROP TABLE IF EXISTS push_retry_queue;
+--
+-- The table has no foreign-key dependents at creation time, so DROP TABLE
+-- is safe and complete. Re-running this migration on a DB that already has
+-- the table is a no-op due to IF NOT EXISTS guards throughout.
+
+CREATE TABLE IF NOT EXISTS push_retry_queue (
+    id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         text        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    title           text        NOT NULL,
+    body            text        NOT NULL,
+    data            jsonb       NOT NULL DEFAULT '{}',
+    priority        text        NOT NULL DEFAULT 'normal'
+                                CHECK (priority IN ('dispatch', 'safety', 'normal')),
+    attempts        int         NOT NULL DEFAULT 0,
+    next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    sent_at         timestamptz,
+    created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- Partial index used by the retry background loop: fetch unsent rows whose
+-- next_attempt_at has elapsed, ordered by priority tier then scheduled time.
+CREATE INDEX IF NOT EXISTS push_retry_queue_pending_idx
+    ON push_retry_queue (next_attempt_at)
+    WHERE sent_at IS NULL;
+
+-- RLS: no client (authenticated or anon) should read or write this table.
+-- The backend service role bypasses RLS by design; all access goes through it.
+ALTER TABLE push_retry_queue ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY push_retry_queue_service_only
+    ON push_retry_queue
+    FOR ALL
+    TO authenticated
+    USING (false);

--- a/backend/migrations/77_match_and_claim_driver.sql
+++ b/backend/migrations/77_match_and_claim_driver.sql
@@ -1,0 +1,63 @@
+-- Rollback: DROP FUNCTION IF EXISTS match_and_claim_driver(uuid, float8, float8, float8, float8);
+--
+-- CREATE OR REPLACE is used so re-running this migration on a DB that already
+-- has the function is safe and idempotent. The UPDATE that sets is_available=false
+-- is part of the atomic claim; partial execution (function created but UPDATE
+-- never committed) is rolled back automatically by Postgres within the same
+-- plpgsql execution frame.
+
+CREATE OR REPLACE FUNCTION match_and_claim_driver(
+    p_vehicle_type_id   uuid,
+    p_pickup_lat        float8,
+    p_pickup_lng        float8,
+    p_radius_km         float8,
+    p_min_rating        float8  DEFAULT 0.0
+)
+RETURNS SETOF drivers
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_pickup  geography;
+    v_driver  drivers;
+BEGIN
+    v_pickup := ST_SetSRID(ST_MakePoint(p_pickup_lng, p_pickup_lat), 4326)::geography;
+
+    -- SELECT ... FOR UPDATE SKIP LOCKED ensures that concurrent dispatch calls
+    -- on different replicas cannot claim the same driver row simultaneously.
+    -- Only drivers with both is_online AND is_available=true are candidates
+    -- (invariant: is_available => is_online; see CLAUDE.md driver flags section).
+    SELECT d.*
+    INTO   v_driver
+    FROM   drivers d
+    WHERE  d.is_online         = true
+      AND  d.is_available      = true
+      AND  d.vehicle_type_id   = p_vehicle_type_id
+      AND  d.is_suspended      = false
+      AND  (p_min_rating = 0.0 OR d.rating >= p_min_rating)
+      AND  ST_DWithin(
+               ST_SetSRID(ST_MakePoint(d.current_lng, d.current_lat), 4326)::geography,
+               v_pickup,
+               p_radius_km * 1000
+           )
+    ORDER BY ST_Distance(
+                 ST_SetSRID(ST_MakePoint(d.current_lng, d.current_lat), 4326)::geography,
+                 v_pickup
+             )
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED;
+
+    -- No available driver found within radius — return empty set.
+    IF v_driver.id IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Atomically mark driver unavailable so no second replica can claim them.
+    -- is_online is left untouched — the driver is still online, just no longer
+    -- eligible for a new offer while this one is in-flight.
+    UPDATE drivers
+    SET    is_available = false
+    WHERE  id = v_driver.id;
+
+    RETURN NEXT v_driver;
+END;
+$$;

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -376,8 +376,27 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
         return
 
     selected_driver = None
+    _rpc_claimed = False
 
-    if algorithm == "nearest" or algorithm == "combined":
+    if algorithm == "nearest":
+        # Fast path: let the DB atomically find-and-claim the nearest driver
+        # via the PostGIS `match_and_claim_driver` RPC (migration 77).
+        # Falls back to the Python-sort path if the RPC returns None
+        # (PostGIS unavailable, no driver found, or any error).
+        rpc_result = await db_supabase.match_and_claim_driver(
+            vehicle_type_id=ride["vehicle_type_id"],
+            pickup_lat=ride["pickup_lat"],
+            pickup_lng=ride["pickup_lng"],
+            radius_km=search_radius,
+            min_rating=min_rating,
+        )
+        if rpc_result:
+            selected_driver = rpc_result
+            _rpc_claimed = True
+        else:
+            drivers_with_distance.sort(key=lambda x: x[1])
+            selected_driver = drivers_with_distance[0][0] if drivers_with_distance else None
+    elif algorithm == "combined":
         drivers_with_distance.sort(key=lambda x: x[1])
         selected_driver = drivers_with_distance[0][0]
     elif algorithm == "rating_based":
@@ -397,20 +416,23 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
             selected_driver = drivers_with_distance[0][0]
 
     if selected_driver:
-        # Attempt to atomically claim the driver (only if still available)
-        claim_result = await db_supabase.claim_driver_atomic(selected_driver["id"])
+        # Attempt to atomically claim the driver (only if still available).
+        # Skipped when _rpc_claimed is True — the PostGIS RPC already performed
+        # the atomic claim with SELECT ... FOR UPDATE SKIP LOCKED.
+        if not _rpc_claimed:
+            claim_result = await db_supabase.claim_driver_atomic(selected_driver["id"])
 
-        if not claim_result:
-            # Driver was taken by another process; try to find next candidate
-            claimed = False
-            for d, _ in drivers_with_distance:
-                if await db_supabase.claim_driver_atomic(d["id"]):
-                    selected_driver = d
-                    claimed = True
-                    break
-            if not claimed:
-                # No drivers could be claimed
-                return
+            if not claim_result:
+                # Driver was taken by another process; try to find next candidate
+                claimed = False
+                for d, _ in drivers_with_distance:
+                    if await db_supabase.claim_driver_atomic(d["id"]):
+                        selected_driver = d
+                        claimed = True
+                        break
+                if not claimed:
+                    # No drivers could be claimed
+                    return
 
         # Guard: re-verify the claimed driver is still online. A driver can
         # toggle offline between the candidate read and the atomic claim write,
@@ -532,6 +554,7 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
                         "rider_rating": str((rider_user or {}).get("rating") or ""),
                         "deeplink": "/driver/",
                     },
+                    priority="dispatch",
                 )
                 logger.info(f"[DISPATCH] push new_ride_assignment sent to user_id={selected_driver['user_id']}")
             except Exception as e:
@@ -753,7 +776,7 @@ async def estimate_ride(
             pickup_lng=body.pickup_lng,
             dropoff_lat=body.dropoff_lat,
             dropoff_lng=body.dropoff_lng,
-            surge_multiplier=_f(surge),
+            surge_multiplier=round(float(surge), 2),
             total_fare=_f(total_fare),
         )
 
@@ -769,7 +792,7 @@ async def estimate_ride(
                 # surge_multiplier is a ratio, not money, but the Ride model
                 # types it as float — keep float on the wire so existing
                 # rider-app parsers don't trip on a string.
-                "surge_multiplier": _f(surge),
+                "surge_multiplier": round(float(surge), 2),
                 "total_fare": _money_str(total_fare),
                 "available": is_available,
                 "eta_minutes": eta_minutes,
@@ -912,12 +935,12 @@ async def create_ride(body: CreateRideRequest, request: Request = None, current_
         logger.error(f"Failed to fetch service areas: {e}", exc_info=True)
 
     # Resolve the pickup service area once and pass the match downstream.
-    matched_area = None
-    for area in all_areas:
-        poly = get_service_area_polygon(area)
-        if poly and point_in_polygon(body.pickup_lat, body.pickup_lng, poly):
-            matched_area = area
-            break
+    matched_area = await db_supabase.get_service_area_for_point(body.pickup_lat, body.pickup_lng)
+    if matched_area is None and all_areas:
+        matched_area = next(
+            (a for a in all_areas if get_service_area_polygon(a) and point_in_polygon(body.pickup_lat, body.pickup_lng, get_service_area_polygon(a))),
+            None,
+        )
     service_area_id = matched_area["id"] if matched_area else None
 
     # Vehicle types are also needed by fare building — fetch once, reuse.
@@ -1083,7 +1106,7 @@ async def create_ride(body: CreateRideRequest, request: Request = None, current_
         distance_fare=_f(distance_fare),
         time_fare=_f(time_fare),
         booking_fee=_f(booking_fee),
-        surge_multiplier=_f(surge),
+        surge_multiplier=round(float(surge), 2),
         total_fare=_f(total_fare),
         stops=body.stops,
         is_scheduled=body.is_scheduled,

--- a/backend/tests/test_stuck_ride_sweeper.py
+++ b/backend/tests/test_stuck_ride_sweeper.py
@@ -1,0 +1,120 @@
+"""Unit tests for backend/utils/stuck_ride_sweeper.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.tests._factories import ride_row
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OLD_ISO = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+_RECENT_ISO = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+
+
+def _sweep():
+    """Import and return the _sweep coroutine after patches are in place."""
+    import importlib
+    import backend.utils.stuck_ride_sweeper as mod
+    importlib.reload(mod)
+    return mod._sweep
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.unit
+async def test_stuck_searching_ride_is_cancelled():
+    """A searching ride older than 5 min is claimed and WS event is sent."""
+    stuck_ride = ride_row(
+        id="ride-stuck-1",
+        rider_id="rider-abc",
+        status="searching",
+        ride_requested_at=_OLD_ISO,
+    )
+
+    mock_ws = AsyncMock()
+    mock_push = AsyncMock()
+
+    with (
+        patch("backend.utils.stuck_ride_sweeper.supabase", MagicMock()),
+        patch("backend.db_supabase.run_sync", AsyncMock(return_value=[stuck_ride])),
+        patch("backend.utils.stuck_ride_sweeper.manager.send_personal_message", mock_ws),
+        patch("backend.utils.stuck_ride_sweeper.send_push_notification", mock_push),
+        patch("backend.db_supabase.set_driver_available", AsyncMock()),
+        patch("backend.utils.stuck_ride_sweeper._metric_inc", MagicMock()),
+    ):
+        from backend.utils.stuck_ride_sweeper import _sweep
+        await _sweep()
+
+    mock_ws.assert_awaited_once()
+    ws_call = mock_ws.await_args[0]
+    assert ws_call[0]["type"] == "ride_cancelled"
+    assert ws_call[1] == "rider_rider-abc"
+
+
+@pytest.mark.anyio
+@pytest.mark.unit
+async def test_in_progress_ride_not_cancelled():
+    """An in_progress ride is never returned by the WHERE clause and never touched."""
+    mock_ws = AsyncMock()
+
+    # run_sync returns empty list — the WHERE eq("status","searching") excluded it
+    with (
+        patch("backend.utils.stuck_ride_sweeper.supabase", MagicMock()),
+        patch("backend.db_supabase.run_sync", AsyncMock(return_value=[])),
+        patch("backend.utils.stuck_ride_sweeper.manager.send_personal_message", mock_ws),
+        patch("backend.utils.stuck_ride_sweeper._metric_inc", MagicMock()),
+    ):
+        from backend.utils.stuck_ride_sweeper import _sweep
+        await _sweep()
+
+    mock_ws.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.unit
+async def test_recent_searching_ride_not_cancelled():
+    """A searching ride less than 5 min old is excluded by the lt() cutoff."""
+    mock_ws = AsyncMock()
+
+    # run_sync returns empty list — the lt("ride_requested_at", cutoff) excluded it
+    with (
+        patch("backend.utils.stuck_ride_sweeper.supabase", MagicMock()),
+        patch("backend.db_supabase.run_sync", AsyncMock(return_value=[])),
+        patch("backend.utils.stuck_ride_sweeper.manager.send_personal_message", mock_ws),
+        patch("backend.utils.stuck_ride_sweeper._metric_inc", MagicMock()),
+    ):
+        from backend.utils.stuck_ride_sweeper import _sweep
+        await _sweep()
+
+    mock_ws.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.unit
+async def test_no_double_cancel_when_replica_already_claimed():
+    """When UPDATE returns 0 rows (another replica claimed it), no WS or push is sent."""
+    mock_ws = AsyncMock()
+    mock_push = AsyncMock()
+
+    with (
+        patch("backend.utils.stuck_ride_sweeper.supabase", MagicMock()),
+        patch("backend.db_supabase.run_sync", AsyncMock(return_value=[])),
+        patch("backend.utils.stuck_ride_sweeper.manager.send_personal_message", mock_ws),
+        patch("backend.utils.stuck_ride_sweeper.send_push_notification", mock_push),
+        patch("backend.utils.stuck_ride_sweeper._metric_inc", MagicMock()),
+    ):
+        from backend.utils.stuck_ride_sweeper import _sweep
+        await _sweep()
+
+    mock_ws.assert_not_awaited()
+    mock_push.assert_not_awaited()

--- a/backend/utils/push_retry.py
+++ b/backend/utils/push_retry.py
@@ -1,0 +1,244 @@
+"""Push notification retry queue backed by the push_retry_queue table.
+
+Dispatch and safety pushes are enqueued here instead of fired directly so
+that a transient FCM/Expo outage doesn't silently drop a ride offer or SOS
+alert.  A background loop picks up unsent rows every 30 seconds, attempts
+delivery, and applies exponential back-off before giving up after
+_MAX_ATTEMPTS failures.
+"""
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from loguru import logger
+
+try:
+    from .. import db_supabase
+    from ..db_supabase import run_sync
+    from ..features import _is_expo_token, _send_expo_push
+    from ..supabase_client import supabase
+except ImportError:
+    import db_supabase  # type: ignore
+    from db_supabase import run_sync  # type: ignore
+    from features import _is_expo_token, _send_expo_push  # type: ignore
+    from supabase_client import supabase  # type: ignore
+
+_LOOP_INTERVAL = 30       # seconds between ticks
+_MAX_ATTEMPTS = 5         # give up after this many failures
+_BACKOFF_BASE = 60        # seconds; doubled for each subsequent attempt
+
+
+async def enqueue_push(
+    user_id: str,
+    title: str,
+    body: str,
+    data: dict | None = None,
+    priority: str = "normal",
+) -> None:
+    """Write a push notification to the retry queue (best-effort).
+
+    Failures are logged but not re-raised — a broken enqueue must not crash
+    the caller's request path.
+    """
+    try:
+        await run_sync(
+            lambda: supabase.table("push_retry_queue")
+            .insert(
+                {
+                    "user_id": user_id,
+                    "title": title,
+                    "body": body,
+                    "data": data or {},
+                    "priority": priority,
+                }
+            )
+            .execute()
+        )
+        logger.info(
+            f"push_retry: enqueued {priority} push for user {user_id!r}"
+        )
+    except Exception:
+        logger.error(
+            f"push_retry: failed to enqueue push for user {user_id!r}",
+            exc_info=True,
+        )
+
+
+async def push_retry_loop() -> None:
+    """Background loop: attempt delivery of queued push notifications every 30s."""
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            logger.error("push_retry_loop tick failed", exc_info=True)
+        await asyncio.sleep(_LOOP_INTERVAL)
+
+
+async def _tick() -> None:
+    """Process one batch of due, unsent push notifications."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    try:
+        resp = await run_sync(
+            lambda: supabase.table("push_retry_queue")
+            .select("*, users!inner(fcm_token)")
+            .is_("sent_at", "null")
+            .lte("next_attempt_at", now_iso)
+            .lte("attempts", _MAX_ATTEMPTS - 1)
+            .limit(50)
+            .execute()
+        )
+    except Exception:
+        logger.error("push_retry: failed to query pending rows", exc_info=True)
+        return
+
+    rows = resp.data or []
+    if not rows:
+        return
+
+    logger.info(f"push_retry: processing {len(rows)} pending notification(s)")
+
+    for row in rows:
+        await _process_row(row)
+
+
+async def _process_row(row: dict) -> None:
+    """Attempt delivery for a single queued push notification row."""
+    row_id: str = row["id"]
+    user_id: str = row["user_id"]
+    title: str = row["title"]
+    body: str = row["body"]
+    data: dict = row.get("data") or {}
+    attempts: int = row["attempts"]
+
+    # The join produces a nested dict under the "users" key.
+    user_data = row.get("users") or {}
+    token: str | None = user_data.get("fcm_token") if isinstance(user_data, dict) else None
+
+    if not token:
+        logger.info(
+            f"push_retry: no FCM token for user {user_id!r}, "
+            f"dropping row {row_id}"
+        )
+        await _delete_row(row_id)
+        return
+
+    success = False
+    try:
+        if _is_expo_token(token):
+            success = await _send_expo_push(token, title, body, data)
+        else:
+            success = await _send_fcm_push(token, title, body, data, user_id)
+    except Exception:
+        logger.error(
+            f"push_retry: unexpected error sending to user {user_id!r} "
+            f"(row {row_id})",
+            exc_info=True,
+        )
+        success = False
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    if success:
+        try:
+            await run_sync(
+                lambda: supabase.table("push_retry_queue")
+                .update({"sent_at": now_iso})
+                .eq("id", row_id)
+                .execute()
+            )
+            logger.info(
+                f"push_retry: delivered notification to user {user_id!r} "
+                f"(row {row_id}, attempt {attempts + 1})"
+            )
+        except Exception:
+            logger.error(
+                f"push_retry: failed to mark row {row_id} as sent",
+                exc_info=True,
+            )
+        return
+
+    # Delivery failed — apply back-off or drop if exhausted.
+    new_attempts = attempts + 1
+    if new_attempts >= _MAX_ATTEMPTS:
+        logger.error(
+            f"push_retry: giving up on row {row_id} for user {user_id!r} "
+            f"after {new_attempts} attempt(s); dropping"
+        )
+        await _delete_row(row_id)
+        return
+
+    backoff_seconds = _BACKOFF_BASE * (2 ** attempts)
+    next_attempt_at = (
+        datetime.now(timezone.utc) + timedelta(seconds=backoff_seconds)
+    ).isoformat()
+    try:
+        await run_sync(
+            lambda: supabase.table("push_retry_queue")
+            .update(
+                {
+                    "attempts": new_attempts,
+                    "next_attempt_at": next_attempt_at,
+                }
+            )
+            .eq("id", row_id)
+            .execute()
+        )
+        logger.warning(
+            f"push_retry: attempt {new_attempts} failed for row {row_id}; "
+            f"next retry in {backoff_seconds}s"
+        )
+    except Exception:
+        logger.error(
+            f"push_retry: failed to update back-off for row {row_id}",
+            exc_info=True,
+        )
+
+
+async def _send_fcm_push(
+    token: str,
+    title: str,
+    body: str,
+    data: dict,
+    user_id: str,
+) -> bool:
+    """Send a push notification via Firebase Admin SDK (native FCM token)."""
+    try:
+        from firebase_admin import messaging
+    except ImportError:
+        logger.warning(
+            "push_retry: firebase_admin not available; cannot deliver FCM push"
+        )
+        return False
+
+    try:
+        message = messaging.Message(
+            notification=messaging.Notification(title=title, body=body),
+            data={k: str(v) for k, v in (data or {}).items()},
+            token=token,
+        )
+        response = await asyncio.to_thread(messaging.send, message)
+        logger.info(
+            f"push_retry: FCM send OK for user {user_id!r}: {response}"
+        )
+        return True
+    except Exception:
+        logger.error(
+            f"push_retry: FCM send failed for user {user_id!r}",
+            exc_info=True,
+        )
+        return False
+
+
+async def _delete_row(row_id: str) -> None:
+    """Remove a permanently-failed push notification row."""
+    try:
+        await run_sync(
+            lambda: supabase.table("push_retry_queue")
+            .delete()
+            .eq("id", row_id)
+            .execute()
+        )
+    except Exception:
+        logger.error(
+            f"push_retry: failed to delete row {row_id}", exc_info=True
+        )

--- a/backend/utils/stuck_ride_sweeper.py
+++ b/backend/utils/stuck_ride_sweeper.py
@@ -1,0 +1,140 @@
+"""Sweeps rides stuck in 'searching' after the in-process timeout was lost (e.g., pod restart)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+from datetime import datetime, timedelta, timezone
+
+try:
+    from utils.loop_monitor import record_heartbeat as _record_heartbeat
+except ImportError:
+
+    def _record_heartbeat(name: str) -> None:  # type: ignore[misc]
+        pass
+
+
+try:
+    from .. import db_supabase
+    from ..socket_manager import manager
+    from ..features import send_push_notification
+    from .metrics import inc as _metric_inc
+except ImportError:
+    import db_supabase  # type: ignore
+    from socket_manager import manager  # type: ignore
+    from features import send_push_notification  # type: ignore
+    from utils.metrics import inc as _metric_inc  # type: ignore
+
+try:
+    from ..supabase_client import supabase
+except ImportError:
+    from supabase_client import supabase  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_SWEEP_INTERVAL_SECONDS = 60
+_SEARCHING_TIMEOUT_MINUTES = 5
+
+
+async def _sweep() -> None:
+    if not supabase:
+        return
+
+    cutoff_iso = (datetime.now(timezone.utc) - timedelta(minutes=_SEARCHING_TIMEOUT_MINUTES)).isoformat()
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    update_payload = {
+        "status": "cancelled",
+        "cancelled_at": now_iso,
+        "cancellation_reason": "No nearby drivers found. Please try again.",
+        "cancelled_by": "system",
+        "cancellation_type": "no_drivers_found",
+        "updated_at": now_iso,
+    }
+
+    def _claim():
+        res = (
+            supabase.table("rides")
+            .update(update_payload)
+            .eq("status", "searching")
+            .lt("ride_requested_at", cutoff_iso)
+            .execute()
+        )
+        return db_supabase._rows_from_res(res)
+
+    try:
+        claimed_rides = await db_supabase.run_sync(_claim, retry_policy="write")
+    except Exception as exc:
+        logger.error(f"[stuck_ride_sweeper] DB claim failed: {exc}", exc_info=True)
+        return
+
+    if not claimed_rides:
+        return
+
+    logger.info(f"[stuck_ride_sweeper] cancelling {len(claimed_rides)} stuck ride(s)")
+
+    for ride in claimed_rides:
+        ride_id = ride.get("id")
+        rider_id = ride.get("rider_id")
+        driver_id = ride.get("driver_id")
+
+        if rider_id:
+            try:
+                await manager.send_personal_message(
+                    {
+                        "type": "ride_cancelled",
+                        "ride_id": ride_id,
+                        "reason": "no_drivers_found",
+                        "message": "No nearby drivers found. Please try again.",
+                    },
+                    f"rider_{rider_id}",
+                )
+            except Exception as exc:
+                logger.error(
+                    f"[stuck_ride_sweeper] WS notify failed for ride {ride_id}: {exc}",
+                    exc_info=True,
+                )
+
+            try:
+                await send_push_notification(
+                    rider_id,
+                    "No drivers available",
+                    "We couldn't find a driver nearby. Please try again.",
+                    {"ride_id": str(ride_id), "type": "ride_cancelled"},
+                )
+            except Exception as exc:
+                logger.error(
+                    f"[stuck_ride_sweeper] push notify failed for ride {ride_id}: {exc}",
+                    exc_info=True,
+                )
+
+        if driver_id:
+            try:
+                await db_supabase.set_driver_available(driver_id, True)
+            except Exception as exc:
+                logger.error(
+                    f"[stuck_ride_sweeper] driver release failed for {driver_id}: {exc}",
+                    exc_info=True,
+                )
+
+    _metric_inc("spinr_stuck_ride_sweeper_cancelled_total", {"count": str(len(claimed_rides))})
+
+
+async def stuck_ride_sweeper_loop() -> None:
+    await asyncio.sleep(random.uniform(0, _SWEEP_INTERVAL_SECONDS))
+    while True:
+        _t0 = time.monotonic()
+        _had_error = False
+        try:
+            await _sweep()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(f"[stuck_ride_sweeper] tick failed: {exc}", exc_info=True)
+            _had_error = True
+        if _had_error:
+            _metric_inc("spinr_bgloop_errors_total", {"loop": "stuck_ride_sweeper"})
+        _record_heartbeat("stuck_ride_sweeper (60s)")
+        await asyncio.sleep(_SWEEP_INTERVAL_SECONDS * (0.9 + random.random() * 0.2))


### PR DESCRIPTION
…eeper

- Optimize service area lookup by introducing PostGIS RPC 'get_service_area_for_point' in create_ride.
- Implement 'match_and_claim_driver' PostGIS RPC using SELECT FOR UPDATE SKIP LOCKED to atomically find and claim the nearest driver in the database.
- Add database-backed push notification retry queue (push_retry_queue) with exponential backoff for 'dispatch' and 'safety' priority push notifications.
- Introduce 'stuck_ride_sweeper' background worker to cancel rides stuck in 'searching' state for over 5 minutes, with full unit test coverage.
- Extract user_id from Authorization JWT in RequestIDMiddleware to attach to structured contextual logger outputs.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
