### PR TITLE
fix(backend/tests): finish patch-target migration to services.payment_service (135 pass / 0 fail)

### DIFF
--- a/backend/tests/test_corporate_ride_payment.py
+++ b/backend/tests/test_corporate_ride_payment.py
@@ -261,8 +261,8 @@ def _mock_process_payment_deps(*, allowance, membership=None):
         "routes.rides.db_supabase.update_ride": AsyncMock(return_value=None),
         "routes.rides.db_supabase.get_user_by_id": AsyncMock(return_value=None),
         "routes.rides.db_supabase.get_driver_by_id": AsyncMock(return_value=None),
-        "routes.rides.corporate_allowance_service.apply_rollback": AsyncMock(return_value={"transaction_id": "t1"}),
-        "routes.rides.corporate_wallet_service.apply_adjustment": AsyncMock(return_value={"transaction_id": "t2"}),
+        "services.payment_service.corporate_allowance_service.apply_rollback": AsyncMock(return_value={"transaction_id": "t1"}),
+        "services.payment_service.corporate_wallet_service.apply_adjustment": AsyncMock(return_value={"transaction_id": "t2"}),
     }
 
 
@@ -289,7 +289,7 @@ def test_personal_ride_skips_corporate_payment_branch(test_client, rider_overrid
         ),
         patch("routes.wallet._record_transaction", AsyncMock()),
         patch(
-            "routes.rides.corporate_allowance_service.apply_rollback",
+            "services.payment_service.corporate_allowance_service.apply_rollback",
             AsyncMock(),
         ) as mock_allowance,
     ):
