### PR TITLE
fix(drivers): online drivers invisible to riders and admin until first location batch

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1442,7 +1442,11 @@ async def get_nearby_drivers_public(
             continue
         d_lat = d.get("lat")
         d_lng = d.get("lng")
-        if d_lat and d_lng:
+        # `is not None` (not truthy) so a driver legitimately at lat=0 or
+        # lng=0 still matches. The literal (0, 0) is the registration
+        # default and means "no GPS yet" — skip those so a freshly-online
+        # driver doesn't surface as a ghost car at the origin.
+        if d_lat is not None and d_lng is not None and (d_lat != 0 or d_lng != 0):
             dist = calculate_distance(lat, lng, d_lat, d_lng)
             if dist <= radius:
                 # hide personal info for riders
@@ -3764,6 +3768,12 @@ async def update_driver_status(
     # query parameters, and the mobile client (which posts it as body) got
     # a 422 and surfaced it as "Request failed".
     is_online: bool = Body(..., embed=True),
+    # Optional GPS coords sent by the driver app on Go Online. Closes the
+    # window between the status flip and the first /drivers/location-batch
+    # POST during which the driver would otherwise sit at the registration
+    # default (0, 0) and be invisible to riders/admins.
+    lat: Optional[float] = Body(None, embed=True),
+    lng: Optional[float] = Body(None, embed=True),
     current_user: dict = Depends(get_current_user),
 ):
     """Toggle the driver's online flag (driver-facing "Go online" / "Go offline").
@@ -4064,6 +4074,13 @@ async def update_driver_status(
     # payload so the flip itself still lands.
     _now_iso = datetime.now(timezone.utc).isoformat()
     _base = {"is_online": is_online, "is_available": is_online, "updated_at": _now_iso}
+    # If the driver app supplied current GPS on Go Online, persist it in the
+    # same write so the rider/admin queries see a real location immediately
+    # instead of the registration default (0, 0). Guarded on is_online so the
+    # Go Offline path doesn't overwrite a perfectly good last-known location.
+    if is_online and lat is not None and lng is not None and (lat != 0 or lng != 0):
+        _base["lat"] = lat
+        _base["lng"] = lng
     # Invariant guardrail: is_available => is_online (see handler docstring).
     # This is a sanity check on the payload we are about to write — never
     # gate user behaviour on the assert; if it ever trips, the bug is in the

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -1013,7 +1013,16 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       const next = !isOnline;
       setIsOnline(next);
       try {
-        await updateDriverStatus(next);
+        // Pass the last known GPS so the backend persists it in the same
+        // write as the is_online flip. Without this the driver row sits
+        // at the (0, 0) registration default until the first background
+        // location-batch arrives, and during that window riders and
+        // admins see an empty map even though the driver is "ONLINE".
+        const loc = locationRef.current;
+        const locationPayload = next && loc?.coords
+          ? { lat: loc.coords.latitude, lng: loc.coords.longitude }
+          : undefined;
+        await updateDriverStatus(next, locationPayload);
       } catch (err: any) {
         setIsOnline(!next);
 

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -204,7 +204,7 @@ interface AuthState {
   refreshProfile: () => Promise<void>;
   registerDriver: (data: DriverRegistrationPayload) => Promise<void>;
   toggleDriverMode: () => void;
-  updateDriverStatus: (isOnline: boolean) => Promise<void>;
+  updateDriverStatus: (isOnline: boolean, location?: { lat: number; lng: number }) => Promise<void>;
   updateProfileImage: (imageUri: string) => Promise<void>;
   logout: () => Promise<void>;
   logoutAll: () => Promise<{ revoked_refresh_tokens: number }>;
@@ -462,13 +462,23 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ isDriverMode: !isDriverMode });
   },
 
-  updateDriverStatus: async (isOnline: boolean) => {
+  updateDriverStatus: async (isOnline: boolean, location?: { lat: number; lng: number }) => {
     const driver = get().driver;
     if (!driver?.id) {
       throw new Error('Driver ID not found');
     }
     try {
-      await api.put(`/drivers/${driver.id}/status`, { is_online: isOnline });
+      // Send current GPS alongside the online flip when available. Without
+      // this, the driver row sits at the (0, 0) registration default until
+      // the first background location-batch arrives — during that window
+      // the rider /drivers/nearby and admin monitoring views can't place
+      // the driver on the map.
+      const body: { is_online: boolean; lat?: number; lng?: number } = { is_online: isOnline };
+      if (isOnline && location && Number.isFinite(location.lat) && Number.isFinite(location.lng)) {
+        body.lat = location.lat;
+        body.lng = location.lng;
+      }
+      await api.put(`/drivers/${driver.id}/status`, body);
       set({ driver: { ...driver, is_online: isOnline } });
     } catch (error: unknown) {
       if (__DEV__) console.log('Failed to update status');


### PR DESCRIPTION
Three compounding causes left newly-online drivers off the rider map and the
admin monitoring view even with is_online=true:

1. GET /drivers/nearby filtered with `if d_lat and d_lng` — a Python truthy
   check that treats 0 as falsy. Drivers register with lat=0, lng=0
   (drivers.py:527/703) and stay at those defaults until the first
   /drivers/location-batch arrives, so they were silently dropped from
   the distance filter even though they passed the DB query. Switched
   to `is not None` with an explicit (0, 0) exclusion to match the
   convention used in rides.py:2716 and admin/rides.py:1202.

2. PUT /drivers/{id}/status only flipped is_online/is_available and never
   persisted a location, guaranteeing a window of stale (0, 0) coords.
   The endpoint now accepts optional lat/lng in the body and writes
   them in the same update.

3. The driver app already had locationRef.current when toggleOnline ran
   (it uses it for the geofence arm) but never sent it. updateDriverStatus
   now takes an optional { lat, lng } and the dashboard passes the last
   known GPS when going online so the very first request carries real
   coords.

Go Offline still works with no location payload; the lat/lng write is
guarded on is_online so going offline never overwrites a good
last-known location.

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
