### PR TITLE
feat(theme): add semantic-color tokens for dark-mode parity

### DIFF
--- a/shared/components/CustomAlert.tsx
+++ b/shared/components/CustomAlert.tsx
@@ -63,38 +63,6 @@ interface CustomAlertProps {
   onInputChange?: (text: string) => void;
 }
 
-const VARIANT_CONFIG: Record<AlertVariant, {
-  icon: string;
-  iconColor: string;
-  iconBg: string;
-  buttonColor: string;
-}> = {
-  info: {
-    icon: 'information-circle',
-    iconColor: '#3B82F6',
-    iconBg: '#EFF6FF',
-    buttonColor: '#3B82F6',
-  },
-  warning: {
-    icon: 'alert-circle',
-    iconColor: '#F59E0B',
-    iconBg: '#FFFBEB',
-    buttonColor: '#F59E0B',
-  },
-  danger: {
-    icon: 'warning',
-    iconColor: '#EF4444',
-    iconBg: '#FEF2F2',
-    buttonColor: '#EF4444',
-  },
-  success: {
-    icon: 'checkmark-circle',
-    iconColor: '#10B981',
-    iconBg: '#ECFDF5',
-    buttonColor: '#10B981',
-  },
-};
-
 export default function CustomAlert({
   visible,
   title,
@@ -111,6 +79,38 @@ export default function CustomAlert({
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const [isPending, setIsPending] = useState(false);
+
+  // Variant config reads from the active theme, so dark mode renders dark
+  // tinted backgrounds instead of the legacy light-only hex literals.
+  const variantConfig = useMemo(
+    () => ({
+      info: {
+        icon: 'information-circle',
+        iconColor: colors.info,
+        iconBg: colors.infoBg,
+        buttonColor: colors.info,
+      },
+      warning: {
+        icon: 'alert-circle',
+        iconColor: colors.warning,
+        iconBg: colors.warningBg,
+        buttonColor: colors.warning,
+      },
+      danger: {
+        icon: 'warning',
+        iconColor: colors.error,        // theme aliases `danger` to error
+        iconBg: colors.dangerBg,
+        buttonColor: colors.error,
+      },
+      success: {
+        icon: 'checkmark-circle',
+        iconColor: colors.success,
+        iconBg: colors.successBg,
+        buttonColor: colors.success,
+      },
+    }),
+    [colors],
+  );
 
   const scaleAnim = useRef(new Animated.Value(0.85)).current;
   const opacityAnim = useRef(new Animated.Value(0)).current;
@@ -142,7 +142,7 @@ export default function CustomAlert({
     }
   }, [visible, showInput]);
 
-  const config = VARIANT_CONFIG[variant];
+  const config = variantConfig[variant];
   const iconName = (icon || config.icon) as keyof typeof Ionicons.glyphMap;
 
   const handlePress = async (button: AlertButton) => {

--- a/shared/theme/index.ts
+++ b/shared/theme/index.ts
@@ -25,10 +25,16 @@ export type ThemeColors = {
   // UI chrome
   border: string;
   overlay: string;
-  // Semantic
+  // Semantic — foreground tones
   error: string;
   success: string;
   warning: string;
+  info: string;
+  // Semantic — surface tints (background behind status icons / pill badges)
+  successBg: string;
+  warningBg: string;
+  dangerBg: string;
+  infoBg: string;
   // Aliases / Legacy
   accent: string;
   accentDim: string;
@@ -51,6 +57,11 @@ export const lightColors: ThemeColors = {
   error: '#DC2626',
   success: '#34C759',
   warning: '#FFCC00',
+  info: '#3B82F6',           // iOS-system-blue
+  successBg: '#ECFDF5',
+  warningBg: '#FFFBEB',
+  dangerBg:  '#FEF2F2',
+  infoBg:    '#EFF6FF',
   accent: '#FF3B30',
   accentDim: '#D32F2F',
   danger: '#DC2626',
@@ -72,6 +83,14 @@ export const darkColors: ThemeColors = {
   error: '#FF453A',
   success: '#30D158',       // iOS system green (dark)
   warning: '#FFD60A',       // iOS system yellow (dark)
+  info: '#0A84FF',          // iOS system blue (dark)
+  // Surface tints — NOT just inverted; very-low-luminance versions of the
+  // foreground hue so they read as a tinted dark surface, not a near-white
+  // tint inverted to off-tone aubergine.
+  successBg: '#0B3D2E',
+  warningBg: '#3D2E0B',
+  dangerBg:  '#3D0B0B',
+  infoBg:    '#0B243D',
   accent: '#FF453A',
   accentDim: '#D32F2F',
   danger: '#FF453A',


### PR DESCRIPTION
## Summary

PR-4 of the UI-foundations sequence. Restores dark-mode parity for
\`CustomAlert\` (and unblocks the same fix for \`SOSButton\` + driver
ride-offer panel as a follow-up). Adds 5 semantic-color tokens to the
theme palette and refactors \`CustomAlert.VARIANT_CONFIG\` to consume
them — no more hardcoded light-mode hex literals on dark surfaces.

## Tokens added

\`ThemeColors\`:

\`\`\`ts
info: string         // semantic blue (didn't exist before)
successBg: string    // surface tint behind success icons
warningBg: string    // surface tint behind warning icons
dangerBg:  string    // surface tint behind danger icons
infoBg:    string    // surface tint behind info icons
\`\`\`

\`lightColors\` gets the legacy CustomAlert tints (which were correct
for light mode but hardcoded into the consumer):

\`\`\`
info: '#3B82F6'              // iOS-system-blue
successBg: '#ECFDF5'
warningBg: '#FFFBEB'
dangerBg:  '#FEF2F2'
infoBg:    '#EFF6FF'
\`\`\`

\`darkColors\` gets deliberately-not-inverted dark tints. Inverting
\`#ECFDF5\` produces an off-tone aubergine; the dark Bg tokens are
very-low-luminance versions of the foreground hue:

\`\`\`
info: '#0A84FF'              // iOS system blue (dark)
successBg: '#0B3D2E'
warningBg: '#3D2E0B'
dangerBg:  '#3D0B0B'
infoBg:    '#0B243D'
\`\`\`

If you have a designer, the dark Bg values are a plausible default and
worth a review pass.

## CustomAlert refactor

The previous module-level \`VARIANT_CONFIG\` hardcoded the variant tints
in 16 hex literals. Replace with a \`useMemo\`'d config inside the
component that reads from the active theme:

\`\`\`ts
variantConfig.info    → colors.info / colors.infoBg
variantConfig.warning → colors.warning / colors.warningBg
variantConfig.danger  → colors.error / colors.dangerBg
variantConfig.success → colors.success / colors.successBg
\`\`\`

(\`danger\` maps to \`colors.error\` — the theme already aliases \`danger\`
to \`error\`; using \`error\` is the canonical token.)

\`config = variantConfig[variant]\` is used in exactly the same call
sites as before. No render-tree shape change, no prop change.

## Behavior

**Light mode: identical at first paint.** The legacy hex literals
migrated to the theme palette, so first-render colors match exactly.

**Dark mode: now works.** Pre-fix, the alert showed light-mode
\`#EFF6FF\` behind icons on a \`#000\` surface — a near-white blob in
dark UI. Post-fix, the dark surface tint reads as intended.

## Follow-up surfaces (NOT in this PR)

The same hardcoded-tint pattern exists in two more places. Once these
tokens land, they're mechanical replacements:

- \`shared/components/SOSButton.tsx\` (lines ~232–265) — 5 button-state
  tints hardcoded
- \`driver-app/app/driver/(tabs)/index.tsx\` (lines ~933–967) — offer-
  panel accept/decline buttons

Either rolled into a follow-up cleanup PR, or paired with the
respective screens during their \`<FormScreen>\` migration.

## Test plan

- [ ] \`yarn tsc --noEmit\` clean in rider-app and driver-app (theme
      type extension is additive — no pre-existing consumer breaks)
- [ ] On the connected Android, toggle dark mode (Settings → Display →
      Dark theme)
- [ ] Trigger each alert variant on rider-app:
   - \"Verification Failed\" (danger) → wrong OTP
   - \"Code Sent\" (success) → resend OTP
   - \"Too Many Attempts\" (warning) → trigger 429 rate limit
   - any \"Coming Soon\" type prompt → info
- [ ] Verify each alert's icon-bg tint reads as a dark surface tint
      (\`#0B3D2E\` etc.), not the legacy light hex on a black surface

## Sequence

1. #759 PR-1 — \`feat(shared): add FormScreen wrapper\`
2. #761 PR-2 — \`chore(ui): strip diagnostic console.logs + remove @ts-nocheck\`
3. #763 PR-3 — \`fix(ui): replace module-level Dimensions.get with useWindowDimensions\`
4. **#PR-4 (this)** — \`feat(theme): add semantic-color tokens for dark-mode parity\`
5. PR-5+ — per-screen migrations to \`<FormScreen>\` (with phone testing)

Note: PR-2, PR-3, and PR-4 all touch \`shared/components/CustomAlert.tsx\`
at non-overlapping lines. Whichever lands second/third will need tiny
mechanical rebases. Recommended merge order: PR-2 → PR-3 → PR-4 (this
order keeps each rebase minimal).

## Source

Audit: \`.planning/UI-REVIEW.md\` — Pillar 3 \"Color\" (score 2/4):
\"theme architecture is correct; bypass is concentrated in shared
components that propagate the bypass to every consumer.\"