@@ -319,14 +319,14 @@ def test_company_allowance_debits_allowance_fully_when_sufficient(test_client, r
         for p in patchers:
             p.stop()
 
-    mocks["routes.rides.corporate_allowance_service.apply_rollback"].assert_called_once()
-    call_kwargs = mocks["routes.rides.corporate_allowance_service.apply_rollback"].call_args.kwargs
+    mocks["services.payment_service.corporate_allowance_service.apply_rollback"].assert_called_once()
+    call_kwargs = mocks["services.payment_service.corporate_allowance_service.apply_rollback"].call_args.kwargs
     assert call_kwargs["amount"] == pytest.approx(25.0)
     assert call_kwargs["wallet_id"] == _WALLET_ID
     assert call_kwargs["allowance_id"] == _ALLOWANCE_ID
     assert call_kwargs["member_id"] == _MEMBER_ID
 
-    mocks["routes.rides.corporate_wallet_service.apply_adjustment"].assert_not_called()
+    mocks["services.payment_service.corporate_wallet_service.apply_adjustment"].assert_not_called()
 
     mocks["routes.rides.db_supabase.insert_one"].assert_called()
     insert_call = mocks["routes.rides.db_supabase.insert_one"].call_args
@@ -356,10 +356,10 @@ def test_company_allowance_splits_when_allowance_partial(test_client, rider_over
         for p in patchers:
             p.stop()
 
-    rollback_kwargs = mocks["routes.rides.corporate_allowance_service.apply_rollback"].call_args.kwargs
+    rollback_kwargs = mocks["services.payment_service.corporate_allowance_service.apply_rollback"].call_args.kwargs
     assert rollback_kwargs["amount"] == pytest.approx(10.0)
 
-    adj_kwargs = mocks["routes.rides.corporate_wallet_service.apply_adjustment"].call_args.kwargs
+    adj_kwargs = mocks["services.payment_service.corporate_wallet_service.apply_adjustment"].call_args.kwargs
     assert adj_kwargs["amount"] == pytest.approx(-15.0)
     assert _RIDE_ID in adj_kwargs["notes"]
 
@@ -391,7 +391,7 @@ def test_company_allowance_debit_and_flag_on_allowance_only_policy(test_client, 
         for p in patchers:
             p.stop()
 
-    mocks["routes.rides.corporate_wallet_service.apply_adjustment"].assert_called_once()
+    mocks["services.payment_service.corporate_wallet_service.apply_adjustment"].assert_called_once()
 
     insert_calls = mocks["routes.rides.db_supabase.insert_one"].call_args_list
     tables = [c.args[0] for c in insert_calls]
@@ -420,8 +420,8 @@ def test_company_allowance_unlimited_covers_full_fare(test_client, rider_overrid
         for p in patchers:
             p.stop()
 
-    mocks["routes.rides.corporate_allowance_service.apply_rollback"].assert_called_once()
-    mocks["routes.rides.corporate_wallet_service.apply_adjustment"].assert_not_called()
+    mocks["services.payment_service.corporate_allowance_service.apply_rollback"].assert_called_once()
+    mocks["services.payment_service.corporate_wallet_service.apply_adjustment"].assert_not_called()
     row = mocks["routes.rides.db_supabase.insert_one"].call_args.args[1]
     assert row["master_fallback_amount"] == pytest.approx(0.0)
 

--- a/backend/tests/test_coverage_rides.py
+++ b/backend/tests/test_coverage_rides.py
@@ -553,9 +553,9 @@ async def test_add_tip_duplicate():
 
 @pytest.mark.anyio
 async def test_record_payment_event_success():
-    from backend.routes.rides import _record_payment_event
+    from backend.services.payment_service import record_payment_event as _record_payment_event
 
-    with patch("backend.routes.rides.db_supabase") as mock_db:
+    with patch("backend.services.payment_service.db_supabase") as mock_db:
         mock_db.insert_one = AsyncMock()
         await _record_payment_event(_RIDE_ID, _RIDER_ID, 1500, "pi_test")
     mock_db.insert_one.assert_called_once()
@@ -564,9 +564,9 @@ async def test_record_payment_event_success():
 @pytest.mark.anyio
 async def test_record_payment_event_swallows_error():
     """Ledger write failure must not propagate."""
-    from backend.routes.rides import _record_payment_event
+    from backend.services.payment_service import record_payment_event as _record_payment_event
 
-    with patch("backend.routes.rides.db_supabase") as mock_db:
+    with patch("backend.services.payment_service.db_supabase") as mock_db:
         mock_db.insert_one = AsyncMock(side_effect=Exception("DB error"))
         # Should not raise
         await _record_payment_event(_RIDE_ID, _RIDER_ID, 1500, "pi_test")
@@ -685,7 +685,7 @@ async def test_process_payment_succeeded():
 
     with (
         patch("backend.routes.rides.db_supabase") as mock_db,
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
         patch("backend.routes.rides.manager") as mock_manager,
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
         patch.dict(sys.modules, {"utils.email_receipt": mock_email_mod}),
@@ -723,7 +723,7 @@ async def test_process_payment_declined():
 
     with (
         patch("backend.routes.rides.db_supabase") as mock_db,
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
     ):
         mock_db.get_ride = AsyncMock(return_value=_ride(status="completed", payment_method_id="pm_1"))
@@ -757,7 +757,7 @@ async def test_process_payment_requires_action():
 
     with (
         patch("backend.routes.rides.db_supabase") as mock_db,
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
     ):
         mock_db.get_ride = AsyncMock(return_value=_ride(status="completed", payment_method_id="pm_1"))
         mock_db.get_user_by_id = AsyncMock(return_value=rider_user)
@@ -2296,7 +2296,7 @@ async def test_process_payment_card_succeeded():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.manager") as mock_manager,
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=True),
     ):
@@ -2323,7 +2323,7 @@ async def test_process_payment_card_requires_action():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
     ):
         with pytest.raises(HTTPException) as exc:
             await process_payment(
@@ -2349,7 +2349,7 @@ async def test_process_payment_card_declined():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
     ):
         with pytest.raises(HTTPException) as exc:
@@ -2374,7 +2374,7 @@ async def test_process_payment_card_unconfigured():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
         result = await process_payment(
@@ -2399,7 +2399,7 @@ async def test_process_payment_card_failed():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
     ):
         with pytest.raises(HTTPException) as exc:
@@ -2746,7 +2746,7 @@ async def test_process_payment_card_succeeded_with_driver():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.manager") as mock_manager,
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=True),
     ):
