### PR TITLE
fix(admin): elevate logger.warning → error on 5 critical-path sites

### DIFF
--- a/backend/routes/admin/auth.py
+++ b/backend/routes/admin/auth.py
@@ -863,7 +863,13 @@ async def break_glass_access(request: Request, body: BreakGlassRequest):
 
     # 1. Feature-gate: disabled unless hash is configured
     if not settings.BREAK_GLASS_TOKEN_HASH:
-        logger.warning("break_glass: attempt from %s — endpoint not configured", client_ip)
+        # Security signal — capture every attempt at a disabled break-glass endpoint
+        # so Sentry surfaces it for the security on-call.
+        logger.error(
+            "break_glass: attempt from %s ua=%s — endpoint not configured",
+            client_ip,
+            user_agent,
+        )
         raise HTTPException(status_code=404, detail="Not found")
 
     # 2. Justification required (non-empty, min 10 chars)

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -188,8 +188,14 @@ async def admin_cancel_ride(
     with_38 = {**with_37, "cancelled_by": "admin", "cancellation_type": "admin_cancel"}
     try:
         await db_supabase.update_ride(ride_id, with_38)
-    except Exception as e38:
-        logger.warning(f"admin_cancel_ride: attribution write failed ({e38}); retrying without mig-38 fields")
+    except Exception:
+        # DB write fallback path — first attempt failed (mig-38 columns may not
+        # exist yet on this DB). Surface to Sentry so we know when/where the
+        # primary path is failing; the retry below is the recovery action.
+        logger.error(
+            "admin_cancel_ride: attribution write failed; retrying without mig-38 fields",
+            exc_info=True,
+        )
         try:
             await db_supabase.update_ride(ride_id, with_37)
         except Exception as e37:
@@ -839,7 +845,14 @@ async def admin_get_ride_route_map(
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(url)
         if resp.status_code != 200:
-            logger.warning(f"Static Maps returned {resp.status_code}: {resp.text[:200]}")
+            # User-visible upstream failure (admin sees missing map). Per
+            # CLAUDE.md observability rules, route to Sentry as error.
+            logger.error(
+                "Static Maps returned %s for ride %s: %s",
+                resp.status_code,
+                ride_id,
+                resp.text[:200],
+            )
             raise HTTPException(status_code=502, detail="Failed to fetch route map")
         return Response(
             content=resp.content,
@@ -847,7 +860,11 @@ async def admin_get_ride_route_map(
             headers={"Cache-Control": "private, max-age=3600"},
         )
     except httpx.HTTPError as e:
-        logger.warning(f"Static Maps fetch error for ride {ride_id}: {e}")
+        logger.error(
+            "Static Maps fetch error for ride %s",
+            ride_id,
+            exc_info=True,
+        )
         raise HTTPException(status_code=502, detail="Failed to fetch route map") from e
 
 
@@ -1125,7 +1142,14 @@ async def admin_get_payout(payout_id: str, _: dict = Depends(get_admin_user)):
         try:
             driver = await db.find_one("drivers", {"id": payout["driver_id"]}) or {}
         except Exception:
-            logger.warning("payout driver lookup failed for %s", payout.get("driver_id"), exc_info=True)
+            # Money-adjacent DB lookup failure — payout response will render
+            # with empty driver fields. Surface to Sentry so the gap is visible
+            # before an admin acts on a payout missing context.
+            logger.error(
+                "payout driver lookup failed for %s",
+                payout.get("driver_id"),
+                exc_info=True,
+            )
             driver = {}
     payout["driver_name"] = driver.get("full_name") or driver.get("name") or payout.get("driver_name")
     payout["driver_email"] = driver.get("email")


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Five `logger.warning` sites in admin routes are elevated to `logger.error` so DB-write failures, money-adjacent DB lookups, user-visible upstream failures, and security signals reach Sentry. Twelve other warning sites stay (best-effort notifications/broadcasts/informational checks).
- **Type**: `fix`
- **Linked issue**: Refs CLAUDE.md "Do not silently swallow errors" rule.
- **Risk**: `low` — only logging-level changes plus comments. No control-flow change.
- **User-visible change**: `none` directly. Indirectly: admin Sentry workspace will start receiving these five error classes; nothing user-facing changes.
- **Scope contract**: `[x]` This PR matches its stated type — only the five critical-path sites; the 12 best-effort/informational warnings are deliberately left.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend `[ ]` rider-app `[ ]` driver-app `[ ]` admin `[ ]` shared `[ ]` migrations `[ ]` infra `[ ]` CI
- **Blast radius**: `single-surface`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe`
- **Dependencies / coordination**: `none`
- **Assumptions**: Sentry is configured to capture `logger.error` from these modules. Existing `logger.error` calls elsewhere in `admin/auth.py` and `admin/rides.py` already do so.
- **Not changing but considered**: also elevating push-notification + admin-broadcast warnings. Decision: keep them as warnings — they are best-effort fan-out paths whose failure is non-blocking, and elevating them would introduce Sentry noise without an actionable signal.

## Tier 3 — Compliance flags

- `[x]` **Auth / RLS** — `auth.py:866` is a security audit signal (break-glass endpoint probe).
- `[x]` **Money-touching** — `rides.py:1128` is money-adjacent (payout driver lookup).

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — logging level only; no behavior change to test.
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: 5 new error-level log lines; no new metric names. All adhere to existing convention (no PII, structured args).
- **Screenshots / video**: not applicable
- **Perf numbers**: not applicable

**Pre-merge checklist**:
- [x] No PII added (verified: only IP + user-agent at break-glass site, ride/driver IDs elsewhere — all permitted by CLAUDE.md PII rules).
- [x] `python -m ruff check routes/admin/{auth,rides}.py` — all checks passed.
- [x] No control-flow changes — every elevated site preserves identical fallback / retry / 502-raise behavior.

## The five sites

| File:Line | Why elevate |
|---|---|
| `auth.py:866` | break_glass probe of disabled endpoint — security audit |
| `rides.py:192` | admin_cancel_ride DB write fallback — primary update failed |
| `rides.py:842` | Static Maps non-200 — user-visible upstream failure (502 raised) |
| `rides.py:850` | Static Maps httpx error — same rationale |
| `rides.py:1128` | payouts driver lookup DB failure — money-adjacent silent degradation |

## Sites NOT changed (deliberately staying as warnings)

- `auth.py:527` — WS kick on logout-all (best-effort cleanup; logout already succeeded)
- `drivers.py:536, 670` — admin push notifications (best-effort fan-out)
- `rides.py:234, 250, 265, 354, 562` — push/broadcast failures (best-effort fan-out)
- `service_areas.py:199` — surge cap manual-override notice (policy event with intentional warning level)
- `support.py:112, 123` — disputes table existence check (informational schema gate)
- `vehicle_fleet.py:325` — lost-item notification (best-effort fan-out)

## Test plan

- [x] Lint clean
- [ ] CI green modulo the documented 6 pre-existing failing checks (per repo memory) — `gh pr merge --squash --admin` is the established override

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
