### PR TITLE
chore(ui): strip diagnostic console.logs + remove @ts-nocheck

### DIFF
--- a/driver-app/app/otp.tsx
+++ b/driver-app/app/otp.tsx
@@ -10,13 +10,9 @@ import {
   KeyboardAvoidingView,
   Animated,
   Dimensions,
-  Modal,
-  ScrollView,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-// DIAG-ONLY (revert with diagnostic block): test BlurView module resolution
-import { BlurView as DiagBlurView } from 'expo-blur';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useAuthStore, type User } from '@shared/store/authStore';
 import api, { setInMemoryToken } from '@shared/api/client';
@@ -214,29 +210,6 @@ export default function OtpScreen() {
   const maskedPhone = phoneNumber
     ? `${phoneNumber.slice(0, -4)}${'•'.repeat(4)}`
     : '';
-
-  // DIAGNOSTIC: log typeof each imported component to find the undefined one.
-  // Remove once OtpScreen render error is fixed.
-  console.log('[OtpScreenDiag]', JSON.stringify({
-    View: typeof View,
-    Text: typeof Text,
-    TextInput: typeof TextInput,
-    TouchableOpacity: typeof TouchableOpacity,
-    ActivityIndicator: typeof ActivityIndicator,
-    KeyboardAvoidingView: typeof KeyboardAvoidingView,
-    ScrollView: typeof ScrollView,
-    Animated: typeof Animated,
-    AnimatedView: typeof Animated?.View,
-    Ionicons: typeof Ionicons,
-    CustomAlert: typeof CustomAlert,
-    // v2 additions — covers CustomAlert's internal sub-tree
-    Modal: typeof Modal,
-    ModalRender: typeof (Modal as any)?.render,
-    ModalDisplayName: String((Modal as any)?.displayName ?? 'n/a'),
-    ModalSymbolType: String((Modal as any)?.$$typeof ?? 'n/a'),
-    BlurView: typeof DiagBlurView,
-    BlurViewDisplayName: String((DiagBlurView as any)?.displayName ?? 'n/a'),
-  }));
 
   return (
     <KeyboardAvoidingView

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -68,7 +68,7 @@ export default function HomeScreen() {
     try {
       const AsyncStorage = require('@react-native-async-storage/async-storage').default;
       await AsyncStorage.setItem('spinr_last_location', JSON.stringify({ lat, lng }));
-    } catch (err) { console.error('[index]', err); }
+    } catch (err) { if (__DEV__) console.error('[rider-home]', err); }
   };
 
   const loadLastLocation = async () => {
@@ -76,7 +76,7 @@ export default function HomeScreen() {
       const AsyncStorage = require('@react-native-async-storage/async-storage').default;
       const saved = await AsyncStorage.getItem('spinr_last_location');
       if (saved) return JSON.parse(saved);
-    } catch (err) { console.error('[index]', err); }
+    } catch (err) { if (__DEV__) console.error('[rider-home]', err); }
     return null;
   };
 
@@ -132,7 +132,7 @@ export default function HomeScreen() {
           setUserLocation({ latitude: lastKnown.coords.latitude, longitude: lastKnown.coords.longitude });
           saveLastLocation(lastKnown.coords.latitude, lastKnown.coords.longitude);
         }
-      } catch (err) { console.error('[index]', err); }
+      } catch (err) { if (__DEV__) console.error('[rider-home]', err); }
     }
 
     Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced })

--- a/rider-app/app/otp.tsx
+++ b/rider-app/app/otp.tsx
@@ -9,12 +9,9 @@ import {
   Platform,
   KeyboardAvoidingView,
   Animated,
-  Modal,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-// DIAG-ONLY (revert with diagnostic block): test BlurView module resolution
-import { BlurView as DiagBlurView } from 'expo-blur';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useAuthStore, type User } from '@shared/store/authStore';
 import api, { setInMemoryToken } from '@shared/api/client';
@@ -220,28 +217,6 @@ export default function OtpScreen() {
       resendInFlight.current = false;
     }
   };
