### PR TITLE
fix(admin-dashboard): patch fast-uri HIGH CVE

### DIFF
--- a/admin-dashboard/package-lock.json
+++ b/admin-dashboard/package-lock.json
@@ -9956,13 +9956,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -10037,9 +10037,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -10770,9 +10770,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10978,9 +10978,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
<!-- spinr-required-fields -->

## Tier 1 — Summary

- **Summary** [required]: Patch transitive `fast-uri` HIGH CVE in admin-dashboard via `npm audit fix` (lockfile-only)
- **Type** [required]: `security`
- **Linked issue** [required]: Refs GHSA-q3j6-qgpj-74h6 (no internal issue tracker entry)
- **Risk** [required]: `low` — only transitive deps bumped, no `package.json` change, build verified clean
- **User-visible change** [required]: `none`
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[x]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `single-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — pure lockfile bump, revert restores prior tree
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: Bumped transitive packages (`fast-uri`, `express-rate-limit`, `hono`, `ip-address`) maintain semver-compatible behavior with admin-dashboard usage; verified by `npm run build` succeeding.

## Tier 3 — Compliance flags

(none — pure dep patch, no functional change)

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — lockfile-only change, no logic touched
- **Integration tests** [required]: `not-applicable` — lockfile-only change
- **Metrics / logs introduced** [required]: `none`

**Pre-merge checklist** [required]:

- [x] Ran `npm audit --audit-level=high` — 0 vulnerabilities remaining
- [x] Ran `npm run build` — admin-dashboard builds clean
- [x] Verified G4b/G4c CI gates pass on this PR
- [x] No PII added — lockfile-only

## CVE detail

- **GHSA-q3j6-qgpj-74h6** — fast-uri path traversal via percent-encoded dot segments (CVSS 7.5)
- **GHSA-v39h-62p7-jpjc** — fast-uri host confusion via percent-encoded authority delimiters (CVSS 7.5)
- Plus moderate findings in `express-rate-limit`, `hono`, `ip-address` cleared by the same fix.

Unblocks G4b (yarn audit) + G4c (npm audit, HIGH blocking) on `main`.
