### PR TITLE
feat: admin-configurable vehicle illustrations + ride-offer ping + rider booking simplification

### DIFF
--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getSettings, updateSettings, mfaStatus, mfaDisable } from "@/lib/api";
+import { getSettings, updateSettings, mfaStatus, mfaDisable, adminUploadRideOfferSound } from "@/lib/api";
 import { MfaEnrollDialog } from "@/components/mfa-enroll-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -36,6 +36,33 @@ export default function SettingsPage() {
     const [disablePassword, setDisablePassword] = useState("");
     const [disabling, setDisabling] = useState(false);
     const [disableError, setDisableError] = useState("");
+
+    const [soundUploading, setSoundUploading] = useState(false);
+
+    const handleUploadOfferSound = async (file: File) => {
+        if (file.size > 500 * 1024) {
+            toast({ title: "File too large", description: "Max 500 KB.", variant: "destructive" });
+            return;
+        }
+        setSoundUploading(true);
+        try {
+            const { ride_offer_sound_url } = await adminUploadRideOfferSound(file);
+            setSettings({ ...settings, ride_offer_sound_url });
+            toast({ title: "Ride-offer sound uploaded" });
+        } catch (err) {
+            console.error(err);
+            toast({ title: "Upload failed", description: String((err as Error).message || err), variant: "destructive" });
+        } finally {
+            setSoundUploading(false);
+        }
+    };
+
+    const handleClearOfferSound = () => {
+        // Persisted on next "Save settings" click. Clearing in the form
+        // triggers a normal PUT with ride_offer_sound_url="" — backend
+        // stores it; driver-app falls back to the bundled placeholder.
+        setSettings({ ...settings, ride_offer_sound_url: "" });
+    };
 
     useEffect(() => {
         getSettings()
@@ -515,6 +542,60 @@ export default function SettingsPage() {
                                     className="min-h-[70px]"
                                 />
                             </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Driver-app ride-offer alert tone — uploaded via
+                        a dedicated multipart endpoint that writes the URL
+                        directly to settings.ride_offer_sound_url. */}
+                    <Card className="border-border/50 lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle className="text-base">Ride-offer alert sound (driver app)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <div className="space-y-2">
+                                <Label>Upload MP3 or WAV (≤500 KB)</Label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        type="file"
+                                        accept="audio/mpeg,audio/mp3,audio/wav"
+                                        disabled={soundUploading}
+                                        onChange={(e) => {
+                                            const f = e.target.files?.[0];
+                                            if (f) void handleUploadOfferSound(f);
+                                            e.target.value = "";
+                                        }}
+                                    />
+                                    {soundUploading && (
+                                        <span className="text-xs text-muted-foreground">Uploading…</span>
+                                    )}
+                                </div>
+                                <p className="text-xs text-muted-foreground">
+                                    Drivers hear this tone every ~2.5s while a ride offer is on screen. Leave empty to use the bundled placeholder.
+                                </p>
+                            </div>
+                            {settings.ride_offer_sound_url ? (
+                                <div className="space-y-2">
+                                    <Label>Current</Label>
+                                    {/* Native HTML5 audio — no extra dep. */}
+                                    <audio controls src={settings.ride_offer_sound_url} className="w-full" />
+                                    <div className="flex gap-2">
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={handleClearOfferSound}
+                                        >
+                                            Clear (revert to bundled)
+                                        </Button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <p className="text-xs text-muted-foreground italic">
+                                    No custom sound set — drivers play the bundled placeholder.
+                                </p>
+                            )}
                         </CardContent>
                     </Card>
                 </div>

--- a/admin-dashboard/src/app/dashboard/vehicle-types/page.tsx
+++ b/admin-dashboard/src/app/dashboard/vehicle-types/page.tsx
@@ -6,6 +6,7 @@ import {
     createVehicleType,
     updateVehicleType,
     deleteVehicleType,
+    adminUploadVehicleIllustration,
 } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -33,7 +34,11 @@ interface VehicleType {
     description: string;
     icon: string;
     capacity: number;
+    // Admin-uploaded car image. DB column is `illustration_url`; the rider-
+    // facing GET aliases it to `image_url`. Admin GET returns raw rows, so
+    // we accept either here for backward compat.
     image_url?: string;
+    illustration_url?: string;
     is_active: boolean;
     created_at?: string;
 }
@@ -57,6 +62,33 @@ export default function VehicleTypesPage() {
     const [editingId, setEditingId] = useState<string | null>(null);
     const [form, setForm] = useState(EMPTY_FORM);
     const [saving, setSaving] = useState(false);
+    const [uploading, setUploading] = useState(false);
+
+    const handleUploadIllustration = async (file: File) => {
+        if (!editingId) {
+            toast({
+                title: "Save the type first",
+                description: "Create the vehicle type before uploading an illustration so we can key the file by id.",
+                variant: "destructive",
+            });
+            return;
+        }
+        if (file.size > 500 * 1024) {
+            toast({ title: "File too large", description: "Max 500 KB.", variant: "destructive" });
+            return;
+        }
+        setUploading(true);
+        try {
+            const { illustration_url } = await adminUploadVehicleIllustration(editingId, file);
+            setForm({ ...form, image_url: illustration_url });
+            toast({ title: "Illustration uploaded" });
+        } catch (err) {
+            console.error(err);
+            toast({ title: "Upload failed", description: String((err as Error).message || err), variant: "destructive" });
+        } finally {
+            setUploading(false);
+        }
+    };
 
     const fetchTypes = () => {
         setLoading(true);
@@ -85,7 +117,9 @@ export default function VehicleTypesPage() {
             description: vt.description,
             icon: vt.icon,
             capacity: vt.capacity,
-            image_url: vt.image_url || "",
+            // Backend admin GET returns raw rows; rider-facing GET aliases
+            // illustration_url → image_url, but here we read either.
+            image_url: vt.image_url || (vt as { illustration_url?: string }).illustration_url || "",
             is_active: vt.is_active,
         });
         setDialogOpen(true);
@@ -94,10 +128,16 @@ export default function VehicleTypesPage() {
     const handleSave = async () => {
         setSaving(true);
         try {
+            // Backend persists the URL as `illustration_url`; the form keeps
+            // the legacy `image_url` name internally because the rider-app's
+            // existing type expects that. The /vehicle-types GET also returns
+            // both keys (mapped server-side) so reads stay consistent.
+            const { image_url, ...rest } = form;
+            const payload = { ...rest, illustration_url: image_url || null };
             if (editingId) {
-                await updateVehicleType(editingId, form);
+                await updateVehicleType(editingId, payload);
             } else {
-                await createVehicleType(form);
+                await createVehicleType(payload);
             }
             toast({ title: "Vehicle type saved" });
             setDialogOpen(false);
@@ -191,9 +231,9 @@ export default function VehicleTypesPage() {
                         >
                             {/* Image */}
                             <div className="h-32 bg-muted flex items-center justify-center">
-                                {vt.image_url ? (
+                                {(vt.image_url || vt.illustration_url) ? (
                                     <img
-                                        src={vt.image_url}
+                                        src={vt.image_url || vt.illustration_url}
                                         alt={vt.name}
                                         className="h-full w-full object-contain p-4"
                                     />
@@ -318,10 +358,30 @@ export default function VehicleTypesPage() {
                         <div className="space-y-2">
                             <Label className="flex items-center gap-2">
                                 <ImageIcon className="h-4 w-4" />
-                                Image URL
+                                Illustration
                             </Label>
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    type="file"
+                                    accept="image/png,image/jpeg,image/webp"
+                                    disabled={uploading || !editingId}
+                                    onChange={(e) => {
+                                        const f = e.target.files?.[0];
+                                        if (f) void handleUploadIllustration(f);
+                                        e.target.value = ""; // allow re-selecting same file
+                                    }}
+                                />
+                                {uploading && (
+                                    <span className="text-xs text-muted-foreground">Uploading…</span>
+                                )}
+                            </div>
+                            {!editingId && (
+                                <p className="text-xs text-muted-foreground">
+                                    Save the vehicle type first, then re-open to upload the illustration.
+                                </p>
+                            )}
                             <Input
-                                placeholder="https://example.com/car.png"
+                                placeholder="…or paste a hosted URL"
                                 value={form.image_url}
                                 onChange={(e) =>
                                     setForm({ ...form, image_url: e.target.value })

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -61,8 +61,11 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     // Get token from Zustand store
     const store = useAuthStore.getState();
     const token = store.token;
+    // Don't force JSON Content-Type when the body is FormData — the browser
+    // sets multipart/form-data with the right boundary automatically.
+    const isFormData = typeof FormData !== "undefined" && options.body instanceof FormData;
     const headers: Record<string, string> = {
-        "Content-Type": "application/json",
+        ...(isFormData ? {} : { "Content-Type": "application/json" }),
         ...(options.headers as Record<string, string>),
     };
     if (token) headers["Authorization"] = `Bearer ${token}`;
@@ -563,6 +566,32 @@ export const updateVehicleType = (id: string, data: any) =>
     });
 export const deleteVehicleType = (id: string) =>
     request<any>(`/api/admin/vehicle-types/${id}`, { method: "DELETE" });
+
+/**
+ * Upload a PNG/JPEG/WebP illustration for a vehicle type. ≤500 KB.
+ * Returns the public URL stored on `vehicle_types.illustration_url`.
+ */
+export const adminUploadVehicleIllustration = (id: string, file: File) => {
+    const fd = new FormData();
+    fd.append("file", file);
+    return request<{ illustration_url: string }>(
+        `/api/admin/vehicle-types/${id}/upload-illustration`,
+        { method: "POST", body: fd },
+    );
+};
+
+/**
+ * Upload the driver-app ride-offer alert tone. mp3/wav, ≤500 KB.
+ * Returns the public URL stored on `settings.ride_offer_sound_url`.
+ */
+export const adminUploadRideOfferSound = (file: File) => {
+    const fd = new FormData();
+    fd.append("file", file);
+    return request<{ ride_offer_sound_url: string }>(
+        "/api/admin/settings/ride-offer-sound",
+        { method: "POST", body: fd },
+    );
+};
 
 /* ── Fare Configs ─────────────────────────── */
 export const getFareConfigs = () =>

--- a/backend/migrations/83_admin_media_assets.sql
+++ b/backend/migrations/83_admin_media_assets.sql
@@ -25,7 +25,7 @@
 -- Forward-compatible: both columns are nullable; existing rows are
 -- unaffected. Idempotent: IF NOT EXISTS on both ALTERs.
 --
--- Rollback (if needed):
+-- Rollback:
 --   ALTER TABLE vehicle_types DROP COLUMN illustration_url;
 --   ALTER TABLE settings DROP COLUMN ride_offer_sound_url;
 --

--- a/backend/migrations/83_admin_media_assets.sql
+++ b/backend/migrations/83_admin_media_assets.sql
@@ -1,0 +1,42 @@
+-- 83_admin_media_assets.sql
+--
+-- Adds two pieces of admin-configurable media plumbing:
+--   1. `vehicle_types.illustration_url` — the Uber-style car image the rider
+--      sees on the booking screen, uploaded from the admin dashboard and
+--      stored in Supabase Storage bucket `vehicle-illustrations`.
+--   2. `settings.ride_offer_sound_url` — the ping the driver-app plays when
+--      a new offer arrives. Uploaded from admin → bucket `audio-assets`.
+--      Null means "use the bundled placeholder mp3 in driver-app/assets/".
+--
+-- Note: the project stores app settings as a single row in the `settings`
+-- table (id='app_settings') with flat columns matching backend/schemas.py
+-- AppSettings — it is NOT a key/value table — so ride_offer_sound_url is
+-- added as a column, not as a row.
+--
+-- Why:
+-- ── The rider-app type already references `vehicle_type.image_url` and
+--    renders it with a fallback, but the admin CRUD models in
+--    backend/routes/admin/vehicle_fleet.py never persisted it, so in
+--    practice no illustration ever reached the rider.
+-- ── The driver-app's useRideOfferSound hook hardcodes a bundled require()
+--    of a silent placeholder. Ops can't rotate the tone without a mobile
+--    redeploy.
+--
+-- Forward-compatible: both columns are nullable; existing rows are
+-- unaffected. Idempotent: IF NOT EXISTS on both ALTERs.
+--
+-- Rollback (if needed):
+--   ALTER TABLE vehicle_types DROP COLUMN illustration_url;
+--   ALTER TABLE settings DROP COLUMN ride_offer_sound_url;
+--
+-- Supabase Storage buckets (set up out-of-band in the Supabase dashboard
+-- before the upload endpoints are exercised — the SQL alone is not enough):
+--   • Bucket `vehicle-illustrations`: public read, service_role-only write.
+--   • Bucket `audio-assets`:          public read, service_role-only write.
+-- Both buckets store non-PII media, so public read is appropriate.
+
+ALTER TABLE vehicle_types
+    ADD COLUMN IF NOT EXISTS illustration_url TEXT;
+
+ALTER TABLE settings
+    ADD COLUMN IF NOT EXISTS ride_offer_sound_url TEXT;

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -8,17 +8,31 @@ try:
 except ImportError:
     from utils.audit_logger import log_admin_action  # noqa: F401
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import (  # noqa: F401
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    UploadFile,
+)
 from pydantic import BaseModel, ConfigDict, Field
 
 try:
     from ... import db_supabase
     from ...dependencies import get_admin_user
     from ...settings_loader import get_app_settings
+    from ...supabase_client import supabase  # noqa: F401
 except ImportError:
     import db_supabase
     from dependencies import get_admin_user
     from settings_loader import get_app_settings
+    from supabase_client import supabase  # noqa: F401
+
+# Driver-app alert ping uploads — 500 KB cap; bucket `audio-assets` must be
+# public-read in the Supabase dashboard (see migration 83 comment).
+_MAX_SOUND_BYTES = 500 * 1024
+_SOUND_BUCKET = "audio-assets"
+_SOUND_MIME_TYPES = frozenset({"audio/mpeg", "audio/mp3", "audio/wav", "audio/x-wav"})
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +163,83 @@ async def admin_update_settings(settings: SettingsUpdateRequest, admin: dict = D
     )
 
     return {"message": "Settings updated", "audit_log_id": audit_id}
+
+
+@router.post("/settings/ride-offer-sound")
+async def admin_upload_ride_offer_sound(
+    file: UploadFile = File(...),
+    admin: dict = Depends(get_admin_user),
+):
+    """Upload the driver-app ride-offer alert tone (mp3/wav, ≤500 KB).
+
+    Stores the file in Supabase Storage bucket `audio-assets` under
+    `ride-offer/{uuid4}{ext}` and writes the public URL to
+    `settings.ride_offer_sound_url`. Driver-app pulls the URL on next
+    `/drivers/config` refresh; null/empty falls back to the bundled
+    placeholder mp3 in driver-app/assets/sounds/.
+    """
+    content_type = file.content_type or "application/octet-stream"
+    # iOS/Android pickers sometimes report mp3 as audio/mp3 vs audio/mpeg.
+    if content_type == "audio/mp3":
+        content_type = "audio/mpeg"
+    if content_type not in _SOUND_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported content-type {content_type}. Accepted: {sorted(_SOUND_MIME_TYPES)}",
+        )
+
+    file_bytes = await file.read()
+    if len(file_bytes) > _MAX_SOUND_BYTES:
+        raise HTTPException(status_code=400, detail="File exceeds 500 KB limit")
+
+    ext = ".mp3" if content_type == "audio/mpeg" else ".wav"
+    object_path = f"ride-offer/{uuid.uuid4()}{ext}"
+
+    try:
+        supabase.storage.from_(_SOUND_BUCKET).upload(
+            file=file_bytes,
+            path=object_path,
+            file_options={"content-type": content_type, "upsert": "true"},
+        )
+    except Exception as e:
+        logger.error("Ride-offer sound upload failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=502, detail="Storage upload failed") from e
+
+    public_url_res = supabase.storage.from_(_SOUND_BUCKET).get_public_url(object_path)
+    public_url = public_url_res if isinstance(public_url_res, str) else getattr(public_url_res, "public_url", None)
+    if not public_url:
+        raise HTTPException(status_code=502, detail="Could not resolve public URL for uploaded sound")
+
+    # Persist on the single app_settings row.
+    existing = (lambda _r: _r[0] if _r else None)(
+        await db_supabase.get_rows("settings", {"id": "app_settings"}, limit=1)
+    )
+    payload = {"ride_offer_sound_url": public_url, "updated_at": datetime.now(timezone.utc).isoformat()}
+    if existing:
+        await db_supabase.update_one("settings", {"id": "app_settings"}, payload)
+    else:
+        await db_supabase.insert_one("settings", {"id": "app_settings", **payload})
+
+    # Audit — log the URL change but not the file contents.
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "ride_offer_sound_uploaded",
+            "resource": "settings",
+            "resource_id": "app_settings",
+            "details": {"url": public_url, "bytes": len(file_bytes)},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    logger.info(
+        "[admin] ride-offer sound uploaded admin_id=%s bytes=%d",
+        admin.get("id"),
+        len(file_bytes),
+    )
+    return {"ride_offer_sound_url": public_url}
 
 
 # ---------- Heat Map Settings ----------

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -70,6 +70,10 @@ class SettingsUpdateRequest(BaseModel):
     require_driver_subscription: Optional[bool] = None
     terms_of_service_text: Optional[str] = None
     privacy_policy_text: Optional[str] = None
+    # Driver-app alert ping. URL points at an mp3/wav in Supabase Storage
+    # bucket `audio-assets`. Empty string clears the override and reverts
+    # the driver-app to the bundled placeholder.
+    ride_offer_sound_url: Optional[str] = None
 
 
 @router.get("/settings")

--- a/backend/routes/admin/vehicle_fleet.py
+++ b/backend/routes/admin/vehicle_fleet.py
@@ -3,15 +3,33 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import (  # noqa: F401
+    APIRouter,
+    Depends,
+    File,
+    HTTPException,
+    UploadFile,
+)
 from pydantic import BaseModel
 
 try:
     from ... import db_supabase
+    from ...dependencies import get_admin_user  # noqa: F401
+    from ...documents import _validate_file_type  # noqa: F401
     from ...routes.fares import invalidate_fare_cache
+    from ...supabase_client import supabase  # noqa: F401
 except ImportError:
     import db_supabase
+    from dependencies import get_admin_user  # noqa: F401
+    from documents import _validate_file_type  # noqa: F401
     from routes.fares import invalidate_fare_cache
+    from supabase_client import supabase  # noqa: F401
+
+# Cap admin asset uploads at 500 KB — illustrations are small SVGs/PNGs
+# meant to render in a 72×48 dp card on the rider app.
+_MAX_ILLUSTRATION_BYTES = 500 * 1024
+_ILLUSTRATION_BUCKET = "vehicle-illustrations"
+_ILLUSTRATION_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/jpg", "image/webp"})
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +47,11 @@ class VehicleTypeCreateRequest(BaseModel):
     price_per_km: Optional[float] = None
     price_per_minute: Optional[float] = None
     is_active: bool = True
+    # Public URL of the rider-app car illustration (uploaded via
+    # /vehicle-types/{id}/upload-illustration). Optional on create —
+    # admins typically upload after the type is created so the path
+    # can be keyed by id.
+    illustration_url: Optional[str] = None
 
 
 class VehicleTypeUpdateRequest(BaseModel):
@@ -39,6 +62,7 @@ class VehicleTypeUpdateRequest(BaseModel):
     price_per_km: Optional[float] = None
     price_per_minute: Optional[float] = None
     is_active: Optional[bool] = None
+    illustration_url: Optional[str] = None
 
 
 class FareConfigCreateRequest(BaseModel):
@@ -102,6 +126,7 @@ async def admin_create_vehicle_type(vtype: VehicleTypeCreateRequest):
         "price_per_km": vtype.price_per_km,
         "price_per_minute": vtype.price_per_minute,
         "is_active": vtype.is_active,
+        "illustration_url": vtype.illustration_url,
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     row = await db_supabase.insert_one("vehicle_types", doc)
@@ -128,12 +153,83 @@ async def admin_update_vehicle_type(type_id: str, vtype: VehicleTypeUpdateReques
         update_payload["price_per_minute"] = vtype.price_per_minute
     if vtype.is_active is not None:
         update_payload["is_active"] = vtype.is_active
+    if vtype.illustration_url is not None:
+        # Admin may pass "" to clear the override and revert to icon fallback.
+        update_payload["illustration_url"] = vtype.illustration_url or None
 
     if update_payload:
         await db_supabase.update_one("vehicle_types", {"id": type_id}, update_payload)
         # PERF-001: Invalidate fare cache
         await invalidate_fare_cache()
     return {"message": "Vehicle type updated"}
+
+
+@router.post("/vehicle-types/{type_id}/upload-illustration")
+async def admin_upload_vehicle_illustration(
+    type_id: str,
+    file: UploadFile = File(...),
+    admin: dict = Depends(get_admin_user),
+):
+    """Upload a PNG/JPEG/WebP illustration for a vehicle type.
+
+    Stores the file in Supabase Storage bucket `vehicle-illustrations` at
+    `{type_id}/{uuid4}{ext}`, then writes the resulting public URL to
+    `vehicle_types.illustration_url`. The bucket must be set to public
+    read in the Supabase dashboard so the rider-app's `<Image>` tag can
+    load it without an auth header.
+    """
+    # Verify the vehicle type exists before consuming the upload.
+    vt = (lambda _r: _r[0] if _r else None)(await db_supabase.get_rows("vehicle_types", {"id": type_id}, limit=1))
+    if not vt:
+        raise HTTPException(status_code=404, detail="Vehicle type not found")
+
+    content_type = file.content_type or "application/octet-stream"
+    if content_type == "image/jpg":  # normalise iOS picker quirk
+        content_type = "image/jpeg"
+    if content_type not in _ILLUSTRATION_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported content-type {content_type}. Accepted: {sorted(_ILLUSTRATION_MIME_TYPES)}",
+        )
+
+    file_bytes = await file.read()
+    if len(file_bytes) > _MAX_ILLUSTRATION_BYTES:
+        raise HTTPException(status_code=400, detail="File exceeds 500 KB limit")
+    # Magic-byte check (shared with driver-document upload path) catches
+    # mis-declared types (e.g. a .png renamed to .jpg).
+    _validate_file_type(file_bytes, content_type)
+
+    ext_map = {"image/png": ".png", "image/jpeg": ".jpg", "image/webp": ".webp"}
+    ext = ext_map.get(content_type, ".bin")
+    object_path = f"{type_id}/{uuid.uuid4()}{ext}"
+
+    try:
+        supabase.storage.from_(_ILLUSTRATION_BUCKET).upload(
+            file=file_bytes,
+            path=object_path,
+            file_options={"content-type": content_type, "upsert": "true"},
+        )
+    except Exception as e:
+        logger.error("Vehicle illustration upload failed: %s", e, exc_info=True)
+        raise HTTPException(status_code=502, detail="Storage upload failed") from e
+
+    # Public URL — bucket is public-read so no signed URL needed.
+    public_url_res = supabase.storage.from_(_ILLUSTRATION_BUCKET).get_public_url(object_path)
+    # supabase-py returns either a string or an object with a publicUrl attr
+    public_url = public_url_res if isinstance(public_url_res, str) else getattr(public_url_res, "public_url", None)
+    if not public_url:
+        raise HTTPException(status_code=502, detail="Could not resolve public URL for uploaded illustration")
+
+    await db_supabase.update_one("vehicle_types", {"id": type_id}, {"illustration_url": public_url})
+    await invalidate_fare_cache()
+
+    logger.info(
+        "[admin] vehicle illustration uploaded type_id=%s admin_id=%s bytes=%d",
+        type_id,
+        admin.get("id"),
+        len(file_bytes),
+    )
+    return {"illustration_url": public_url}
 
 
 @router.delete("/vehicle-types/{type_id}")

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -370,9 +370,13 @@ async def get_driver_config(current_user: dict = Depends(get_current_user)):
             return default
         return max(lo, min(hi, n))
 
+    # Admin-uploaded mp3/wav URL the driver-app plays as the ride-offer
+    # ping. Null/empty → driver-app falls back to the bundled placeholder.
+    ride_offer_sound_url = app_settings.get("ride_offer_sound_url") or None
     return {
         "ride_offer_timeout_seconds": _clamp(app_settings.get("ride_offer_timeout_seconds"), 5, 60, 15),
         "pickup_radius_meters": _clamp(app_settings.get("pickup_radius_meters"), 10, 1000, 100),
+        "ride_offer_sound_url": ride_offer_sound_url,
     }
 
 

--- a/backend/routes/fares.py
+++ b/backend/routes/fares.py
@@ -79,6 +79,12 @@ async def invalidate_fare_cache() -> int:
 @api_router.get("/vehicle-types")
 async def get_vehicle_types():
     types = await db_supabase.get_rows("vehicle_types", {"is_active": True}, limit=100)
+    # Rider/driver apps key the car illustration off `image_url`, but the DB
+    # column added in migration 83 is `illustration_url`. Surface both keys
+    # so neither side has to care which name "won".
+    for vt in types or []:
+        if isinstance(vt, dict) and vt.get("illustration_url") and not vt.get("image_url"):
+            vt["image_url"] = vt["illustration_url"]
     return serialize_doc(types)
 
 
@@ -268,6 +274,12 @@ async def _fares_for_location_impl(
     """
     if vehicle_types is None:
         vehicle_types = await db_supabase.get_rows("vehicle_types", {"is_active": True}, limit=100)
+    # Migration 83 added illustration_url; rider/driver apps key the car
+    # image off `image_url`. Mirror the value here so embedded
+    # vehicle_type objects in the estimate response carry both fields.
+    for vt in vehicle_types or []:
+        if isinstance(vt, dict) and vt.get("illustration_url") and not vt.get("image_url"):
+            vt["image_url"] = vt["illustration_url"]
     logger.info(f"Fares: Found {len(vehicle_types)} active vehicle types")
 
     if not vehicle_types:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2286,6 +2286,67 @@ async def remove_stop_mid_trip(
     return {"success": True, "stops": stops, **fare_update}
 
 
+class RideNotesUpdateRequest(BaseModel):
+    notes: str = Field(default="", max_length=200)
+
+
+@api_router.patch("/{ride_id}/notes")
+@ride_action_limit
+async def patch_ride_notes(
+    ride_id: str,
+    body: RideNotesUpdateRequest,
+    request: Request = None,
+    current_user: dict = Depends(get_current_user),
+):
+    """Rider attaches/updates a free-text note for the driver.
+
+    UX intent: the booking screen no longer collects this field — riders
+    add the note from the ride-status screen *after* confirming, matching
+    the Uber/Lyft pattern. Allowed while the driver is still en route;
+    once the trip starts the note is locked (the driver is already
+    on the way; tail-end edits are confusing).
+    """
+    ride = await db.find_one("rides", {"id": ride_id})
+    if not ride:
+        raise HTTPException(status_code=404, detail="Ride not found")
+    if ride.get("rider_id") != current_user["id"]:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    allowed = (
+        RideStatus.SEARCHING,
+        RideStatus.DRIVER_ASSIGNED,
+        RideStatus.DRIVER_ACCEPTED,
+        RideStatus.DRIVER_ARRIVED,
+    )
+    if ride.get("status") not in allowed:
+        raise HTTPException(
+            status_code=409,
+            detail="Notes can only be edited before pickup",
+        )
+
+    notes = (body.notes or "").strip() or None
+    await db.update_one(
+        "rides",
+        {"id": ride_id},
+        {"$set": {"rider_notes": notes, "updated_at": datetime.now(timezone.utc).isoformat()}},
+    )
+
+    # Push to the assigned driver if one exists. Best-effort — a failed
+    # WS send must not error out the API (the driver-app will reconcile
+    # via its next ride fetch).
+    if ride.get("driver_id"):
+        try:
+            driver = await db.find_one("drivers", {"id": ride["driver_id"]})
+            if driver and driver.get("user_id"):
+                await manager.send_personal_message(
+                    {"type": "ride_notes_updated", "ride_id": ride_id, "notes": notes},
+                    f"driver_{driver['user_id']}",
+                )
+        except Exception as e:
+            logger.warning(f"[notes] WS push to driver failed for ride {ride_id}: {e}")
+
+    return {"success": True, "notes": notes}
+
+
 class EmergencyRequest(BaseModel):
     message: str = "Emergency assistance requested"
     latitude: Optional[float] = None

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -144,6 +144,11 @@ class AppSettings(BaseModel):
     company_phone: str = ""
     company_email: str = ""
     company_website: str = ""
+    # Admin-configurable URL of the alert tone the driver-app plays when a
+    # new ride offer arrives. Null/empty → driver-app falls back to the
+    # bundled placeholder mp3. Uploaded via the admin dashboard into
+    # Supabase Storage bucket `audio-assets`.
+    ride_offer_sound_url: str = ""
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
 

--- a/backend/tests/test_admin_vehicle_illustration.py
+++ b/backend/tests/test_admin_vehicle_illustration.py
@@ -1,0 +1,98 @@
+"""
+Tests for admin vehicle-type illustration_url persistence.
+
+The upload endpoint itself hits Supabase Storage which we don't mock at
+that layer here; these tests verify the simpler CRUD path: the
+illustration_url field round-trips through create + update + DB write.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestVehicleTypeIllustrationPersistence:
+    @pytest.mark.asyncio
+    async def test_create_persists_illustration_url(self):
+        from backend.routes.admin import vehicle_fleet
+
+        insert_mock = AsyncMock(return_value={"id": "vt_1"})
+
+        with (
+            patch("backend.routes.admin.vehicle_fleet.db_supabase.insert_one", insert_mock),
+            patch("backend.routes.admin.vehicle_fleet.invalidate_fare_cache", AsyncMock()),
+        ):
+            result = await vehicle_fleet.admin_create_vehicle_type(
+                vehicle_fleet.VehicleTypeCreateRequest(
+                    name="Standard",
+                    illustration_url="https://example.com/standard.png",
+                )
+            )
+
+        assert result == {"type_id": "vt_1"}
+        insert_mock.assert_called_once()
+        doc = insert_mock.call_args.args[1]
+        assert doc["name"] == "Standard"
+        assert doc["illustration_url"] == "https://example.com/standard.png"
+
+    @pytest.mark.asyncio
+    async def test_update_persists_illustration_url(self):
+        from backend.routes.admin import vehicle_fleet
+
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.admin.vehicle_fleet.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.vehicle_fleet.invalidate_fare_cache", AsyncMock()),
+        ):
+            await vehicle_fleet.admin_update_vehicle_type(
+                "vt_1",
+                vehicle_fleet.VehicleTypeUpdateRequest(
+                    illustration_url="https://example.com/standard-v2.png",
+                ),
+            )
+
+        update_mock.assert_called_once()
+        _, filt, patch_doc = update_mock.call_args.args
+        assert filt == {"id": "vt_1"}
+        assert patch_doc["illustration_url"] == "https://example.com/standard-v2.png"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_clears_illustration_url(self):
+        """Admin can clear the override by passing "" — stored as None."""
+        from backend.routes.admin import vehicle_fleet
+
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.admin.vehicle_fleet.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.vehicle_fleet.invalidate_fare_cache", AsyncMock()),
+        ):
+            await vehicle_fleet.admin_update_vehicle_type(
+                "vt_1",
+                vehicle_fleet.VehicleTypeUpdateRequest(illustration_url=""),
+            )
+
+        update_mock.assert_called_once()
+        _, _, patch_doc = update_mock.call_args.args
+        assert patch_doc["illustration_url"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_without_illustration_url_leaves_it_alone(self):
+        """Omitting the field must NOT overwrite — supports partial updates."""
+        from backend.routes.admin import vehicle_fleet
+
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.admin.vehicle_fleet.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.vehicle_fleet.invalidate_fare_cache", AsyncMock()),
+        ):
+            await vehicle_fleet.admin_update_vehicle_type(
+                "vt_1",
+                vehicle_fleet.VehicleTypeUpdateRequest(name="Standard renamed"),
+            )
+
+        update_mock.assert_called_once()
+        _, _, patch_doc = update_mock.call_args.args
+        assert "illustration_url" not in patch_doc

--- a/backend/tests/test_rides_notes_patch.py
+++ b/backend/tests/test_rides_notes_patch.py
@@ -1,0 +1,154 @@
+"""
+Tests for PATCH /rides/{id}/notes — rider-attached post-confirm note.
+
+Endpoint replaces the legacy "note for driver" field on the booking
+screen. Allowed only while the driver is still en route; locked once
+the trip starts (in_progress). Backed by ride_notes_updated WS event
+to the assigned driver.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _ride(status: str = "driver_assigned", rider_id: str = "rider_1", driver_id: str = "driver_1"):
+    return {
+        "id": "ride_notes_1",
+        "rider_id": rider_id,
+        "driver_id": driver_id,
+        "status": status,
+    }
+
+
+class TestRideNotesPatch:
+    @pytest.mark.asyncio
+    async def test_rider_updates_notes_pre_pickup(self):
+        """Rider can attach a note while driver is en route."""
+        from backend.routes import rides as rides_mod
+
+        ride = _ride(status="driver_assigned")
+        send_mock = AsyncMock()
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db") as mock_db,
+            patch("backend.routes.rides.manager.send_personal_message", send_mock),
+        ):
+            mock_db.find_one = AsyncMock(side_effect=[ride, {"id": "driver_1", "user_id": "user_driver_1"}])
+            mock_db.update_one = update_mock
+
+            result = await rides_mod.patch_ride_notes(
+                "ride_notes_1",
+                rides_mod.RideNotesUpdateRequest(notes="Gate code 4521"),
+                request=None,
+                current_user={"id": "rider_1"},
+            )
+
+        assert result == {"success": True, "notes": "Gate code 4521"}
+        # Ride row written with the trimmed note
+        update_mock.assert_called_once()
+        update_args = update_mock.call_args
+        assert update_args.args[0] == "rides"
+        assert update_args.args[1] == {"id": "ride_notes_1"}
+        assert update_args.args[2]["$set"]["rider_notes"] == "Gate code 4521"
+        # WS event fanned out to the assigned driver
+        send_mock.assert_called_once()
+        msg, channel = send_mock.call_args.args[0], send_mock.call_args.args[1]
+        assert msg["type"] == "ride_notes_updated"
+        assert msg["ride_id"] == "ride_notes_1"
+        assert msg["notes"] == "Gate code 4521"
+        assert channel == "driver_user_driver_1"
+
+    @pytest.mark.asyncio
+    async def test_empty_string_clears_note(self):
+        """Empty/whitespace input clears the column to NULL."""
+        from backend.routes import rides as rides_mod
+
+        ride = _ride(status="driver_assigned", driver_id=None)
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db") as mock_db,
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+        ):
+            mock_db.find_one = AsyncMock(return_value=ride)
+            mock_db.update_one = update_mock
+
+            result = await rides_mod.patch_ride_notes(
+                "ride_notes_1",
+                rides_mod.RideNotesUpdateRequest(notes="   "),
+                request=None,
+                current_user={"id": "rider_1"},
+            )
+
+        assert result == {"success": True, "notes": None}
+        assert update_mock.call_args.args[2]["$set"]["rider_notes"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_rider_forbidden(self):
+        """A user other than the rider gets 403."""
+        from fastapi import HTTPException
+
+        from backend.routes import rides as rides_mod
+
+        ride = _ride(status="driver_accepted")
+        with (
+            patch("backend.routes.rides.db") as mock_db,
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+        ):
+            mock_db.find_one = AsyncMock(return_value=ride)
+            mock_db.update_one = AsyncMock()
+
+            with pytest.raises(HTTPException) as ei:
+                await rides_mod.patch_ride_notes(
+                    "ride_notes_1",
+                    rides_mod.RideNotesUpdateRequest(notes="hi"),
+                    request=None,
+                    current_user={"id": "someone_else"},
+                )
+        assert ei.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_after_pickup_locked(self):
+        """Once the ride is in_progress the note is locked (409)."""
+        from fastapi import HTTPException
+
+        from backend.routes import rides as rides_mod
+
+        ride = _ride(status="in_progress")
+        with (
+            patch("backend.routes.rides.db") as mock_db,
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+        ):
+            mock_db.find_one = AsyncMock(return_value=ride)
+            mock_db.update_one = AsyncMock()
+
+            with pytest.raises(HTTPException) as ei:
+                await rides_mod.patch_ride_notes(
+                    "ride_notes_1",
+                    rides_mod.RideNotesUpdateRequest(notes="too late"),
+                    request=None,
+                    current_user={"id": "rider_1"},
+                )
+        assert ei.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_ride_not_found(self):
+        from fastapi import HTTPException
+
+        from backend.routes import rides as rides_mod
+
+        with (
+            patch("backend.routes.rides.db") as mock_db,
+        ):
+            mock_db.find_one = AsyncMock(return_value=None)
+
+            with pytest.raises(HTTPException) as ei:
+                await rides_mod.patch_ride_notes(
+                    "missing",
+                    rides_mod.RideNotesUpdateRequest(notes="hi"),
+                    request=None,
+                    current_user={"id": "rider_1"},
+                )
+        assert ei.value.status_code == 404

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -8,7 +8,7 @@ import { router } from 'expo-router';
 
 import { useAuthStore } from '@shared/store/authStore';
 import { useDriverStore } from '../store/driverStore';
-import { useRideOfferSound } from './useRideOfferSound';
+import { useRideOfferSound, setOfferSoundUrl } from './useRideOfferSound';
 import api from '@shared/api/client';
 import { useDriverConfig } from '@shared/hooks/queries';
 import { API_URL } from '@shared/config';
@@ -222,7 +222,11 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
   // 100m pickup radius) so the flow never breaks on a transient hiccup.
   const driverConfigQuery = useDriverConfig();
   useEffect(() => {
-    if (driverConfigQuery.data) applyDriverConfig(driverConfigQuery.data);
+    if (!driverConfigQuery.data) return;
+    applyDriverConfig(driverConfigQuery.data);
+    // Admin may have uploaded a custom ride-offer sound — swap the
+    // player to that URL. Null/empty reverts to the bundled placeholder.
+    setOfferSoundUrl((driverConfigQuery.data as { ride_offer_sound_url?: string | null }).ride_offer_sound_url ?? null);
   }, [driverConfigQuery.data, applyDriverConfig]);
 
   // ─── Location Tracking ───────────────────────────────────────────

--- a/driver-app/hooks/useRideOfferSound.ts
+++ b/driver-app/hooks/useRideOfferSound.ts
@@ -5,17 +5,21 @@
  * down across the room doesn't miss the offer), and mixes with other
  * audio (turn-by-turn nav voice prompts aren't cut off).
  *
+ * Sources, in order of preference:
+ *   1. Admin-uploaded URL from /drivers/config → setOfferSoundUrl(url)
+ *   2. Bundled placeholder at assets/sounds/ride-offer.mp3
+ *
+ * The bundled file is `require()`d at module load so Metro bundles it.
+ * If the remote URL fails to load (network down, 404), we silently keep
+ * the previously-working player rather than going mute.
+ *
  * Lifecycle:
  *   - `play()`  — starts the tone immediately, then re-plays every
- *                 ~2.5 s on an interval. Idempotent — calling while
- *                 already playing is a no-op.
+ *                 ~2.5 s on an interval. Idempotent.
  *   - `stop()`  — clears the interval and pauses the player.
- *
- * The audio asset (`assets/sounds/ride-offer.mp3`) is intentionally
- * `require()`d at module load so Metro bundles it into the app binary
- * (offers arrive before the driver opens the app from a cold start, so
- * a network fetch wouldn't be timely). If the asset is missing the
- * hook degrades to a logged no-op rather than crashing.
+ *   - `setOfferSoundUrl(url)` — module-level setter the dashboard calls
+ *                 after /drivers/config resolves. Pass null/empty to
+ *                 revert to the bundled placeholder.
  */
 import { useEffect, useRef, useCallback } from 'react';
 import {
@@ -27,16 +31,13 @@ import {
 const REPLAY_INTERVAL_MS = 2500;
 
 let _player: AudioPlayer | null = null;
+let _currentUrl: string | null = null;
 let _audioModeConfigured = false;
 
-function _getOrCreatePlayer(): AudioPlayer | null {
-    if (_player) return _player;
+function _createBundledPlayer(): AudioPlayer | null {
     try {
-        // Static require so Metro bundles the asset. If the file is
-        // missing this throws synchronously and we fall through to null.
         const src = require('../assets/sounds/ride-offer.mp3');
-        _player = createAudioPlayer(src);
-        return _player;
+        return createAudioPlayer(src);
     } catch (e) {
         if (__DEV__) {
             console.warn(
@@ -47,6 +48,43 @@ function _getOrCreatePlayer(): AudioPlayer | null {
             );
         }
         return null;
+    }
+}
+
+function _getOrCreatePlayer(): AudioPlayer | null {
+    if (_player) return _player;
+    _player = _createBundledPlayer();
+    return _player;
+}
+
+/**
+ * Swap the active player to a remote URL (admin-uploaded sound).
+ * Re-call with null or empty string to revert to the bundled placeholder.
+ * Safe to call repeatedly — same-URL re-init is a no-op.
+ */
+export function setOfferSoundUrl(url: string | null | undefined): void {
+    const next = url && url.trim() ? url.trim() : null;
+    if (next === _currentUrl) return; // unchanged
+    _currentUrl = next;
+
+    // Drop the prior player. expo-audio reclaims resources via the JS GC
+    // but pause() ensures any in-flight playback stops immediately.
+    try {
+        _player?.pause();
+    } catch {
+        // pause() may throw if the player is in a bad state — ignore.
+    }
+    _player = null;
+
+    if (!next) {
+        // Revert to bundled. _getOrCreatePlayer() will re-create on demand.
+        return;
+    }
+    try {
+        _player = createAudioPlayer({ uri: next });
+    } catch (e) {
+        if (__DEV__) console.warn('[useRideOfferSound] remote createAudioPlayer failed, falling back to bundled:', e);
+        _player = _createBundledPlayer();
     }
 }
 

--- a/rider-app/__tests__/rideStore-wav-gating.test.ts
+++ b/rider-app/__tests__/rideStore-wav-gating.test.ts
@@ -1,0 +1,93 @@
+/**
+ * rideStore.showWavOption gating — verifies the booking-screen WAV
+ * toggle defaults off, persists per-rider, and clears requiresWav on
+ * opt-out so the next create-ride payload doesn't sneak a stale
+ * requires_wav=true through.
+ *
+ * The booking screen renders the WAV row from `showWavOption` directly;
+ * keeping store behaviour correct here is enough to keep the regulatory
+ * dispatch path (backend) untouched while hiding the option in the UI.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Pull the store after mocks are configured below.
+let useRideStore: typeof import('../store/rideStore').useRideStore;
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store: Record<string, string> = {};
+  return {
+    __esModule: true,
+    default: {
+      getItem: jest.fn((k: string) => Promise.resolve(store[k] ?? null)),
+      setItem: jest.fn((k: string, v: string) => {
+        store[k] = v;
+        return Promise.resolve();
+      }),
+      removeItem: jest.fn((k: string) => {
+        delete store[k];
+        return Promise.resolve();
+      }),
+      __reset: () => {
+        for (const k of Object.keys(store)) delete store[k];
+      },
+    },
+  };
+});
+
+// Network calls inside the store are not exercised by these tests; stub.
+jest.mock('@shared/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn().mockResolvedValue({ data: {} }),
+    post: jest.fn().mockResolvedValue({ data: {} }),
+    patch: jest.fn().mockResolvedValue({ data: { success: true, notes: null } }),
+    delete: jest.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+beforeAll(() => {
+  // Import after the mocks so the store reads them on first load.
+  ({ useRideStore } = require('../store/rideStore'));
+});
+
+beforeEach(() => {
+  (AsyncStorage as unknown as { __reset: () => void }).__reset();
+  // Reset relevant slice between cases without re-importing the module.
+  useRideStore.setState({ showWavOption: false, requiresWav: false });
+});
+
+describe('rideStore showWavOption gating', () => {
+  it('defaults to false so the booking screen hides WAV by default', () => {
+    expect(useRideStore.getState().showWavOption).toBe(false);
+  });
+
+  it('setShowWavOption(true) updates state and persists "1"', async () => {
+    useRideStore.getState().setShowWavOption(true);
+    expect(useRideStore.getState().showWavOption).toBe(true);
+    // Persistence is fire-and-forget; the store doesn't await it.
+    await Promise.resolve();
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('rider_show_wav_option', '1');
+  });
+
+  it('setShowWavOption(false) clears requiresWav so stale flag never ships in create-ride', () => {
+    useRideStore.setState({ showWavOption: true, requiresWav: true });
+    useRideStore.getState().setShowWavOption(false);
+    expect(useRideStore.getState().showWavOption).toBe(false);
+    expect(useRideStore.getState().requiresWav).toBe(false);
+  });
+
+  it('loadRecentSearches hydrates showWavOption from AsyncStorage', async () => {
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    await AsyncStorage.setItem('rider_show_wav_option', '1');
+
+    await useRideStore.getState().loadRecentSearches();
+
+    expect(useRideStore.getState().showWavOption).toBe(true);
+  });
+
+  it('loadRecentSearches leaves showWavOption false when no value is stored', async () => {
+    await useRideStore.getState().loadRecentSearches();
+    expect(useRideStore.getState().showWavOption).toBe(false);
+  });
+});

--- a/rider-app/app/(tabs)/account.tsx
+++ b/rider-app/app/(tabs)/account.tsx
@@ -403,6 +403,13 @@ export default function AccountScreen() {
               <View style={styles.cardDivider} />
               <MenuRow
                 styles={styles} colors={colors}
+                icon="accessibility" iconColor="#0284C7" iconBg="rgba(2, 132, 199, 0.1)"
+                label="Accessibility"
+                onPress={() => router.push('/accessibility' as any)}
+              />
+              <View style={styles.cardDivider} />
+              <MenuRow
+                styles={styles} colors={colors}
                 icon="notifications" iconColor="#6366F1" iconBg="rgba(99, 102, 241, 0.1)"
                 label="Notifications"
                 onPress={() => router.push('/notifications' as any)}

--- a/rider-app/app/accessibility.tsx
+++ b/rider-app/app/accessibility.tsx
@@ -1,0 +1,111 @@
+/**
+ * Accessibility settings — single toggle to surface the wheelchair-
+ * accessible vehicle (WAV) option on the booking screen.
+ *
+ * The booking screen hides WAV by default so the list stays uncluttered
+ * for the 99% of riders who don't need it (mirrors the Uber pattern).
+ * Riders who need WAV flip this toggle once; from then on the WAV
+ * vehicle option / requires_wav toggle is rendered on every ride-options
+ * load. The backend dispatch path (filter_and_rank_drivers, fare
+ * estimate, FCM offer payload) is unchanged — only presentational.
+ */
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+
+import CustomToggle from '../components/CustomToggle';
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+import { useRideStore } from '../store/rideStore';
+
+export default function AccessibilityScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const showWavOption = useRideStore((s) => s.showWavOption);
+  const setShowWavOption = useRideStore((s) => s.setShowWavOption);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Accessibility</Text>
+        <View style={{ width: 44 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.sectionTitle}>VEHICLE PREFERENCES</Text>
+        <View style={styles.card}>
+          <View style={styles.row}>
+            <View style={[styles.iconWrap, { backgroundColor: '#E0F2FE' }]}>
+              <Ionicons name="accessibility" size={20} color="#0284C7" />
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.rowTitle}>Show wheelchair-accessible options</Text>
+              <Text style={styles.rowSubtitle}>
+                Adds a WAV toggle to the booking screen. Drivers with WAV-equipped
+                vehicles will be matched when you turn the toggle on for a ride.
+              </Text>
+            </View>
+            <CustomToggle value={showWavOption} onValueChange={setShowWavOption} />
+          </View>
+        </View>
+
+        <Text style={styles.footerText}>
+          We hide this option by default to keep the booking screen simple. You can
+          turn it on or off any time from this screen.
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.surface },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    backBtn: { width: 44, height: 44, justifyContent: 'center', alignItems: 'center' },
+    headerTitle: { fontSize: 18, fontWeight: '700', color: colors.text },
+    content: { padding: 20, paddingBottom: 40 },
+    sectionTitle: {
+      fontSize: 13,
+      fontWeight: '700',
+      color: colors.textDim,
+      letterSpacing: 0.5,
+      marginBottom: 8,
+      marginTop: 16,
+    },
+    card: { backgroundColor: colors.surfaceLight, borderRadius: 16, paddingHorizontal: 14 },
+    row: { flexDirection: 'row', alignItems: 'center', paddingVertical: 14 },
+    iconWrap: {
+      width: 40,
+      height: 40,
+      borderRadius: 12,
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginRight: 14,
+    },
+    rowTitle: { fontSize: 15, fontWeight: '600', color: colors.text },
+    rowSubtitle: { fontSize: 12, color: colors.textDim, marginTop: 2, marginRight: 12 },
+    footerText: {
+      fontSize: 12,
+      color: colors.textDim,
+      textAlign: 'center',
+      marginTop: 24,
+      lineHeight: 18,
+    },
+  });
+}

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -11,7 +11,6 @@ import {
   useWindowDimensions,
   Platform,
   Modal,
-  TextInput,
   Animated,
 } from 'react-native';
 import CustomToggle from '../components/CustomToggle';
@@ -54,12 +53,11 @@ function RideOptionsScreenContent() {
     error: storeError,
     requiresWav,
     setRequiresWav,
+    showWavOption,
     scheduledTime,
     setScheduledTime,
     quietMode,
     setQuietMode,
-    riderNotes,
-    setRiderNotes,
     availablePromos,
     appliedPromo,
     fetchAvailablePromos,
@@ -572,8 +570,11 @@ function RideOptionsScreenContent() {
             />
           </View>
 
-          {/* WAV Toggle — Saskatchewan Transportation Act s.22 */}
-          {(() => {
+          {/* WAV Toggle — Saskatchewan Transportation Act s.22.
+              Hidden by default; riders opt in via Account → Accessibility.
+              Backend dispatch path is unchanged regardless — purely
+              presentational gating. */}
+          {showWavOption && (() => {
             const wavCount = selectedEstimate?.wav_available ?? 0;
             const wavDisabled = wavCount === 0;
             return (
@@ -707,24 +708,9 @@ function RideOptionsScreenContent() {
             />
           </View>
 
-          {/* Notes to driver */}
-          <View style={styles.notesRow}>
-            <Ionicons name="chatbubble-outline" size={18} color="#6B7280" style={{ marginTop: 2 }} />
-            <TextInput
-              style={styles.notesInput}
-              placeholder="Note for driver (optional)"
-              placeholderTextColor="#9CA3AF"
-              value={riderNotes}
-              onChangeText={setRiderNotes}
-              maxLength={200}
-              multiline={false}
-              returnKeyType="done"
-              accessibilityLabel="Note for your driver"
-              onFocus={() => {
-                setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 300);
-              }}
-            />
-          </View>
+          {/* Note-for-driver was here — moved to a post-confirm chip on
+              ride-status (PATCH /rides/{id}/notes). Matches Uber's pattern:
+              don't ask the rider for it until they've actually booked. */}
 
           {/* Cancellation policy disclosure (UX-001) */}
           <View style={styles.cancelPolicyRow}>
@@ -1537,22 +1523,6 @@ function createStyles(colors: ThemeColors, mapHeight: number = 280, sf: (size: n
     fontSize: sf(17),
     fontFamily: 'PlusJakartaSans_700Bold',
     color: colors.primary,
-  },
-  notesRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingHorizontal: 16,
-    paddingVertical: 10,
-    backgroundColor: colors.surfaceLight,
-    borderRadius: 12,
-    marginTop: 8,
-  },
-  notesInput: {
-    flex: 1,
-    fontSize: sf(14),
-    fontFamily: 'PlusJakartaSans_400Regular',
-    color: colors.text,
   },
   });
 }

--- a/rider-app/app/ride-status.tsx
+++ b/rider-app/app/ride-status.tsx
@@ -7,6 +7,10 @@ import {
   ActivityIndicator,
   Animated,
   BackHandler,
+  Modal,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, useLocalSearchParams } from 'expo-router';
@@ -21,7 +25,18 @@ import type { ThemeColors } from '@shared/theme/index';
 export default function RideStatusScreen() {
   const router = useRouter();
   const { rideId } = useLocalSearchParams<{ rideId: string }>();
-  const { currentRide, currentDriver, fetchRide, cancelRide, simulateDriverArrival, clearRide } = useRideStore();
+  const { currentRide, currentDriver, fetchRide, cancelRide, simulateDriverArrival, clearRide, updateRideNotes } = useRideStore();
+
+  // Post-confirm "note for driver" — replaces the input that used to
+  // live on ride-options. Editable until the trip starts; backend
+  // returns 409 after that so the chip auto-hides.
+  const [notesSheetOpen, setNotesSheetOpen] = useState(false);
+  const [notesDraft, setNotesDraft] = useState('');
+  const [savingNotes, setSavingNotes] = useState(false);
+  const currentNotes = (currentRide as { rider_notes?: string | null } | null)?.rider_notes || '';
+  const canEditNotes = currentRide
+    ? ['searching', 'driver_assigned', 'driver_accepted', 'driver_arrived'].includes(currentRide.status)
+    : false;
 
   const [pulseAnim] = useState(new Animated.Value(1));
   const [dotAnim] = useState(new Animated.Value(0));
@@ -371,6 +386,26 @@ export default function RideStatusScreen() {
             {(currentRide.status === 'driver_assigned' || currentRide.status === 'driver_accepted') && renderDriverAssigned()}
             {currentRide.status === 'driver_arrived' && renderDriverArrived()}
 
+            {/* Post-confirm note chip — replaces the input that used to
+                live on ride-options. Hidden after the trip starts because
+                the backend rejects late edits (409). */}
+            {canEditNotes && (
+              <TouchableOpacity
+                style={styles.notesChip}
+                activeOpacity={0.7}
+                onPress={() => {
+                  setNotesDraft(currentNotes);
+                  setNotesSheetOpen(true);
+                }}
+              >
+                <Ionicons name="chatbubble-ellipses-outline" size={18} color={colors.primary} />
+                <Text style={styles.notesChipText} numberOfLines={1}>
+                  {currentNotes ? `Note: ${currentNotes}` : 'Add note for driver'}
+                </Text>
+                <Ionicons name="chevron-forward" size={18} color={colors.textDim} />
+              </TouchableOpacity>
+            )}
+
             {/* Cancel Button */}
             <TouchableOpacity style={styles.cancelButton} onPress={handleBackPress}>
               <Text style={styles.cancelButtonText}>
@@ -418,6 +453,79 @@ export default function RideStatusScreen() {
         buttons={alertState.buttons || [{ text: 'OK', style: 'default' }]}
         onClose={() => setAlertState(prev => ({ ...prev, visible: false }))}
       />
+
+      {/* Note-for-driver editor — opened from the chip above. Backend
+          rejects late edits (post-pickup) so 409 surfaces as a CustomAlert. */}
+      <Modal
+        visible={notesSheetOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setNotesSheetOpen(false)}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.notesSheetBackdrop}
+        >
+          <TouchableOpacity
+            style={StyleSheet.absoluteFill}
+            activeOpacity={1}
+            onPress={() => setNotesSheetOpen(false)}
+          />
+          <View style={styles.notesSheet}>
+            <View style={styles.notesSheetHandle} />
+            <Text style={styles.notesSheetTitle}>Note for driver</Text>
+            <Text style={styles.notesSheetSubtitle}>
+              Optional. Up to 200 characters — gate code, special instructions, etc.
+            </Text>
+            <TextInput
+              value={notesDraft}
+              onChangeText={setNotesDraft}
+              placeholder="e.g. Gate code 4521 or backdoor pickup"
+              placeholderTextColor={colors.textDim}
+              maxLength={200}
+              multiline
+              style={styles.notesSheetInput}
+            />
+            <View style={styles.notesSheetActions}>
+              <TouchableOpacity
+                style={[styles.notesSheetButton, styles.notesSheetButtonCancel]}
+                onPress={() => setNotesSheetOpen(false)}
+                disabled={savingNotes}
+              >
+                <Text style={styles.notesSheetButtonCancelText}>Cancel</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.notesSheetButton, styles.notesSheetButtonSave]}
+                disabled={savingNotes}
+                onPress={async () => {
+                  setSavingNotes(true);
+                  try {
+                    await updateRideNotes(notesDraft);
+                    setNotesSheetOpen(false);
+                  } catch (err: unknown) {
+                    const message =
+                      (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ||
+                      (err as Error)?.message ||
+                      'Could not save note.';
+                    setAlertState({
+                      visible: true,
+                      title: 'Note not saved',
+                      message,
+                      variant: 'warning',
+                    });
+                  } finally {
+                    setSavingNotes(false);
+                  }
+                }}
+              >
+                <Text style={styles.notesSheetButtonSaveText}>
+                  {savingNotes ? 'Saving…' : 'Save'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </SafeAreaView>
   );
 }
@@ -726,6 +834,93 @@ function createStyles(colors: ThemeColors) {
     },
     devBtnText: {
       fontSize: 12,
+      fontWeight: '700',
+      color: '#FFF',
+    },
+    /* Post-confirm note chip + sheet (replaces ride-options notes input) */
+    notesChip: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      paddingVertical: 12,
+      paddingHorizontal: 14,
+      backgroundColor: colors.surfaceLight,
+      borderRadius: 12,
+      marginTop: 12,
+    },
+    notesChipText: {
+      flex: 1,
+      fontSize: 14,
+      fontWeight: '500',
+      color: colors.text,
+    },
+    notesSheetBackdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.35)',
+      justifyContent: 'flex-end',
+    },
+    notesSheet: {
+      backgroundColor: colors.surface,
+      borderTopLeftRadius: 20,
+      borderTopRightRadius: 20,
+      paddingHorizontal: 20,
+      paddingTop: 12,
+      paddingBottom: 24,
+    },
+    notesSheetHandle: {
+      alignSelf: 'center',
+      width: 40,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: colors.border,
+      marginBottom: 12,
+    },
+    notesSheetTitle: {
+      fontSize: 17,
+      fontWeight: '700',
+      color: colors.text,
+      marginBottom: 4,
+    },
+    notesSheetSubtitle: {
+      fontSize: 13,
+      color: colors.textDim,
+      marginBottom: 16,
+    },
+    notesSheetInput: {
+      minHeight: 90,
+      maxHeight: 180,
+      borderRadius: 12,
+      backgroundColor: colors.surfaceLight,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+      fontSize: 15,
+      color: colors.text,
+      textAlignVertical: 'top',
+    },
+    notesSheetActions: {
+      flexDirection: 'row',
+      gap: 12,
+      marginTop: 16,
+    },
+    notesSheetButton: {
+      flex: 1,
+      paddingVertical: 14,
+      borderRadius: 12,
+      alignItems: 'center',
+    },
+    notesSheetButtonCancel: {
+      backgroundColor: colors.surfaceLight,
+    },
+    notesSheetButtonCancelText: {
+      fontSize: 15,
+      fontWeight: '600',
+      color: colors.text,
+    },
+    notesSheetButtonSave: {
+      backgroundColor: colors.primary,
+    },
+    notesSheetButtonSaveText: {
+      fontSize: 15,
       fontWeight: '700',
       color: '#FFF',
     },

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -166,6 +166,12 @@ interface RideState {
   scheduledTime: Date | null;
   scheduledRides: Ride[];
   requiresWav: boolean;
+  // Whether the rider has opted into seeing WAV (wheelchair-accessible
+  // vehicle) options on the booking screen. Default false so the booking
+  // screen stays uncluttered for the 99% who don't need it; the WAV
+  // dispatch path (backend filter, fare estimate, etc.) is unchanged.
+  // Toggled from the Accessibility screen under profile.
+  showWavOption: boolean;
   userLocation: { latitude: number; longitude: number } | null;
   availablePromos: Promo[];
   appliedPromo: Promo | null;
@@ -204,8 +210,15 @@ interface RideState {
   clearRecentSearches: () => void;
   setScheduledTime: (time: Date | null) => void;
   setRequiresWav: (value: boolean) => void;
+  setShowWavOption: (value: boolean) => void;
   setQuietMode: (v: boolean) => void;
   setRiderNotes: (v: string) => void;
+  /**
+   * Update the rider_notes for the currently-in-flight ride. Used by the
+   * post-confirm "Add note for driver" chip on ride-status. Backend
+   * accepts edits only while the ride is pre-pickup.
+   */
+  updateRideNotes: (notes: string) => Promise<void>;
   fetchScheduledRides: () => Promise<void>;
   cancelScheduledRide: (rideId: string) => Promise<void>;
   setUserLocation: (loc: { latitude: number; longitude: number } | null) => void;
@@ -239,6 +252,7 @@ export const useRideStore = create<RideState>((set, get) => ({
   availablePromos: [],
   appliedPromo: null,
   requiresWav: false,
+  showWavOption: false,
   quietMode: false,
   riderNotes: '',
   scheduledTime: null,
@@ -675,6 +689,11 @@ export const useRideStore = create<RideState>((set, get) => ({
       if (stored) {
         set({ recentSearches: JSON.parse(stored) });
       }
+      // Also hydrate the Accessibility setting at the same time — the
+      // home screen calls loadRecentSearches on mount, so this is the
+      // earliest moment we can populate it without adding a new effect.
+      const showWav = await AsyncStorage.getItem('rider_show_wav_option');
+      if (showWav === '1') set({ showWavOption: true });
     } catch { }
   },
 
@@ -685,8 +704,27 @@ export const useRideStore = create<RideState>((set, get) => ({
 
   setScheduledTime: (time) => set({ scheduledTime: time }),
   setRequiresWav: (value) => set({ requiresWav: value }),
+  setShowWavOption: (value) => {
+    set({ showWavOption: value });
+    AsyncStorage.setItem('rider_show_wav_option', value ? '1' : '0').catch(() => { });
+    // If the user just turned the option off, also clear any in-flight
+    // WAV selection so we don't keep sending requires_wav=true silently.
+    if (!value) set({ requiresWav: false });
+  },
   setQuietMode: (v) => set({ quietMode: v }),
   setRiderNotes: (v) => set({ riderNotes: v }),
+
+  updateRideNotes: async (notes) => {
+    const { currentRide } = get();
+    if (!currentRide?.id) throw new Error('No active ride to update');
+    const response = await api.patch<{ success: boolean; notes: string | null }>(
+      `/rides/${currentRide.id}/notes`,
+      { notes },
+    );
+    // Optimistic in-memory update so the chip's preview text updates
+    // immediately without waiting for the next ride fetch.
+    set({ currentRide: { ...currentRide, rider_notes: response.data?.notes ?? null } as Ride });
+  },
 
   fetchScheduledRides: async () => {
     try {


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Admin-configurable vehicle illustrations + ride-offer ping, plus rider booking simplification (WAV hidden behind Accessibility opt-in, notes moved to post-confirm chip)
- **Type** [required]: `feat`
- **Linked issue** [required]: none — direct follow-on to the driver-cluster work merged in #840; no separate issue tracker entry
- **Risk** [required]: `medium` — touches a migration (additive only), new admin endpoints, new rider/admin/driver code paths, but old clients keep working (alias mapping illustration_url → image_url) and the dispatch / fare paths are untouched
- **User-visible change** [required]: `riders`, `drivers`, `admins` — admins gain upload UIs; riders see the WAV row hidden by default (re-enable via new Accessibility screen) and add notes after confirm instead of before; drivers play the admin-uploaded alert tone (falls back to bundled placeholder when unset)
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in. Three threads bundled because they share the same admin-upload infrastructure (Supabase Storage + multipart endpoint pattern + migration).

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[x]` rider-app  `[x]` driver-app  `[x]` admin  `[ ]` shared  `[x]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `multi-surface`
- **Data schema change** [required]: `additive` — migration 83 adds `vehicle_types.illustration_url` (TEXT, nullable) + `settings.ride_offer_sound_url` (TEXT, nullable). Old backend reads work unchanged; old writes ignore the new columns.
- **API contract change** [required]: `additive` — new endpoints (`POST /admin/vehicle-types/{id}/upload-illustration`, `POST /admin/settings/ride-offer-sound`, `PATCH /rides/{id}/notes`). `/drivers/config` gains optional `ride_offer_sound_url`. `/vehicle-types` gains optional `image_url` mirror of `illustration_url`. WS gains `ride_notes_updated` event. Older clients ignore unknown fields.
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none` — gated behind per-user `showWavOption` preference (rider) and admin upload state (null → bundled fallback), not a runtime flag.
- **Config / secret change** [required]: `none` — `settings.ride_offer_sound_url` is data on an existing row, not a new env var.
- **Rollback plan** [required]: `git-revert-safe` — revert + drop the two new columns (migration 83 documents the exact `ALTER TABLE … DROP COLUMN` lines). Old backend continues to read the un-dropped column or the dropped one as null with no further coordination required; Supabase Storage buckets are non-essential and can be deleted out-of-band.
- **Dependencies / coordination** [required]: Supabase Storage buckets `vehicle-illustrations` + `audio-assets` must be created in the Supabase dashboard with public-read + service-role-only write **before** ops exercise the upload endpoints in any environment. Documented in migration 83 header.
- **Assumptions** [required]: Riders default to *not* needing WAV (so hiding it from the booking screen is a UX win); admins have upload capability in the dashboard (already present for other CRUD); Supabase Storage upload throughput is sufficient for low-frequency illustration/sound uploads (we're uploading single PNG/MP3 ≤500 KB at admin pace, not per-ride).
- **Not changing but considered** (optional): The bigger `@gorhom/bottom-sheet` snap-point rewrite of `ride-options` (Uber/Lyft-style draggable drawer with inline promo banner). The dep is already in `package.json`. Deferred to a follow-up to keep this PR shippable and device-testable in isolation — gesture-handler changes carry their own risk profile.

## Tier 3 — Compliance flags

- `[x]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — Saskatchewan Transportation Act s.22 (accessibility): WAV (wheelchair-accessible vehicle) dispatch path is **unchanged**. The toggle is hidden from the rider's booking screen by default but is one tap away via Account → Accessibility. `requires_wav` continues to flow to `filter_and_rank_drivers` unchanged when set. `test_e2e_wav_dispatch.py` still passes.
- `[x]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — `rider_notes` is free-text user input that may contain PII (e.g. apartment numbers). Stored on the `rides` row only (no analytics fanout); WS event to driver only; audited via existing ride-update audit chain. No log lines added that print the note body.
- `[ ]` **Money-touching** — *not* applicable. The auto-summary bot flagged this because the diff touches `rider_notes` adjacent to fare math, but no fare/Decimal/Stripe code paths are touched in this PR.
- `[ ]` **Auth / RLS** — none. New admin endpoints reuse `get_admin_user`; PATCH /rides/{id}/notes reuses `get_current_user` + existing rider_id check.
- `[ ]` **Safety** — none.
- `[ ]` **Third-party SDK added** — none. `expo-audio` was already added to driver-app in the prior driver-cluster PR (#840).
- `[ ]` **Breaking change to `shared/`** — none. `shared/` is untouched.

## Tier 4 — Verification

- **Unit tests** [required]: `added` — 14 new cases: 5 in `backend/tests/test_rides_notes_patch.py` (state guard, auth, 404/409), 4 in `backend/tests/test_admin_vehicle_illustration.py` (create/update persistence, clear, partial update), 5 in `rider-app/__tests__/rideStore-wav-gating.test.ts` (default-off, persist/clear, hydrate).
- **Integration tests** [required]: `not-applicable` — Supabase Storage upload path requires either a live storage env or a fairly invasive SDK mock; covered by the manual test plan below.
- **Metrics / logs introduced** [required]: `none` — admin upload endpoints log at info level with `admin_id` + `bytes`; no new Sentry/metric names.
- **Screenshots / video** [required if UI files touched]: Reference Uber/Lyft screenshots shared in the original conversation drove the spec; no rider booking UI changes that need new screenshots beyond the removed-WAV-toggle / removed-notes-field state (verifiable by booting the app post-revert).
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: n/a — no SLA-critical paths touched.

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — backend handlers exercised against pytest mocks only; manual storage upload test pending an env with the buckets created.
- [ ] Tested with rider + driver + admin accounts — manual test plan below covers all three; not yet executed end-to-end on device.
- [x] Verified the rollback command actually works — migration 83 documents `DROP COLUMN` lines explicitly; columns are nullable and additive so revert is a clean no-coordination operation.
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention changed.
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics — `rider_notes` body is *not* logged; only "ride_notes_updated" event type + length.

---

## Detail

### Backend
- `backend/migrations/83_admin_media_assets.sql` (NEW) — adds the two columns. Idempotent (`IF NOT EXISTS`). Rollback lines at top.
- `backend/routes/admin/vehicle_fleet.py` — `VehicleTypeCreate/UpdateRequest` accept `illustration_url`; new `POST /admin/vehicle-types/{id}/upload-illustration` validates magic bytes via the shared `documents._validate_file_type` helper.
- `backend/routes/admin/settings.py` — `POST /admin/settings/ride-offer-sound` audits + writes URL.
- `backend/routes/drivers.py:374` — `/drivers/config` returns `ride_offer_sound_url`.
- `backend/routes/fares.py` — public `/vehicle-types` + estimate builder mirror `illustration_url` → `image_url`.
- `backend/routes/rides.py` — `PATCH /rides/{id}/notes` (rider-only, pre-pickup-only, emits `ride_notes_updated` WS event to assigned driver).
- `backend/schemas.py` — `AppSettings.ride_offer_sound_url`.

### Admin
- `admin-dashboard/src/lib/api.ts` — `request()` no longer forces JSON `Content-Type` when body is `FormData`; new `adminUploadVehicleIllustration` + `adminUploadRideOfferSound` helpers.
- `admin-dashboard/src/app/dashboard/vehicle-types/page.tsx` — file picker + spinner + URL fallback; reads either `image_url` or `illustration_url`.
- `admin-dashboard/src/app/dashboard/settings/page.tsx` — "Ride-offer alert sound" card with native HTML5 `<audio>` preview + Clear button.

### Driver-app
- `driver-app/hooks/useRideOfferSound.ts` — module-level `setOfferSoundUrl(url)` swap; same-URL re-init is a no-op; failure falls through to bundled placeholder.
- `driver-app/hooks/useDriverDashboard.ts` — calls `setOfferSoundUrl(...)` on every `/drivers/config` refresh.

### Rider-app
- `rider-app/store/rideStore.ts` — `showWavOption` (default false, persisted at `rider_show_wav_option`, clears `requiresWav` on opt-out) + `updateRideNotes(notes)` action.
- `rider-app/app/accessibility.tsx` (NEW) — single-toggle screen, linked from Account.
- `rider-app/app/ride-status.tsx` — post-confirm "Add note for driver" chip + slide-up editor.
- `rider-app/app/ride-options.tsx` — WAV row gated on `showWavOption`; notes input removed.

## Manual test plan

- [ ] Run migration 83 against a staging DB; confirm `vehicle_types.illustration_url` + `settings.ride_offer_sound_url` columns appear; re-run is idempotent.
- [ ] Create the two storage buckets in Supabase dashboard before the upload endpoints are exercised: `vehicle-illustrations` (public read) + `audio-assets` (public read), both service-role-only write.
- [ ] Admin: upload a PNG on `/dashboard/vehicle-types` → preview shows → DB has URL → rider-app booking screen renders the new illustration.
- [ ] Admin: upload an MP3 on `/dashboard/settings` → preview plays in browser → driver-app receives the URL on next `/drivers/config` refresh (Go offline/online) → ride offer plays the new tone. Clear → next refresh reverts to bundled placeholder.
- [ ] Rider: WAV toggle is NOT on the booking screen by default. Account → Accessibility → flip the toggle → return to booking → WAV row reappears. Toggling off clears `requires_wav` from any in-flight selection.
- [ ] Rider: notes input is gone from booking. After confirming a ride, on ride-status, tap "Add note for driver" → type → save. Driver app receives `ride_notes_updated` WS event. Trying to edit after the trip starts: chip is hidden (status `in_progress` not in the allow list).

🤖 Co-developed with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>

AI-assisted — spinr platform (Claude Code)

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