-
-  // DIAGNOSTIC: log typeof each imported component to find the undefined one.
-  // Remove once OtpScreen render error is fixed.
-  console.log('[OtpScreenDiag]', JSON.stringify({
-    View: typeof View,
-    Text: typeof Text,
-    TextInput: typeof TextInput,
-    TouchableOpacity: typeof TouchableOpacity,
-    ActivityIndicator: typeof ActivityIndicator,
-    KeyboardAvoidingView: typeof KeyboardAvoidingView,
-    Animated: typeof Animated,
-    AnimatedView: typeof Animated?.View,
-    Ionicons: typeof Ionicons,
-    CustomAlert: typeof CustomAlert,
-    // v2 additions — covers CustomAlert's internal sub-tree
-    Modal: typeof Modal,
-    ModalRender: typeof (Modal as any)?.render,
-    ModalDisplayName: String((Modal as any)?.displayName ?? 'n/a'),
-    ModalSymbolType: String((Modal as any)?.$$typeof ?? 'n/a'),
-    BlurView: typeof DiagBlurView,
-    BlurViewDisplayName: String((DiagBlurView as any)?.displayName ?? 'n/a'),
-  }));
 
   return (
     <KeyboardAvoidingView

--- a/shared/components/CustomAlert.tsx
+++ b/shared/components/CustomAlert.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useEffect, useRef, useMemo, useState } from 'react';
 import {
   View,
@@ -13,32 +12,10 @@ import {
   Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { BlurView } from 'expo-blur';
 import { useTheme } from '../theme/ThemeContext';
 import type { ThemeColors } from '../theme/index';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
-
-// DIAGNOSTIC (revert once OtpScreen render error is fixed): logs at module
-// evaluation time so we know what CustomAlert's own imports resolve to —
-// independent of OtpScreen's import surface.
-console.log('[CustomAlertDiag-module]', JSON.stringify({
-  View: typeof View,
-  Text: typeof Text,
-  StyleSheet: typeof StyleSheet,
-  TouchableOpacity: typeof TouchableOpacity,
-  Modal: typeof Modal,
-  ModalRender: typeof (Modal as any)?.render,
-  ModalSymbolType: String((Modal as any)?.$$typeof ?? 'n/a'),
-  Animated: typeof Animated,
-  AnimatedView: typeof Animated?.View,
-  Dimensions: typeof Dimensions,
-  TextInput: typeof TextInput,
-  KeyboardAvoidingView: typeof KeyboardAvoidingView,
-  Platform: typeof Platform,
-  Ionicons: typeof Ionicons,
-  BlurView: typeof BlurView,
-}));
 
 export type AlertVariant = 'info' | 'warning' | 'danger' | 'success';
 

--- a/shared/components/OfflineBanner.tsx
+++ b/shared/components/OfflineBanner.tsx
@@ -57,11 +57,13 @@ export function OfflineBanner({
   useEffect(() => {
     // Subscribe to network status changes
     const unsubscribe = NetInfo.addEventListener(state => {
-      console.log('[OfflineBanner] Network state changed:', {
-        isConnected: state.isConnected,
-        isInternetReachable: state.isInternetReachable,
-        type: state.type,
-      });
+      if (__DEV__) {
+        console.log('[OfflineBanner] Network state changed:', {
+          isConnected: state.isConnected,
+          isInternetReachable: state.isInternetReachable,
+          type: state.type,
+        });
+      }
       updateNetworkStatus(state.isConnected ?? state.isInternetReachable);
     });
 


### PR DESCRIPTION
## Summary

PR-2 of the UI-foundations sequence (after #759 FormScreen). Removes
diagnostic instrumentation that was added during the OtpScreen
\"Element type is invalid\" investigation and never reverted — the
diag blocks ship to release builds today, violate the project TS rule
\"No console.log statements in production code,\" and pollute the
Hermes JS log buffer on flaky-network devices.

## Specifics

**5 files, -83/+10 lines (net -73 lines of dead code):**

- \`rider-app/app/otp.tsx\` — drop \`[OtpScreenDiag]\` console.log block + the
  diag-only \`BlurView as DiagBlurView\` import. Drop unused \`Modal\` from
  the \`react-native\` destructure (only the diag referenced it).
- \`driver-app/app/otp.tsx\` — same; also drop unused \`ScrollView\` from
  the destructure.
- \`shared/components/CustomAlert.tsx\` — drop module-level
  \`[CustomAlertDiag-module]\` console.log (fires at every cold start
  before any UI renders), drop the \`BlurView\` import it depended on,
  **drop \`// @ts-nocheck\`** which had been disabling TypeScript on the
  most-used shared component in the app.
- \`shared/components/OfflineBanner.tsx\` — gate the per-NetInfo-event log
  behind \`__DEV__\`. Long-term: route through \`shared/utils/logger.ts\`
  per the CLAUDE.md observability conventions.
- \`rider-app/app/(tabs)/index.tsx\` — replace 3 instances of
  \`console.error('[index]', err)\` with \`__DEV__\`-gated form using a real
  surface tag (\`'[rider-home]'\`). The original \`[index]\` was meant to be
  \`__filename\` but Expo doesn't expand it, so the literal string
  \`[index]\` shipped — useless for triage.

## Behavior

**Zero behavior change.** All removed code was either (a) dead
instrumentation logged to console with no side effects, or (b) imports
that supported only that instrumentation. \`@ts-nocheck\` removal is
behavior-preserving by design — TypeScript is now type-checking
\`CustomAlert.tsx\`, which may surface latent \`any\` casts as warnings;
those are fixable in a follow-up if any appear.

## Test plan

- [ ] \`yarn tsc --noEmit\` clean in rider-app and driver-app (CustomAlert
      may surface previously-suppressed type errors after \`@ts-nocheck\`
      removal — confirm none break the build, fix any that do)
- [ ] Cold-start each app on the connected Android — confirm no
      \`[OtpScreenDiag]\` / \`[CustomAlertDiag-module]\` / \`[OfflineBanner]
      Network state changed\` lines in \`adb logcat ReactNativeJS:V *:S\`
- [ ] Toggle airplane mode while OfflineBanner is mounted — confirm no
      log spam on each transition (release build); \`__DEV__\` build still
      logs as before
- [ ] OTP screen renders identically (the diag block was just a
      console.log; removing it changes nothing visible)

## Sequence

1. #759 PR-1 — \`feat(shared): add FormScreen wrapper\`
2. **#PR-2 (this)** — \`chore(ui): strip diagnostic console.logs + remove @ts-nocheck\`
3. PR-3 — \`fix(ui): replace module-level Dimensions.get with useWindowDimensions\`
4. PR-4 — \`feat(theme): add semantic-color tokens (info, *Bg) for dark-mode parity\`
5. PR-5+ — per-screen migrations to \`<FormScreen>\` (with phone testing)

Full sequence in \`.planning/UI-FIX-HANDOFF.md\` (committed on the
fix/rider-app-expo-sdk55 branch; will be cherry-picked into a docs PR
or this branch when convenient).

## Source

Audit: \`.planning/UI-REVIEW.md\` — BLOCKER 3 \"Diagnostic logs in
production code path,\" Pillar 6 Experience Design.

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
