### PR TITLE
fix(airport-fee): airport zones must be sub-regions; fee from child only

### DIFF
--- a/backend/features.py
+++ b/backend/features.py
@@ -107,23 +107,32 @@ async def calculate_airport_fee(
     Returns {'airport_fee': float, 'airport_zone_name': str | None,
     'is_pickup': bool, 'is_dropoff': bool, 'is_stop': bool}
     """
+
+    # Airport zone model:
+    #   service_areas is a parent/child tree. A "service area" is a top-level
+    #   row (e.g. Regina) with parent_service_area_id IS NULL. An "airport
+    #   zone" is a CHILD row (parent_service_area_id set) with is_airport=true,
+    #   its own polygon (just the airport property), and its own airport_fee.
+    #   The parent's airport_fee column is functionally dead and must be ignored
+    #   — surcharging by parent caused every Regina ride to look airport-bound.
+    # Only sub-regions matched + active + flagged + fee > 0 + valid polygon
+    # below count as airport zones.
+    def _is_real_airport_zone(a: Dict[str, Any]) -> bool:
+        return bool(
+            a.get("is_airport")
+            and a.get("is_active", True) is not False
+            and a.get("parent_service_area_id")  # must be a sub-region
+        )
+
     if _all_areas is not None:
-        # Filter strictly: only count an area as an airport zone when BOTH
-        # is_airport is truthy AND is_active is not False. A row that's been
-        # soft-deactivated in the admin (is_active=false) must not surcharge
-        # rides — that's the same intent as "remove this airport zone".
-        areas = [a for a in _all_areas if a.get("is_airport") and a.get("is_active", True) is not False]
+        areas = [a for a in _all_areas if _is_real_airport_zone(a)]
     else:
-        # Same intent at the DB layer: exclude soft-deactivated rows. Without
-        # the is_active filter, unchecking "Active" on an airport zone in the
-        # admin UI leaves the row matching every ride — the exact failure
-        # mode reported in the "I removed the airport zone but surcharge
-        # still applies" thread.
-        areas = await db_supabase.get_rows(
+        raw = await db_supabase.get_rows(
             "service_areas",
             {"is_airport": True, "is_active": True},
             limit=50,
         )
+        areas = [a for a in raw if a.get("parent_service_area_id")]
     result: Dict[str, Any] = {
         "airport_fee": 0.0,
         "airport_zone_name": None,
@@ -735,7 +744,15 @@ async def calculate_all_fees(
     # row (is_active=false) must not count as an airport zone, otherwise an
     # area_fees row with fee_type='airport' would still be gated to "in_airport"
     # against a ghost zone the admin thought they had removed.
-    airport_areas = [a for a in all_areas if a.get("is_airport") and a.get("is_active", True) is not False]
+    # Only sub-region rows (parent_service_area_id set) count as airport
+    # zones — same rule applied in calculate_airport_fee. A top-level row
+    # with is_airport=true is a misconfiguration and must not gate
+    # area_fees of fee_type='airport'.
+    airport_areas = [
+        a
+        for a in all_areas
+        if a.get("is_airport") and a.get("is_active", True) is not False and a.get("parent_service_area_id")
+    ]
     in_airport = False
     for ap in airport_areas:
         ap_poly = get_service_area_polygon(ap)

--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -86,6 +86,54 @@ def _guard_airport_polygon(is_airport: bool, polygon: Any) -> None:
         )
 
 
+def _guard_airport_is_subregion(is_airport: bool, parent_service_area_id: Optional[str]) -> None:
+    """Reject is_airport=true on a top-level row.
+
+    The data model is parent / child: a service area like Regina is a
+    top-level row (parent_service_area_id NULL); an airport zone like
+    YQR is a CHILD row under Regina. Letting a top-level row carry
+    is_airport=true is what produced the "every Regina ride gets the
+    surcharge" report — the city-sized polygon then matches every
+    pickup/dropoff.
+
+    The runtime helpers (calculate_airport_fee, calculate_all_fees)
+    already ignore top-level rows for the airport check; this guard
+    keeps the data shape consistent so a future regression can't
+    re-introduce the bug.
+    """
+    if is_airport and not parent_service_area_id:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "is_airport may only be set on a sub-region (a service area "
+                "with a parent_service_area_id). Top-level service areas "
+                "cannot be airport zones — create the airport as a child "
+                "row under its parent service area instead."
+            ),
+        )
+
+
+def _coerce_airport_fields(is_airport: Optional[bool], airport_fee: Optional[float]) -> Dict[str, Any]:
+    """Keep `is_airport` and `airport_fee` mutually consistent on writes.
+
+      * is_airport=false  → airport_fee must be 0
+      * airport_fee == 0  → is_airport must be false
+
+    Caller passes the values being written (None when unchanged). Returns
+    overrides to fold into the update payload. This makes "the admin
+    deletes the airport fee" automatically also turn off the zone, which
+    matches what an operator means when they zero the amount.
+    """
+    overrides: Dict[str, Any] = {}
+    if is_airport is False:
+        overrides["airport_fee"] = 0
+    if airport_fee is not None and float(airport_fee) == 0 and is_airport is not False:
+        # Treat explicit fee=0 as "this is no longer an airport zone" — also
+        # flip the flag off so future queries skip the row cleanly.
+        overrides["is_airport"] = False
+    return overrides
+
+
 # ---------- Pydantic models ----------
 
 
@@ -244,6 +292,8 @@ async def admin_airport_zones_diagnostic():
             continue
         bbox = _polygon_bbox_km(r.get("polygon"))
         too_large = bool(bbox and (bbox["lat_km"] > _AIRPORT_MAX_BBOX_KM or bbox["lng_km"] > _AIRPORT_MAX_BBOX_KM))
+        parent_id = r.get("parent_service_area_id")
+        is_top_level_with_flag = is_flagged and not parent_id
         out.append(
             {
                 "id": r.get("id"),
@@ -253,10 +303,11 @@ async def admin_airport_zones_diagnostic():
                 "is_airport_effective": is_flagged,
                 "airport_fee": fee,
                 "is_active": r.get("is_active"),
-                "parent_service_area_id": r.get("parent_service_area_id"),
+                "parent_service_area_id": parent_id,
                 "bbox_km": bbox,
                 "max_allowed_km": _AIRPORT_MAX_BBOX_KM,
-                "looks_misconfigured": too_large,
+                "looks_misconfigured": too_large or is_top_level_with_flag,
+                "is_top_level_with_airport_flag": is_top_level_with_flag,
             }
         )
 
@@ -305,6 +356,10 @@ async def admin_create_service_area(area: ServiceAreaCreateRequest, admin: dict 
     """Create service area with full configuration."""
     polygon = area.geojson if area.geojson is not None else area.polygon or []
     _guard_airport_polygon(area.is_airport, polygon)
+    _guard_airport_is_subregion(area.is_airport, area.parent_service_area_id)
+    coerced = _coerce_airport_fields(area.is_airport, area.airport_fee)
+    effective_is_airport = bool(coerced.get("is_airport", area.is_airport))
+    effective_airport_fee = coerced.get("airport_fee", area.airport_fee)
     surge_active = area.surge_active if area.surge_active is not None else (area.surge_enabled or False)
     doc = {
         "id": str(uuid.uuid4()),
@@ -313,8 +368,8 @@ async def admin_create_service_area(area: ServiceAreaCreateRequest, admin: dict 
         "polygon": polygon,
         "is_active": area.is_active,
         "parent_service_area_id": area.parent_service_area_id,
-        "is_airport": area.is_airport,
-        "airport_fee": area.airport_fee,
+        "is_airport": effective_is_airport,
+        "airport_fee": effective_airport_fee,
         "surge_active": surge_active,
         "surge_multiplier": area.surge_multiplier,
         "gst_enabled": area.gst_enabled,
@@ -366,12 +421,20 @@ async def admin_update_service_area(
 
     # Block "city polygon flipped to airport" — the failure mode that
     # surcharges every ride in town. Resolve the effective is_airport +
-    # polygon by overlaying the request on the current row before checking.
-    if area.is_airport is True or polygon is not None:
+    # polygon + parent by overlaying the request on the current row before
+    # checking. Same lookup also enforces the sub-region requirement so a
+    # top-level row cannot become an airport zone via an update.
+    if area.is_airport is True or polygon is not None or area.airport_fee is not None:
         existing = await db_supabase.find_one("service_areas", {"id": area_id}) or {}
         effective_is_airport = area.is_airport if area.is_airport is not None else existing.get("is_airport", False)
         effective_polygon = polygon if polygon is not None else existing.get("polygon")
+        effective_parent = (
+            area.parent_service_area_id
+            if area.parent_service_area_id is not None
+            else existing.get("parent_service_area_id")
+        )
         _guard_airport_polygon(bool(effective_is_airport), effective_polygon)
+        _guard_airport_is_subregion(bool(effective_is_airport), effective_parent)
 
     # Validate surge_multiplier at the API boundary (F-26).
     # fare_service.py always applies SURGE_CAP (2.5×) at calculation time, so
@@ -436,6 +499,13 @@ async def admin_update_service_area(
         update_payload["polygon"] = polygon
     if surge_active is not None:
         update_payload["surge_active"] = surge_active
+
+    # Keep is_airport <-> airport_fee consistent: deleting the fee turns the
+    # zone off; turning the zone off zeroes the fee. Operators can do either
+    # one and get the same end state.
+    coerced_airport = _coerce_airport_fields(area.is_airport, area.airport_fee)
+    for k, v in coerced_airport.items():
+        update_payload[k] = v
 
     if update_payload:
         # NOTE: service_areas table does not have an updated_at column in Supabase schema.


### PR DESCRIPTION
The data model is parent / child: a service area like Regina is a top-level row (parent_service_area_id NULL); an airport zone like YQR is a CHILD row under Regina with is_airport=true, its own narrow polygon, and its own airport_fee. The parent's airport_fee is functionally dead — surcharging by parent caused every Regina ride to look airport-bound.

Enforce that model end-to-end:

- backend/features.py:
  * calculate_airport_fee: only match sub-region rows (parent_service_area_id set + is_airport + is_active + fee > 0). The fee comes from the matching child, never the parent.
  * calculate_all_fees: same sub-region requirement for the `in_airport` gate used by area_fees of fee_type='airport'.

- backend/routes/admin/service_areas.py:
  * _guard_airport_is_subregion: reject is_airport=true on create/update of a top-level row (no parent).
  * _coerce_airport_fields: keep is_airport <-> airport_fee consistent on writes — setting airport_fee=0 flips is_airport=false, and is_airport=false zeroes the fee. Either of "delete the amount" or "uncheck the flag" reaches the same end state.
  * GET /admin/airport-zones/diagnostic: surfaces a new is_top_level_with_airport_flag flag and rolls it into looks_misconfigured so the offending row (e.g. Regina parent with the airport flag set) shows up immediately.

After this: only valid sub-region airport zones surcharge a ride. Top-level rows can never be airport zones, by data model and by runtime check. Deleting the fee (or the flag) is enough — no need to remember both.

https://claude.ai/code/session_0176Df2jeJ7fqPENGpa8Js89

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