@@ -2849,8 +2849,8 @@ async def test_process_payment_company_allowance_unlimited_happy_path():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.corporate_allowance_service", mock_allowance_svc),
-        patch("backend.routes.rides.corporate_wallet_service", mock_wallet_svc),
+        patch("backend.services.payment_service.corporate_allowance_service", mock_allowance_svc),
+        patch("backend.services.payment_service.corporate_wallet_service", mock_wallet_svc),
         patch("backend.routes.rides.evaluate_policy", mock_policy_eval),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
@@ -2895,8 +2895,8 @@ async def test_process_payment_company_allowance_capped_with_master():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.corporate_allowance_service", mock_allowance_svc),
-        patch("backend.routes.rides.corporate_wallet_service", mock_wallet_svc),
+        patch("backend.services.payment_service.corporate_allowance_service", mock_allowance_svc),
+        patch("backend.services.payment_service.corporate_wallet_service", mock_wallet_svc),
         patch("backend.routes.rides.evaluate_policy", mock_policy_eval),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
@@ -2941,8 +2941,8 @@ async def test_process_payment_company_allowance_master_debit_fails():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.rides.corporate_allowance_service", mock_allowance_svc),
-        patch("backend.routes.rides.corporate_wallet_service", mock_wallet_svc),
+        patch("backend.services.payment_service.corporate_allowance_service", mock_allowance_svc),
+        patch("backend.services.payment_service.corporate_wallet_service", mock_wallet_svc),
     ):
         with pytest.raises(HTTPException) as exc:
             await process_payment(

--- a/backend/tests/test_coverage_rides.py
+++ b/backend/tests/test_coverage_rides.py
@@ -553,9 +553,9 @@ async def test_add_tip_duplicate():
 
 @pytest.mark.anyio
 async def test_record_payment_event_success():
-    from backend.services.payment_service import record_payment_event as _record_payment_event
+    from services.payment_service import record_payment_event as _record_payment_event
 
-    with patch("backend.services.payment_service.db_supabase") as mock_db:
+    with patch("services.payment_service.db_supabase") as mock_db:
         mock_db.insert_one = AsyncMock()
         await _record_payment_event(_RIDE_ID, _RIDER_ID, 1500, "pi_test")
     mock_db.insert_one.assert_called_once()
@@ -564,9 +564,9 @@ async def test_record_payment_event_success():
 @pytest.mark.anyio
 async def test_record_payment_event_swallows_error():
     """Ledger write failure must not propagate."""
-    from backend.services.payment_service import record_payment_event as _record_payment_event
+    from services.payment_service import record_payment_event as _record_payment_event
 
-    with patch("backend.services.payment_service.db_supabase") as mock_db:
+    with patch("services.payment_service.db_supabase") as mock_db:
         mock_db.insert_one = AsyncMock(side_effect=Exception("DB error"))
         # Should not raise
         await _record_payment_event(_RIDE_ID, _RIDER_ID, 1500, "pi_test")
@@ -685,7 +685,7 @@ async def test_process_payment_succeeded():
 
     with (
         patch("backend.routes.rides.db_supabase") as mock_db,
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
         patch("backend.routes.rides.manager") as mock_manager,
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
         patch.dict(sys.modules, {"utils.email_receipt": mock_email_mod}),
@@ -723,7 +723,7 @@ async def test_process_payment_declined():
 
     with (
         patch("backend.routes.rides.db_supabase") as mock_db,
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
     ):
         mock_db.get_ride = AsyncMock(return_value=_ride(status="completed", payment_method_id="pm_1"))
@@ -757,7 +757,7 @@ async def test_process_payment_requires_action():
 
     with (
         patch("backend.routes.rides.db_supabase") as mock_db,
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=mock_outcome),
     ):
         mock_db.get_ride = AsyncMock(return_value=_ride(status="completed", payment_method_id="pm_1"))
         mock_db.get_user_by_id = AsyncMock(return_value=rider_user)
@@ -1044,6 +1044,7 @@ async def test_match_driver_to_ride_assigns_driver():
         patch("backend.routes.rides.asyncio.create_task"),
     ):
         mock_db.get_ride = AsyncMock(return_value=ride)
