### PR TITLE
fix(both-apps): RN 0.85 Switch + ScrollView render-time defensive guard

### DIFF
--- a/driver-app/patches/react-native+0.85.2.patch
+++ b/driver-app/patches/react-native+0.85.2.patch
@@ -432,3 +432,144 @@ index 4ba5b68..a746a97 100644
  }>;
  
  export default codegenNativeComponent<VirtualViewNativeProps>('VirtualView', {
+diff --git a/node_modules/react-native/Libraries/Components/Switch/Switch.js b/node_modules/react-native/Libraries/Components/Switch/Switch.js
+--- a/node_modules/react-native/Libraries/Components/Switch/Switch.js
++++ b/node_modules/react-native/Libraries/Components/Switch/Switch.js
+@@ -16,7 +16,7 @@
+ import StyleSheet from '../../StyleSheet/StyleSheet';
+ import Platform from '../../Utilities/Platform';
+ import useMergeRefs from '../../Utilities/useMergeRefs';
+-import AndroidSwitchNativeComponent, {
++import _NativeAndroidSwitch, {
+   Commands as AndroidSwitchCommands,
+ } from './AndroidSwitchNativeComponent';
+ import SwitchNativeComponent, {
+@@ -24,3 +24,83 @@
+ } from './SwitchNativeComponent';
+ import * as React from 'react';
+ import {useLayoutEffect, useRef, useState} from 'react';
++
++// PATCH (spinr rider-app/driver-app):
++// RN 0.85.2's AndroidSwitchNativeComponent is declared with
++// `interfaceOnly: true` — codegenNativeComponent returns a non-renderable
++// placeholder object. Under the New Architecture (Bridgeless), JSX
++// `<AndroidSwitchNativeComponent>` throws "Element type is invalid... got:
++// object". Reproduced on driver-app SettingsScreen.
++//
++// Strategy: detect the broken codegen object and fall back to a JS-only
++// Pressable toggle that fires onChange on press. Visual chrome is a
++// minimal track + thumb in the requested colors. Loses the native
++// material switch animation; functionally equivalent for state.
++const _PressableModule = require('../Pressable/Pressable');
++const _Pressable = _PressableModule.default || _PressableModule;
++const _ViewModule = require('../View/View');
++const _SwitchView = _ViewModule.default || _ViewModule;
++const _isAndroidSwitchNativeValid =
++  typeof _NativeAndroidSwitch === 'function' ||
++  typeof _NativeAndroidSwitch === 'string';
++
++function AndroidSwitchJSFallback(props: $FlowFixMe): React.Node {
++  const {
++    on,
++    enabled,
++    style,
++    thumbTintColor,
++    trackTintColor,
++    trackColorForTrue,
++    trackColorForFalse,
++    onChange,
++    accessibilityState,
++    accessibilityRole,
++    ...rest
++  } = props;
++  const isOn = on === true;
++  const trackBg =
++    (isOn ? trackColorForTrue : trackColorForFalse) ?? trackTintColor ?? (isOn ? '#34C759' : '#787880');
++  const thumbBg = thumbTintColor ?? '#FFFFFF';
++  const handlePress = () => {
++    if (enabled === false) return;
++    if (typeof onChange === 'function') {
++      onChange({nativeEvent: {value: !isOn, target: 0}});
++    }
++  };
++  return (
++    <_Pressable
++      {...rest}
++      accessibilityRole={accessibilityRole ?? 'switch'}
++      accessibilityState={{...(accessibilityState ?? {}), checked: isOn, disabled: enabled === false}}
++      disabled={enabled === false}
++      onPress={handlePress}
++      style={[
++        {
++          width: 51,
++          height: 31,
++          borderRadius: 31 / 2,
++          padding: 2,
++          backgroundColor: trackBg,
++          opacity: enabled === false ? 0.5 : 1,
++          justifyContent: 'center',
++        },
++        style,
++      ]}>
++      <_SwitchView
++        style={{
++          width: 27,
++          height: 27,
++          borderRadius: 27 / 2,
++          backgroundColor: thumbBg,
++          alignSelf: isOn ? 'flex-end' : 'flex-start',
++        }}
++      />
++    </_Pressable>
++  );
++}
++
++const AndroidSwitchNativeComponent: $FlowFixMe =
++  Platform.OS === 'android' && !_isAndroidSwitchNativeValid
++    ? AndroidSwitchJSFallback
++    : _NativeAndroidSwitch;
+diff --git a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
+--- a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
++++ b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
+@@ -1643,10 +1643,38 @@
+   render(): React.Node {
+     const horizontal = this.props.horizontal === true;
+ 
+-    const NativeScrollView = horizontal
++    // PATCH (spinr): defensive guard. The H/VScrollView native components are
++    // patched to fall back to View on Android, but if for any reason
++    // (module-init order, Hermes quirk, partial patch apply) they resolve to
++    // a non-renderable value, swap in View directly so ScrollView renders
++    // instead of crashing with "Element type is invalid... got: undefined".
++    let NativeScrollView: $FlowFixMe = horizontal
+       ? HScrollViewNativeComponent
+       : VScrollViewNativeComponent;
+-
+-    const NativeScrollContentView = horizontal
++    let NativeScrollContentView: $FlowFixMe = horizontal
+       ? HScrollContentViewNativeComponent
+       : VScrollContentViewNativeComponent;
++    const _isRenderable = (c: $FlowFixMe): boolean =>
++      typeof c === 'function' ||
++      typeof c === 'string' ||
++      (c != null && typeof c === 'object' && c.$$typeof != null);
++    if (!_isRenderable(NativeScrollView)) {
++      if (__DEV__) {
++        // eslint-disable-next-line no-console
++        console.warn(
++          '[spinr-patch] NativeScrollView non-renderable, falling back to View. typeof=',
++          typeof NativeScrollView,
++        );
++      }
++      NativeScrollView = View;
++    }
++    if (!_isRenderable(NativeScrollContentView)) {
++      if (__DEV__) {
++        // eslint-disable-next-line no-console
++        console.warn(
++          '[spinr-patch] NativeScrollContentView non-renderable, falling back to View. typeof=',
++          typeof NativeScrollContentView,
++        );
++      }
++      NativeScrollContentView = View;
++    }

--- a/rider-app/patches/react-native+0.85.2.patch
+++ b/rider-app/patches/react-native+0.85.2.patch
@@ -455,3 +455,144 @@ diff --git a/node_modules/react-native/src/private/components/scrollview/HScroll
 -    ? AndroidHorizontalScrollContentViewNativeComponent
 +    ? View
      : ScrollContentViewNativeComponent;
+diff --git a/node_modules/react-native/Libraries/Components/Switch/Switch.js b/node_modules/react-native/Libraries/Components/Switch/Switch.js
+--- a/node_modules/react-native/Libraries/Components/Switch/Switch.js
++++ b/node_modules/react-native/Libraries/Components/Switch/Switch.js
+@@ -16,7 +16,7 @@
+ import StyleSheet from '../../StyleSheet/StyleSheet';
+ import Platform from '../../Utilities/Platform';
+ import useMergeRefs from '../../Utilities/useMergeRefs';
+-import AndroidSwitchNativeComponent, {
++import _NativeAndroidSwitch, {
+   Commands as AndroidSwitchCommands,
+ } from './AndroidSwitchNativeComponent';
+ import SwitchNativeComponent, {
+@@ -24,3 +24,83 @@
+ } from './SwitchNativeComponent';
+ import * as React from 'react';
+ import {useLayoutEffect, useRef, useState} from 'react';
++
++// PATCH (spinr rider-app/driver-app):
++// RN 0.85.2's AndroidSwitchNativeComponent is declared with
++// `interfaceOnly: true` — codegenNativeComponent returns a non-renderable
++// placeholder object. Under the New Architecture (Bridgeless), JSX
++// `<AndroidSwitchNativeComponent>` throws "Element type is invalid... got:
++// object". Reproduced on driver-app SettingsScreen.
++//
++// Strategy: detect the broken codegen object and fall back to a JS-only
++// Pressable toggle that fires onChange on press. Visual chrome is a
++// minimal track + thumb in the requested colors. Loses the native
++// material switch animation; functionally equivalent for state.
++const _PressableModule = require('../Pressable/Pressable');
++const _Pressable = _PressableModule.default || _PressableModule;
++const _ViewModule = require('../View/View');
++const _SwitchView = _ViewModule.default || _ViewModule;
++const _isAndroidSwitchNativeValid =
++  typeof _NativeAndroidSwitch === 'function' ||
++  typeof _NativeAndroidSwitch === 'string';
++
++function AndroidSwitchJSFallback(props: $FlowFixMe): React.Node {
++  const {
++    on,
++    enabled,
++    style,
++    thumbTintColor,
++    trackTintColor,
++    trackColorForTrue,
++    trackColorForFalse,
++    onChange,
++    accessibilityState,
++    accessibilityRole,
++    ...rest
++  } = props;
++  const isOn = on === true;
++  const trackBg =
++    (isOn ? trackColorForTrue : trackColorForFalse) ?? trackTintColor ?? (isOn ? '#34C759' : '#787880');
++  const thumbBg = thumbTintColor ?? '#FFFFFF';
++  const handlePress = () => {
++    if (enabled === false) return;
++    if (typeof onChange === 'function') {
++      onChange({nativeEvent: {value: !isOn, target: 0}});
++    }
++  };
++  return (
++    <_Pressable
++      {...rest}
++      accessibilityRole={accessibilityRole ?? 'switch'}
++      accessibilityState={{...(accessibilityState ?? {}), checked: isOn, disabled: enabled === false}}
++      disabled={enabled === false}
++      onPress={handlePress}
++      style={[
++        {
++          width: 51,
++          height: 31,
++          borderRadius: 31 / 2,
++          padding: 2,
++          backgroundColor: trackBg,
++          opacity: enabled === false ? 0.5 : 1,
++          justifyContent: 'center',
++        },
++        style,
++      ]}>
++      <_SwitchView
++        style={{
++          width: 27,
++          height: 27,
++          borderRadius: 27 / 2,
++          backgroundColor: thumbBg,
++          alignSelf: isOn ? 'flex-end' : 'flex-start',
++        }}
++      />
++    </_Pressable>
++  );
++}
++
++const AndroidSwitchNativeComponent: $FlowFixMe =
++  Platform.OS === 'android' && !_isAndroidSwitchNativeValid
++    ? AndroidSwitchJSFallback
++    : _NativeAndroidSwitch;
+diff --git a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
+--- a/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
++++ b/node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js
+@@ -1643,10 +1643,38 @@
+   render(): React.Node {
+     const horizontal = this.props.horizontal === true;
+ 
+-    const NativeScrollView = horizontal
++    // PATCH (spinr): defensive guard. The H/VScrollView native components are
++    // patched to fall back to View on Android, but if for any reason
++    // (module-init order, Hermes quirk, partial patch apply) they resolve to
++    // a non-renderable value, swap in View directly so ScrollView renders
++    // instead of crashing with "Element type is invalid... got: undefined".
++    let NativeScrollView: $FlowFixMe = horizontal
+       ? HScrollViewNativeComponent
+       : VScrollViewNativeComponent;
+-
+-    const NativeScrollContentView = horizontal
++    let NativeScrollContentView: $FlowFixMe = horizontal
+       ? HScrollContentViewNativeComponent
+       : VScrollContentViewNativeComponent;
++    const _isRenderable = (c: $FlowFixMe): boolean =>
++      typeof c === 'function' ||
++      typeof c === 'string' ||
++      (c != null && typeof c === 'object' && c.$$typeof != null);
++    if (!_isRenderable(NativeScrollView)) {
++      if (__DEV__) {
++        // eslint-disable-next-line no-console
++        console.warn(
++          '[spinr-patch] NativeScrollView non-renderable, falling back to View. typeof=',
++          typeof NativeScrollView,
++        );
++      }
++      NativeScrollView = View;
++    }
++    if (!_isRenderable(NativeScrollContentView)) {
++      if (__DEV__) {
++        // eslint-disable-next-line no-console
++        console.warn(
++          '[spinr-patch] NativeScrollContentView non-renderable, falling back to View. typeof=',
++          typeof NativeScrollContentView,
++        );
++      }
++      NativeScrollContentView = View;
++    }


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Adds two more RN 0.85.2 + Bridgeless codegen workarounds — Switch JS-fallback and a defensive guard inside ScrollView's render — to address two crash signatures observed on the post-#747/#753 EAS test build.
- **Type**: `fix`
- **Linked issue**: Refs #747 / #753 — third in the RN 0.85 codegen-patch series.
- **Risk**: `low` — both changes are additive workarounds in `patches/react-native+0.85.2.patch`. No iOS impact, no behavior change when the underlying native components resolve correctly.
- **User-visible change**: `riders` `drivers` — driver Settings page Switches will now toggle (a JS Pressable rendered in place of the broken native switch); rider screens that hit FlatList → ScrollView will stop crashing. Visual: the JS Switch is a minimal track + thumb, not the material animated switch.
- **Scope contract**: `[x]` This PR matches its stated type — only the two patch hunks discussed in `project_rn_0_85_remaining_bugs.md`.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend `[x]` rider-app `[x]` driver-app `[ ]` admin `[ ]` shared `[ ]` migrations `[ ]` infra `[ ]` CI
- **Blast radius**: `multi-surface` (mobile only)
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — patches are file-local under `patches/`; revert restores prior 8/7-hunk state.
- **Dependencies / coordination**: `none` — needs an EAS preview build per app to ship to devices.
- **Assumptions**: RN stays pinned at 0.85.2; if Expo SDK is bumped, all `patches/` will need re-generation. The `patches/**` cache key fix from #753 makes that safe in CI.
- **Not changing but considered**: re-adding the `VScrollViewNativeComponents.js` hunk that was removed from driver-app's patch by `bb64aa2f`. Decision: respect the user's prior choice (likely paired with the `SafeRefreshControl` wrapper); the new ScrollView render-time guard catches the underlying crash regardless.

## Tier 3 — Compliance flags

None apply.

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — `patches/` workarounds are tested via `yarn tsc --noEmit` + on-device smoke tests after EAS build.
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none` (the dev-warn `console.warn('[spinr-patch] NativeScrollView non-renderable…')` is `__DEV__`-gated and never fires in release builds)
- **Screenshots / video**: pending — will attach captures of driver SettingsScreen Switch + rider SearchDestinationScreen after EAS build + install.
- **Perf numbers**: `not-applicable`

**Pre-merge checklist**:

- [x] Local `yarn tsc --noEmit` passes in both apps (no type changes)
- [ ] Tested with rider + driver accounts — pending EAS build + APK install
- [x] No PII introduced
- [x] Local `patch --dry-run` semantics: hunks added with the same generator that produced the working ScrollView hunks in #747

## Background — what the post-#747/#753 EAS test on commit `311ac3a4` showed

Build URLs from the prior session:
- rider `b6b8a918-104e-4a90-a1d8-e4709144b89a`
- driver `48985a12-b37a-48f7-a074-6da4533a7d33`

| Surface | Screen | Component | Symptom |
|---|---|---|---|
| Rider | `SearchDestinationScreen` (tap "Where to?") | `FlatList → VirtualizedList → ScrollView` | `got: undefined` — hard crash to launcher |
| Driver | `SettingsScreen` | `Switch` | `got: object` (4 occurrences) — ErrorBoundary catches, app stays alive |

Bundle inspection of the rider APK confirms our prior patches DID land (zero occurrences of `RCTScrollView`, `RCTScrollContentView`, `AndroidHorizontalScrollView`, `AndroidSwipeRefreshLayout` strings — only `RCTView` remains, the one we depend on).

So the `got: undefined` inside ScrollView happens AFTER the native-component lookup is bypassed by the patch. Suspect: a module-init / Hermes quirk where `H/VScrollViewNativeComponent` evaluates to a non-renderable value despite being patched to `View`. The render-time guard added here catches that case directly inside ScrollView's render method.

## Patches added

| Hunk | File | Pattern |
|---|---|---|
| `Switch.js` | `node_modules/react-native/Libraries/Components/Switch/Switch.js` | Same as `RefreshControl` patch — rename import to `_NativeAndroidSwitch`, detect broken codegen, fall back to JS `Pressable` toggle |
| `ScrollView.js` (defensive guard) | `node_modules/react-native/Libraries/Components/ScrollView/ScrollView.js` | At render time, verify `NativeScrollView` and `NativeScrollContentView` are renderable (`function | string | object-with-$$typeof`); if not, swap in `View` and dev-warn with the actual `typeof`. |

`rider-app/patches/react-native+0.85.2.patch`: 8 → 10 hunks.
`driver-app/patches/react-native+0.85.2.patch`: 7 → 9 hunks.

## Test plan

- [ ] Trigger EAS preview Android build per app
- [ ] Install + manual nav on the connected device:
  - Driver: Settings → toggle every Switch on the page → should not crash, state changes
  - Rider: home → tap "Where to?" → SearchDestinationScreen should render the FlatList without crashing
- [ ] Verify `[spinr-patch] NativeScrollView non-renderable` dev-warn is NOT emitted in a clean run (it being silent confirms our V/H patch is also working in this build; if it fires, we have actionable info)
- [ ] If both screens are stable, run the broader nav matrix (profile, activity, ride flow, etc.) and capture logcat for any new component stacks

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
