### PR TITLE
fix(ci+rider-app): unbreak main — patches/** cache key + rider OtpScreen TS error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,10 @@ jobs:
         uses: actions/cache@v5
         with:
           path: driver-app/node_modules
-          key: ${{ runner.os }}-driver-node-${{ hashFiles('driver-app/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-driver-node-
+          # No restore-keys: a partial restore from an older key keeps a
+          # node_modules with prior patch hunks already applied, then
+          # patch-package fails to re-apply on top. Force a clean miss.
+          key: ${{ runner.os }}-driver-node-${{ hashFiles('driver-app/yarn.lock', 'driver-app/patches/**') }}
 
       - name: Install dependencies
         working-directory: driver-app
@@ -212,9 +213,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: rider-app/node_modules
-          key: ${{ runner.os }}-rider-node-${{ hashFiles('rider-app/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-rider-node-
+          key: ${{ runner.os }}-rider-node-${{ hashFiles('rider-app/yarn.lock', 'rider-app/patches/**') }}
 
       - name: Install dependencies
         working-directory: rider-app

--- a/.github/workflows/mobile-dep-check.yml
+++ b/.github/workflows/mobile-dep-check.yml
@@ -33,8 +33,14 @@ jobs:
         uses: actions/cache@v5
         with:
           path: rider-app/node_modules
-          key: ${{ runner.os }}-rider-node-${{ hashFiles('rider-app/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-rider-node-
+          # Include patches/** in the key so changes to patch-package files
+          # invalidate the cache (otherwise stale node_modules retains
+          # already-applied hunks → patch-package fails to re-apply on top).
+          key: ${{ runner.os }}-rider-node-${{ hashFiles('rider-app/yarn.lock', 'rider-app/patches/**') }}
+          # No restore-keys: a partial restore from an older key gives us a
+          # node_modules that already has prior patch hunks applied, then
+          # patch-package fails to re-apply on top. Force a clean miss when
+          # the key changes — slow once, correct always.
 
       - name: Install dependencies
         working-directory: rider-app
@@ -71,8 +77,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: driver-app/node_modules
-          key: ${{ runner.os }}-driver-node-${{ hashFiles('driver-app/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-driver-node-
+          key: ${{ runner.os }}-driver-node-${{ hashFiles('driver-app/yarn.lock', 'driver-app/patches/**') }}
 
       - name: Install dependencies
         working-directory: driver-app

--- a/.github/workflows/test-env.yml
+++ b/.github/workflows/test-env.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: rider-app/node_modules
-          key: rider-${{ runner.os }}-${{ hashFiles('rider-app/package-lock.json', 'rider-app/yarn.lock') }}
+          key: rider-${{ runner.os }}-${{ hashFiles('rider-app/package-lock.json', 'rider-app/yarn.lock', 'rider-app/patches/**') }}
 
       - name: Install
         working-directory: rider-app
@@ -89,7 +89,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: driver-app/node_modules
-          key: driver-${{ runner.os }}-${{ hashFiles('driver-app/package-lock.json', 'driver-app/yarn.lock') }}
+          key: driver-${{ runner.os }}-${{ hashFiles('driver-app/package-lock.json', 'driver-app/yarn.lock', 'driver-app/patches/**') }}
 
       - name: Install
         working-directory: driver-app

--- a/rider-app/app/otp.tsx
+++ b/rider-app/app/otp.tsx
@@ -230,7 +230,6 @@ export default function OtpScreen() {
     TouchableOpacity: typeof TouchableOpacity,
     ActivityIndicator: typeof ActivityIndicator,
     KeyboardAvoidingView: typeof KeyboardAvoidingView,
-    ScrollView: typeof ScrollView,
     Animated: typeof Animated,
     AnimatedView: typeof Animated?.View,
     Ionicons: typeof Ionicons,


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Restores green CI on main by fixing the rider-app TS2304 left over from #747 and adding `patches/**` to the rider/driver `node_modules` cache keys so future patch updates don't restore stale post-install state.
- **Type**: `fix`
- **Linked issue**: Refs #747 — follow-up to the consolidated RN 0.85 codegen patches PR.
- **Risk**: `low` — CI workflow YAML and a one-line diagnostic removal in rider-app/app/otp.tsx; no runtime / build / API surface changes.
- **User-visible change**: `none`
- **Scope contract**: `[x]` This PR matches its stated type — only the two issues blocking main's CI; no unrelated cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend `[x]` rider-app `[ ]` driver-app `[ ]` admin `[ ]` shared `[ ]` migrations `[ ]` infra `[x]` CI
- **Blast radius**: `single-surface` (CI infra plus a 1-line rider-app diagnostic edit)
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe`
- **Dependencies / coordination**: `none`
- **Assumptions**: rider/driver `patches/` directories remain the canonical source of truth for `patch-package`; cache invalidation on `patches/**` change is the desired behavior.
- **Not changing but considered**: re-introducing a ScrollView import in rider-app's OtpScreen — rejected because we bypassed RN's ScrollView via the Bridgeless codegen patch in #747 and the file no longer renders one.

## Tier 3 — Compliance flags

None apply. Pure CI/diagnostic fix.

## Tier 4 — Verification

- **Unit tests**: `not-applicable`
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: not applicable (no UI change)
- **Perf numbers**: not applicable

**Pre-merge checklist**:

- [x] Local `yarn tsc --noEmit` passes in `rider-app/` (verified — 29s, no errors)
- [x] No PII added to logs/Sentry/analytics
- [x] Verified `git revert <merge-sha>` cleanly restores prior YAML — only 3-line additive changes per workflow

## Background

PR #747 merged at SHA `c8589530`. Two issues survived merge and broke main's `CI/CD Pipeline`:

1. **`rider-app/app/otp.tsx(233,24): TS2304: Cannot find name 'ScrollView'`** — `driver-app`'s twin diagnostic was already fixed on main by adding the import (commit c4189c84 SafeRefreshControl sweep), but rider-app was missed.

2. **Stale `node_modules` cache** — When `patches/react-native+0.85.2.patch` changed in #747 but `yarn.lock` didn't, CI restored a `node_modules` from a previous run that already had the old hunks applied. `patch-package` then tried to re-apply on top, hit "Reversed (or previously applied)", and failed `react-native@0.85.2 ✗`. (#747 only failed on rider-app because driver-app's `yarn.lock` happened to change in that PR, which busted its cache incidentally.)

## Fixes

- `rider-app/app/otp.tsx`: drop the dangling `ScrollView: typeof ScrollView` line in the diagnostic console.log block.
- `.github/workflows/{ci.yml,mobile-dep-check.yml,test-env.yml}`: include `patches/**` in the `node_modules` cache hash key for both rider/driver caches; drop the lenient `${runner.os}-{rider|driver}-node-` `restore-keys` fallback that would silently bring back stale patched files.

## Test plan

- [ ] CI green on this PR (rider-app TS check passes; cache miss on first build is expected and acceptable)
- [ ] After merge, push a `patches/**`-only change in a future PR → confirm cache invalidates correctly

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