+        mock_db.match_and_claim_driver = AsyncMock(return_value=None)  # fall through to Python-sort path
         mock_db.get_rows = AsyncMock(return_value=[driver])
         mock_db.claim_driver_atomic = AsyncMock(return_value={"id": _DRIVER_ID})
         mock_db.get_driver_by_id = AsyncMock(return_value=driver)
@@ -1408,6 +1409,7 @@ async def test_match_driver_no_claim_returns_early():
         patch("backend.routes.rides.filter_and_rank_drivers", return_value=[(driver, 1.0)]),
     ):
         mock_db.get_ride = AsyncMock(return_value=ride)
+        mock_db.match_and_claim_driver = AsyncMock(return_value=None)  # fall through to Python-sort path
         mock_db.get_rows = AsyncMock(return_value=[driver])
         mock_db.claim_driver_atomic = AsyncMock(return_value=None)  # claim always fails
         mock_db.update_ride = AsyncMock()
@@ -1443,6 +1445,7 @@ async def test_match_driver_offline_after_claim():
         patch("backend.routes.rides.match_driver_to_ride", new_callable=AsyncMock),  # prevent recursion
     ):
         mock_db.get_ride = AsyncMock(return_value=ride)
+        mock_db.match_and_claim_driver = AsyncMock(return_value=None)  # fall through to Python-sort path
         mock_db.get_rows = AsyncMock(return_value=[driver])
         mock_db.claim_driver_atomic = AsyncMock(return_value={"id": _DRIVER_ID})
         # Driver is now offline after claim
@@ -2162,6 +2165,7 @@ async def test_create_ride_full_happy_path():
     ):
         mock_db.find_one = AsyncMock(return_value=None)  # no idempotency match
         mock_db.get_rows = AsyncMock(return_value=[])  # always empty (no active ride, no corp members, etc.)
+        mock_db.get_service_area_for_point = AsyncMock(return_value=None)  # no matched service area
         mock_ddb.find_one = AsyncMock(return_value={"id": _RIDER_ID, "status": "active", "stripe_customer_id": "cus_1"})
         mock_db.insert_ride = AsyncMock(return_value=inserted_ride)
         mock_db.get_ride = AsyncMock(return_value={**inserted_ride, "status": "driver_assigned"})
@@ -2296,7 +2300,7 @@ async def test_process_payment_card_succeeded():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.manager") as mock_manager,
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=True),
     ):
@@ -2323,7 +2327,7 @@ async def test_process_payment_card_requires_action():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
     ):
         with pytest.raises(HTTPException) as exc:
             await process_payment(
@@ -2349,7 +2353,7 @@ async def test_process_payment_card_declined():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
     ):
         with pytest.raises(HTTPException) as exc:
@@ -2374,7 +2378,7 @@ async def test_process_payment_card_unconfigured():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
         result = await process_payment(
@@ -2399,7 +2403,7 @@ async def test_process_payment_card_failed():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.send_push_notification", new_callable=AsyncMock),
     ):
         with pytest.raises(HTTPException) as exc:
@@ -2622,14 +2626,15 @@ async def test_process_payment_wallet_success():
         rider_id=_RIDER_ID,
         driver_id=None,
     )
-    wallet = {"id": "wlt-1", "balance": 50.0, "is_active": True}
+    wallet = {"id": "wlt-1", "user_id": _RIDER_ID, "balance": "50.00", "is_active": True}
     mock_db = _mock_db_for_payment(ride)
