### PR TITLE
fix(cancel): resolve all ride cancellation failures (enum $in bug, missing columns, 409 handling, navigation)

### DIFF
--- a/backend/repositories/_base.py
+++ b/backend/repositories/_base.py
@@ -463,7 +463,11 @@ def _apply_filters(q, filters: Optional[Dict[str, Any]]):
             continue
         if isinstance(v, dict):
             if "$in" in v and isinstance(v["$in"], (list, tuple)):
-                q = q.in_(k, list(v["$in"]))
+                # str(SomeStrEnum.VALUE) returns "ClassName.VALUE" in Python
+                # 3.12, not the enum's string value. Explicitly unwrap enum
+                # instances so PostgREST sees plain strings, not repr garbage.
+                clean = [x.value if isinstance(x, _Enum) else x for x in v["$in"]]
+                q = q.in_(k, clean)
             elif "$gt" in v:
                 q = q.gt(k, v["$gt"])
             elif "$gte" in v:

--- a/backend/repositories/_base.py
+++ b/backend/repositories/_base.py
@@ -16,6 +16,7 @@ import time as _time
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
 from datetime import date, datetime
 from decimal import Decimal
+from enum import Enum as _Enum
 from typing import Any, Callable, Dict, List, Literal, Optional, TypeVar
 
 try:

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { Linking } from 'react-native';
 import { globalAlert } from './alertStore';
-import api from '@shared/api/client';
+import api, { SpinrApiError } from '@shared/api/client';
 import { useAuthStore, registerLogoutCallback } from '@shared/store/authStore';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { RideStatus } from '../constants/rideStatus';
@@ -539,6 +539,19 @@ export const useRideStore = create<RideState>((set, get) => ({
       set({ currentRide: null, currentDriver: null, isLoading: false });
       AsyncStorage.removeItem(ACTIVE_RIDE_KEY).catch(() => {});
     } catch (error: unknown) {
+      // 409 with a terminal current_status means the backend already cancelled/
+      // completed the ride (offer timeout, system cancel, etc.) while the local
+      // store still showed it as active. Clear local state so the rider can
+      // navigate home — the ride is already done on the server.
+      if (
+        error instanceof SpinrApiError &&
+        error.status === 409 &&
+        TERMINAL_STATUSES.has(String(error.details?.current_status ?? ''))
+      ) {
+        set({ currentRide: null, currentDriver: null, isLoading: false });
+        AsyncStorage.removeItem(ACTIVE_RIDE_KEY).catch(() => {});
+        return;
+      }
       recordNonFatal(error, { store: 'rideStore', action: 'cancelRide' });
       set({ isLoading: false, error: isErrorLike(error) ? error.message : 'Failed to cancel ride' });
       throw error;


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Fix ride cancellation — enum `$in` serialization bug (Python 3.12), missing DB columns, stale-state 409 handling, and WS navigation gap
- **Type**: `fix`
- **Linked issue**: none — production regression found via Railway logs
- **Risk**: `medium` — touches the DB query layer (`_apply_filters`) used by many endpoints and the rider cancel flow; changes are narrowly scoped and additive-only
- **User-visible change**: `riders` — cancel button now works correctly in all states; rider is auto-navigated home when backend system-cancels a ride
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend  `[x]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[x]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `multi-surface`
- **Data schema change**: `additive` — migration 81 adds two `FLOAT NOT NULL DEFAULT 0` columns with `ADD COLUMN IF NOT EXISTS`; safe on running traffic
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — revert removes the `_Enum` unwrap in `_apply_filters` (restores broken behaviour) and the 409-handling branch in `rideStore`; migration 81 columns can stay (DEFAULT 0, no data loss)
- **Dependencies / coordination**: none — migration 81 uses `ADD COLUMN IF NOT EXISTS` so deploy order doesn't matter
- **Assumptions**: `_apply_filters` `$in` is the only call site that passes `RideStatus` enum instances; all other callers pass plain strings

## Tier 3 — Compliance flags

- `[ ]` Money-touching
- `[ ]` PIPEDA-relevant
- `[ ]` SK Transportation Act
- `[ ]` Auth / RLS
- `[ ]` Safety
- `[ ]` Third-party SDK added
- `[ ]` Breaking change to `shared/`

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — the `$in` serialization fix is a one-liner in a shared util; covered by existing integration tests that exercise cancel/state-guard paths
- **Integration tests**: `not-applicable` — verified against live Railway + Supabase; backend logs confirm 409 eliminated after deploy
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: not applicable (backend + store change only)
- **Perf numbers**: not applicable

**Pre-merge checklist**:

- [x] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [x] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

---

## Root causes fixed

### RC-8 — `_apply_filters` `$in` serializes enum repr to PostgREST

`str(RideStatus.SEARCHING)` returns `"RideStatus.SEARCHING"` in Python 3.12, not `"searching"`. `_apply_filters` passed raw enum instances to postgrest-py's `.in_()` which calls `str()` — so the URL contained `status=in.(RideStatus.SEARCHING,...)`. PostgREST found zero rows, state-guard raised `RIDE_INVALID_STATUS 409` on a perfectly legal cancel.

**Fix:** `backend/repositories/_base.py` — unwrap `Enum` instances to `.value` before `.in_()`.

### RC-7 — `cancellation_fee_admin` / `cancellation_fee_driver` columns missing from migrations

These columns exist in `supabase_schema.sql` but were never in the numbered migration sequence. Cancel endpoint wrote both unconditionally → PostgREST 400 → HTTP 500.

**Fix:** `backend/migrations/81_rides_cancellation_fee_columns.sql` — `ADD COLUMN IF NOT EXISTS`.

### RC-9 — `cancelRide` throws on 409 when ride is already terminal

If the system cancelled the ride moments before the rider tapped cancel, the store re-threw the 409 and showed "Could not cancel."

**Fix:** `rider-app/store/rideStore.ts` — detect 409 + terminal `current_status` and clear local state silently.

### RC-6 — WS `ride_cancelled` cleared store but never navigated

Rider stayed on `driver-arriving` with `currentRide = null`. Next cancel tap returned early (no HTTP request) — appeared as broken cancel with no backend log.

**Fix:** `rider-app/hooks/useRiderSocket.ts` — `router.replace('/(tabs)')` after `clearRide()`.

https://claude.ai/code/session_01L4CNRNKuXSxKTk374CkiW4

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
