### PR TITLE
fix(ui): replace module-level Dimensions.get with useWindowDimensions

### DIFF
--- a/driver-app/app/login.tsx
+++ b/driver-app/app/login.tsx
@@ -10,7 +10,6 @@ import {
   Platform,
   StatusBar,
   Animated,
-  Dimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -23,8 +22,6 @@ import { useLanguageStore } from '../store/languageStore';
 import CustomAlert from '@shared/components/CustomAlert';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
-
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 export default function LoginScreen() {
   const router = useRouter();

--- a/driver-app/app/otp.tsx
+++ b/driver-app/app/otp.tsx
@@ -9,7 +9,6 @@ import {
   Platform,
   KeyboardAvoidingView,
   Animated,
-  Dimensions,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
@@ -20,8 +19,6 @@ import CustomAlert from '@shared/components/CustomAlert';
 import { useLanguageStore } from '../store/languageStore';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
-
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 // Platform-safe token storage
 const storage = {

--- a/shared/components/CustomAlert.tsx
+++ b/shared/components/CustomAlert.tsx
@@ -6,16 +6,14 @@ import {
   TouchableOpacity,
   Modal,
   Animated,
-  Dimensions,
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  useWindowDimensions,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '../theme/ThemeContext';
 import type { ThemeColors } from '../theme/index';
-
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 export type AlertVariant = 'info' | 'warning' | 'danger' | 'success';
 
@@ -54,6 +52,8 @@ export default function CustomAlert({
   onInputChange,
 }: CustomAlertProps) {
   const { colors } = useTheme();
+  const { width: windowWidth } = useWindowDimensions();
+  const containerWidth = Math.min(windowWidth - 56, 360);
   const styles = useMemo(() => createStyles(colors), [colors]);
   const [isPending, setIsPending] = useState(false);
 
@@ -152,6 +152,7 @@ export default function CustomAlert({
           style={[
             styles.container,
             {
+              width: containerWidth,
               transform: [{ scale: scaleAnim }],
               opacity: opacityAnim,
             },
@@ -244,8 +245,6 @@ function createStyles(colors: ThemeColors) {
       backgroundColor: 'rgba(0, 0, 0, 0.5)',
     },
     container: {
-      width: SCREEN_WIDTH - 56,
-      maxWidth: 360,
       backgroundColor: colors.surface,
       borderRadius: 24,
       padding: 28,


### PR DESCRIPTION
## Summary

PR-3 of the UI-foundations sequence. Three files cached
\`Dimensions.get('window').width\` at module evaluation time; the
captured value never updated. Replace with \`useWindowDimensions()\` so
layouts respond to rotation, foldable unfold, and split-screen.

## Specifics

**3 files, +4 / -12 lines:**

### \`shared/components/CustomAlert.tsx\` — the worst offender

\`SCREEN_WIDTH\` was used in the alert container's style as
\`width: SCREEN_WIDTH - 56\` capped to \`maxWidth: 360\`. The formula is
**preserved exactly** at first render — replaced with a runtime-
computed \`containerWidth = Math.min(width - 56, 360)\` applied via
inline style on \`Animated.View\`. The \`width\` and \`maxWidth\` are
removed from the styles factory's \`container\` rule (the inline style
supersedes them).

### \`driver-app/app/login.tsx\` and \`driver-app/app/otp.tsx\`

Both captured \`SCREEN_WIDTH\` at module load and **never read it**. Pure
dead code. Drop the capture lines and the \`Dimensions\` imports.
Verified by \`grep -c SCREEN_WIDTH\` returning 1 (the capture itself)
in each file.

## Behavior

\`CustomAlert\` is mathematically equivalent at first render —
\`min(width - 56, 360)\` produces the same number as the previous
\`width: SCREEN_WIDTH - 56, maxWidth: 360\` combination. The new code
re-evaluates on every render, so the alert resizes correctly when:

- Device rotates while the alert is open
- App moves between phone outer / inner display on a foldable
- Window changes size in Android split-screen

The driver auth files lose only dead code; no behavior change at all.

## Test plan

- [ ] \`yarn tsc --noEmit\` clean in both apps
- [ ] Open any \`CustomAlert\` variant on phone, rotate device — alert
      width should adjust live (pre-fix, it stayed at the launch-time
      width)
- [ ] Foldable smoke test (if available): open on outer, unfold —
      alert width tracks the new screen size
- [ ] No visual change on first paint — the formula is preserved

## Sequence

1. #759 PR-1 — \`feat(shared): add FormScreen wrapper\`
2. #761 PR-2 — \`chore(ui): strip diagnostic console.logs + remove @ts-nocheck\`
3. **#PR-3 (this)** — \`fix(ui): replace module-level Dimensions.get with useWindowDimensions\`
4. PR-4 — \`feat(theme): add semantic-color tokens for dark-mode parity\`
5. PR-5+ — per-screen migrations to \`<FormScreen>\`

Note: PR-2 and PR-3 both touch \`shared/components/CustomAlert.tsx\` at
non-overlapping lines (PR-2 removes the diag block at the top of the
file; PR-3 modifies the imports / Animated.View / styles factory).
Whichever lands second will need a tiny mechanical rebase.

## Source

Audit: \`.planning/UI-REVIEW.md\` — BLOCKER 2 \"Frozen
Dimensions.get('window')\".

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