+    # settle_wallet (in services.payment_service) calls db_supabase.find_one("wallets", ...) directly.
+    mock_db.find_one = AsyncMock(return_value=wallet)
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
+        patch("services.payment_service.db_supabase", mock_db),
         patch("backend.routes.rides.db") as mock_ddb,
-        patch("backend.routes.wallet.get_or_create_wallet", new_callable=AsyncMock, return_value=wallet),
-        patch("backend.routes.wallet._record_transaction", new_callable=AsyncMock),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
         mock_ddb.update_one = AsyncMock()
@@ -2655,12 +2660,13 @@ async def test_process_payment_wallet_suspended():
         payment_status="pending",
         rider_id=_RIDER_ID,
     )
-    wallet = {"id": "wlt-1", "balance": 50.0, "is_active": False}
+    wallet = {"id": "wlt-1", "user_id": _RIDER_ID, "balance": "50.00", "is_active": False}
     mock_db = _mock_db_for_payment(ride)
+    mock_db.find_one = AsyncMock(return_value=wallet)
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.routes.wallet.get_or_create_wallet", new_callable=AsyncMock, return_value=wallet),
+        patch("services.payment_service.db_supabase", mock_db),
     ):
         with pytest.raises(HTTPException) as exc:
             await process_payment(
@@ -2746,7 +2752,7 @@ async def test_process_payment_card_succeeded_with_driver():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
+        patch("services.payment_service.charge_ride", new_callable=AsyncMock, return_value=outcome),
         patch("backend.routes.rides.manager") as mock_manager,
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=True),
     ):
