### PR TITLE
chore(hygiene): refresh STATE.md + drop unused Supabase JS-client config

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,13 +2,13 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-status: BLOCKED — .env files not created for backend, rider-app, driver-app
-last_updated: "2026-05-07T17:16:08.332Z"
+status: IN PROGRESS — Phase 3 device testing in flight; UI foundations stack landed (#759/#761/#763/#765/#767/#773); Switch + ScrollView guard pending on-device verification
+last_updated: "2026-05-10T17:00:00.000Z"
 ---
 
 # Spinr — GSD Project State
 
-*Last updated: 2026-05-02 | Branch: main*
+*Last updated: 2026-05-10 | Branch: main*
 
 ---
 
@@ -16,49 +16,72 @@ last_updated: "2026-05-07T17:16:08.332Z"
 
 **Phase 3 — Device Testing Preparation & Execution**
 
-Status: BLOCKED — .env files not created for backend, rider-app, driver-app
+Status: IN PROGRESS. Environment files exist on all four surfaces (backend/.env, rider-app/.env, driver-app/.env, admin-dashboard/.env.local — all populated for ≥ 1 week). Real EAS preview Android builds installed on device `51161FDAS001WB` on 2026-05-10. Two crash signatures identified that day (rider FlatList → ScrollView `got: undefined`, driver SettingsScreen Switch `got: object`); follow-up patches landed in PR #756 (`afd866ed`) — defensive `ScrollView` render-time guard + `Switch` JS-fallback. Awaiting EAS rebuild + on-device re-verification against current main.
 
 ## Phase Progress
 
 | Phase | Status | Notes |
 |---|---|---|
 | Phase 1: P0 Security & Safety Hardening | ✅ Complete | All 6 P0s shipped (PRs #95/#97/#117/#126/#172/#240/#266) as of 2026-04-27 |
-| Phase 2: CI Health & Dev Environment | ✅ Complete | All CI gates green (PR #401 merged); docs/dev-setup.md + ENV-3 still outstanding |
-| Phase 3: Device Testing | 🚧 Blocked | Needs .env files: backend, rider-app, driver-app |
-| Phase 4: Type Safety & Code Quality | ⏳ Pending | |
+| Phase 2: CI Health & Dev Environment | ✅ Complete | All CI gates green; `docs/dev-setup.md` + ENV-3 still outstanding |
+| Phase 3: Device Testing | 🟡 In progress | `.env` files in place; EAS preview builds installed and tested on real device 2026-05-10; one crash class still pending validation post-#756 |
+| Phase 4: Type Safety & Code Quality | ⏳ Pending | Branch `feat/phase4-type-safety-docs` exists locally; not yet started |
 | Phase 5: Pre-Production Hardening | ⏳ Pending | |
 | Phase 6: Production Deployment | ⏳ Pending | |
 
-## Recent Work (2026-05-02)
+## Recent Work (2026-05-03 → 2026-05-10)
 
-- PR #401 merged to main: G5b Gitleaks fix, claude-review OIDC permission, GSD planning structure, E2E cookie auth mock (CI-4), test fixes
-- Phase 2 CI fully complete: all 5 CI gates green, E2E auth fixture created (admin-dashboard/e2e/auth-fixture.ts)
-- G4c pino lockfile drift resolved (npm dedupe)
-- All 6 P0 sprint items confirmed shipped; sprint marked complete
+132 PRs merged to main across the past week. Highlights:
+
+- **Mobile platform upgrade** (#406, #429, #434): Expo SDK 54 → 55, RN 0.85.2, native dep alignment.
+- **Audit sweep, 2026-05-06** (41 PRs): Decimal money precision, RLS hardening (`SECURITY DEFINER` + `search_path` on money RPCs, #606), audit-log coverage (#609), atomic claims for payment retry (#595), surge cap 2.5× (#510), PIPEDA log redaction (#555), CORS / rate-limit fail-closed (#537), WAV accessibility matching + E2E (#557), T4A annual issuance (#484, CRA Feb 28 deadline).
+- **Comprehensive code review + EAS pipeline unblock** (2026-05-07): #697, #672, #650 (coverage close-out: payments 32→91%, rides 49→80%), #695 EAS pipeline, #707 Google Maps spend cut.
+- **Backend dispatch optimization + RN 0.85 codegen patches** (2026-05-08): #723, #730 (initial codegen patches: ActivityIndicator, Modal).
+- **RN 0.85 consolidated codegen patches** (2026-05-09): #747 — 8 patch hunks per app (ActivityIndicator, Modal, RefreshControl, DebuggingOverlay, VirtualView ×2, V/HScrollView).
+- **CI cache + rider OtpScreen TS** (2026-05-10): #753 — `patches/**` added to mobile node_modules cache key.
+- **RN 0.85 Switch + ScrollView render-time guard** (2026-05-10): #756.
+- **UI foundations stack** (2026-05-10, six PRs): #759 (FormScreen wrapper), #761 (strip diagnostic console.logs + remove @ts-nocheck), #763 (`useWindowDimensions` migration), #765 (semantic theme tokens for dark-mode parity), #767 (audit + handoff docs), #773 (drop dead Firebase verifyOTP stub).
+- **Admin CVE patch** (2026-05-10): PR #775 — `npm audit fix` resolves `fast-uri` HIGH + 3 moderate (`hono`, `ip-address`, `express-rate-limit`).
+- Backend test coverage: **53% → 65%+**.
+
+See `memory/project_rn_0_85_remaining_bugs.md` for the live Bridgeless-component matrix and `memory/project_ui_foundations_landed.md` for the six UI primitives now on main.
 
 ## Blockers
 
-- Phase 3: Three .env files need manual creation (user action required):
-  1. `backend/.env` — Supabase URL+key, JWT secret, Firebase service account JSON, ENV=development
-  2. `rider-app/.env` — EXPO_PUBLIC_BACKEND_URL=http://<LAN-IP>:8000, EXPO_PUBLIC_GOOGLE_MAPS_API_KEY
-  3. `driver-app/.env` — same as rider-app
-- Phase 2 minor: docs/dev-setup.md not yet created (ENV-2); device LAN reachability not verified (ENV-3)
+_None hard-blocking._ Minor gaps:
+
+- `backend/.env` is missing `TRUSTED_PROXY_COUNT` (documented in `.env.example`; defaults to 0 ⇒ direct-IP rate-limiting). Set to the production proxy hop count when promoting to staging/prod.
+- `admin-dashboard/.env.local` is missing `NEXT_PUBLIC_SENTRY_DSN` and `SENTRY_DSN` (documented in `.env.example`; admin errors won't reach Sentry without them). Optional in dev; required for production observability.
+- `docs/dev-setup.md` not yet created (Phase 2 ENV-2 carry-over).
+- Device LAN reachability (Phase 2 ENV-3) not formally verified — unblocked in practice because EAS preview APKs hit the deployed Railway backend.
 
 ## Next Actions
 
-1. (User) Create backend/.env, rider-app/.env, driver-app/.env from .env.example templates
-2. Once .env files exist: start backend (`pip install -r requirements.txt && python3 -m backend.server`)
-3. Launch Expo dev server for rider-app and driver-app
-4. Optionally: create docs/dev-setup.md to document the .env setup process (ENV-2)
+1. Cut a fresh EAS preview build per app off current main (post-#756 + post-UI-foundations) and install over the existing APKs on `51161FDAS001WB`. Verify rider SearchDestinationScreen + driver SettingsScreen Switch are crash-free.
+2. Run the broader on-device nav matrix once #1 is green: rider profile / activity / ride-details / saved-places, driver earnings / rides / notifications / payout-history / quests / tax-documents.
+3. Capture logcat for any new component stacks; the `[spinr-patch] NativeScrollView non-renderable` dev-warn from #756 will fire if the V/H patch isn't holding at runtime.
+4. Backfill the three minor env keys flagged in Blockers when promoting to staging.
+5. Begin Phase 4 (Type Safety & Code Quality) after Phase 3 closes — branch `feat/phase4-type-safety-docs` is already scaffolded.
+
+## Open Follow-Up Items (not blocking Phase 3 but worth tracking)
+
+- **Diagnostic logs and `@ts-nocheck` cleanup** — landed on main via #761; verify nothing slipped back.
+- `logger.warning` sweep incomplete on admin-side critical paths (~15 sites in `backend/routes/admin/{auth,drivers,rides,service_areas,support}.py`).
+- `driver-app-test` fails on `TripCompletedPanel.test.tsx` + `ActiveRidePanel.test.tsx` (pre-existing; needs triage).
+- iOS Bridgeless behavior unverified — every patch is Android-conditional. iOS preview build never cut this cycle.
+- No automated mobile regression net (Maestro flows backlogged).
+- Kiran's PR #728 (Comprehensive Architectural Code Review) is stale by 2 days; rebase or close+reopen needed.
 
 ## Key Facts for Next Session
 
 - Project root: `C:/Users/TabUsrDskOff111/Documents/Spinrvm/spinrvm`
-- Active branch: `main` (after PR #401 merge)
-- Next migration slot: `62_*.sql`
+- Active branch: `main`
+- Next migration slot: `80_*.sql` (highest applied per CLAUDE.md is `79_add_missing_query_indexes.sql`)
 - GSD mode: YOLO, standard granularity, research-first
 - Dev secrets: `.env.local` gitignored; `.gitleaks.toml` allowlist active
 - P0 sprint context: `.claude/context/sprint-current.md`
 - Backend hosted on Railway (staging): spinr-backend-test.up.railway.app
-- Admin dashboard: already configured (.env.local has NEXT_PUBLIC_API_URL + BACKEND_URL)
+- Admin dashboard: already configured (`.env.local` has `NEXT_PUBLIC_API_URL` + `BACKEND_URL`)
+- Coordination: Kiran Kumar (`srikumarimuddana-lab`) commits in parallel; per `memory/project_contributor_coordination.md` — stash before checkout-main; never rebase his commits
+- CI baseline: 6 pre-existing failing checks on every PR (per `memory/reference_ci_failures_pattern.md`); `gh pr merge --squash --admin` is the established override
 - Memory: access prior session work via `get_observations([IDs])` in the `$CMEM spinrvm` timeline

--- a/shared/config/supabase.ts
+++ b/shared/config/supabase.ts
@@ -1,8 +1,0 @@
-import 'react-native-url-polyfill/auto';
-import { createClient } from '@supabase/supabase-js';
-
-// TODO: Replace with your actual Supabase URL and Anon Key from your Supabase Dashboard
-const supabaseUrl = 'YOUR_SUPABASE_URL';
-const supabaseAnonKey = 'YOUR_SUPABASE_ANON_KEY';
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/shared/package.json
+++ b/shared/package.json
@@ -14,7 +14,6 @@
     "./validators": "./validators/index.ts",
     "./config": "./config/index.ts",
     "./config/spinr.config": "./config/spinr.config.ts",
-    "./config/supabase": "./config/supabase.ts",
     "./config/firebaseConfig": "./config/firebaseConfig.ts",
     "./store/authStore": "./store/authStore.ts",
     "./store/locationStore": "./store/locationStore.ts",


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Two isolated documentation/dead-code cleanups. No runtime behavior change. Refreshes `.planning/STATE.md` to reflect actual current project state, and removes the unreferenced `shared/config/supabase.ts` template (which shipped placeholder credentials).
- **Type**: `chore`
- **Linked issue**: none — surfaced in the gap-audit report run during 2026-05-10 session.
- **Risk**: `low` — only docs and unreferenced shared config file. No code paths affected.
- **User-visible change**: `none`.
- **Scope contract**: `[x]` Matches type — only the two items described, no unrelated bundling.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend `[ ]` rider-app `[ ]` driver-app `[ ]` admin `[x]` shared `[ ]` migrations `[ ]` infra `[ ]` CI
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none` (removed file shipped only placeholder strings, never used)
- **Rollback plan**: `git-revert-safe`
- **Dependencies / coordination**: `none` (admin npm-audit-fix is being landed separately as PR #775)
- **Assumptions**: nothing in the repo imports `shared/config/supabase.ts`. Verified by grep across backend/, rider-app/, driver-app/, admin-dashboard/, shared/ — only the matching export entry in `shared/package.json` referenced it.
- **Not changing but considered**: leaving the file with a clearer `// DEAD CODE` comment instead of deleting it. Decision: delete. Future developer copying `.env` templates would otherwise see `YOUR_SUPABASE_URL` / `YOUR_SUPABASE_ANON_KEY` and waste time wiring it up to a JS client we don't use (mobile goes through FastAPI / supabase-py).

## Tier 3 — Compliance flags

None apply.

## Tier 4 — Verification

- **Unit tests**: `not-applicable`
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: not applicable
- **Perf numbers**: not applicable

**Pre-merge checklist**:
- [x] grep confirmed zero importers of `config/supabase` across all four surfaces
- [x] `shared/package.json` `exports` map updated to drop the matching entry
- [x] No PII added to logs / Sentry / analytics
- [x] Pre-commit hooks all green

## Background

The pre-existing `STATE.md` declared `status: BLOCKED — .env files not created` and was last updated 2026-05-07. The blocker was stale: backend/.env, rider-app/.env, driver-app/.env, admin-dashboard/.env.local have all been populated for 7+ days (file mtimes), and real EAS preview builds + on-device install have been running since 2026-05-09. The doc refresh brings `STATE.md` into alignment with reality and lists the remaining minor follow-ups (TRUSTED_PROXY_COUNT, two optional Sentry DSNs).

`shared/config/supabase.ts` had a TODO comment (`// TODO: Replace with your actual Supabase URL...`) and exported a `supabase` client built from placeholder strings. No code path imports it — verified across all four surfaces via repo-wide grep. Shipping the file invites a future developer to "fix the placeholders" and end up wiring a Supabase JS client into a mobile flow that's supposed to go through the FastAPI backend.

## Test plan

- [x] `git status` clean after commit
- [x] No grep hits for `config/supabase` in source
- [ ] CI green (modulo the 6 known pre-existing failing checks documented in repo memory — `gh pr merge --squash --admin` is the established override)