### PR TITLE
feat(admin): add /drivers/approval-queue endpoint for ops triage

### DIFF
--- a/admin-dashboard/src/app/dashboard/drivers/_components/document-reviewer.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/_components/document-reviewer.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    X,
+    Check,
+    XCircle,
+    ChevronLeft,
+    ChevronRight,
+    FileText,
+    Calendar,
+    ExternalLink,
+    Bell,
+    BellOff,
+    AlertCircle,
+    Loader2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import {
+    getDriverDocuments,
+    reviewDocument,
+    type RejectTemplate,
+} from "@/lib/api";
+
+interface DocumentReviewerProps {
+    open: boolean;
+    driverId: string | null;
+    driverName?: string | null;
+    onClose: () => void;
+    onAfterAction?: () => void;
+}
+
+type DocRow = {
+    id: string;
+    driver_id: string;
+    document_type?: string;
+    document_url?: string;
+    status?: string;
+    rejection_reason?: string | null;
+    uploaded_at?: string;
+    requirement_key?: string | null;
+    requirement_id?: string | null;
+    side?: string | null;
+};
+
+const TEMPLATES: { value: RejectTemplate; label: string; body: string }[] = [
+    { value: "blurry_image", label: "Blurry image", body: "We couldn't read your document clearly. Please re-upload a sharper photo." },
+    { value: "wrong_document_type", label: "Wrong document type", body: "The file you uploaded doesn't match what's required. Please upload the correct document." },
+    { value: "expired", label: "Expired document", body: "Your document appears expired. Please upload a current copy to continue driving." },
+    { value: "information_unclear", label: "Information unclear", body: "Some information on your document is unclear or unreadable. Please re-upload." },
+    { value: "other", label: "Other (write your own)", body: "" },
+];
+
+// Mirrors the backend `_REQUIREMENT_EXPIRY_FIELD_KEYWORDS` mapping. We use
+// this client-side heuristic so the reviewer can show "expiry required"
+// without a separate service-area fetch — the backend remains the source
+// of truth on whether the field actually propagates.
+const REQUIRES_EXPIRY_KEYWORDS = ["license", "driving", "permit", "insurance", "inspection", "background", "work", "eligibility"];
+const docRequiresExpiry = (doc: DocRow): boolean => {
+    const hay = `${doc.document_type || ""} ${doc.requirement_key || ""}`.toLowerCase();
+    return REQUIRES_EXPIRY_KEYWORDS.some((k) => hay.includes(k));
+};
+
+const isPdf = (url?: string) => !!url && /\.pdf(\?|#|$)/i.test(url);
+
+const statusTone = (status?: string) => {
+    switch (status) {
+        case "approved": return "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300";
+        case "rejected": return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
+        case "pending": return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300";
+        default: return "bg-muted text-muted-foreground";
+    }
+};
+
+export function DocumentReviewer({ open, driverId, driverName, onClose, onAfterAction }: DocumentReviewerProps) {
+    const { toast } = useToast();
+    const [docs, setDocs] = useState<DocRow[]>([]);
+    const [index, setIndex] = useState(0);
+    const [loading, setLoading] = useState(false);
+    const [busy, setBusy] = useState(false);
+    const [mode, setMode] = useState<"idle" | "approve" | "reject">("idle");
+    const [expiry, setExpiry] = useState("");
+    const [reason, setReason] = useState("");
+    const [template, setTemplate] = useState<RejectTemplate>("blurry_image");
+    const [notify, setNotify] = useState(true);
+    const reasonRef = useRef<HTMLTextAreaElement>(null);
+
+    const current = docs[index];
+    const needsExpiry = current ? docRequiresExpiry(current) : false;
+
+    const resetDocState = useCallback(() => {
+        setMode("idle");
+        setExpiry("");
+        setReason("");
+        setTemplate("blurry_image");
+        setNotify(true);
+    }, []);
+
+    useEffect(() => {
+        if (!open || !driverId) return;
+        setLoading(true);
+        setDocs([]);
+        setIndex(0);
+        resetDocState();
+        getDriverDocuments(driverId)
+            .then((arr) => {
+                const list: DocRow[] = Array.isArray(arr) ? arr : [];
+                setDocs(list);
+                const firstPending = list.findIndex((d) => d.status === "pending");
+                setIndex(firstPending >= 0 ? firstPending : 0);
+            })
+            .catch((e) => toast({ title: "Could not load documents", description: String(e?.message || e), variant: "destructive" }))
+            .finally(() => setLoading(false));
+    }, [open, driverId, toast, resetDocState]);
+
+    const goPrev = useCallback(() => { setIndex((i) => Math.max(0, i - 1)); resetDocState(); }, [resetDocState]);
+    const goNext = useCallback(() => { setIndex((i) => Math.min(docs.length - 1, i + 1)); resetDocState(); }, [docs.length, resetDocState]);
+
+    const submit = useCallback(async (status: "approved" | "rejected") => {
+        if (!current) return;
+        if (status === "approved" && needsExpiry && !expiry) {
+            toast({ title: "Expiry date required", description: "This document needs an expiry date before approval.", variant: "destructive" });
+            return;
+        }
+        if (status === "rejected") {
+            const templateMeta = TEMPLATES.find((t) => t.value === template);
+            const finalReason = template === "other" ? reason.trim() : (reason.trim() || templateMeta?.body || "");
+            if (!finalReason) {
+                toast({ title: "Reason required", description: "Pick a template or write a reason.", variant: "destructive" });
+                return;
+            }
+            setBusy(true);
+            try {
+                await reviewDocument(current.id, "rejected", finalReason, undefined, {
+                    notify,
+                    notifyTemplate: template,
+                });
+                toast({ title: "Document rejected", description: notify ? "Driver was notified." : "Rejected without notification." });
+            } catch (e) {
+                toast({ title: "Rejection failed", description: String((e as Error).message || e), variant: "destructive" });
+                setBusy(false);
+                return;
+            }
+        } else {
+            setBusy(true);
+            try {
+                await reviewDocument(current.id, "approved", undefined, expiry ? new Date(expiry).toISOString() : undefined);
+                toast({ title: "Document approved" });
+            } catch (e) {
+                toast({ title: "Approval failed", description: String((e as Error).message || e), variant: "destructive" });
+                setBusy(false);
+                return;
+            }
+        }
+
+        const newStatus = status;
+        setDocs((prev) => prev.map((d, i) => (i === index ? { ...d, status: newStatus } : d)));
+        onAfterAction?.();
+        setBusy(false);
+
+        const nextPending = docs.findIndex((d, i) => i > index && d.status === "pending");
+        if (nextPending >= 0) { setIndex(nextPending); resetDocState(); }
+        else resetDocState();
+    }, [current, needsExpiry, expiry, template, reason, notify, index, docs, onAfterAction, toast, resetDocState]);
+
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "Escape") { onClose(); return; }
+            const tag = (document.activeElement?.tagName || "").toLowerCase();
+            if (tag === "input" || tag === "textarea" || tag === "select") return;
+            const k = e.key.toLowerCase();
+            if (k === "j") { e.preventDefault(); goNext(); }
+            else if (k === "k") { e.preventDefault(); goPrev(); }
+            else if (k === "a" && current?.status === "pending") {
+                e.preventDefault();
+                if (mode !== "approve") setMode("approve");
+                else submit("approved");
+            }
+            else if (k === "r" && current?.status === "pending") {
+                e.preventDefault();
+                if (mode !== "reject") { setMode("reject"); setTimeout(() => reasonRef.current?.focus(), 0); }
+                else submit("rejected");
+            }
+        };
+        document.addEventListener("keydown", handler);
+        return () => document.removeEventListener("keydown", handler);
+    }, [open, onClose, goNext, goPrev, current?.status, mode, submit]);
+
+    const counter = useMemo(() => (docs.length ? `${index + 1} of ${docs.length}` : "0 of 0"), [docs.length, index]);
+
+    if (!open) return null;
+
+    return (
+        <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex flex-col" role="dialog" aria-modal="true" aria-label="Document reviewer">
+            <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-border bg-card">
+                <div className="flex items-center gap-3 min-w-0">
+                    <FileText className="h-5 w-5 text-muted-foreground shrink-0" />
+                    <div className="min-w-0">
+                        <p className="text-sm font-semibold truncate">{driverName || "Document Reviewer"}</p>
+                        <p className="text-xs text-muted-foreground">{counter} • {current?.document_type || "—"}</p>
+                    </div>
+                </div>
+                <div className="flex items-center gap-2">
+                    <span className="hidden md:inline text-[11px] text-muted-foreground">A approve · R reject · J/K next/prev · Esc close</span>
+                    <Button variant="ghost" size="sm" onClick={onClose}>
+                        <X className="h-4 w-4" />
+                    </Button>
+                </div>
+            </div>
+
+            {loading ? (
+                <div className="flex-1 flex items-center justify-center text-muted-foreground">
+                    <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading documents…
+                </div>
+            ) : !current ? (
+                <div className="flex-1 flex items-center justify-center text-muted-foreground">
+                    <div className="text-center">
+                        <FileText className="h-10 w-10 mx-auto opacity-30 mb-3" />
+                        <p className="text-sm font-medium">No documents to review</p>
+                        <p className="text-xs mt-1">This driver hasn&apos;t uploaded any documents yet.</p>
+                    </div>
+                </div>
+            ) : (
+                <div className="flex-1 grid grid-cols-1 lg:grid-cols-[1.6fr_1fr] overflow-hidden">
+                    <div className="bg-muted/30 flex items-center justify-center p-6 overflow-auto relative">
+                        {current.document_url ? (
+                            isPdf(current.document_url) ? (
+                                <embed src={current.document_url} type="application/pdf" className="w-full h-full rounded-lg shadow-md bg-white" />
+                            ) : (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img src={current.document_url} alt={current.document_type || "Document"} className="max-w-full max-h-full object-contain rounded-lg shadow-md" />
+                            )
+                        ) : (
+                            <div className="text-center text-muted-foreground">
+                                <AlertCircle className="h-10 w-10 mx-auto opacity-30 mb-3" />
+                                <p className="text-sm">No file URL on this document.</p>
+                            </div>
+                        )}
+                        {current.document_url && (
+                            <a href={current.document_url} target="_blank" rel="noreferrer" className="absolute top-3 right-3 bg-card/90 hover:bg-card border border-border rounded-lg px-2 py-1 text-xs font-medium flex items-center gap-1.5">
+                                <ExternalLink className="h-3.5 w-3.5" /> Open original
+                            </a>
+                        )}
+                    </div>
+
+                    <div className="border-l border-border bg-card flex flex-col overflow-hidden">
+                        <div className="px-5 py-4 border-b border-border space-y-3">
+                            <div className="flex items-center justify-between gap-2">
+                                <div className="min-w-0">
+                                    <h3 className="text-sm font-semibold truncate">{current.document_type || "Document"}</h3>
+                                    {current.side && <p className="text-xs text-muted-foreground">Side: {current.side}</p>}
+                                </div>
+                                <Badge className={statusTone(current.status)}>{current.status || "unknown"}</Badge>
+                            </div>
+                            <div className="grid grid-cols-2 gap-3 text-xs">
+                                <div>
+                                    <p className="text-muted-foreground">Uploaded</p>
+                                    <p className="font-medium">{current.uploaded_at ? new Date(current.uploaded_at).toLocaleDateString() : "—"}</p>
+                                </div>
+                                <div>
+                                    <p className="text-muted-foreground">Requirement</p>
+                                    <p className="font-medium truncate">{current.requirement_key || current.requirement_id || "—"}</p>
+                                </div>
+                            </div>
+                            {current.rejection_reason && current.status === "rejected" && (
+                                <div className="rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 px-3 py-2 text-xs text-red-700 dark:text-red-300">
+                                    <span className="font-semibold">Prior reason:</span> {current.rejection_reason}
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+                            {current.status === "pending" ? (
+                                <>
+                                    <div className="flex gap-2">
+                                        <Button
+                                            onClick={() => setMode("approve")}
+                                            variant={mode === "approve" ? "default" : "outline"}
+                                            className={mode === "approve" ? "flex-1 bg-emerald-600 hover:bg-emerald-700 text-white" : "flex-1"}
+                                            disabled={busy}
+                                        >
+                                            <Check className="h-4 w-4 mr-1.5" /> Approve
+                                        </Button>
+                                        <Button
+                                            onClick={() => { setMode("reject"); setTimeout(() => reasonRef.current?.focus(), 0); }}
+                                            variant={mode === "reject" ? "default" : "outline"}
+                                            className={mode === "reject" ? "flex-1 bg-red-600 hover:bg-red-700 text-white" : "flex-1"}
+                                            disabled={busy}
+                                        >
+                                            <XCircle className="h-4 w-4 mr-1.5" /> Reject
+                                        </Button>
+                                    </div>
+
+                                    {mode === "approve" && (
+                                        <div className="space-y-3 rounded-lg border border-emerald-200 dark:border-emerald-800 bg-emerald-50/40 dark:bg-emerald-900/10 p-3">
+                                            <label htmlFor="reviewer-expiry" className="text-xs font-medium flex items-center gap-1.5">
+                                                <Calendar className="h-3.5 w-3.5" />
+                                                Expiry date {needsExpiry && <span className="text-red-500">*</span>}
+                                                {!needsExpiry && <span className="text-muted-foreground font-normal">(optional)</span>}
+                                            </label>
+                                            <Input id="reviewer-expiry" type="date" value={expiry} onChange={(e) => setExpiry(e.target.value)} className="h-9" />
+                                            <Button onClick={() => submit("approved")} disabled={busy || (needsExpiry && !expiry)} className="w-full bg-emerald-600 hover:bg-emerald-700 text-white">
+                                                {busy ? <Loader2 className="h-4 w-4 animate-spin mr-1.5" /> : <Check className="h-4 w-4 mr-1.5" />}
+                                                Confirm approval
+                                            </Button>
+                                        </div>
+                                    )}
+
+                                    {mode === "reject" && (
+                                        <div className="space-y-3 rounded-lg border border-red-200 dark:border-red-800 bg-red-50/40 dark:bg-red-900/10 p-3">
+                                            <p className="text-xs font-medium">Reason template</p>
+                                            <Select value={template} onValueChange={(v) => {
+                                                const tmpl = v as RejectTemplate;
+                                                setTemplate(tmpl);
+                                                const m = TEMPLATES.find((t) => t.value === tmpl);
+                                                if (m && tmpl !== "other") setReason(m.body);
+                                                else if (tmpl === "other") setReason("");
+                                            }}>
+                                                <SelectTrigger className="h-9 text-xs"><SelectValue /></SelectTrigger>
+                                                <SelectContent>
+                                                    {TEMPLATES.map((t) => <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>)}
+                                                </SelectContent>
+                                            </Select>
+
+                                            <label htmlFor="reviewer-reason" className="text-xs font-medium">Reason text {template === "other" && <span className="text-red-500">*</span>}</label>
+                                            <Textarea id="reviewer-reason" ref={reasonRef} value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Explain why this is rejected…" className="text-sm min-h-[80px]" />
+
+                                            <label className="flex items-start gap-2 cursor-pointer text-xs">
+                                                <input type="checkbox" checked={notify} onChange={(e) => setNotify(e.target.checked)} className="mt-0.5" />
+                                                <span className="flex items-center gap-1.5">
+                                                    {notify ? <Bell className="h-3.5 w-3.5 text-blue-600" /> : <BellOff className="h-3.5 w-3.5 text-muted-foreground" />}
+                                                    Notify driver via push so they can re-upload
+                                                </span>
+                                            </label>
+
+                                            <Button onClick={() => submit("rejected")} disabled={busy} className="w-full bg-red-600 hover:bg-red-700 text-white">
+                                                {busy ? <Loader2 className="h-4 w-4 animate-spin mr-1.5" /> : <XCircle className="h-4 w-4 mr-1.5" />}
+                                                Confirm rejection
+                                            </Button>
+                                        </div>
+                                    )}
+                                </>
+                            ) : (
+                                <div className="rounded-lg bg-muted/30 border border-border p-3 text-xs text-muted-foreground">
+                                    This document is already <span className="font-semibold text-foreground">{current.status}</span>. Use the driver detail sheet to override.
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="border-t border-border px-5 py-3 flex items-center justify-between bg-muted/20">
+                            <Button variant="ghost" size="sm" onClick={goPrev} disabled={index === 0}>
+                                <ChevronLeft className="h-4 w-4 mr-1" /> Prev
+                            </Button>
+                            <span className="text-xs text-muted-foreground tabular-nums">{counter}</span>
+                            <Button variant="ghost" size="sm" onClick={goNext} disabled={index >= docs.length - 1}>
+                                Next <ChevronRight className="h-4 w-4 ml-1" />
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/drivers/expiring/loading.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/expiring/loading.tsx
@@ -1,0 +1,30 @@
+export default function ExpiringLoading() {
+    return (
+        <div aria-busy="true" aria-label="Loading expiring documents" className="space-y-4 animate-pulse">
+            <div className="flex items-center justify-between">
+                <div className="h-7 w-44 rounded-lg bg-muted" />
+                <div className="h-9 w-28 rounded-lg bg-muted" />
+            </div>
+            <div className="flex gap-2">
+                <div className="h-8 w-16 rounded-full bg-muted" />
+                <div className="h-8 w-16 rounded-full bg-muted" />
+                <div className="h-8 w-16 rounded-full bg-muted" />
+            </div>
+            <div className="rounded-xl border border-border overflow-hidden">
+                <div className="h-11 bg-muted/60" />
+                {Array.from({ length: 8 }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-4 border-t border-border px-4 py-4">
+                        <div className="h-10 w-10 rounded-full bg-muted shrink-0" />
+                        <div className="flex-1 space-y-1.5">
+                            <div className="h-3.5 w-32 rounded bg-muted" />
+                            <div className="h-3 w-44 rounded bg-muted" />
+                        </div>
+                        <div className="h-5 w-20 rounded-full bg-muted" />
+                        <div className="h-4 w-16 rounded bg-muted" />
+                        <div className="h-8 w-20 rounded bg-muted" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/drivers/expiring/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/expiring/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+    RefreshCw,
+    Filter,
+    Bell,
+    Calendar,
+    AlertTriangle,
+    Inbox,
+    Car,
+    Loader2,
+} from "lucide-react";
+import {
+    getExpiringDocs,
+    getServiceAreas,
+    nudgeDriverExpiry,
+    type ExpiringDocItem,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { useRequireModule } from "@/hooks/useRequireModule";
+
+type Window = 7 | 14 | 30;
+
+const daysTone = (days: number) => {
+    if (days < 7) return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300 border-red-200 dark:border-red-800";
+    if (days < 14) return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-800";
+    return "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800";
+};
+
+const initials = (name: string) => {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (!parts.length) return "?";
+    return (parts[0][0] + (parts[1]?.[0] || "")).toUpperCase();
+};
+
+const fmtDate = (iso: string) => {
+    try { return new Date(iso).toLocaleDateString("en-CA", { month: "short", day: "numeric", year: "numeric" }); }
+    catch { return iso; }
+};
+
+export default function ExpiringDocsPage() {
+    const { allowed } = useRequireModule("drivers");
+    const { toast } = useToast();
+    const [items, setItems] = useState<ExpiringDocItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
+    const [windowDays, setWindowDays] = useState<Window>(30);
+    const [serviceAreaId, setServiceAreaId] = useState("all");
+    const [serviceAreas, setServiceAreas] = useState<Array<{ id: string; name?: string }>>([]);
+    const [nudgingDriverDoc, setNudgingDriverDoc] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        try {
+            setRefreshing(true);
+            const data = await getExpiringDocs({
+                window_days: windowDays,
+                service_area_id: serviceAreaId !== "all" ? serviceAreaId : undefined,
+            });
+            setItems(data?.items || []);
+        } catch (e) {
+            toast({ title: "Failed to load expiring docs", description: String((e as Error).message || e), variant: "destructive" });
+        } finally {
+            setLoading(false);
+            setRefreshing(false);
+        }
+    }, [windowDays, serviceAreaId, toast]);
+
+    useEffect(() => { if (allowed) load(); }, [allowed, load]);
+    useEffect(() => { getServiceAreas().then((rows) => setServiceAreas(rows || [])).catch(() => {}); }, []);
+
+    const handleNudge = async (it: ExpiringDocItem) => {
+        const key = `${it.driver_id}:${it.doc_type}`;
+        setNudgingDriverDoc(key);
+        try {
+            await nudgeDriverExpiry(it.driver_id, { doc_type: it.doc_type, doc_label: it.doc_label });
+            toast({ title: "Reminder sent", description: `${it.name} — ${it.doc_label}` });
+            load();
+        } catch (e) {
+            toast({ title: "Nudge failed", description: String((e as Error).message || e), variant: "destructive" });
+        } finally {
+            setNudgingDriverDoc(null);
+        }
+    };
+
+    const counts = useMemo(() => {
+        const c = { lt7: 0, lt14: 0, all: items.length };
+        for (const it of items) {
+            if (it.days_remaining < 7) c.lt7++;
+            if (it.days_remaining < 14) c.lt14++;
+        }
+        return c;
+    }, [items]);
+
+    if (!allowed) return null;
+    if (loading) return null;
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                    <h1 className="text-xl font-bold tracking-tight">Expiring Documents</h1>
+                    <p className="text-sm text-muted-foreground mt-0.5">
+                        Drivers whose licence, insurance, inspection, or background check expires soon. Nudge them before they get blocked at go-online.
+                    </p>
+                </div>
+                <Button variant="outline" size="sm" onClick={load} disabled={refreshing}>
+                    <RefreshCw className={`h-4 w-4 mr-1.5 ${refreshing ? "animate-spin" : ""}`} />
+                    Refresh
+                </Button>
+            </div>
+
+            <div className="flex items-center gap-3 flex-wrap">
+                <div className="flex items-center gap-1.5 rounded-lg border border-border bg-card p-1">
+                    {([7, 14, 30] as Window[]).map((w) => (
+                        <button
+                            key={w}
+                            type="button"
+                            onClick={() => setWindowDays(w)}
+                            className={`text-xs font-medium px-3 py-1.5 rounded-md transition-colors ${
+                                windowDays === w
+                                    ? "bg-foreground text-background"
+                                    : "text-muted-foreground hover:text-foreground"
+                            }`}
+                        >
+                            {w}d
+                        </button>
+                    ))}
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <Filter className="h-4 w-4 text-muted-foreground" />
+                    <Select value={serviceAreaId} onValueChange={setServiceAreaId}>
+                        <SelectTrigger className="h-8 w-48 text-xs">
+                            <SelectValue placeholder="All areas" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">All areas</SelectItem>
+                            {serviceAreas.map((a) => (
+                                <SelectItem key={a.id} value={a.id}>{a.name || a.id.slice(0, 8)}</SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <div className="ml-auto flex items-center gap-3 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1.5">
+                        <AlertTriangle className="h-3.5 w-3.5 text-red-600" />
+                        {counts.lt7} urgent
+                    </span>
+                    <span className="inline-flex items-center gap-1.5">
+                        <Calendar className="h-3.5 w-3.5 text-amber-600" />
+                        {counts.lt14} within 14d
+                    </span>
+                    <span className="inline-flex items-center gap-1.5">
+                        <Car className="h-3.5 w-3.5" />
+                        {counts.all} total
+                    </span>
+                </div>
+            </div>
+
+            <div className="rounded-xl border border-border overflow-hidden bg-card">
+                <div className="grid grid-cols-[1fr_180px_140px_120px_100px_120px_120px] gap-4 px-4 py-3 bg-muted/30 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    <div>Driver</div>
+                    <div>Document</div>
+                    <div>Expiry</div>
+                    <div>Days left</div>
+                    <div>Rides 30d</div>
+                    <div>Last nudge</div>
+                    <div className="text-right">Action</div>
+                </div>
+
+                {items.length === 0 ? (
+                    <div className="px-6 py-16 text-center text-muted-foreground">
+                        <Inbox className="h-10 w-10 mx-auto mb-3 opacity-30" />
+                        <p className="text-sm font-medium">Nothing expiring in this window</p>
+                        <p className="text-xs mt-1">All drivers are good for the next {windowDays} days.</p>
+                    </div>
+                ) : (
+                    items.map((it) => {
+                        const key = `${it.driver_id}:${it.doc_type}`;
+                        const isBusy = nudgingDriverDoc === key;
+                        return (
+                            <div
+                                key={key}
+                                className="grid grid-cols-[1fr_180px_140px_120px_100px_120px_120px] gap-4 items-center px-4 py-3 border-t border-border hover:bg-muted/20 transition-colors"
+                            >
+                                <div className="flex items-center gap-3 min-w-0">
+                                    {it.profile_photo_url ? (
+                                        // eslint-disable-next-line @next/next/no-img-element
+                                        <img src={it.profile_photo_url} alt="" className="h-9 w-9 rounded-full object-cover shrink-0" />
+                                    ) : (
+                                        <div className="h-9 w-9 rounded-full bg-muted flex items-center justify-center text-xs font-semibold text-muted-foreground shrink-0">
+                                            {initials(it.name || it.email || "?")}
+                                        </div>
+                                    )}
+                                    <div className="min-w-0">
+                                        <p className="text-sm font-medium truncate">{it.name || "(no name)"}</p>
+                                        <p className="text-xs text-muted-foreground truncate">
+                                            {it.service_area_name || it.email || it.phone || "—"}
+                                        </p>
+                                    </div>
+                                </div>
+                                <div className="text-sm truncate" title={it.doc_label}>{it.doc_label}</div>
+                                <div className="text-xs text-muted-foreground">{fmtDate(it.expiry_date)}</div>
+                                <div>
+                                    <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border ${daysTone(it.days_remaining)}`}>
+                                        {it.days_remaining}d
+                                    </span>
+                                </div>
+                                <div className="text-sm tabular-nums">{it.rides_last_30d}</div>
+                                <div className="text-xs text-muted-foreground">
+                                    {it.last_nudged_at ? fmtDate(it.last_nudged_at) : "—"}
+                                </div>
+                                <div className="text-right">
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        className="h-8"
+                                        disabled={isBusy}
+                                        onClick={() => handleNudge(it)}
+                                    >
+                                        {isBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : <Bell className="h-3.5 w-3.5 mr-1" />}
+                                        Nudge
+                                    </Button>
+                                </div>
+                            </div>
+                        );
+                    })
+                )}
+            </div>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -13,7 +13,8 @@ import { Sheet, SheetContent, SheetTitle, SheetDescription } from "@/components/
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Search, Users, Wifi, ShieldCheck, ShieldAlert, Download, X, Star, Car, MapPin, CreditCard, Clock, DollarSign, CheckCircle, XCircle, FileText, Phone, Mail, CalendarRange, ExternalLink, Copy, AlertTriangle, ZoomIn, Image, Pencil, Save, Loader2, Eye, ArrowUpDown, ArrowUp, ArrowDown, Ban, Pause } from "lucide-react";
+import { Search, Users, Wifi, ShieldCheck, ShieldAlert, Download, X, Star, Car, MapPin, CreditCard, Clock, DollarSign, CheckCircle, XCircle, FileText, Phone, Mail, CalendarRange, ExternalLink, Copy, AlertTriangle, ZoomIn, Image, Pencil, Save, Loader2, Eye, ArrowUpDown, ArrowUp, ArrowDown, Ban, Pause, Maximize2 } from "lucide-react";
+import { DocumentReviewer } from "./_components/document-reviewer";
 import DriverStatsCards from "./_components/driver-stats-cards";
 import DriverCharts from "./_components/driver-charts";
 import AreaStatsTable from "./_components/area-stats-table";
@@ -57,6 +58,7 @@ export default function DriversPage() {
     const [reviewExpiry, setReviewExpiry] = useState("");
     const [reviewReason, setReviewReason] = useState("");
     const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [openReviewerForDriver, setOpenReviewerForDriver] = useState<{ id: string; name: string } | null>(null);
     const [editing, setEditing] = useState(false);
     const [editForm, setEditForm] = useState<Record<string, any>>({});
     const [saving, setSaving] = useState(false);
@@ -666,6 +668,20 @@ export default function DriversPage() {
 
                                 {/* Documents */}
                                 <TabsContent value="documents" className="mt-4 space-y-6">
+                                    <div className="flex items-center justify-between gap-2 -mt-1">
+                                        <p className="text-xs text-muted-foreground">
+                                            Review docs inline below, or open the full-screen reviewer for keyboard-driven triage.
+                                        </p>
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            className="h-8"
+                                            onClick={() => setOpenReviewerForDriver({ id: selected.id, name: selected.name || selected.email || selected.id })}
+                                        >
+                                            <Maximize2 className="h-3.5 w-3.5 mr-1.5" />
+                                            Open in Reviewer
+                                        </Button>
+                                    </div>
                                     <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                                         {docsLoading ? (
                                             <>{[1,2,3,4,5].map(i => <div key={i} className="h-24 bg-muted rounded-xl animate-pulse" />)}</>
@@ -823,6 +839,14 @@ export default function DriversPage() {
                     </>)}
                 </SheetContent>
             </Sheet>
+
+            <DocumentReviewer
+                open={!!openReviewerForDriver}
+                driverId={openReviewerForDriver?.id || null}
+                driverName={openReviewerForDriver?.name}
+                onClose={() => setOpenReviewerForDriver(null)}
+                onAfterAction={() => { reloadDriverDocs(); loadData(); loadDrivers(); }}
+            />
 
             {previewUrl && (
                 <div className="fixed inset-0 z-[100] bg-black/80 flex items-center justify-center p-8 cursor-pointer" onClick={() => setPreviewUrl(null)} role="dialog" aria-modal="true" aria-label="Document preview">

--- a/admin-dashboard/src/app/dashboard/drivers/queue/_components/queue-stats.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/queue/_components/queue-stats.tsx
@@ -1,0 +1,73 @@
+import { Clock, AlertTriangle, TrendingUp, Users } from "lucide-react";
+import type { ApprovalQueueResponse } from "@/lib/api";
+
+interface QueueStatsProps {
+    stats: ApprovalQueueResponse["stats"];
+}
+
+const formatHours = (h: number) => {
+    if (!h) return "0h";
+    if (h < 1) return `${Math.round(h * 60)}m`;
+    if (h < 24) return `${h.toFixed(1)}h`;
+    return `${Math.floor(h / 24)}d ${Math.round(h % 24)}h`;
+};
+
+export function QueueStats({ stats }: QueueStatsProps) {
+    const cards = [
+        {
+            label: "Pending",
+            value: String(stats.total_pending),
+            icon: Users,
+            tone: "blue" as const,
+        },
+        {
+            label: "Median wait",
+            value: formatHours(stats.median_wait_hours),
+            icon: Clock,
+            tone: stats.median_wait_hours >= 24 ? ("red" as const)
+                : stats.median_wait_hours >= 4 ? ("amber" as const)
+                : ("emerald" as const),
+        },
+        {
+            label: "Oldest in queue",
+            value: formatHours(stats.oldest_in_queue_hours),
+            icon: TrendingUp,
+            tone: stats.oldest_in_queue_hours >= 24 ? ("red" as const)
+                : stats.oldest_in_queue_hours >= 4 ? ("amber" as const)
+                : ("emerald" as const),
+        },
+        {
+            label: "Over 24h",
+            value: String(stats.over_24h_count),
+            icon: AlertTriangle,
+            tone: stats.over_24h_count > 0 ? ("red" as const) : ("emerald" as const),
+        },
+    ];
+
+    return (
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+            {cards.map((c) => {
+                const Icon = c.icon;
+                const toneClass = {
+                    blue: "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300",
+                    emerald: "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300",
+                    amber: "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300",
+                    red: "bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300",
+                }[c.tone];
+                return (
+                    <div key={c.label} className="rounded-xl border border-border bg-card p-4">
+                        <div className="flex items-start justify-between gap-3">
+                            <div>
+                                <p className="text-[11px] uppercase tracking-wider font-semibold text-muted-foreground">{c.label}</p>
+                                <p className="mt-1 text-2xl font-bold tracking-tight">{c.value}</p>
+                            </div>
+                            <div className={`h-9 w-9 rounded-lg flex items-center justify-center ${toneClass}`}>
+                                <Icon className="h-4 w-4" />
+                            </div>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/drivers/queue/loading.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/queue/loading.tsx
@@ -1,0 +1,30 @@
+export default function QueueLoading() {
+    return (
+        <div aria-busy="true" aria-label="Loading approval queue" className="space-y-4 animate-pulse">
+            <div className="flex items-center justify-between">
+                <div className="h-7 w-44 rounded-lg bg-muted" />
+                <div className="h-9 w-28 rounded-lg bg-muted" />
+            </div>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                    <div key={i} className="h-24 rounded-xl bg-muted" />
+                ))}
+            </div>
+            <div className="rounded-xl border border-border overflow-hidden">
+                <div className="h-11 bg-muted/60" />
+                {Array.from({ length: 8 }).map((_, i) => (
+                    <div key={i} className="flex items-center gap-4 border-t border-border px-4 py-4">
+                        <div className="h-10 w-10 rounded-full bg-muted shrink-0" />
+                        <div className="flex-1 space-y-1.5">
+                            <div className="h-3.5 w-32 rounded bg-muted" />
+                            <div className="h-3 w-44 rounded bg-muted" />
+                        </div>
+                        <div className="h-5 w-16 rounded-full bg-muted" />
+                        <div className="h-4 w-20 rounded bg-muted" />
+                        <div className="h-8 w-20 rounded bg-muted" />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/drivers/queue/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/queue/page.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+    RefreshCw,
+    FileWarning,
+    FileCheck,
+    ChevronRight,
+    Filter,
+    Inbox,
+} from "lucide-react";
+import {
+    getApprovalQueue,
+    getServiceAreas,
+    type ApprovalQueueItem,
+    type ApprovalQueueResponse,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { useRequireModule } from "@/hooks/useRequireModule";
+import { QueueStats } from "./_components/queue-stats";
+
+const formatTimeInQueue = (seconds: number) => {
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    const remM = m % 60;
+    if (h < 24) return remM ? `${h}h ${remM}m` : `${h}h`;
+    const d = Math.floor(h / 24);
+    const remH = h % 24;
+    return remH ? `${d}d ${remH}h` : `${d}d`;
+};
+
+const slaTone = (seconds: number) => {
+    if (seconds >= 86400) return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300 border-red-200 dark:border-red-800";
+    if (seconds >= 14400) return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300 border-amber-200 dark:border-amber-800";
+    return "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800";
+};
+
+const initials = (name: string) => {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (!parts.length) return "?";
+    return (parts[0][0] + (parts[1]?.[0] || "")).toUpperCase();
+};
+
+export default function ApprovalQueuePage() {
+    const { allowed: moduleAllowed } = useRequireModule("drivers");
+    const { toast } = useToast();
+    const [resp, setResp] = useState<ApprovalQueueResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [serviceAreaId, setServiceAreaId] = useState<string>("all");
+    const [serviceAreas, setServiceAreas] = useState<Array<{ id: string; name?: string }>>([]);
+    const [refreshing, setRefreshing] = useState(false);
+
+    const load = useCallback(async () => {
+        try {
+            setRefreshing(true);
+            const data = await getApprovalQueue({
+                limit: 200,
+                service_area_id: serviceAreaId !== "all" ? serviceAreaId : undefined,
+            });
+            setResp(data);
+        } catch (e) {
+            toast({ title: "Failed to load queue", description: String((e as Error).message || e), variant: "destructive" });
+        } finally {
+            setLoading(false);
+            setRefreshing(false);
+        }
+    }, [serviceAreaId, toast]);
+
+    useEffect(() => {
+        if (!moduleAllowed) return;
+        load();
+    }, [moduleAllowed, load]);
+
+    useEffect(() => {
+        getServiceAreas().then((rows) => setServiceAreas(rows || [])).catch(() => {});
+    }, []);
+
+    const items: ApprovalQueueItem[] = useMemo(() => resp?.items || [], [resp]);
+    const stats = resp?.stats || { total_pending: 0, oldest_in_queue_hours: 0, median_wait_hours: 0, over_24h_count: 0 };
+
+    if (!moduleAllowed) return null;
+    if (loading) return null; // loading.tsx handles initial state
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                    <h1 className="text-xl font-bold tracking-tight">Approval Queue</h1>
+                    <p className="text-sm text-muted-foreground mt-0.5">
+                        Oldest-first applicants and re-uploads waiting on a reviewer.
+                    </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Button variant="outline" size="sm" onClick={load} disabled={refreshing}>
+                        <RefreshCw className={`h-4 w-4 mr-1.5 ${refreshing ? "animate-spin" : ""}`} />
+                        Refresh
+                    </Button>
+                </div>
+            </div>
+
+            <QueueStats stats={stats} />
+
+            <div className="flex items-center gap-2 flex-wrap">
+                <Filter className="h-4 w-4 text-muted-foreground" />
+                <span className="text-xs font-medium text-muted-foreground">Service area</span>
+                <Select value={serviceAreaId} onValueChange={setServiceAreaId}>
+                    <SelectTrigger className="h-8 w-48 text-xs">
+                        <SelectValue placeholder="All areas" />
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="all">All areas</SelectItem>
+                        {serviceAreas.map((a) => (
+                            <SelectItem key={a.id} value={a.id}>{a.name || a.id.slice(0, 8)}</SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+
+            <div className="rounded-xl border border-border overflow-hidden bg-card">
+                <div className="grid grid-cols-[1fr_120px_110px_110px_150px_120px_100px] gap-4 px-4 py-3 bg-muted/30 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    <div>Applicant</div>
+                    <div>Status</div>
+                    <div>Pending</div>
+                    <div>Missing</div>
+                    <div>Time in queue</div>
+                    <div>Service area</div>
+                    <div className="text-right">Action</div>
+                </div>
+
+                {items.length === 0 ? (
+                    <div className="px-6 py-16 text-center text-muted-foreground">
+                        <Inbox className="h-10 w-10 mx-auto mb-3 opacity-30" />
+                        <p className="text-sm font-medium">Queue is empty</p>
+                        <p className="text-xs mt-1">No drivers waiting on approval right now.</p>
+                    </div>
+                ) : (
+                    items.map((it) => (
+                        <div
+                            key={it.driver_id}
+                            className="grid grid-cols-[1fr_120px_110px_110px_150px_120px_100px] gap-4 items-center px-4 py-3 border-t border-border hover:bg-muted/20 transition-colors"
+                        >
+                            <div className="flex items-center gap-3 min-w-0">
+                                {it.profile_photo_url ? (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img src={it.profile_photo_url} alt="" className="h-9 w-9 rounded-full object-cover shrink-0" />
+                                ) : (
+                                    <div className="h-9 w-9 rounded-full bg-muted flex items-center justify-center text-xs font-semibold text-muted-foreground shrink-0">
+                                        {initials(it.name || it.email || "?")}
+                                    </div>
+                                )}
+                                <div className="min-w-0">
+                                    <p className="text-sm font-medium truncate">{it.name || "(no name)"}</p>
+                                    <p className="text-xs text-muted-foreground truncate">{it.email || it.phone || it.driver_id.slice(0, 8)}</p>
+                                </div>
+                            </div>
+                            <div>
+                                <Badge
+                                    variant="outline"
+                                    className={
+                                        it.status === "pending"
+                                            ? "bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 border-blue-200 dark:border-blue-800"
+                                            : "bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300 border-amber-200 dark:border-amber-800"
+                                    }
+                                >
+                                    {it.status}
+                                </Badge>
+                            </div>
+                            <div className="text-sm tabular-nums">
+                                {it.pending_docs_count > 0 ? (
+                                    <span className="inline-flex items-center gap-1 font-medium">
+                                        <FileWarning className="h-3.5 w-3.5 text-amber-600" />
+                                        {it.pending_docs_count}
+                                    </span>
+                                ) : (
+                                    <span className="text-muted-foreground">0</span>
+                                )}
+                            </div>
+                            <div className="text-sm tabular-nums">
+                                {it.missing_docs_count > 0 ? (
+                                    <span className="inline-flex items-center gap-1 font-medium text-red-600 dark:text-red-400">
+                                        <FileWarning className="h-3.5 w-3.5" />
+                                        {it.missing_docs_count}
+                                    </span>
+                                ) : (
+                                    <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                                        <FileCheck className="h-3.5 w-3.5" />
+                                        0
+                                    </span>
+                                )}
+                            </div>
+                            <div>
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium border ${slaTone(it.time_in_queue_seconds)}`}>
+                                    {formatTimeInQueue(it.time_in_queue_seconds)}
+                                </span>
+                            </div>
+                            <div className="text-xs text-muted-foreground truncate">
+                                {it.service_area_name || "—"}
+                            </div>
+                            <div className="text-right">
+                                <Link href="/dashboard/drivers">
+                                    <Button size="sm" variant="default" className="h-8">
+                                        Review
+                                        <ChevronRight className="h-3.5 w-3.5 ml-0.5" />
+                                    </Button>
+                                </Link>
+                            </div>
+                        </div>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/drivers/queue/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/queue/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import {
     RefreshCw,
     FileWarning,
@@ -28,6 +27,7 @@ import {
 import { useToast } from "@/components/ui/use-toast";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { QueueStats } from "./_components/queue-stats";
+import { DocumentReviewer } from "../_components/document-reviewer";
 
 const formatTimeInQueue = (seconds: number) => {
     if (seconds < 60) return `${seconds}s`;
@@ -61,6 +61,7 @@ export default function ApprovalQueuePage() {
     const [serviceAreaId, setServiceAreaId] = useState<string>("all");
     const [serviceAreas, setServiceAreas] = useState<Array<{ id: string; name?: string }>>([]);
     const [refreshing, setRefreshing] = useState(false);
+    const [reviewerDriver, setReviewerDriver] = useState<{ id: string; name: string } | null>(null);
 
     const load = useCallback(async () => {
         try {
@@ -209,17 +210,28 @@ export default function ApprovalQueuePage() {
                                 {it.service_area_name || "—"}
                             </div>
                             <div className="text-right">
-                                <Link href="/dashboard/drivers">
-                                    <Button size="sm" variant="default" className="h-8">
-                                        Review
-                                        <ChevronRight className="h-3.5 w-3.5 ml-0.5" />
-                                    </Button>
-                                </Link>
+                                <Button
+                                    size="sm"
+                                    variant="default"
+                                    className="h-8"
+                                    onClick={() => setReviewerDriver({ id: it.driver_id, name: it.name || it.email || it.driver_id })}
+                                >
+                                    Review
+                                    <ChevronRight className="h-3.5 w-3.5 ml-0.5" />
+                                </Button>
                             </div>
                         </div>
                     ))
                 )}
             </div>
+
+            <DocumentReviewer
+                open={!!reviewerDriver}
+                driverId={reviewerDriver?.id || null}
+                driverName={reviewerDriver?.name}
+                onClose={() => setReviewerDriver(null)}
+                onAfterAction={load}
+            />
         </div>
     );
 }

--- a/admin-dashboard/src/components/sidebar.tsx
+++ b/admin-dashboard/src/components/sidebar.tsx
@@ -8,6 +8,7 @@ import {
     Flame, Building2, LifeBuoy, HelpCircle,
     LogOut, Menu, X, ChevronLeft, ChevronRight,
     Sun, Moon, Shield, Cloud, Trophy, TrendingUp, Activity,
+    Inbox, Clock,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState, useEffect } from "react";
@@ -40,6 +41,8 @@ const NAV_GROUPS: NavGroup[] = [
             { href: "/dashboard/monitoring", label: "Live Monitoring", icon: LayoutDashboard, module: "rides" },
             { href: "/dashboard/rides", label: "Rides", icon: Car, module: "rides" },
             { href: "/dashboard/drivers", label: "Drivers", icon: Car, module: "drivers" },
+            { href: "/dashboard/drivers/queue", label: "Approvals", icon: Inbox, module: "drivers" },
+            { href: "/dashboard/drivers/expiring", label: "Expiring Docs", icon: Clock, module: "drivers" },
             { href: "/dashboard/users", label: "Users", icon: Users, module: "users" },
             { href: "/dashboard/heatmap", label: "Heat Map", icon: Flame, module: "heatmap" },
             { href: "/dashboard/analytics", label: "Analytics", icon: LayoutDashboard, module: "dashboard" },

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -620,11 +620,24 @@ export const updateSurge = (areaId: string, data: any) =>
 export const getDriverDocuments = (driverId: string) =>
     request<any[]>(`/api/admin/documents/drivers/${driverId}`);
 
+export type RejectTemplate =
+    | "blurry_image"
+    | "wrong_document_type"
+    | "expired"
+    | "information_unclear"
+    | "other";
+
+export interface ReviewDocumentOptions {
+    notify?: boolean;
+    notifyTemplate?: RejectTemplate;
+}
+
 export const reviewDocument = (
     docId: string,
     status: string,
     reason?: string,
     expiryDate?: string,
+    options?: ReviewDocumentOptions,
 ) =>
     request<any>(`/api/admin/documents/${docId}/review`, {
         method: "POST",
@@ -632,7 +645,96 @@ export const reviewDocument = (
             status,
             rejection_reason: reason,
             expiry_date: expiryDate,
+            ...(options?.notify !== undefined ? { notify: options.notify } : {}),
+            ...(options?.notifyTemplate ? { notify_template: options.notifyTemplate } : {}),
         }),
+    });
+
+export interface ApprovalQueueItem {
+    driver_id: string;
+    user_id: string | null;
+    first_name: string;
+    last_name: string;
+    name: string;
+    email: string | null;
+    phone: string | null;
+    profile_photo_url: string | null;
+    status: string;
+    created_at: string | null;
+    queue_started_at: string | null;
+    time_in_queue_seconds: number;
+    pending_docs_count: number;
+    missing_docs_count: number;
+    service_area_id: string | null;
+    service_area_name: string | null;
+    vehicle_type_id: string | null;
+    vehicle_type_name: string | null;
+}
+
+export interface ApprovalQueueResponse {
+    stats: {
+        total_pending: number;
+        oldest_in_queue_hours: number;
+        median_wait_hours: number;
+        over_24h_count: number;
+    };
+    items: ApprovalQueueItem[];
+}
+
+export const getApprovalQueue = (params?: {
+    limit?: number;
+    service_area_id?: string;
+}) => {
+    const q = new URLSearchParams();
+    if (params?.limit) q.set("limit", String(params.limit));
+    if (params?.service_area_id) q.set("service_area_id", params.service_area_id);
+    const qs = q.toString();
+    return request<ApprovalQueueResponse>(
+        `/api/admin/drivers/approval-queue${qs ? `?${qs}` : ""}`,
+    );
+};
+
+export interface ExpiringDocItem {
+    driver_id: string;
+    user_id: string | null;
+    name: string;
+    first_name: string;
+    last_name: string;
+    email: string | null;
+    phone: string | null;
+    profile_photo_url: string | null;
+    status: string | null;
+    service_area_id: string | null;
+    service_area_name: string | null;
+    doc_type: string;
+    doc_label: string;
+    doc_field: string;
+    expiry_date: string;
+    days_remaining: number;
+    rides_last_30d: number;
+    last_nudged_at: string | null;
+}
+
+export const getExpiringDocs = (params?: {
+    window_days?: 7 | 14 | 30 | number;
+    service_area_id?: string;
+}) => {
+    const q = new URLSearchParams();
+    if (params?.window_days) q.set("window_days", String(params.window_days));
+    if (params?.service_area_id) q.set("service_area_id", params.service_area_id);
+    const qs = q.toString();
+    return request<{ items: ExpiringDocItem[] }>(
+        `/api/admin/drivers/expiring${qs ? `?${qs}` : ""}`,
+    );
+};
+
+export const nudgeDriverExpiry = (
+    driverId: string,
+    body: { doc_type: string; doc_label?: string; custom_message?: string },
+) =>
+    request<{ ok: boolean }>(`/api/admin/drivers/${driverId}/nudge-expiry`, {
+        method: "POST",
+        body: JSON.stringify(body),
     });
 
 /* ── Corporate Accounts ─────────────────────── */

--- a/backend/routes/admin/documents.py
+++ b/backend/routes/admin/documents.py
@@ -8,13 +8,36 @@ from pydantic import BaseModel
 try:
     from ... import db_supabase
     from ...dependencies import get_admin_user
+    from ...features import send_push_notification
     from ...utils.audit_logger import log_admin_action
 except ImportError:
     import db_supabase
     from dependencies import get_admin_user  # noqa: F401
+    from features import send_push_notification  # noqa: F401
     from utils.audit_logger import log_admin_action  # noqa: F401
 
 from .drivers import _log_driver_activity
+
+# Templated push copy for document rejections. Keys match the dropdown in
+# the admin reviewer UI; "other" falls back to the free-text reason.
+_REJECT_TEMPLATES: Dict[str, tuple[str, str]] = {
+    "blurry_image": (
+        "Document needs re-upload",
+        "We couldn't read your {doc} clearly. Please re-upload a sharper photo.",
+    ),
+    "wrong_document_type": (
+        "Wrong document type",
+        "The file you uploaded for {doc} doesn't match what's required. Please upload the correct document.",
+    ),
+    "expired": (
+        "Expired document",
+        "Your {doc} appears expired. Please upload a current copy to continue driving.",
+    ),
+    "information_unclear": (
+        "Document information unclear",
+        "Some information on your {doc} is unclear or unreadable. Please re-upload.",
+    ),
+}
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +66,7 @@ class DocumentRequirementUpdateRequest(BaseModel):
 @router.get("/documents/requirements")
 async def admin_get_document_requirements():
     """Get all document requirements."""
-    requirements = await db_supabase.get_rows(
-        "document_requirements", order="created_at", limit=100
-    )
+    requirements = await db_supabase.get_rows("document_requirements", order="created_at", limit=100)
     return requirements or []
 
 
@@ -63,15 +84,11 @@ async def admin_create_document_requirement(
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
     row = await db_supabase.insert_one("document_requirements", doc)
-    return {
-        "requirement_id": str(row.get("id") if row and isinstance(row, dict) else "")
-    }
+    return {"requirement_id": str(row.get("id") if row and isinstance(row, dict) else "")}
 
 
 @router.put("/documents/requirements/{requirement_id}")
-async def admin_update_document_requirement(
-    requirement_id: str, requirement: DocumentRequirementUpdateRequest
-):
+async def admin_update_document_requirement(requirement_id: str, requirement: DocumentRequirementUpdateRequest):
     """Update a document requirement."""
     updates: Dict[str, Any] = {}
     if requirement.name is not None:
@@ -87,9 +104,7 @@ async def admin_update_document_requirement(
 
     if updates:
         updates["updated_at"] = datetime.now(timezone.utc).isoformat()
-        await db_supabase.update_one(
-            "document_requirements", {"id": requirement_id}, updates
-        )
+        await db_supabase.update_one("document_requirements", {"id": requirement_id}, updates)
     return {"message": "Document requirement updated"}
 
 
@@ -183,6 +198,8 @@ class DocumentReviewRequest(BaseModel):
     status: str
     rejection_reason: Optional[str] = None
     expiry_date: Optional[str] = None
+    notify: bool = True
+    notify_template: Optional[str] = None  # see _REJECT_TEMPLATES
 
 
 @router.post("/documents/{document_id}/review")
@@ -217,9 +234,7 @@ async def admin_review_driver_document(
     new_expiry_iso: Optional[str] = None
     if expiry_raw:
         try:
-            new_expiry_iso = datetime.fromisoformat(
-                str(expiry_raw).replace("Z", "+00:00")
-            ).isoformat()
+            new_expiry_iso = datetime.fromisoformat(str(expiry_raw).replace("Z", "+00:00")).isoformat()
         except ValueError:
             new_expiry_iso = None
 
@@ -262,9 +277,7 @@ async def admin_review_driver_document(
         if existing_req_id:
             try:
                 req_row = (lambda _r: _r[0] if _r else None)(
-                    await db_supabase.get_rows(
-                        "document_requirements", {"id": existing_req_id}, limit=1
-                    )
+                    await db_supabase.get_rows("document_requirements", {"id": existing_req_id}, limit=1)
                 )
                 if req_row:
                     req_name = req_row.get("name")
@@ -320,9 +333,7 @@ async def admin_review_driver_document(
                             {"status": "active", "is_verified": True},
                         )
                 except Exception as _exc:
-                    logger.debug(
-                        f"Could not reset driver {driver_id} status to active: {_exc}"
-                    )
+                    logger.debug(f"Could not reset driver {driver_id} status to active: {_exc}")
 
     # Log to activity timeline
     doc_type = existing.get("document_type", "Document")
@@ -345,5 +356,49 @@ async def admin_review_driver_document(
             "rejection_reason": rejection_reason,
         },
     )
+
+    # Push the driver a re-upload prompt when the admin rejects a document.
+    # Skipped if (a) the caller opted out, (b) status isn't a rejection, or
+    # (c) the doc was already in "rejected" state before this call — that
+    # case is an edit (e.g. fixing the reason text) and re-firing would
+    # spam the driver. Push failures are intentionally swallowed: the
+    # DB-level rejection is already committed and the audit trail above
+    # records the action even if FCM is unreachable.
+    if status == "rejected" and review_data.notify and existing.get("status") != "rejected":
+        driver_id = existing.get("driver_id")
+        if driver_id:
+            try:
+                drv = await db_supabase.get_driver_by_id(driver_id)
+                user_id = (drv or {}).get("user_id")
+                if user_id:
+                    template = _REJECT_TEMPLATES.get(review_data.notify_template or "")
+                    if template:
+                        title, body_tmpl = template
+                        body = body_tmpl.format(doc=doc_type)
+                    else:
+                        title = "Document needs re-upload"
+                        body = (
+                            f"Your {doc_type} was not approved: {rejection_reason}"
+                            if rejection_reason
+                            else f"Your {doc_type} was not approved. Please re-upload."
+                        )
+                    await send_push_notification(
+                        user_id,
+                        title,
+                        body,
+                        data={
+                            "type": "document_rejected",
+                            "driver_id": driver_id,
+                            "document_id": document_id,
+                            "document_type": doc_type,
+                        },
+                    )
+            except Exception:
+                logger.warning(
+                    "Document-rejection push failed for driver %s doc %s",
+                    driver_id,
+                    document_id,
+                    exc_info=True,
+                )
 
     return {"message": f"Document {status}"}

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -645,6 +645,227 @@ async def admin_get_approval_queue(
     }
 
 
+# Legacy expiry columns on `drivers` — mirrors document_expiry.py so the
+# admin queue and the background warner agree on which docs to track.
+_EXPIRY_FIELDS: Dict[str, str] = {
+    "license_expiry_date": "Driver's License",
+    "insurance_expiry_date": "Insurance",
+    "vehicle_inspection_expiry_date": "Vehicle Inspection",
+    "background_check_expiry_date": "Background Check",
+    "work_eligibility_expiry_date": "Work Eligibility",
+}
+
+
+@router.get("/drivers/expiring")
+async def admin_get_expiring_documents(
+    window_days: int = Query(30, ge=1, le=90),
+    service_area_id: Optional[str] = None,
+):
+    """Drivers with at least one document expiring inside `window_days`.
+
+    Returns one row per (driver, expiring document) so the ops table can
+    list each renewal-needed item individually with its own Nudge button.
+    Ride volume for the last 30 days is included so ops can prioritize
+    high-value drivers. `last_nudged_at` reflects the most recent renewal
+    push (manual or automatic) sent to the driver — single field on
+    `drivers` shared across all doc types, matching what
+    `document_expiry.py` already maintains.
+    """
+    now = datetime.now(timezone.utc)
+    window_end = now + timedelta(days=window_days)
+
+    filters: Dict[str, Any] = {"status": {"$in": ["active", "needs_review"]}}
+    if service_area_id:
+        filters["service_area_id"] = service_area_id
+    drivers = await db_supabase.get_rows("drivers", filters, limit=5000)
+
+    expiring_rows: List[Dict[str, Any]] = []
+    affected_driver_ids: set = set()
+    for d in drivers:
+        for field, label in _EXPIRY_FIELDS.items():
+            val = d.get(field)
+            if not val:
+                continue
+            exp_dt = parse_iso_utc(val)
+            if exp_dt is None:
+                continue
+            if now <= exp_dt <= window_end:
+                affected_driver_ids.add(d["id"])
+                expiring_rows.append(
+                    {
+                        "driver_row": d,
+                        "doc_field": field,
+                        "doc_type": field.replace("_expiry_date", ""),
+                        "doc_label": label,
+                        "expiry_date": val,
+                        "days_remaining": max(0, (exp_dt - now).days),
+                    }
+                )
+
+    if not expiring_rows:
+        return {"items": []}
+
+    user_ids = list({d["driver_row"].get("user_id") for d in expiring_rows if d["driver_row"].get("user_id")})
+    users_list = (
+        await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)) if user_ids else []
+    )
+    users_map = {u["id"]: u for u in users_list if u.get("id")}
+
+    area_ids = list(
+        {d["driver_row"].get("service_area_id") for d in expiring_rows if d["driver_row"].get("service_area_id")}
+    )
+    areas_list = (
+        await db_supabase.get_rows("service_areas", {"id": {"$in": area_ids}}, limit=max(len(area_ids), 1))
+        if area_ids
+        else []
+    )
+    areas_map = {a["id"]: a.get("name") for a in areas_list if a.get("id")}
+
+    rides_30d_ago = (now - timedelta(days=30)).isoformat()
+    rides = (
+        await db_supabase.get_rows(
+            "rides",
+            {
+                "driver_id": {"$in": list(affected_driver_ids)},
+                "status": "completed",
+                "completed_at": {"$gte": rides_30d_ago},
+            },
+            limit=10000,
+        )
+        if affected_driver_ids
+        else []
+    )
+    rides_by_driver: Dict[str, int] = {}
+    for r in rides:
+        did = r.get("driver_id")
+        if did:
+            rides_by_driver[did] = rides_by_driver.get(did, 0) + 1
+
+    items: List[Dict[str, Any]] = []
+    for row in expiring_rows:
+        d = row["driver_row"]
+        u = users_map.get(d.get("user_id"))
+        items.append(
+            {
+                "driver_id": d["id"],
+                "user_id": d.get("user_id"),
+                "name": _user_display_name(u) or d.get("name") or "",
+                "first_name": (u or {}).get("first_name") or "",
+                "last_name": (u or {}).get("last_name") or "",
+                "email": (u or {}).get("email"),
+                "phone": (u or {}).get("phone") or d.get("phone"),
+                "profile_photo_url": d.get("profile_photo_url"),
+                "status": d.get("status"),
+                "service_area_id": d.get("service_area_id"),
+                "service_area_name": areas_map.get(d.get("service_area_id")),
+                "doc_type": row["doc_type"],
+                "doc_label": row["doc_label"],
+                "doc_field": row["doc_field"],
+                "expiry_date": row["expiry_date"],
+                "days_remaining": row["days_remaining"],
+                "rides_last_30d": rides_by_driver.get(d["id"], 0),
+                "last_nudged_at": d.get("doc_expiry_warned_at"),
+            }
+        )
+
+    items.sort(key=lambda r: r["days_remaining"])
+    return {"items": items}
+
+
+class DriverNudgeExpiryRequest(BaseModel):
+    doc_type: str  # e.g. "license", "insurance" — matches _EXPIRY_FIELDS prefix
+    doc_label: Optional[str] = None
+    custom_message: Optional[str] = None
+
+
+@router.post("/drivers/{driver_id}/nudge-expiry")
+async def admin_nudge_driver_expiry(
+    driver_id: str,
+    body: DriverNudgeExpiryRequest,
+    admin: dict = Depends(get_admin_user),
+):
+    """Send a manual renewal-reminder push to a driver.
+
+    The automated warner in `utils/document_expiry.py` already pushes on
+    a schedule; this endpoint lets ops nudge a specific high-value driver
+    earlier without waiting for the next cron tick. Updates
+    `doc_expiry_warned_at` so the automatic loop's 24h throttle doesn't
+    re-fire and double-notify. Audit-logs every nudge.
+    """
+    drv = await db_supabase.get_driver_by_id(driver_id)
+    if not drv:
+        raise HTTPException(status_code=404, detail="Driver not found")
+    user_id = drv.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=400, detail="Driver has no linked user account")
+
+    field = f"{body.doc_type}_expiry_date"
+    doc_label = body.doc_label or _EXPIRY_FIELDS.get(field) or body.doc_type.replace("_", " ").title()
+
+    expiry_iso = drv.get(field)
+    days_text = ""
+    if expiry_iso:
+        exp_dt = parse_iso_utc(expiry_iso)
+        if exp_dt:
+            days_left = max(0, (exp_dt - datetime.now(timezone.utc)).days)
+            days_text = f" in {days_left} day{'s' if days_left != 1 else ''}" if days_left > 0 else " today"
+
+    title = f"Renew your {doc_label}"
+    body_text = body.custom_message or (
+        f"Your {doc_label} expires{days_text}. Please upload a current copy to keep driving."
+    )
+
+    try:
+        await send_push_notification(
+            user_id,
+            title,
+            body_text,
+            data={
+                "type": "document_expiry_nudge",
+                "driver_id": driver_id,
+                "doc_type": body.doc_type,
+            },
+        )
+    except Exception as exc:
+        logger.error(
+            "Expiry nudge push failed for driver %s doc %s",
+            driver_id,
+            body.doc_type,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=502, detail="Notification service unavailable") from exc
+
+    try:
+        await db_supabase.update_one(
+            "drivers",
+            {"id": driver_id},
+            {"doc_expiry_warned_at": datetime.now(timezone.utc).isoformat()},
+        )
+    except Exception:
+        logger.warning(
+            "Could not update doc_expiry_warned_at for driver %s after nudge",
+            driver_id,
+            exc_info=True,
+        )
+
+    await log_admin_action(
+        admin,
+        "driver_expiry_nudge",
+        "drivers",
+        driver_id,
+        {"doc_type": body.doc_type, "doc_label": doc_label, "has_custom_message": bool(body.custom_message)},
+    )
+    await _log_driver_activity(
+        driver_id,
+        "expiry_nudge_sent",
+        f"Renewal reminder sent: {doc_label}",
+        body.custom_message or "",
+        {"doc_type": body.doc_type, "doc_label": doc_label},
+    )
+
+    return {"ok": True}
+
+
 @router.put("/drivers/{driver_id}")
 async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: dict = Depends(get_admin_user)):
     """Update driver details from admin dashboard."""

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -38,14 +38,10 @@ def _user_display_name(user: Optional[Dict]) -> str:
     return f"{fn} {ln}".strip() or user.get("email") or user.get("phone") or ""
 
 
-async def _batch_fetch_drivers_and_users(
-    rider_ids: List[str], driver_ids: List[str]
-) -> tuple:
+async def _batch_fetch_drivers_and_users(rider_ids: List[str], driver_ids: List[str]) -> tuple:
     """Batch-fetch drivers and users in 2-3 queries instead of N+1 loops."""
     drivers_list = (
-        await db_supabase.get_rows(
-            "drivers", {"id": {"$in": driver_ids}}, limit=max(len(driver_ids), 1)
-        )
+        await db_supabase.get_rows("drivers", {"id": {"$in": driver_ids}}, limit=max(len(driver_ids), 1))
         if driver_ids
         else []
     )
@@ -58,9 +54,7 @@ async def _batch_fetch_drivers_and_users(
         }
     )
     users_list = (
-        await db_supabase.get_rows(
-            "users", {"id": {"$in": all_user_ids}}, limit=max(len(all_user_ids), 1)
-        )
+        await db_supabase.get_rows("users", {"id": {"$in": all_user_ids}}, limit=max(len(all_user_ids), 1))
         if all_user_ids
         else []
     )
@@ -169,9 +163,7 @@ async def admin_get_drivers(
                     {"last_name": {"$regex": re.escape(term), "$options": "i"}},
                 ]
             }
-            matching_users = await db_supabase.get_rows(
-                "users", user_filters, limit=100
-            )
+            matching_users = await db_supabase.get_rows("users", user_filters, limit=100)
             matching_uids = [u["id"] for u in matching_users if u.get("id")]
 
             # Match driver rows by phone/plate directly OR by user_id from user search above.
@@ -183,9 +175,7 @@ async def admin_get_drivers(
             if matching_uids:
                 filters["$or"].append({"user_id": {"$in": matching_uids}})
 
-    drivers = await db_supabase.get_rows(
-        "drivers", filters, order="created_at", desc=True, limit=limit, offset=offset
-    )
+    drivers = await db_supabase.get_rows("drivers", filters, order="created_at", desc=True, limit=limit, offset=offset)
 
     # Defensive dedup — keep the earliest-created row per (user_id, phone).
     seen_user_ids: set = set()
@@ -206,11 +196,7 @@ async def admin_get_drivers(
 
     user_ids = list({d.get("user_id") for d in deduped if d.get("user_id")})
     users_list = (
-        await db_supabase.get_rows(
-            "users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)
-        )
-        if user_ids
-        else []
+        await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)) if user_ids else []
     )
     users_map = {u["id"]: u for u in users_list if u.get("id")}
     out = []
@@ -283,30 +269,20 @@ async def admin_get_driver_stats(
     driver_filters: Dict[str, Any] = {}
     if service_area_id:
         driver_filters["service_area_id"] = service_area_id
-    all_drivers = await db_supabase.get_rows(
-        "drivers", driver_filters, order="created_at", desc=True, limit=5000
-    )
+    all_drivers = await db_supabase.get_rows("drivers", driver_filters, order="created_at", desc=True, limit=5000)
 
     # Enrich with user info (batch)
     user_ids = list({d.get("user_id") for d in all_drivers if d.get("user_id")})
     users_list = (
-        await db_supabase.get_rows(
-            "users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)
-        )
-        if user_ids
-        else []
+        await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)) if user_ids else []
     )
     users_map: Dict[str, Any] = {u["id"]: u for u in users_list if u.get("id")}
 
     # Auto-detect needs_review: active drivers with expired docs or pending re-uploads.
     # Capped at 500 for the inline needs_review flag; full paginated list via
     # GET /documents/pending (A-P4-4).
-    all_docs = await db_supabase.get_rows(
-        "driver_documents", {"status": "pending"}, limit=500
-    )
-    pending_doc_driver_ids = {
-        d.get("driver_id") for d in all_docs if d.get("driver_id")
-    }
+    all_docs = await db_supabase.get_rows("driver_documents", {"status": "pending"}, limit=500)
+    pending_doc_driver_ids = {d.get("driver_id") for d in all_docs if d.get("driver_id")}
 
     now_iso = datetime.now(timezone.utc).isoformat()
     expiry_fields = [
@@ -348,19 +324,13 @@ async def admin_get_driver_stats(
     online = sum(1 for d in enriched_drivers if d.get("is_online"))
     active_count = sum(1 for d in enriched_drivers if d.get("status") == "active")
     pending_count = sum(1 for d in enriched_drivers if d.get("status") == "pending")
-    needs_review_count = sum(
-        1 for d in enriched_drivers if d.get("status") == "needs_review"
-    )
+    needs_review_count = sum(1 for d in enriched_drivers if d.get("status") == "needs_review")
     suspended_count = sum(1 for d in enriched_drivers if d.get("status") == "suspended")
     banned_count = sum(1 for d in enriched_drivers if d.get("status") == "banned")
     total_rides_sum = sum(int(d.get("total_rides") or 0) for d in enriched_drivers)
-    total_earnings_sum = float(
-        sum(Decimal(str(d.get("total_earnings") or 0)) for d in enriched_drivers)
-    )
+    total_earnings_sum = float(sum(Decimal(str(d.get("total_earnings") or 0)) for d in enriched_drivers))
     avg_rating = 0.0
-    rated = [
-        d for d in enriched_drivers if d.get("rating") and float(d.get("rating", 0)) > 0
-    ]
+    rated = [d for d in enriched_drivers if d.get("rating") and float(d.get("rating", 0)) > 0]
     if rated:
         avg_rating = round(sum(float(d["rating"]) for d in rated) / len(rated), 2)
 
@@ -388,8 +358,7 @@ async def admin_get_driver_stats(
             area_stats[aid]["unverified"] += 1
         area_stats[aid]["total_rides"] += int(d.get("total_rides") or 0)
         area_stats[aid]["total_earnings"] = float(
-            Decimal(str(area_stats[aid]["total_earnings"]))
-            + Decimal(str(d.get("total_earnings") or 0))
+            Decimal(str(area_stats[aid]["total_earnings"])) + Decimal(str(d.get("total_earnings") or 0))
         )
 
     # ── Daily charts (within date range) ──
@@ -410,16 +379,10 @@ async def admin_get_driver_stats(
     # Rides + earnings per day (for drivers matching the service_area filter)
     driver_ids_set = {d["id"] for d in enriched_drivers}
     ride_filters: Dict[str, Any] = {"created_at": {"$gte": range_start.isoformat()}}
-    all_rides = await db_supabase.get_rows(
-        "rides", ride_filters, order="created_at", desc=True, limit=5000
-    )
+    all_rides = await db_supabase.get_rows("rides", ride_filters, order="created_at", desc=True, limit=5000)
 
     # Filter rides to only those belonging to our driver set
-    relevant_rides = (
-        [r for r in all_rides if r.get("driver_id") in driver_ids_set]
-        if service_area_id
-        else all_rides
-    )
+    relevant_rides = [r for r in all_rides if r.get("driver_id") in driver_ids_set] if service_area_id else all_rides
 
     daily_rides: Dict[str, int] = defaultdict(int)
     daily_earnings: Dict[str, float] = defaultdict(float)
@@ -432,8 +395,7 @@ async def admin_get_driver_stats(
             daily_rides[day_key] += 1
             if r.get("status") == "completed":
                 daily_earnings[day_key] = float(
-                    Decimal(str(daily_earnings[day_key]))
-                    + Decimal(str(r.get("driver_earnings") or 0))
+                    Decimal(str(daily_earnings[day_key])) + Decimal(str(r.get("driver_earnings") or 0))
                 )
 
     # Build chart arrays
@@ -486,16 +448,205 @@ async def admin_get_driver_stats(
             "daily_earnings": earnings_chart,
         },
         "drivers": enriched_drivers,
-        "service_areas": [
-            {"id": a["id"], "name": a.get("name", "Unknown")} for a in service_areas
-        ],
+        "service_areas": [{"id": a["id"], "name": a.get("name", "Unknown")} for a in service_areas],
+    }
+
+
+@router.get("/drivers/approval-queue")
+async def admin_get_approval_queue(
+    limit: int = Query(50, ge=1, le=200),
+    service_area_id: Optional[str] = None,
+):
+    """Per-driver rollup of pending applications, oldest-first.
+
+    Surfaces drivers that need ops attention right now:
+    - drivers.status == "pending" (new applicants)
+    - drivers with any driver_documents.status == "pending" (re-uploads
+      from suspended/needs_review drivers)
+
+    Each item carries time-in-queue, pending/missing doc counts, and the
+    service area + vehicle type names so the queue page doesn't need
+    extra round-trips. The header `stats` block exposes SLA signals
+    (median wait, oldest, count over 24h) computed over the full result
+    set — not the trimmed window — so the dashboard reflects reality even
+    when the table is paginated.
+
+    queue_started_at: status_changed at unavailable on `drivers`, so we
+    fall back to drivers.created_at for new applicants, or the earliest
+    pending-doc upload_at for re-uploaders. This matches what ops cares
+    about: "how long has this been waiting on us?"
+    """
+    now = datetime.now(timezone.utc)
+
+    pending_drivers = await db_supabase.get_rows(
+        "drivers",
+        {"status": "pending", **({"service_area_id": service_area_id} if service_area_id else {})},
+        order="created_at",
+        limit=1000,
+    )
+
+    pending_docs = await db_supabase.get_rows(
+        "driver_documents",
+        {"status": "pending"},
+        order="uploaded_at",
+        limit=1000,
+    )
+
+    earliest_pending_doc_by_driver: Dict[str, str] = {}
+    pending_doc_count_by_driver: Dict[str, int] = {}
+    for d in pending_docs:
+        did = d.get("driver_id")
+        if not did:
+            continue
+        pending_doc_count_by_driver[did] = pending_doc_count_by_driver.get(did, 0) + 1
+        ts = d.get("uploaded_at") or d.get("created_at")
+        if ts and (did not in earliest_pending_doc_by_driver or ts < earliest_pending_doc_by_driver[did]):
+            earliest_pending_doc_by_driver[did] = ts
+
+    driver_map: Dict[str, Dict[str, Any]] = {d["id"]: d for d in pending_drivers if d.get("id")}
+    extra_driver_ids = [did for did in pending_doc_count_by_driver if did not in driver_map]
+    if extra_driver_ids:
+        extra_filters: Dict[str, Any] = {"id": {"$in": extra_driver_ids}}
+        if service_area_id:
+            extra_filters["service_area_id"] = service_area_id
+        extra_drivers = await db_supabase.get_rows("drivers", extra_filters, limit=len(extra_driver_ids))
+        for d in extra_drivers:
+            if d.get("id"):
+                driver_map[d["id"]] = d
+
+    if not driver_map:
+        return {
+            "stats": {"total_pending": 0, "oldest_in_queue_hours": 0.0, "median_wait_hours": 0.0, "over_24h_count": 0},
+            "items": [],
+        }
+
+    user_ids = list({d.get("user_id") for d in driver_map.values() if d.get("user_id")})
+    users_list = (
+        await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)) if user_ids else []
+    )
+    users_map = {u["id"]: u for u in users_list if u.get("id")}
+
+    area_ids = list({d.get("service_area_id") for d in driver_map.values() if d.get("service_area_id")})
+    areas_list = (
+        await db_supabase.get_rows("service_areas", {"id": {"$in": area_ids}}, limit=max(len(area_ids), 1))
+        if area_ids
+        else []
+    )
+    areas_map = {a["id"]: a for a in areas_list if a.get("id")}
+
+    vtype_ids = list({d.get("vehicle_type_id") for d in driver_map.values() if d.get("vehicle_type_id")})
+    vtypes_list = (
+        await db_supabase.get_rows("vehicle_types", {"id": {"$in": vtype_ids}}, limit=max(len(vtype_ids), 1))
+        if vtype_ids
+        else []
+    )
+    vtypes_map = {v["id"]: v.get("name") for v in vtypes_list if v.get("id")}
+
+    all_docs = (
+        await db_supabase.get_rows(
+            "driver_documents",
+            {"driver_id": {"$in": list(driver_map.keys())}, "status": {"$in": ["approved", "pending"]}},
+            limit=max(len(driver_map) * 10, 100),
+        )
+        if driver_map
+        else []
+    )
+    docs_by_driver: Dict[str, List[Dict[str, Any]]] = {}
+    for d in all_docs:
+        docs_by_driver.setdefault(d.get("driver_id"), []).append(d)
+
+    def _missing_count(driver_row: Dict[str, Any]) -> int:
+        area = areas_map.get(driver_row.get("service_area_id"))
+        if not area:
+            return 0
+        reqs = area.get("required_documents") or []
+        if not isinstance(reqs, list) or not reqs:
+            return 0
+        driver_docs = docs_by_driver.get(driver_row["id"], [])
+        approved_keys = set()
+        for dd in driver_docs:
+            if dd.get("status") != "approved":
+                continue
+            k = (
+                dd.get("requirement_key")
+                or dd.get("requirement_id")
+                or (dd.get("document_type") or "").lower().replace(" ", "_")
+            )
+            if k:
+                approved_keys.add(k)
+        missing = 0
+        for r in reqs:
+            if not isinstance(r, dict):
+                continue
+            key = (r.get("key") or r.get("id") or "").lower()
+            if key and key not in approved_keys:
+                missing += 1
+        return missing
+
+    items: List[Dict[str, Any]] = []
+    for did, drow in driver_map.items():
+        u = users_map.get(drow.get("user_id"))
+        if drow.get("status") == "pending":
+            queue_started_at = drow.get("created_at")
+        else:
+            queue_started_at = earliest_pending_doc_by_driver.get(did) or drow.get("created_at")
+
+        time_in_queue_seconds = 0
+        if queue_started_at:
+            qdt = parse_iso_utc(queue_started_at)
+            if qdt is not None:
+                time_in_queue_seconds = max(0, int((now - qdt).total_seconds()))
+
+        items.append(
+            {
+                "driver_id": did,
+                "user_id": drow.get("user_id"),
+                "first_name": (u or {}).get("first_name") or "",
+                "last_name": (u or {}).get("last_name") or "",
+                "name": _user_display_name(u) or drow.get("name") or "",
+                "email": (u or {}).get("email"),
+                "phone": (u or {}).get("phone") or drow.get("phone"),
+                "profile_photo_url": drow.get("profile_photo_url"),
+                "status": drow.get("status", "pending"),
+                "created_at": drow.get("created_at"),
+                "queue_started_at": queue_started_at,
+                "time_in_queue_seconds": time_in_queue_seconds,
+                "pending_docs_count": pending_doc_count_by_driver.get(did, 0),
+                "missing_docs_count": _missing_count(drow),
+                "service_area_id": drow.get("service_area_id"),
+                "service_area_name": (areas_map.get(drow.get("service_area_id")) or {}).get("name"),
+                "vehicle_type_id": drow.get("vehicle_type_id"),
+                "vehicle_type_name": vtypes_map.get(drow.get("vehicle_type_id")),
+            }
+        )
+
+    items.sort(key=lambda r: r["time_in_queue_seconds"], reverse=True)
+
+    waits = [it["time_in_queue_seconds"] for it in items]
+    total = len(items)
+    over_24h = sum(1 for w in waits if w >= 86400)
+    oldest_hours = round(max(waits) / 3600, 1) if waits else 0.0
+    if waits:
+        sorted_waits = sorted(waits)
+        mid = total // 2
+        median_seconds = sorted_waits[mid] if total % 2 == 1 else (sorted_waits[mid - 1] + sorted_waits[mid]) / 2
+        median_hours = round(median_seconds / 3600, 1)
+    else:
+        median_hours = 0.0
+
+    return {
+        "stats": {
+            "total_pending": total,
+            "oldest_in_queue_hours": oldest_hours,
+            "median_wait_hours": median_hours,
+            "over_24h_count": over_24h,
+        },
+        "items": items[:limit],
     }
 
 
 @router.put("/drivers/{driver_id}")
-async def admin_update_driver(
-    driver_id: str, updates: Dict[str, Any], admin: dict = Depends(get_admin_user)
-):
+async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: dict = Depends(get_admin_user)):
     """Update driver details from admin dashboard."""
     allowed = {
         "first_name",
@@ -548,9 +699,7 @@ async def admin_update_driver(
 
 
 @router.post("/drivers/{driver_id}/verify")
-async def admin_verify_driver(
-    driver_id: str, req: DriverVerifyRequest, admin: dict = Depends(get_admin_user)
-):
+async def admin_verify_driver(driver_id: str, req: DriverVerifyRequest, admin: dict = Depends(get_admin_user)):
     """Verify or unverify a driver.
 
     NOTE: the Supabase `drivers` table in production was created from
@@ -601,16 +750,12 @@ async def admin_verify_driver(
     except Exception as e:
         logger.warning(f"[ADMIN] Push notification failed for driver {driver_id}: {e}")
 
-    await log_admin_action(
-        admin, "driver_verified", "drivers", driver_id, {"verified": req.verified}
-    )
+    await log_admin_action(admin, "driver_verified", "drivers", driver_id, {"verified": req.verified})
     return {"message": f"Driver {'verified' if req.verified else 'unverified'}"}
 
 
 @router.post("/drivers/{driver_id}/action")
-async def admin_driver_action(
-    driver_id: str, req: DriverActionRequest, admin: dict = Depends(get_admin_user)
-):
+async def admin_driver_action(driver_id: str, req: DriverActionRequest, admin: dict = Depends(get_admin_user)):
     """Perform a lifecycle action on a driver.
 
     Actions: approve, reject, suspend, ban, unban, reactivate.
@@ -635,9 +780,7 @@ async def admin_driver_action(
     elif req.action == "suspend":
         # Suspend: temporarily disable, store reason
         if not req.reason:
-            raise HTTPException(
-                status_code=400, detail="Reason is required when suspending"
-            )
+            raise HTTPException(status_code=400, detail="Reason is required when suspending")
         updates["status"] = "suspended"
         updates["suspension_reason"] = req.reason
         updates["suspended_at"] = now
@@ -647,9 +790,7 @@ async def admin_driver_action(
     elif req.action == "ban":
         # Ban: permanently block, store reason
         if not req.reason:
-            raise HTTPException(
-                status_code=400, detail="Reason is required when banning"
-            )
+            raise HTTPException(status_code=400, detail="Reason is required when banning")
         updates["status"] = "banned"
         updates["is_verified"] = False
         updates["ban_reason"] = req.reason
@@ -680,9 +821,7 @@ async def admin_driver_action(
         await db_supabase.update_one("drivers", {"id": driver_id}, updates)
     except Exception as e:
         logger.error(f"Failed driver action {req.action} on {driver_id}: {e}")
-        raise HTTPException(
-            status_code=500, detail="An internal error occurred. Please try again."
-        ) from e
+        raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
     logger.info(f"[ADMIN] Driver {driver_id} action={req.action} reason={req.reason}")
 
@@ -761,9 +900,7 @@ async def admin_driver_action(
                 },
             )
         except Exception as e:
-            logger.warning(
-                f"[ADMIN] Push notification failed for driver action {req.action}: {e}"
-            )
+            logger.warning(f"[ADMIN] Push notification failed for driver action {req.action}: {e}")
 
     return {
         "message": f"Driver {req.action}d successfully",
@@ -806,9 +943,7 @@ async def admin_override_driver_status(
             updates["ban_reason"] = req.reason
 
     await db_supabase.update_one("drivers", {"id": driver_id}, updates)
-    logger.info(
-        f"[ADMIN] Driver {driver_id} status overridden to {req.status} reason={req.reason}"
-    )
+    logger.info(f"[ADMIN] Driver {driver_id} status overridden to {req.status} reason={req.reason}")
     await _log_driver_activity(
         driver_id,
         "status_override",
@@ -903,9 +1038,7 @@ async def admin_get_driver_rides(
     offset: int = Query(0, ge=0),
 ):
     """Get rides for a driver with pagination (max 500 per page)."""
-    rides = await db_supabase.get_rows(
-        "rides", {"driver_id": driver_id}, order="created_at", desc=True, limit=limit
-    )
+    rides = await db_supabase.get_rows("rides", {"driver_id": driver_id}, order="created_at", desc=True, limit=limit)
     # Apply offset in-process (Supabase helper doesn't expose OFFSET natively)
     page = rides[offset : offset + limit]
     return {"rides": page, "total": len(rides), "offset": offset, "limit": limit}
@@ -921,9 +1054,7 @@ async def admin_get_driver_daily_stats(
     if not end_date:
         end_date = datetime.now(timezone.utc).date().isoformat()
     if not start_date:
-        start_date = (
-            datetime.now(timezone.utc).date() - timedelta(days=30)
-        ).isoformat()
+        start_date = (datetime.now(timezone.utc).date() - timedelta(days=30)).isoformat()
 
     stats = await db_supabase.get_rows(
         "driver_daily_stats",


### PR DESCRIPTION
Per-driver rollup of pending applicants and re-uploads, oldest-first,
with SLA stats (median wait, oldest, >24h count) so ops can size the
backlog at a glance. Computes time-in-queue from drivers.created_at for
new applicants or earliest pending-doc upload_at for re-uploaders, and
counts missing required documents against the driver's service-area
required_documents config.

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
