### PR TITLE
fix(push): 5 silent-failure bugs across FCM delivery pipeline

### DIFF
--- a/backend/core/security.py
+++ b/backend/core/security.py
@@ -1,9 +1,12 @@
 import json
+import logging
 
 import firebase_admin
 from firebase_admin import credentials as firebase_credentials
 
 from .config import settings
+
+logger = logging.getLogger(__name__)
 
 
 def init_firebase():
@@ -22,5 +25,5 @@ def init_firebase():
                 firebase_admin.initialize_app()
             except Exception:  # noqa: S110
                 pass
-    except Exception as e:
-        print(f"Firebase initialization failed: {e}")
+    except Exception:
+        logger.error("Firebase initialization failed — all FCM pushes will be silently dropped", exc_info=True)

--- a/backend/features.py
+++ b/backend/features.py
@@ -1200,7 +1200,7 @@ async def _send_expo_push(token: str, title: str, body: str, data: Dict[str, str
             if status == "ok":
                 logger.info(f"Expo push sent OK to {token[:35]}...")
                 return True
-            logger.warning(f"Expo push non-ok response: {result}")
+            logger.error(f"Expo push non-ok response: {result}")
             return False
     except Exception as e:
         logger.error(f"Failed to send Expo push notification: {e}")
@@ -1230,8 +1230,8 @@ async def send_push_notification(
 
             await enqueue_push(user_id, title, body, data, priority=priority)
             return True
-        except Exception as exc:
-            logger.warning(f"push enqueue failed, falling back to direct send: {exc}")
+        except Exception:
+            logger.error("push enqueue failed, falling back to direct send", exc_info=True)
 
     user = await db.find_one("users", {"id": user_id})
     if not user or not user.get("fcm_token"):
@@ -1246,12 +1246,7 @@ async def send_push_notification(
     try:
         from firebase_admin import messaging
     except ImportError:
-        logger.warning("firebase_admin not available for push notifications")
-        return False
-
-    user = await db_supabase.get_user_by_id(user_id)
-    if not user or not user.get("fcm_token"):
-        logger.info(f"No FCM token for user {user_id}")
+        logger.error("firebase_admin not available for push notifications — FCM delivery will fail")
         return False
 
     is_dispatch = (data or {}).get("type") == "new_ride_assignment"

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3907,13 +3907,13 @@ async def rider_report_lost_item(
         driver = await db_supabase.get_driver_by_id(driver_id)
         if driver and driver.get("user_id"):
             driver_user = await db_supabase.get_user_by_id(driver["user_id"])
-            if driver_user and driver_user.get("fcm_token"):
+            if driver_user:
                 try:
                     from ..features import send_push_notification
                 except ImportError:
                     from features import send_push_notification  # type: ignore
                 await send_push_notification(
-                    driver_user["fcm_token"],
+                    driver_user["id"],
                     "Lost Item Report",
                     f"A rider reported a lost item: {req.item_description}. Please check your vehicle.",
                     {"type": "lost_and_found", "ride_id": ride_id},
@@ -3926,7 +3926,7 @@ async def rider_report_lost_item(
                     },
                 )
     except Exception as e:
-        logger.warning(f"Lost item driver notification failed for ride {ride_id}: {e}")
+        logger.error(f"Lost item driver notification failed for ride {ride_id}: {e}", exc_info=True)
 
     return {"success": True, "item": item}
 

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -326,6 +326,21 @@ export default function RootLayout() {
         return;
       }
 
+      // Display a local notification banner — FCM foreground messages are
+      // not shown by the OS automatically; we must present them ourselves.
+      if (Notifications && remoteMessage?.notification?.title) {
+        Notifications.scheduleNotificationAsync({
+          content: {
+            title: remoteMessage.notification.title,
+            body: remoteMessage.notification.body ?? '',
+            data: (remoteMessage.data ?? {}) as Record<string, unknown>,
+            sound: 'default',
+            ...(Platform.OS === 'android' ? { channelId: 'ride-updates' } : {}),
+          },
+          trigger: null,
+        }).catch(() => {});
+      }
+
       const currentRide = useRideStore.getState().currentRide;
       if (currentRide?.id) {
         useRideStore.getState().fetchRide(currentRide.id).catch((e) => console.warn('[Layout] fetchRide on foreground failed:', e?.message ?? e));


### PR DESCRIPTION
1. rides.py: lost-and-found notification passed driver_user["fcm_token"]
   (raw token string) as user_id — send_push_notification did a DB lookup
   on the token value, found nothing, silently dropped every notification.
   Fixed to pass driver_user["id"]. Also simplifies the pre-check guard
   (send_push_notification already handles missing tokens internally).

2. features.py: redundant second DB fetch in the native FCM path — user was
   fetched at line 1236, token extracted, then the user was fetched again
   unnecessarily before building the Message. Removed the dead code.

3. features.py: logger.warning → logger.error on dispatch enqueue failure,
   firebase_admin import failure, and Expo push non-ok response. All three
   are hard failures that must reach Sentry per CLAUDE.md conventions.

4. security.py: Firebase init failure was swallowed with print() — now
   routes through logger.error with exc_info so Sentry captures it. Without
   this, a malformed FIREBASE_SERVICE_ACCOUNT_JSON would silently disable
   all FCM delivery with no alert.

5. rider-app _layout.tsx: foreground FCM messages were handled (scheduled
   ride reminder and safety check-in have custom UX) but generic ride-update
   notifications had no display path — only fetchRide() was called. Added
   scheduleNotificationAsync(trigger: null) so the OS shows a banner when
   the app is in the foreground, matching background behaviour.

https://claude.ai/code/session_01LMiJ9NUyRdEsj2HW9X1eP6

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
