### PR TITLE
fix(rider-app): cap promo discount at ride fare in quote display

### DIFF
--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -998,6 +998,12 @@ class RideEstimateRequest(BaseModel):
     corporate_account_id: Optional[str] = None
     work_profile: Optional[bool] = False
     requires_wav: bool = False
+    # Optional promo code. When provided we validate it (no consumption)
+    # against this rider + ride fare so the quote breakdown can include
+    # the discount line and a final_total that matches what settlement
+    # will actually charge. Backwards-compatible: omit it for the
+    # unaffected pre-promo quote.
+    promo_code: Optional[str] = None
 
 
 @api_router.post("/estimate")
@@ -1182,6 +1188,58 @@ async def estimate_ride(
             tax_breakdown=fees_result.get("tax_breakdown", {}),
         )
 
+        # Promo line — append to fare_breakdown in the same shape the
+        # completed-ride view emits at _build_fare_breakdown (rides.py:332)
+        # so every surface (estimate, in-progress, receipt, history) renders
+        # an identical discount row. The validator already caps the amount
+        # at ride_fare for flat promos and at max_discount for percentage
+        # promos, so the line never over-discounts fees + GST. Settlement
+        # uses the same _validate_promo_for_user helper, so the quote total
+        # equals what the rider is actually charged.
+        promo_discount = Decimal("0")
+        if body.promo_code:
+            try:
+                try:
+                    from .promotions import _validate_promo_for_user
+                except ImportError:
+                    from routes.promotions import _validate_promo_for_user  # type: ignore
+                _validation = await _validate_promo_for_user(
+                    body.promo_code,
+                    current_user["id"],
+                    ride_fare=fb.total_fare,
+                    grand_total=_d(grand_total),
+                )
+                promo_discount = _d(_validation.get("discount_amount") or 0)
+                if promo_discount > 0:
+                    fare_breakdown_lines.append(
+                        {
+                            "label": f"Promo ({_validation['code']})",
+                            "amount": _f(-promo_discount),
+                            "type": "discount",
+                        }
+                    )
+            except HTTPException:
+                # Silently skip an invalid promo at quote time. The user
+                # already saw the validation error when they applied it
+                # via POST /promo/validate, and we don't want to break the
+                # whole estimate response because one vehicle type's quote
+                # crossed a min-fare gate, etc.
+                promo_discount = Decimal("0")
+            except Exception as exc:
+                logger.error(
+                    "[estimate] promo validation crashed for code=%s: %s",
+                    body.promo_code,
+                    exc,
+                    exc_info=True,
+                )
+                promo_discount = Decimal("0")
+
+        # final_total is the single source of truth for the post-promo
+        # price. Equals sum(fare_breakdown_lines.amount) by construction
+        # — the frontend can either render `final_total` directly or sum
+        # the lines; both yield the same number.
+        final_total = _f(_round(_d(grand_total) - promo_discount))
+
         estimates.append(
             {
                 "vehicle_type": fare_info["vehicle_type"],
@@ -1198,6 +1256,8 @@ async def estimate_ride(
                 "tax_breakdown": fees_result.get("tax_breakdown", {}),
                 "tax_amount": tax_amount,
                 "grand_total": grand_total,
+                "promo_discount": _f(promo_discount),
+                "final_total": final_total,
                 "fare_breakdown": fare_breakdown_lines,
                 "available": is_available,
                 "eta_minutes": eta_minutes,

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -119,16 +119,20 @@ function RideOptionsScreenContent() {
   const selectedEstimate = estimates.length > selectedIndex ? estimates[selectedIndex] : null;
 
   const allUnavailable = estimates.length > 0 && !estimates.some(e => e.available);
-  // Promo discount caps at the ride_fare portion, NOT the grand total.
-  // Backend settlement (backend/routes/rides.py:1786) does
-  //   final = grand_total - min(promo.discount_amount, ride_fare)
-  // because fees + GST are not discountable. If the frontend subtracts the
-  // raw promo from grand_total it shows e.g. $0.00 for a ride that actually
-  // charges $2.57 — misleading the rider into expecting a free trip.
-  const ridePortion = parseFloat(selectedEstimate?.total_fare || '0');
-  const grandTotal = parseFloat((selectedEstimate as any)?.grand_total || selectedEstimate?.total_fare || '0');
-  const promoDiscount = Math.min(appliedPromo?.discount_amount ?? 0, ridePortion);
-  const totalFare = Math.max(0, grandTotal - promoDiscount);
+  // Single source of truth: the backend's final_total. It is computed
+  // server-side from the same _validate_promo_for_user helper that
+  // settlement uses, so quote == actual charge by construction. Falls
+  // back to grand_total / total_fare for pre-promo or legacy responses.
+  // Do NOT re-derive this from individual line items in JS — that path
+  // is what caused the $0.00-quote-but-$2.57-charged display bug.
+  const totalFare = parseFloat(
+    String(
+      (selectedEstimate as any)?.final_total
+        ?? (selectedEstimate as any)?.grand_total
+        ?? selectedEstimate?.total_fare
+        ?? '0'
+    )
+  );
 
   const paymentLabel = useMemo(() => {
     if (useCorporate && selectedCorporateId) {
@@ -643,8 +647,26 @@ function RideOptionsScreenContent() {
           {selectedEstimate?.fare_breakdown && selectedEstimate.fare_breakdown.length > 0 && (
             <View style={styles.fareBreakdownCard}>
               <Text style={styles.fareBreakdownTitle}>Fare breakdown</Text>
-              {selectedEstimate.fare_breakdown.map((line, i) => (
-                line.amount != null ? (
+              {selectedEstimate.fare_breakdown.map((line, i) => {
+                if (line.amount == null) return null;
+                const amt = parseFloat(String(line.amount));
+                const isDiscount = line.type === 'discount';
+                // Discounts render in green with an explicit "-$X.XX"
+                // shape; the absolute value is shown so we don't end up
+                // with "$-6.73". All other types use the default styling.
+                const labelStyle = [
+                  styles.fareBreakdownLabel,
+                  line.type === 'tax' && { color: '#6B7280' },
+                  isDiscount && { color: '#10B981' },
+                ];
+                const valueStyle = [
+                  styles.fareBreakdownValue,
+                  isDiscount && { color: '#10B981' },
+                ];
+                const valueText = isDiscount
+                  ? `-$${Math.abs(amt).toFixed(2)}`
+                  : `$${amt.toFixed(2)}`;
+                return (
                   <View key={i} style={[styles.fareBreakdownRow, line.type === 'ride' && { alignItems: 'flex-start' }]}>
                     {line.type === 'ride' ? (
                       <View style={{ flex: 1 }}>
@@ -652,18 +674,12 @@ function RideOptionsScreenContent() {
                         <Text style={styles.fareBreakdownDriverBadge}>100% goes to your driver · ride local, support local</Text>
                       </View>
                     ) : (
-                      <Text style={[styles.fareBreakdownLabel, line.type === 'tax' && { color: '#6B7280' }]}>{line.label}</Text>
+                      <Text style={labelStyle}>{line.label}</Text>
                     )}
-                    <Text style={styles.fareBreakdownValue}>${parseFloat(String(line.amount)).toFixed(2)}</Text>
+                    <Text style={valueStyle}>{valueText}</Text>
                   </View>
-                ) : null
-              ))}
-              {appliedPromo && promoDiscount > 0 && (
-                <View style={[styles.fareBreakdownRow, { marginTop: 2 }]}>
-                  <Text style={[styles.fareBreakdownLabel, { color: '#10B981' }]}>Promo ({appliedPromo.code})</Text>
-                  <Text style={[styles.fareBreakdownValue, { color: '#10B981' }]}>-${promoDiscount.toFixed(2)}</Text>
-                </View>
-              )}
+                );
+              })}
               <View style={[styles.fareBreakdownRow, styles.fareBreakdownTotal]}>
                 <Text style={styles.fareBreakdownTotalLabel}>Total</Text>
                 <Text style={styles.fareBreakdownTotalValue}>${totalFare.toFixed(2)}</Text>
@@ -1065,24 +1081,28 @@ function AnimatedVehicleCard({
           )}
         </View>
         <View style={[styles.optionPriceContainer, !isAvailable && { opacity: 0.4 }]}>
-          {appliedPromo && (appliedPromo.discount_amount ?? 0) > 0 && isSelected ? (() => {
-            // Same cap-at-ride-fare rule as the totalFare computation above —
-            // mirrors backend settlement at backend/routes/rides.py:1786.
-            const tierRide = parseFloat(estimate.total_fare || '0');
-            const tierGrand = parseFloat((estimate as any).grand_total || estimate.total_fare || '0');
-            const tierDiscount = Math.min(appliedPromo.discount_amount ?? 0, tierRide);
-            const tierFinal = Math.max(0, tierGrand - tierDiscount);
-            return (
-              <View style={{ alignItems: 'flex-end' }}>
-                <Text style={styles.optionPriceStruck} allowFontScaling={false}>
-                  ${tierGrand.toFixed(2)}
-                </Text>
-                <Text style={styles.optionPriceDiscounted} allowFontScaling={false}>
-                  ${tierFinal.toFixed(2)}
-                </Text>
-              </View>
-            );
-          })() : (
+          {(() => {
+            // Pull both prices straight from the backend. final_total is
+            // post-promo (already capped at ride_fare server-side);
+            // grand_total is the pre-promo price we strike through to
+            // show the savings. No client-side promo math.
+            const tierGrand = parseFloat(String((estimate as any).grand_total ?? estimate.total_fare ?? '0'));
+            const tierFinal = parseFloat(String((estimate as any).final_total ?? tierGrand));
+            const hasDiscount = tierFinal < tierGrand - 0.005;
+            if (hasDiscount && isSelected) {
+              return (
+                <View style={{ alignItems: 'flex-end' }}>
+                  <Text style={styles.optionPriceStruck} allowFontScaling={false}>
+                    ${tierGrand.toFixed(2)}
+                  </Text>
+                  <Text style={styles.optionPriceDiscounted} allowFontScaling={false}>
+                    ${tierFinal.toFixed(2)}
+                  </Text>
+                </View>
+              );
+            }
+            return null;
+          })() || (
             <Text style={styles.optionPrice} allowFontScaling={false}>
               ${parseFloat((estimate as any).grand_total || estimate.total_fare || '0').toFixed(2)}
             </Text>

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -119,9 +119,16 @@ function RideOptionsScreenContent() {
   const selectedEstimate = estimates.length > selectedIndex ? estimates[selectedIndex] : null;
 
   const allUnavailable = estimates.length > 0 && !estimates.some(e => e.available);
-  // Use server-computed discount_amount — correct for percentage promos and free_ride.
-  const promoDiscount = appliedPromo?.discount_amount ?? 0;
-  const totalFare = Math.max(0, parseFloat((selectedEstimate as any)?.grand_total || selectedEstimate?.total_fare || '0') - promoDiscount);
+  // Promo discount caps at the ride_fare portion, NOT the grand total.
+  // Backend settlement (backend/routes/rides.py:1786) does
+  //   final = grand_total - min(promo.discount_amount, ride_fare)
+  // because fees + GST are not discountable. If the frontend subtracts the
+  // raw promo from grand_total it shows e.g. $0.00 for a ride that actually
+  // charges $2.57 — misleading the rider into expecting a free trip.
+  const ridePortion = parseFloat(selectedEstimate?.total_fare || '0');
+  const grandTotal = parseFloat((selectedEstimate as any)?.grand_total || selectedEstimate?.total_fare || '0');
+  const promoDiscount = Math.min(appliedPromo?.discount_amount ?? 0, ridePortion);
+  const totalFare = Math.max(0, grandTotal - promoDiscount);
 
   const paymentLabel = useMemo(() => {
     if (useCorporate && selectedCorporateId) {
@@ -1058,16 +1065,24 @@ function AnimatedVehicleCard({
           )}
         </View>
         <View style={[styles.optionPriceContainer, !isAvailable && { opacity: 0.4 }]}>
-          {appliedPromo && (appliedPromo.discount_amount ?? 0) > 0 && isSelected ? (
-            <View style={{ alignItems: 'flex-end' }}>
-              <Text style={styles.optionPriceStruck} allowFontScaling={false}>
-                ${parseFloat((estimate as any).grand_total || estimate.total_fare || '0').toFixed(2)}
-              </Text>
-              <Text style={styles.optionPriceDiscounted} allowFontScaling={false}>
-                ${Math.max(0, parseFloat((estimate as any).grand_total || estimate.total_fare || '0') - (appliedPromo.discount_amount ?? 0)).toFixed(2)}
-              </Text>
-            </View>
-          ) : (
+          {appliedPromo && (appliedPromo.discount_amount ?? 0) > 0 && isSelected ? (() => {
+            // Same cap-at-ride-fare rule as the totalFare computation above —
+            // mirrors backend settlement at backend/routes/rides.py:1786.
+            const tierRide = parseFloat(estimate.total_fare || '0');
+            const tierGrand = parseFloat((estimate as any).grand_total || estimate.total_fare || '0');
+            const tierDiscount = Math.min(appliedPromo.discount_amount ?? 0, tierRide);
+            const tierFinal = Math.max(0, tierGrand - tierDiscount);
+            return (
+              <View style={{ alignItems: 'flex-end' }}>
+                <Text style={styles.optionPriceStruck} allowFontScaling={false}>
+                  ${tierGrand.toFixed(2)}
+                </Text>
+                <Text style={styles.optionPriceDiscounted} allowFontScaling={false}>
+                  ${tierFinal.toFixed(2)}
+                </Text>
+              </View>
+            );
+          })() : (
             <Text style={styles.optionPrice} allowFontScaling={false}>
               ${parseFloat((estimate as any).grand_total || estimate.total_fare || '0').toFixed(2)}
             </Text>

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -315,7 +315,7 @@ export const useRideStore = create<RideState>((set, get) => ({
   },
 
   fetchEstimates: async () => {
-    const { pickup, dropoff, stops, estimates: existing } = get();
+    const { pickup, dropoff, stops, estimates: existing, appliedPromo } = get();
     if (!pickup || !dropoff) return;
 
     try {
@@ -324,12 +324,18 @@ export const useRideStore = create<RideState>((set, get) => ({
       if (existing.length === 0) {
         set({ isLoading: true, error: null });
       }
+      // Pass the applied promo so the backend returns the discount line
+      // in fare_breakdown and a post-promo final_total. The rider app no
+      // longer hand-rolls the promo line or computes the total — the API
+      // is the single source of truth (matches the receipt / in-progress
+      // / history surfaces which already use this pattern).
       const response = await api.post<RideEstimate[]>('/rides/estimate', {
         pickup_lat: pickup.lat,
         pickup_lng: pickup.lng,
         dropoff_lat: dropoff.lat,
         dropoff_lng: dropoff.lng,
         stops: stops,
+        promo_code: appliedPromo?.code || null,
       });
       const fresh = Array.isArray(response.data) ? response.data as RideEstimate[] : [];
       // Never replace a populated list with an empty one during a background
@@ -375,7 +381,14 @@ export const useRideStore = create<RideState>((set, get) => ({
       // Auto-apply best eligible promo (sorted: eligible first, then by discount)
       if (promos.length > 0 && !get().appliedPromo) {
         const best = promos.find((p: any) => p.eligible !== false);
-        if (best) set({ appliedPromo: best });
+        if (best) {
+          set({ appliedPromo: best });
+          // Re-fetch estimates so the backend returns the discount line
+          // and post-promo final_total — otherwise the UI shows the
+          // pre-promo total because the previous estimate response had
+          // no promo_code in its request.
+          get().fetchEstimates();
+        }
       }
     } catch (error) {
       console.log('Error fetching promos:', error);
@@ -383,7 +396,14 @@ export const useRideStore = create<RideState>((set, get) => ({
     }
   },
 
-  applyPromo: (promo) => set({ appliedPromo: promo }),
+  // Setting / clearing a promo must trigger a re-quote so the displayed
+  // breakdown and totals match what settlement will charge. Without this,
+  // tapping "Remove promo" would leave the previously-discounted totals
+  // on screen until the next background refresh.
+  applyPromo: (promo) => {
+    set({ appliedPromo: promo });
+    get().fetchEstimates();
+  },
 
   // Sync offline queued requests when back online.
   // Queue entry shape: { id, type, rideId, data, retryCount, timestamp }


### PR DESCRIPTION
The "Choose a ride" screen was subtracting the promo's full discount_amount from grand_total, capped at 0. Backend settlement (backend/routes/rides.py:1786) does the math correctly:

  final = grand_total - min(promo.discount_amount, ride_portion)

because platform/insurance/city/infrastructure fees and GST are not discountable — only the ride fare is. The frontend formula not mirroring this produced a misleading display: a 2.4km ride with SAVE10 (-$10) and a $6.73 ride fare showed Total $0.00 in the quote breakdown and "Confirm · $0.00" on the button, but the rider was actually charged $2.57 (the non-discountable fees + GST). Riders saw a free ride and got a $2.57 charge.

Two display sites fixed in rider-app/app/ride-options.tsx:
- L122-131 (the bottom-of-screen Total + Confirm button label)
- L1068-1083 (the per-tier card struck-out / discounted price pair)

Both now compute:
  ridePortion = total_fare       (ride-only, pre-fees)
  cappedDiscount = min(promo, ridePortion)
  displayedTotal = max(0, grand_total - cappedDiscount)

The "$10 off" face-value label in the promo banner (line 571) is unchanged — that one correctly shows the promo's nominal value.

Settlement math is unchanged; this is a display-only fix. Ships with the next EAS rider-app build.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
