### PR TITLE
chore(auth): remove dead Firebase verifyOTP stub from authStore + OTP screens

### DIFF
--- a/driver-app/app/otp.tsx
+++ b/driver-app/app/otp.tsx
@@ -39,12 +39,11 @@ const storage = {
 export default function OtpScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const params = useLocalSearchParams<{ verificationId?: string; phoneNumber: string; mode?: string }>();
-  const { phoneNumber, verificationId, mode } = params;
+  const params = useLocalSearchParams<{ phoneNumber: string }>();
+  const { phoneNumber } = params;
   const { t } = useLanguageStore();
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const isBackendMode = mode === 'backend' || !verificationId;
   const codeLength = 4;
 
   const [code, setCode] = useState('');
@@ -52,7 +51,7 @@ export default function OtpScreen() {
   const [hasAttemptedVerification, setHasAttemptedVerification] = useState(false);
   const [countdown, setCountdown] = useState(30);
   const [canResend, setCanResend] = useState(false);
-  const { verifyOTP, user, initialize, clearError } = useAuthStore();
+  const { user, initialize, clearError } = useAuthStore();
   const inputRef = useRef<TextInput>(null);
 
   // Animations
@@ -144,28 +143,24 @@ export default function OtpScreen() {
     clearError();
 
     try {
-      if (isBackendMode) {
-        const response = await api.post<{ token?: string; refresh_token?: string; expires_in?: number; user?: User }>('/auth/verify-otp', {
-          phone: phoneNumber,
-          code: code,
-        });
-        if (!response.data) throw new Error('Empty response from auth server');
-        const otpData = response.data as { token?: string; refresh_token?: string; expires_in?: number; user?: any };
-        const { token, refresh_token, expires_in, user: userData } = otpData;
-        if (token) {
-          await useAuthStore.getState().setTokens(token, refresh_token ?? '', expires_in ?? 900);
-          if (userData) {
-            useAuthStore.setState({
-              user: userData,
-              isInitialized: true,
-              isLoading: false,
-            });
-          } else {
-            await initialize();
-          }
+      const response = await api.post<{ token?: string; refresh_token?: string; expires_in?: number; user?: User }>('/auth/verify-otp', {
+        phone: phoneNumber,
+        code: code,
+      });
+      if (!response.data) throw new Error('Empty response from auth server');
+      const otpData = response.data as { token?: string; refresh_token?: string; expires_in?: number; user?: any };
+      const { token, refresh_token, expires_in, user: userData } = otpData;
+      if (token) {
+        await useAuthStore.getState().setTokens(token, refresh_token ?? '', expires_in ?? 900);
+        if (userData) {
+          useAuthStore.setState({
+            user: userData,
+            isInitialized: true,
+            isLoading: false,
+          });
+        } else {
+          await initialize();
         }
-      } else {
-        await verifyOTP(verificationId!, code);
       }
     } catch (err: any) {
       triggerShake();

--- a/rider-app/app/otp.tsx
+++ b/rider-app/app/otp.tsx
@@ -39,16 +39,15 @@ const storage = {
 export default function OtpScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const params = useLocalSearchParams<{ verificationId?: string; phoneNumber: string; mode?: string }>();
-  const { phoneNumber, verificationId, mode } = params;
-  const isBackendMode = mode === 'backend' || !verificationId;
+  const params = useLocalSearchParams<{ phoneNumber: string }>();
+  const { phoneNumber } = params;
   const codeLength = 4;
 
   const [code, setCode] = useState('');
   const [verifying, setVerifying] = useState(false);
   const [countdown, setCountdown] = useState(30);
   const [canResend, setCanResend] = useState(false);
-  const { verifyOTP, user, initialize, clearError } = useAuthStore();
+  const { user, initialize, clearError } = useAuthStore();
   const inputRef = useRef<TextInput>(null);
   const resendInFlight = useRef(false);
   const { colors, isDark } = useTheme();
@@ -139,30 +138,26 @@ export default function OtpScreen() {
     clearError();
 
     try {
-      if (isBackendMode) {
-        const response = await api.post<{ token?: string; refresh_token?: string; expires_in?: number; user?: User }>('/auth/verify-otp', {
-          phone: phoneNumber,
-          code: code,
+      const response = await api.post<{ token?: string; refresh_token?: string; expires_in?: number; user?: User }>('/auth/verify-otp', {
+        phone: phoneNumber,
+        code: code,
+      });
+      if (!response.data) throw new Error('Empty response from auth server');
+      const { token, refresh_token, expires_in, user: userData } = response.data as { token: string; refresh_token?: string; expires_in?: number; user?: any };
+      // P3 cookie auth: token is "" when HTTP-only cookies are used
+      if (token) {
+        await useAuthStore.getState().setTokens(token, refresh_token ?? "", expires_in ?? 900);
+      }
+      Analytics.otpVerified();
+      if (userData) {
+        useAuthStore.setState({
+          user: userData,
+          isInitialized: true,
+          isLoading: false,
         });
-        if (!response.data) throw new Error('Empty response from auth server');
-        const { token, refresh_token, expires_in, user: userData } = response.data as { token: string; refresh_token?: string; expires_in?: number; user?: any };
-        // P3 cookie auth: token is "" when HTTP-only cookies are used
-        if (token) {
-          await useAuthStore.getState().setTokens(token, refresh_token ?? "", expires_in ?? 900);
-        }
-        Analytics.otpVerified();
-        if (userData) {
-          useAuthStore.setState({
-            user: userData,
-            isInitialized: true,
-            isLoading: false,
-          });
-          Analytics.login();
-        } else {
-          await initialize();
-        }
+        Analytics.login();
       } else {
-        await verifyOTP(verificationId!, code);
+        await initialize();
       }
     } catch (err: any) {
       triggerShake();

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -198,7 +198,6 @@ interface AuthState {
 
   // Actions
   initialize: () => Promise<void>;
-  verifyOTP: (verificationId: string, code: string) => Promise<void>;
   setTokens: (token: string, refreshToken: string, expiresIn: number, csrfToken?: string | null) => Promise<void>;
   refreshTokens: () => Promise<boolean>;
   createProfile: (data: {
@@ -343,14 +342,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (__DEV__) console.log('[Auth] No stored token → logged out');
     await clearAuthStorage();
     set({ user: null, driver: null, token: null, refreshToken: null, tokenExpiresAt: null, isInitialized: true, isLoading: false });
-  },
-
-  verifyOTP: async (_verificationId: string, _code: string) => {
-    // OTP verification is handled via the backend API (POST /auth/verify-otp),
-    // not through Firebase Auth. This method is preserved for interface
-    // compatibility but should not be called directly — use the backend
-    // OTP flow in otp.tsx instead.
-    throw new Error('verifyOTP via Firebase is not used. Use backend OTP verification.');
   },
 
   createProfile: async (data: Parameters<AuthState['createProfile']>[0]) => {


### PR DESCRIPTION
## Summary

Follow-up cleanup to Kiran's [\`0e2987fe\`](https://github.com/srikumarimuddana-lab/spinrvm/commit/0e2987fe) which
removed Firebase Phone Auth from \`authStore\` and stubbed \`verifyOTP()\`
to throw for "interface compatibility." The stub stayed because two
OTP screens still imported it — but both callers were already dead
branches:

\`\`\`tsx
if (isBackendMode) {                       // always true in production
  /* backend OTP via POST /auth/verify-otp */
} else {
  await verifyOTP(verificationId!, code);  // never reached
}
\`\`\`

\`isBackendMode = mode === 'backend' || !verificationId\`. Both login
screens (\`rider-app/app/login.tsx:84\`, \`driver-app/app/login.tsx:112\`)
always navigate with \`mode: 'backend'\` and never pass \`verificationId\`,
so \`isBackendMode\` is **structurally always true** in production.

## Changes

**\`shared/store/authStore.ts\`** (-9 lines):
- Drop \`verifyOTP\` from the \`AuthState\` type
- Drop the throwing stub method body (was 7 lines of \`throw new Error(...)\`)

**\`rider-app/app/otp.tsx\` + \`driver-app/app/otp.tsx\`** (mostly indentation reduction):
- Drop \`verificationId\` and \`mode\` from \`useLocalSearchParams\` type + destructure
- Drop \`isBackendMode\` const
- Drop \`verifyOTP\` from \`useAuthStore()\` destructure
- Unwrap the \`if (isBackendMode) { … } else { verifyOTP(…) }\` block to leave the if-body inline (one indentation level removed)

## What was NOT touched

- **\`driver-app/store/driverStore.ts:verifyOTP\`** — different function entirely (signature \`(rideId, otp)\` for ride-pickup OTP, vs auth's \`(verificationId, code)\`). Used by driver dashboard line 715. Different concern, untouched.
- **\`isApiError\` import in authStore.ts** — my review handoff erroneously called this dead. \`isApiError\` is still used in 6 other places throughout the file (token refresh, profile creation, driver registration). Left intact. Correcting the prior handoff note here for the record.
- **\`driver-app/__tests__/store/authStore.initialize.test.ts\`** — has stale \`jest.mock('firebase/auth', …)\` calls that mock now-unimported symbols. Harmless (jest.mock of unused modules is a no-op) and the test still passes. Worth a follow-up to clean up the mock setup but not blocking.

## Behavior change

If a future bug ever routes a user to OTP without \`mode: 'backend'\`,
the previous behavior was to call the throwing stub (loud error).
Post-this-PR, the user is silently routed through the backend flow
with whatever \`phoneNumber\` they have. Acceptable trade-off because
the only known way to reach OTP is via login screens that hard-code
\`mode: 'backend'\`; if a third entrypoint emerges later, it'll be
added with the backend default.

## Test plan

- [ ] \`yarn tsc --noEmit\` clean in both apps
- [ ] OTP verification on rider works end-to-end (enter wrong code triggers shake; correct code routes to /(tabs)/activity or /profile-setup)
- [ ] OTP verification on driver works end-to-end (correct code routes to /driver or /profile-setup)
- [ ] \`yarn test driver-app/__tests__/store/authStore.initialize.test.ts\` still passes (the dead jest.mocks are still in place; just unused now)

## Source

Audit: \`.planning/UI-FIX-HANDOFF.md\` "Findings I Should Surface" #6
("Two divergent OTP implementations" — this PR is the smaller half of
the consolidation; the larger half — extracting a \`useOtpVerification\`
shared hook — is a separate ticket).

Builds on: #0e2987fe (Kiran), #759, #761, #763, #765, #767.

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