@@ -2849,9 +2855,10 @@ async def test_process_payment_company_allowance_unlimited_happy_path():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.corporate_allowance_service", mock_allowance_svc),
-        patch("backend.services.payment_service.corporate_wallet_service", mock_wallet_svc),
-        patch("backend.routes.rides.evaluate_policy", mock_policy_eval),
+        patch("services.payment_service.db_supabase", mock_db),
+        patch("services.payment_service.corporate_allowance_service", mock_allowance_svc),
+        patch("services.payment_service.corporate_wallet_service", mock_wallet_svc),
+        patch("services.payment_service.evaluate_policy", mock_policy_eval),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
         result = await process_payment(
@@ -2895,9 +2902,10 @@ async def test_process_payment_company_allowance_capped_with_master():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.corporate_allowance_service", mock_allowance_svc),
-        patch("backend.services.payment_service.corporate_wallet_service", mock_wallet_svc),
-        patch("backend.routes.rides.evaluate_policy", mock_policy_eval),
+        patch("services.payment_service.db_supabase", mock_db),
+        patch("services.payment_service.corporate_allowance_service", mock_allowance_svc),
+        patch("services.payment_service.corporate_wallet_service", mock_wallet_svc),
+        patch("services.payment_service.evaluate_policy", mock_policy_eval),
         patch("utils.email_receipt.send_receipt_email", new_callable=AsyncMock, return_value=False),
     ):
         result = await process_payment(
@@ -2941,8 +2949,9 @@ async def test_process_payment_company_allowance_master_debit_fails():
 
     with (
         patch("backend.routes.rides.db_supabase", mock_db),
-        patch("backend.services.payment_service.corporate_allowance_service", mock_allowance_svc),
-        patch("backend.services.payment_service.corporate_wallet_service", mock_wallet_svc),
+        patch("services.payment_service.db_supabase", mock_db),
+        patch("services.payment_service.corporate_allowance_service", mock_allowance_svc),
+        patch("services.payment_service.corporate_wallet_service", mock_wallet_svc),
     ):
         with pytest.raises(HTTPException) as exc:
             await process_payment(


### PR DESCRIPTION
<!-- spinr-required-fields -->

## Tier 1 — Summary

- **Summary** [required]: Fix all backend tests in `test_coverage_rides.py` + `test_corporate_ride_payment.py` after the corporate-billing extraction into `services/payment_service.py` (135 pass / 0 fail)
- **Type** [required]: `fix`
- **Linked issue** [required]: Refs main `backend-test` failures (broken since the payment-services extraction)
- **Risk** [required]: `low` — test-only edits, no production code touched
- **User-visible change** [required]: `none`
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `single-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — test-only changes
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: The dual-import pattern means `services.payment_service` (no `backend.` prefix) is the canonical module name at runtime; `backend.services.payment_service` is a separate module object never executed from. Verified empirically: only the no-prefix path makes patches take effect.

## Tier 3 — Compliance flags

(none — test infrastructure only)

## Tier 4 — Verification

- **Unit tests** [required]: `updated` — all 135 tests in the two affected files now pass locally
- **Integration tests** [required]: `not-applicable` — test-only edits
- **Metrics / logs introduced** [required]: `none`

**Pre-merge checklist** [required]:

- [x] Ran `pytest tests/test_corporate_ride_payment.py tests/test_coverage_rides.py --no-cov` → **135 pass / 0 fail**
- [x] Pre-commit hooks all green (PII, money-arithmetic, branch, console-log)
- [x] No PII added — test files only

## What broke and how

The corporate-billing payment logic was extracted from `routes/rides.py` into `services/payment_service.py`. Tests still patched the old import paths. Five distinct categories of breakage are fixed here:

### 1. Symbol relocation — patch path migrations

```
routes.rides.corporate_allowance_service       -> services.payment_service.corporate_allowance_service
routes.rides.corporate_wallet_service          -> services.payment_service.corporate_wallet_service
backend.routes.rides.charge_ride               -> services.payment_service.charge_ride
backend.routes.rides.corporate_allowance_service -> services.payment_service.corporate_allowance_service
backend.routes.rides.corporate_wallet_service  -> services.payment_service.corporate_wallet_service
backend.routes.rides._record_payment_event     -> services.payment_service.record_payment_event  (also renamed: dropped underscore)
backend.routes.rides.evaluate_policy           -> services.payment_service.evaluate_policy
```

Note: paths use `services.payment_service` (no `backend.` prefix). The dual-import pattern at the top of `services/payment_service.py` means the runtime always hits the no-prefix module; `backend.services.payment_service` is a phantom object that patching does nothing to.

### 2. Match-driver tests — new PostGIS RPC fall-through

Migration 77 added `match_and_claim_driver` PostGIS RPC. The route now tries the RPC first and falls back to the Python-sort path only if the RPC returns None. Three tests now stub `mock_db.match_and_claim_driver = AsyncMock(return_value=None)` to keep them on the original Python path they were written for.

### 3. `create_ride_full_happy_path` — service-area lookup added

`create_ride` now awaits `db_supabase.get_service_area_for_point(...)` before the polygon-search fallback. Test stubs an `AsyncMock(return_value=None)` for it.

### 4. Wallet tests — settle_wallet uses db_supabase directly

`settle_wallet` (extracted into payment_service) now calls `db_supabase.find_one("wallets", ...)` directly instead of going through `routes.wallet.get_or_create_wallet`. Tests:
- Drop the obsolete `routes.wallet.get_or_create_wallet` patch
- Mirror `mock_db` at `services.payment_service.db_supabase` so `settle_wallet`'s namespace sees it
- Stub `mock_db.find_one` to return the test wallet row

### 5. Corporate-allowance tests — same db_supabase mirror

`settle_corporate` runs in `services.payment_service`'s namespace too. Added `services.payment_service.db_supabase` mock mirror to the three corporate-allowance tests.

## Net effect

| Stage | Pass | Fail |
|-------|------|------|
| Before this PR (main) | 0 useful runs | ~30 collection errors |
| After commit 1 | 121 | 14 |
| **After commit 2 (current)** | **135** | **0** |

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
