### PR TITLE
Claude/push notification debug d kf5z

### DIFF
--- a/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
+++ b/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
@@ -303,7 +303,14 @@ export default function CloudMessagingPage() {
         URL.revokeObjectURL(url);
     };
 
-    const getChannels = (m: CloudMessage) => m.channels || (m.channel ? [m.channel] : ["push"]);
+    const getChannels = (m: CloudMessage): string[] => {
+        let ch: unknown = m.channels;
+        if (typeof ch === "string") {
+            try { ch = JSON.parse(ch); } catch { ch = [ch]; }
+        }
+        if (Array.isArray(ch) && ch.length > 0) return ch as string[];
+        return m.channel ? [m.channel] : ["push"];
+    };
 
     if (!allowed) return null;
 

--- a/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
+++ b/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
@@ -164,7 +164,7 @@ export default function CloudMessagingPage() {
         try {
             const data = type === "customer" ? await getUsers() : await getDrivers();
             const opts: UserOption[] = (data || []).map((u: any) => ({
-                id: u.id,
+                id: type === "driver" ? (u.user_id || u.id) : u.id,
                 label: `${u.first_name || ""} ${u.last_name || ""}`.trim() || u.email || u.phone || u.id,
                 email: u.email,
                 phone: u.phone,

--- a/backend/features.py
+++ b/backend/features.py
@@ -1196,14 +1196,19 @@ async def _send_expo_push(token: str, title: str, body: str, data: Dict[str, str
                 headers={"Accept": "application/json", "Content-Type": "application/json"},
             )
             result = resp.json()
-            status = result.get("data", {}).get("status") if isinstance(result.get("data"), dict) else None
+            data_block = result.get("data", {}) if isinstance(result.get("data"), dict) else {}
+            status = data_block.get("status")
             if status == "ok":
                 logger.info(f"Expo push sent OK to {token[:35]}...")
                 return True
-            logger.error(f"Expo push non-ok response: {result}")
+            error_code = data_block.get("details", {}).get("error", "")
+            if error_code == "DeviceNotRegistered":
+                logger.warning(f"Expo token unregistered (DeviceNotRegistered): {token[:35]}...")
+            else:
+                logger.error(f"Expo push non-ok response: {result}")
             return False
     except Exception as e:
-        logger.error(f"Failed to send Expo push notification: {e}")
+        logger.error(f"Failed to send Expo push notification: {e}", exc_info=True)
         return False
 
 
@@ -1244,6 +1249,7 @@ async def send_push_notification(
         return await _send_expo_push(token, title, body, data)
 
     try:
+        from firebase_admin import exceptions as firebase_exceptions
         from firebase_admin import messaging
     except ImportError:
         logger.error("firebase_admin not available for push notifications — FCM delivery will fail")
@@ -1278,8 +1284,20 @@ async def send_push_notification(
         response = await asyncio.to_thread(messaging.send, message)
         logger.info(f"Push notification sent to {user_id}: {response} (dispatch={is_dispatch})")
         return True
+    except firebase_exceptions.NotFoundError:
+        # Token is stale (app uninstalled / token rotated). Purge it so the
+        # next login registers a fresh token and delivery resumes.
+        logger.warning(f"Stale FCM token for user {user_id} — purging from users and push_tokens")
+        try:
+            await db.update_one("users", {"id": user_id}, {"fcm_token": None})
+            rows = await db_supabase.get_rows("push_tokens", {"user_id": user_id, "token": token}, limit=1)
+            if rows:
+                await db_supabase.delete_one("push_tokens", {"id": rows[0]["id"]})
+        except Exception:
+            logger.error("Failed to purge stale FCM token", exc_info=True)
+        return False
     except Exception as e:
-        logger.error(f"Failed to send push notification: {e}")
+        logger.error(f"Failed to send push notification to user {user_id}: {e}", exc_info=True)
         return False
 
 

--- a/backend/features.py
+++ b/backend/features.py
@@ -1235,7 +1235,7 @@ async def send_push_notification(
 
     user = await db.find_one("users", {"id": user_id})
     if not user or not user.get("fcm_token"):
-        logger.info(f"No push token for user {user_id}")
+        logger.warning(f"No FCM token on file for user {user_id} — push dropped")
         return False
 
     token: str = user["fcm_token"]

--- a/backend/migrations/100_users_add_fcm_token.sql
+++ b/backend/migrations/100_users_add_fcm_token.sql
@@ -1,0 +1,27 @@
+-- Migration: 100_users_add_fcm_token.sql
+-- Rollback: ALTER TABLE users DROP COLUMN IF EXISTS fcm_token;
+--
+-- The `fcm_token` column on `users` was originally defined in sql/03_features.sql
+-- which is not run by the migration runner, so it was never applied to production.
+-- Every call to notifications/register-token silently caught a "column does not
+-- exist" error and returned success=True with no token actually saved.
+-- send_push_notification() reads users.fcm_token → NULL → drops every push.
+--
+-- This migration:
+--   1. Adds the column
+--   2. Backfills from push_tokens (most-recently-updated token wins per user)
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS fcm_token TEXT;
+
+-- Backfill: for each user pick their most recently updated token from push_tokens
+UPDATE users u
+SET    fcm_token = pt.token
+FROM   (
+    SELECT DISTINCT ON (user_id)
+           user_id,
+           token
+    FROM   push_tokens
+    ORDER  BY user_id, updated_at DESC NULLS LAST
+) pt
+WHERE  u.id = pt.user_id
+  AND  u.fcm_token IS NULL;

--- a/backend/migrations/98_create_ride_messages.sql
+++ b/backend/migrations/98_create_ride_messages.sql
@@ -1,0 +1,34 @@
+-- Migration: 98_create_ride_messages.sql
+-- Rollback: DROP TABLE IF EXISTS ride_messages;
+--
+-- Creates the ride_messages table for in-ride and post-trip chat.
+-- Column names match what routes/rides.py actually reads/writes:
+--   `text` (not `message`), `sender` (not `sender_id`+`sender_role`),
+--   `timestamp` (used by the ORDER BY in get_ride_messages).
+--
+-- Note: 08_complete_schema.sql contains an outdated definition with
+-- different column names; that file was never applied to production for
+-- this table. This migration is the authoritative create.
+
+CREATE TABLE IF NOT EXISTS ride_messages (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    ride_id     TEXT        NOT NULL,
+    text        TEXT        NOT NULL,
+    sender      TEXT        NOT NULL CHECK (sender IN ('rider', 'driver')),
+    timestamp   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for the common query pattern: all messages for a ride, oldest-first
+CREATE INDEX IF NOT EXISTS idx_ride_messages_ride_timestamp
+    ON ride_messages (ride_id, timestamp ASC);
+
+ALTER TABLE ride_messages ENABLE ROW LEVEL SECURITY;
+
+-- The backend service role bypasses RLS.
+-- App clients never query this table directly — all access goes through
+-- the authenticated REST endpoints (GET/POST /rides/{id}/messages).
+CREATE POLICY "ride_messages_no_direct_client_access"
+    ON ride_messages
+    FOR ALL
+    TO authenticated
+    USING (false);

--- a/backend/migrations/99_cloud_messages_jsonb_columns.sql
+++ b/backend/migrations/99_cloud_messages_jsonb_columns.sql
@@ -1,0 +1,29 @@
+-- Migration: 99_cloud_messages_jsonb_columns.sql
+-- Rollback:
+--   ALTER TABLE cloud_messages ALTER COLUMN channels TYPE TEXT USING channels::text;
+--   ALTER TABLE cloud_messages ALTER COLUMN particular_ids TYPE TEXT USING particular_ids::text;
+--
+-- The original migration (06_cloud_messaging.sql) declared `channels` and
+-- `particular_ids` as TEXT. The backend inserts Python lists into these
+-- columns; PostgREST serialises them as JSON strings on the wire.
+-- The admin frontend called .map() on the returned string → TypeError crash,
+-- and the fan-out loop iterated over zero users (string != array).
+-- Converting to JSONB fixes both: PostgREST returns parsed arrays.
+
+ALTER TABLE cloud_messages
+    ALTER COLUMN channels
+    TYPE JSONB
+    USING CASE
+        WHEN channels IS NULL THEN NULL
+        WHEN channels LIKE '[%' THEN channels::jsonb
+        ELSE to_jsonb(ARRAY[channels])
+    END;
+
+ALTER TABLE cloud_messages
+    ALTER COLUMN particular_ids
+    TYPE JSONB
+    USING CASE
+        WHEN particular_ids IS NULL THEN NULL
+        WHEN particular_ids LIKE '[%' THEN particular_ids::jsonb
+        ELSE to_jsonb(ARRAY[particular_ids])
+    END;

--- a/backend/routes/notifications.py
+++ b/backend/routes/notifications.py
@@ -161,11 +161,9 @@ async def register_push_token(body: RegisterTokenRequest, current_user: dict = D
             },
         )
 
-    # Mirror to users.fcm_token so features.send_push_notification can find it.
-    # This is best-effort: if the column doesn't exist yet (pre sql/03_features),
-    # the update is a no-op rather than a hard failure.
+    # Mirror to users.fcm_token — this is what send_push_notification reads.
     try:
-        await db.update_one("users", {"id": current_user["id"]}, {"$set": {"fcm_token": token}})
+        await db.update_one("users", {"id": current_user["id"]}, {"fcm_token": token})
     except Exception as exc:
         logger.error(f"Failed to mirror FCM token onto users.fcm_token: {exc}", exc_info=True)
 


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
