### PR TITLE
Claude/push notification debug d kf5z

### DIFF
--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -40,7 +40,7 @@ import {
 import { Pagination } from "@/components/ui/pagination";
 import { Users, Search, Mail, Phone, MapPin, Star, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff } from "lucide-react";
 import { formatDate } from "@/lib/utils";
-import { getUsersPaginated, updateUserStatus, updateUserRole, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
+import { getUsersPaginated, updateUserStatus, updateUserFlags, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
 import { maskEmail, maskPhone } from "@/lib/pii";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { useToast } from "@/components/ui/use-toast";
@@ -55,7 +55,7 @@ export default function UsersPage() {
     const [error, setError] = useState("");
     const [search, setSearch] = useState("");
     const [statusUpdating, setStatusUpdating] = useState<string | null>(null);
-    const [roleFilter, setRoleFilter] = useState<"all" | "rider" | "driver">("all");
+    const [roleFilter, setRoleFilter] = useState<"all" | "rider" | "driver" | "both">("all");
     const [selectedUser, setSelectedUser] = useState<any>(null);
     const [page, setPage] = useState(0);
     const [hasNextPage, setHasNextPage] = useState(false);
@@ -330,14 +330,15 @@ export default function UsersPage() {
                         className="pl-9"
                     />
                 </div>
-                <Select value={roleFilter} onValueChange={(v) => setRoleFilter(v as "all" | "rider" | "driver")}>
+                <Select value={roleFilter} onValueChange={(v) => setRoleFilter(v as "all" | "rider" | "driver" | "both")}>
                     <SelectTrigger className="w-36" aria-label="Filter by role">
                         <SelectValue placeholder="Role" />
                     </SelectTrigger>
                     <SelectContent>
                         <SelectItem value="all">All Roles</SelectItem>
-                        <SelectItem value="rider">Riders</SelectItem>
-                        <SelectItem value="driver">Drivers</SelectItem>
+                        <SelectItem value="rider">Riders only</SelectItem>
+                        <SelectItem value="driver">Drivers only</SelectItem>
+                        <SelectItem value="both">Dual-role</SelectItem>
                     </SelectContent>
                 </Select>
                 {(search || roleFilter !== "all") && (
@@ -593,48 +594,52 @@ export default function UsersPage() {
                                 </div>
                             </div>
 
-                            {/* Role Correction */}
+                            {/* Role Flags (independent toggles — dual-role supported) */}
                             <div className="border-t pt-4">
-                                <Label className="text-xs text-muted-foreground mb-2 block">Role Correction</Label>
+                                <Label className="text-xs text-muted-foreground mb-2 block">Role Flags</Label>
                                 <p className="text-xs text-muted-foreground mb-2">
-                                    Use if a user's role in the DB doesn't match how they actually use the app.
+                                    Each flag is independent. A user can be both a rider and a driver.
                                 </p>
                                 <div className="flex gap-2">
                                     <Button
                                         className="flex-1"
-                                        variant="outline"
-                                        disabled={selectedUser.role === "rider" || statusUpdating === selectedUser.id}
+                                        variant={selectedUser.is_rider ? "default" : "outline"}
+                                        size="sm"
+                                        disabled={statusUpdating === selectedUser.id}
                                         onClick={async () => {
                                             setStatusUpdating(selectedUser.id);
+                                            const next = !selectedUser.is_rider;
                                             try {
-                                                await updateUserRole(selectedUser.id, "rider");
-                                                setSelectedUser({ ...selectedUser, role: "rider" });
-                                                setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, role: "rider" } : u));
-                                                toast({ title: "Role changed to Rider" });
+                                                await updateUserFlags(selectedUser.id, { is_rider: next });
+                                                setSelectedUser({ ...selectedUser, is_rider: next });
+                                                setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, is_rider: next } : u));
+                                                toast({ title: next ? "Rider flag enabled" : "Rider flag disabled" });
                                             } catch (err: any) {
-                                                toast({ title: "Failed to change role", description: err?.message, variant: "destructive" });
+                                                toast({ title: "Failed to update flag", description: err?.message, variant: "destructive" });
                                             } finally { setStatusUpdating(null); }
                                         }}
                                     >
-                                        Set as Rider
+                                        {selectedUser.is_rider ? "✓ Rider" : "Rider off"}
                                     </Button>
                                     <Button
                                         className="flex-1"
-                                        variant="outline"
-                                        disabled={selectedUser.role === "driver" || statusUpdating === selectedUser.id}
+                                        variant={selectedUser.is_driver ? "default" : "outline"}
+                                        size="sm"
+                                        disabled={statusUpdating === selectedUser.id}
                                         onClick={async () => {
                                             setStatusUpdating(selectedUser.id);
+                                            const next = !selectedUser.is_driver;
                                             try {
-                                                await updateUserRole(selectedUser.id, "driver");
-                                                setSelectedUser({ ...selectedUser, role: "driver" });
-                                                setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, role: "driver" } : u));
-                                                toast({ title: "Role changed to Driver" });
+                                                await updateUserFlags(selectedUser.id, { is_driver: next });
+                                                setSelectedUser({ ...selectedUser, is_driver: next });
+                                                setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, is_driver: next } : u));
+                                                toast({ title: next ? "Driver flag enabled" : "Driver flag disabled" });
                                             } catch (err: any) {
-                                                toast({ title: "Failed to change role", description: err?.message, variant: "destructive" });
+                                                toast({ title: "Failed to update flag", description: err?.message, variant: "destructive" });
                                             } finally { setStatusUpdating(null); }
                                         }}
                                     >
-                                        Set as Driver
+                                        {selectedUser.is_driver ? "✓ Driver" : "Driver off"}
                                     </Button>
                                 </div>
                             </div>

--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -40,7 +40,7 @@ import {
 import { Pagination } from "@/components/ui/pagination";
 import { Users, Search, Mail, Phone, MapPin, Star, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff } from "lucide-react";
 import { formatDate } from "@/lib/utils";
-import { getUsersPaginated, updateUserStatus, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
+import { getUsersPaginated, updateUserStatus, updateUserRole, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
 import { maskEmail, maskPhone } from "@/lib/pii";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { useToast } from "@/components/ui/use-toast";
@@ -590,6 +590,52 @@ export default function UsersPage() {
                                             <Ban className="h-4 w-4 mr-2" /> Ban
                                         </Button>
                                     )}
+                                </div>
+                            </div>
+
+                            {/* Role Correction */}
+                            <div className="border-t pt-4">
+                                <Label className="text-xs text-muted-foreground mb-2 block">Role Correction</Label>
+                                <p className="text-xs text-muted-foreground mb-2">
+                                    Use if a user's role in the DB doesn't match how they actually use the app.
+                                </p>
+                                <div className="flex gap-2">
+                                    <Button
+                                        className="flex-1"
+                                        variant="outline"
+                                        disabled={selectedUser.role === "rider" || statusUpdating === selectedUser.id}
+                                        onClick={async () => {
+                                            setStatusUpdating(selectedUser.id);
+                                            try {
+                                                await updateUserRole(selectedUser.id, "rider");
+                                                setSelectedUser({ ...selectedUser, role: "rider" });
+                                                setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, role: "rider" } : u));
+                                                toast({ title: "Role changed to Rider" });
+                                            } catch (err: any) {
+                                                toast({ title: "Failed to change role", description: err?.message, variant: "destructive" });
+                                            } finally { setStatusUpdating(null); }
+                                        }}
+                                    >
+                                        Set as Rider
+                                    </Button>
+                                    <Button
+                                        className="flex-1"
+                                        variant="outline"
+                                        disabled={selectedUser.role === "driver" || statusUpdating === selectedUser.id}
+                                        onClick={async () => {
+                                            setStatusUpdating(selectedUser.id);
+                                            try {
+                                                await updateUserRole(selectedUser.id, "driver");
+                                                setSelectedUser({ ...selectedUser, role: "driver" });
+                                                setUsers(prev => prev.map(u => u.id === selectedUser.id ? { ...u, role: "driver" } : u));
+                                                toast({ title: "Role changed to Driver" });
+                                            } catch (err: any) {
+                                                toast({ title: "Failed to change role", description: err?.message, variant: "destructive" });
+                                            } finally { setStatusUpdating(null); }
+                                        }}
+                                    >
+                                        Set as Driver
+                                    </Button>
                                 </div>
                             </div>
 

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -1423,6 +1423,12 @@ export const updateUserStatus = (id: string, statusData: any) =>
         body: JSON.stringify(statusData),
     });
 
+export const updateUserRole = (id: string, role: "rider" | "driver") =>
+    request<any>(`/api/admin/users/${id}/role`, {
+        method: "PATCH",
+        body: JSON.stringify({ role }),
+    });
+
 export const exportUsers = (limit = 1000) =>
     request<{ users: any[]; count: number }>(`/api/admin/export/users?limit=${limit}`);
 

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -1401,7 +1401,7 @@ export const getUsers = (role: "all" | "rider" | "driver" | "admin" = "all") =>
     request<any[]>(`/api/admin/users?role=${role}`);
 
 export const getUsersPaginated = (opts: {
-    role?: "all" | "rider" | "driver" | "admin";
+    role?: "all" | "rider" | "driver" | "both" | "admin";
     search?: string;
     limit?: number;
     offset?: number;
@@ -1423,10 +1423,10 @@ export const updateUserStatus = (id: string, statusData: any) =>
         body: JSON.stringify(statusData),
     });
 
-export const updateUserRole = (id: string, role: "rider" | "driver") =>
+export const updateUserFlags = (id: string, flags: { is_rider?: boolean; is_driver?: boolean }) =>
     request<any>(`/api/admin/users/${id}/role`, {
         method: "PATCH",
-        body: JSON.stringify({ role }),
+        body: JSON.stringify(flags),
     });
 
 export const exportUsers = (limit = 1000) =>

--- a/backend/migrations/101_users_add_is_rider.sql
+++ b/backend/migrations/101_users_add_is_rider.sql
@@ -1,0 +1,24 @@
+-- Migration: 101_users_add_is_rider.sql
+-- Rollback: ALTER TABLE users DROP COLUMN IF EXISTS is_rider;
+--
+-- Adds is_rider boolean flag to complement the existing is_driver flag,
+-- enabling dual-role accounts (a person who both rides and drives).
+--
+-- Previously, users.role was a single-valued enum (rider | driver | admin).
+-- Anyone who completed even partial driver onboarding had their role flipped
+-- to 'driver', which excluded them from rider-targeted notifications and
+-- features even if they still used the rider app.
+--
+-- With this migration:
+--   is_rider = true  → user can book rides (receives "all customers" pushes)
+--   is_driver = true → user has a driver profile and can accept rides
+--   Both true        → dual-role (Uber-style); receives both sets of pushes
+--
+-- The role column is NOT dropped — it remains for admin JWT RBAC
+-- (super_admin | operations | support | finance | custom | admin).
+-- All rider/driver discrimination now uses these two boolean flags.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_rider BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- Everyone can ride by default, including existing drivers.
+UPDATE users SET is_rider = TRUE WHERE is_rider IS NULL OR is_rider = FALSE;

--- a/backend/onboarding_status.py
+++ b/backend/onboarding_status.py
@@ -114,10 +114,6 @@ async def derive_driver_onboarding_status(
     if not user:
         return None, None, None
 
-    # Only compute for users who are drivers or on the driver app flow.
-    # The driver app sets role='driver' on registration; if role isn't set
-    # yet we still compute because the user is about to become a driver.
-    role = (user.get("role") or "").lower()
     user_id = user.get("id")
 
     # Step 1: profile fields
@@ -133,9 +129,8 @@ async def derive_driver_onboarding_status(
     except Exception:
         driver = None
 
-    # If we're on the rider app (role=rider, no driver row, is_driver=False),
-    # don't emit a driver onboarding status at all — this is a rider.
-    if role != "driver" and not driver:
+    # If the user has no driver flag and no driver row, skip onboarding status.
+    if not user.get("is_driver") and not driver:
         return None, None, None
 
     if not _has_vehicle(driver):

--- a/backend/routes/admin/faqs.py
+++ b/backend/routes/admin/faqs.py
@@ -139,12 +139,12 @@ async def admin_send_notification(request: Request, notification: NotificationRe
             await send_push_notification(u["id"], title, body)
         logger.info(f"Broadcast notification to all users: {title}")
     elif audience == "riders":
-        riders = await db.get_rows("users", {"role": "rider"}, limit=10000)
+        riders = await db.get_rows("users", {"is_rider": True}, limit=10000)
         for u in riders or []:
             await send_push_notification(u["id"], title, body)
         logger.info(f"Broadcast notification to all riders: {title}")
     elif audience == "drivers":
-        drivers = await db.get_rows("users", {"role": "driver"}, limit=10000)
+        drivers = await db.get_rows("users", {"is_driver": True}, limit=10000)
         for u in drivers or []:
             await send_push_notification(u["id"], title, body)
         logger.info(f"Broadcast notification to all drivers: {title}")
@@ -172,12 +172,7 @@ async def admin_get_notifications(
         order=(
             "created_at"
             if "created_at"
-            in (
-                (lambda _r: _r[0] if _r else None)(
-                    await db_supabase.get_rows("notifications", {}, limit=1)
-                )
-                or {}
-            )
+            in ((lambda _r: _r[0] if _r else None)(await db_supabase.get_rows("notifications", {}, limit=1)) or {})
             else "sent_at"
         ),
         desc=True,

--- a/backend/routes/admin/messaging.py
+++ b/backend/routes/admin/messaging.py
@@ -22,18 +22,14 @@ router = APIRouter()
 class CloudMessageRequest(BaseModel):
     title: str = Field(..., min_length=1, max_length=100)
     description: str = Field(..., min_length=1, max_length=500)
-    audience: Literal[
-        "customers", "drivers", "particular_customer", "particular_driver", "all"
-    ] = "customers"
+    audience: Literal["customers", "drivers", "particular_customer", "particular_driver", "all"] = "customers"
     type: str = "info"
     channels: List[Literal["push", "sms", "email"]] = ["push"]
     particular_ids: Optional[List[str]] = None
     scheduled_at: Optional[str] = None
 
 
-async def _fan_out_push(
-    message_id: str, target_users: list, title: str, description: str
-) -> None:
+async def _fan_out_push(message_id: str, target_users: list, title: str, description: str) -> None:
     """Fan-out push notifications concurrently and persist final stats to the cloud_messages record."""
     try:
         from ...features import send_push_notification
@@ -52,15 +48,11 @@ async def _fan_out_push(
     uids = [u.get("id") if isinstance(u, dict) else u for u in target_users]
     uids = [uid for uid in uids if uid]
 
-    results = await asyncio.gather(
-        *[_send_one(uid) for uid in uids], return_exceptions=True
-    )
+    results = await asyncio.gather(*[_send_one(uid) for uid in uids], return_exceptions=True)
     successful = sum(1 for r in results if r is True)
     failed_count = len(results) - successful
 
-    logger.info(
-        f"Cloud message {message_id} fan-out complete: success={successful} failed={failed_count}"
-    )
+    logger.info(f"Cloud message {message_id} fan-out complete: success={successful} failed={failed_count}")
 
     try:
         await db_supabase.update_one(
@@ -69,9 +61,7 @@ async def _fan_out_push(
             {"successful": successful, "failed_count": failed_count},
         )
     except Exception:
-        logger.error(
-            f"Failed to update cloud_message stats for {message_id}", exc_info=True
-        )
+        logger.error(f"Failed to update cloud_message stats for {message_id}", exc_info=True)
 
 
 # ---------- Cloud Messaging ----------
@@ -107,10 +97,10 @@ async def admin_send_cloud_message(
     if audience in ("particular_customer", "particular_driver"):
         total_recipients = len(particular_ids) if particular_ids else 1
     elif audience == "customers":
-        count = await db_supabase.count_documents("users", {"role": "rider"})
+        count = await db_supabase.count_documents("users", {"is_rider": True})
         total_recipients = count if count > 0 else 0
     elif audience == "drivers":
-        count = await db_supabase.count_documents("users", {"role": "driver"})
+        count = await db_supabase.count_documents("users", {"is_driver": True})
         total_recipients = count if count > 0 else 0
 
     target_users: list = []
@@ -118,9 +108,9 @@ async def admin_send_cloud_message(
         if audience in ("particular_customer", "particular_driver"):
             target_users = [{"id": uid} for uid in particular_ids]
         elif audience == "customers":
-            target_users = await db.get_rows("users", {"role": "rider"}, limit=10000)
+            target_users = await db.get_rows("users", {"is_rider": True}, limit=10000)
         elif audience == "drivers":
-            target_users = await db.get_rows("users", {"role": "driver"}, limit=10000)
+            target_users = await db.get_rows("users", {"is_driver": True}, limit=10000)
 
     doc = {
         "id": str(uuid.uuid4()),
@@ -151,9 +141,7 @@ async def admin_send_cloud_message(
         ) from e
 
     if not is_scheduled:
-        background_tasks.add_task(
-            _fan_out_push, doc["id"], target_users, title, description
-        )
+        background_tasks.add_task(_fan_out_push, doc["id"], target_users, title, description)
         response.status_code = 202
 
     return {"success": True, "message": doc}
@@ -203,11 +191,7 @@ async def admin_get_cloud_message_stats():
     total_failed = sum(1 for m in all_messages if m.get("status") == "failed")
     total_reached = sum(m.get("successful", 0) for m in all_messages)
     total_recipients = sum(m.get("total_recipients", 0) for m in all_messages)
-    success_rate = (
-        round((total_reached / total_recipients * 100), 1)
-        if total_recipients > 0
-        else 0
-    )
+    success_rate = round((total_reached / total_recipients * 100), 1) if total_recipients > 0 else 0
 
     return {
         "total_messages": total,
@@ -231,7 +215,5 @@ async def admin_delete_cloud_message(message_id: str):
     if existing.get("status") == "sent":
         raise HTTPException(status_code=400, detail="Cannot delete a sent message")
 
-    await db_supabase.update_one(
-        "cloud_messages", {"id": message_id}, {"status": "cancelled"}
-    )
+    await db_supabase.update_one("cloud_messages", {"id": message_id}, {"status": "cancelled"})
     return {"message": "Message cancelled"}

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -132,6 +132,61 @@ async def admin_update_user_status(user_id: str, status_data: UserStatusRequest,
     return {"message": f"User status updated to {new_status}"}
 
 
+class UserRoleRequest(BaseModel):
+    role: str  # "rider" | "driver"
+
+
+@router.patch("/users/{user_id}/role")
+async def admin_update_user_role(
+    user_id: str,
+    body: UserRoleRequest,
+    admin: dict = Depends(get_admin_user),
+):
+    """Correct a user's role (rider ↔ driver).
+
+    Use when a user's role in the DB doesn't match how they actually use
+    the app — e.g. someone who started driver onboarding but never completed
+    it and now only rides, but their role was flipped to 'driver'.
+
+    Changing rider → driver does NOT create a drivers-table row.
+    Changing driver → rider sets is_driver = False (doesn't delete the
+    drivers row — that preserves trip history).
+    """
+    if body.role not in ("rider", "driver"):
+        raise HTTPException(status_code=400, detail="role must be 'rider' or 'driver'")
+
+    user = await db_supabase.get_user_by_id(user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    old_role = user.get("role")
+    if old_role == body.role:
+        return {"message": f"User is already {body.role}"}
+
+    update: dict = {"role": body.role, "updated_at": datetime.now(timezone.utc).isoformat()}
+    if body.role == "rider":
+        update["is_driver"] = False
+
+    await db_supabase.update_one("users", {"id": user_id}, update)
+
+    await db_supabase.insert_one(
+        "audit_logs",
+        {
+            "id": str(uuid.uuid4()),
+            "actor_id": admin["id"],
+            "actor_role": admin.get("role"),
+            "action": "role_change",
+            "entity_type": "user",
+            "entity_id": user_id,
+            "details": {"old_role": old_role, "new_role": body.role},
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+    logger.info(f"Admin {admin['id']} changed user {user_id} role: {old_role} → {body.role}")
+    return {"message": f"User role changed from {old_role} to {body.role}"}
+
+
 # ---------- Export & PII Audit ----------
 
 _EXPORT_MAX_ROWS = 5000

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -43,14 +43,21 @@ async def admin_get_users(
     """
     filters: Dict[str, Any] = {}
     role_param = (role or "all").lower()
-    if role_param in ("rider", "driver", "admin"):
-        filters["role"] = role_param
+    if role_param == "rider":
+        filters["is_rider"] = True
+        filters["role"] = {"$ne": "admin"}
+    elif role_param == "driver":
+        filters["is_driver"] = True
+    elif role_param == "both":
+        filters["is_rider"] = True
+        filters["is_driver"] = True
+    elif role_param == "admin":
+        filters["role"] = "admin"
     elif role_param == "all":
-        # Every non-admin. Admin dashboard users are managed on the Staff
-        # page, not here.
+        # Every non-admin user — managed on the Staff page instead.
         filters["role"] = {"$ne": "admin"}
     else:
-        raise HTTPException(status_code=400, detail="role must be one of rider, driver, admin, all")
+        raise HTTPException(status_code=400, detail="role must be one of rider, driver, both, admin, all")
 
     if search:
         # Basic contains-match on phone / email / first_name; callers typically
@@ -132,40 +139,49 @@ async def admin_update_user_status(user_id: str, status_data: UserStatusRequest,
     return {"message": f"User status updated to {new_status}"}
 
 
-class UserRoleRequest(BaseModel):
-    role: str  # "rider" | "driver"
+class UserFlagsRequest(BaseModel):
+    is_rider: Optional[bool] = None
+    is_driver: Optional[bool] = None
 
 
 @router.patch("/users/{user_id}/role")
-async def admin_update_user_role(
+async def admin_update_user_flags(
     user_id: str,
-    body: UserRoleRequest,
+    body: UserFlagsRequest,
     admin: dict = Depends(get_admin_user),
 ):
-    """Correct a user's role (rider ↔ driver).
+    """Set is_rider / is_driver flags independently (dual-role support).
 
-    Use when a user's role in the DB doesn't match how they actually use
-    the app — e.g. someone who started driver onboarding but never completed
-    it and now only rides, but their role was flipped to 'driver'.
+    Each flag is optional — send only the ones you want to change.
+    A user can have both flags true (rides and drives), either alone,
+    or neither (deactivated from both roles).
 
-    Changing rider → driver does NOT create a drivers-table row.
-    Changing driver → rider sets is_driver = False (doesn't delete the
-    drivers row — that preserves trip history).
+    Setting is_driver=False does NOT delete the drivers row — trip history
+    is preserved. Setting is_driver=True does NOT create a drivers row —
+    the user must complete onboarding first.
     """
-    if body.role not in ("rider", "driver"):
-        raise HTTPException(status_code=400, detail="role must be 'rider' or 'driver'")
+    if body.is_rider is None and body.is_driver is None:
+        raise HTTPException(status_code=400, detail="Provide at least one of is_rider or is_driver")
 
     user = await db_supabase.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
 
-    old_role = user.get("role")
-    if old_role == body.role:
-        return {"message": f"User is already {body.role}"}
+    update: dict = {"updated_at": datetime.now(timezone.utc).isoformat()}
+    old_flags = {"is_rider": user.get("is_rider"), "is_driver": user.get("is_driver")}
+    new_flags: dict = {}
 
-    update: dict = {"role": body.role, "updated_at": datetime.now(timezone.utc).isoformat()}
-    if body.role == "rider":
-        update["is_driver"] = False
+    if body.is_rider is not None:
+        update["is_rider"] = body.is_rider
+        new_flags["is_rider"] = body.is_rider
+    if body.is_driver is not None:
+        update["is_driver"] = body.is_driver
+        new_flags["is_driver"] = body.is_driver
+        # Keep role column in sync for backward-compat (admin queries, JWT)
+        if body.is_driver and user.get("role") not in ("driver", "admin"):
+            update["role"] = "driver"
+        elif not body.is_driver and not body.is_rider and user.get("role") == "driver":
+            update["role"] = "rider"
 
     await db_supabase.update_one("users", {"id": user_id}, update)
 
@@ -175,16 +191,16 @@ async def admin_update_user_role(
             "id": str(uuid.uuid4()),
             "actor_id": admin["id"],
             "actor_role": admin.get("role"),
-            "action": "role_change",
+            "action": "flags_change",
             "entity_type": "user",
             "entity_id": user_id,
-            "details": {"old_role": old_role, "new_role": body.role},
+            "details": {"old_flags": old_flags, "new_flags": new_flags},
             "created_at": datetime.now(timezone.utc).isoformat(),
         },
     )
 
-    logger.info(f"Admin {admin['id']} changed user {user_id} role: {old_role} → {body.role}")
-    return {"message": f"User role changed from {old_role} to {body.role}"}
+    logger.info(f"Admin {admin['id']} updated user {user_id} flags: {old_flags} → {new_flags}")
+    return {"message": "User flags updated", "old": old_flags, "new": new_flags}
 
 
 # ---------- Export & PII Audit ----------

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -150,9 +150,7 @@ async def _record_otp_failure(phone: str) -> None:
                 "1",
                 settings.OTP_LOCKOUT_DURATION_SECONDS,
             )
-            logger.warning(
-                f"OTP_LOCKOUT_TRIGGERED phone=...{phone[-4:]} after {count} failures"
-            )
+            logger.warning(f"OTP_LOCKOUT_TRIGGERED phone=...{phone[-4:]} after {count} failures")
             try:
                 import asyncio
 
@@ -166,9 +164,7 @@ async def _record_otp_failure(phone: str) -> None:
                     )
                 )
             except Exception:
-                logger.debug(
-                    "audit_log write failed for OTP failure event", exc_info=True
-                )
+                logger.debug("audit_log write failed for OTP failure event", exc_info=True)
     except Exception as e:
         logger.error(f"_record_otp_failure: {e}", exc_info=True)
 
@@ -412,9 +408,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
             exc_info=True,
         )
         try:
-            await db_supabase.update_one(
-                "otp_records", {"id": otp_record["id"]}, {"verified": True}
-            )
+            await db_supabase.update_one("otp_records", {"id": otp_record["id"]}, {"verified": True})
         except Exception:
             logger.error(
                 "auth: failed to mark OTP %s as verified — reuse risk",
@@ -435,11 +429,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
             # Surface the real underlying Supabase error. DatabaseError
             # wraps the original exception in .details["original"]; str(e)
             # only gives the generic "Database operation failed" message.
-            original = (
-                getattr(e, "details", {}).get("original")
-                if hasattr(e, "details")
-                else None
-            )
+            original = getattr(e, "details", {}).get("original") if hasattr(e, "details") else None
             logger.error(
                 f"get_user_by_phone failed for ***{phone[-4:]}: type={type(e).__name__} msg={e} original={original}",
                 exc_info=True,
@@ -470,9 +460,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
                 )
                 existing_user["current_session_id"] = session_id
             except Exception as e:
-                logger.error(
-                    f"Could not update session_id for existing user: {e}", exc_info=True
-                )
+                logger.error(f"Could not update session_id for existing user: {e}", exc_info=True)
             # Mirror session_id in Redis so revocation propagates instantly across
             # all replicas without waiting for a Postgres read on every request.
             await redis_set(
@@ -482,9 +470,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
             )
             user_id = existing_user["id"]
             token_version = int(existing_user.get("token_version") or 0)
-            access_expires_at = datetime.now(timezone.utc) + timedelta(
-                minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
-            )
+            access_expires_at = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
             token = create_jwt_token(
                 user_id,
                 phone,
@@ -547,6 +533,8 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
                 "id": user_id,
                 "phone": phone,
                 "role": "rider",
+                "is_rider": True,
+                "is_driver": False,
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "profile_complete": False,
                 "current_session_id": session_id,
@@ -570,12 +558,8 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
                 session_id,
                 ttl=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
             )
-            access_expires_at = datetime.now(timezone.utc) + timedelta(
-                minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
-            )
-            token = create_jwt_token(
-                user_id, phone, session_id=session_id, token_version=0
-            )
+            access_expires_at = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+            token = create_jwt_token(user_id, phone, session_id=session_id, token_version=0)
             refresh_raw, _, refresh_expires_at = await issue_refresh_token(
                 user_id, audience="rider", user_agent=user_agent, ip=client_ip
             )
@@ -644,9 +628,7 @@ class FirebaseAuthRequest(BaseModel):
 
 @api_router.post("/firebase", response_model=AuthResponse)
 @limiter.limit("10/minute")
-async def firebase_auth_login(
-    request: Request, response: Response, body: FirebaseAuthRequest
-):
+async def firebase_auth_login(request: Request, response: Response, body: FirebaseAuthRequest):
     """Exchange a Firebase ID token for Spinr access + refresh tokens.
 
     Mirrors the OTP verify flow: verify identity, find-or-create the user
@@ -656,9 +638,7 @@ async def firebase_auth_login(
     try:
         from firebase_admin import auth as _firebase_auth  # type: ignore
 
-        payload = _firebase_auth.verify_id_token(
-            body.firebase_token, check_revoked=True
-        )
+        payload = _firebase_auth.verify_id_token(body.firebase_token, check_revoked=True)
     except Exception as e:
         raise SpinrException(
             message="Invalid Firebase token",
@@ -713,6 +693,8 @@ async def firebase_auth_login(
             "id": uid,
             "phone": phone,
             "role": "rider",
+            "is_rider": True,
+            "is_driver": False,
             "created_at": datetime.now(timezone.utc).isoformat(),
             "profile_complete": False,
             "current_session_id": session_id,
@@ -737,9 +719,7 @@ async def firebase_auth_login(
         user = new_user
     else:
         try:
-            await db_supabase.update_one(
-                "users", {"id": uid}, {"current_session_id": session_id}
-            )
+            await db_supabase.update_one("users", {"id": uid}, {"current_session_id": session_id})
         except Exception as e:
             # Without a persisted current_session_id, single-device login
             # can't enforce ERR_SESSION_EXPIRED on the prior device, and
@@ -759,12 +739,8 @@ async def firebase_auth_login(
 
     user_id = user["id"]
     token_version = int(user.get("token_version") or 0)
-    access_expires_at = datetime.now(timezone.utc) + timedelta(
-        minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES
-    )
-    token = create_jwt_token(
-        user_id, phone, session_id=session_id, token_version=token_version
-    )
+    access_expires_at = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    token = create_jwt_token(user_id, phone, session_id=session_id, token_version=token_version)
     refresh_raw, _, refresh_expires_at = await issue_refresh_token(
         user_id, audience="driver", user_agent=user_agent, ip=client_ip
     )
@@ -833,9 +809,7 @@ async def get_me(current_user: dict = Depends(get_current_user)):
     if has_profile_data and not current_user.get("profile_complete"):
         # Self-heal the column so the next login is fast and consistent.
         try:
-            await db_supabase.update_one(
-                "users", {"id": current_user["id"]}, {"profile_complete": True}
-            )
+            await db_supabase.update_one("users", {"id": current_user["id"]}, {"profile_complete": True})
         except Exception as e:
             # B-P1-5 / CLAUDE.md: this is a DB write failure, not a
             # recoverable anomaly. Mutating `current_user` in memory
@@ -852,9 +826,7 @@ async def get_me(current_user: dict = Depends(get_current_user)):
     except ImportError:
         from ..onboarding_status import derive_driver_onboarding_status  # type: ignore
     try:
-        status, detail, next_screen = await derive_driver_onboarding_status(
-            current_user
-        )
+        status, detail, next_screen = await derive_driver_onboarding_status(current_user)
         current_user["driver_onboarding_status"] = status
         current_user["driver_onboarding_detail"] = detail
         current_user["driver_onboarding_next_screen"] = next_screen
@@ -892,9 +864,7 @@ class LogoutRequest(BaseModel):
 
 @api_router.post("/refresh", response_model=RefreshResponse)
 @limiter.limit("20/minute")
-async def refresh_access_token(
-    request: Request, response: Response, body: Optional[RefreshRequest] = None
-):
+async def refresh_access_token(request: Request, response: Response, body: Optional[RefreshRequest] = None):
     """Exchange a refresh token for a new access token + rotated refresh token.
 
     P3: Now reads refresh_token from HTTP-only cookie instead of request body.
@@ -977,9 +947,7 @@ async def refresh_access_token(
 
     session_id = user.get("current_session_id") or row.get("user_agent") or ""
     token_version = int(user.get("token_version") or 0)
-    access_expires_at = datetime.now(timezone.utc) + timedelta(
-        days=settings.ACCESS_TOKEN_TTL_DAYS
-    )
+    access_expires_at = datetime.now(timezone.utc) + timedelta(days=settings.ACCESS_TOKEN_TTL_DAYS)
     token = create_jwt_token(
         user_id,
         user.get("phone", ""),
@@ -1070,9 +1038,7 @@ async def logout(
 
 @api_router.post("/logout-all")
 @limiter.limit("5/minute")
-async def logout_all(
-    request: Request, response: Response, current_user: dict = Depends(get_current_user)
-):
+async def logout_all(request: Request, response: Response, current_user: dict = Depends(get_current_user)):
     """Force-invalidate every session for the caller.
 
     Bumps ``users.token_version`` so all outstanding access tokens are
@@ -1084,9 +1050,7 @@ async def logout_all(
     user_id = current_user["id"]
     new_version = int(current_user.get("token_version") or 0) + 1
     try:
-        await db.update_one(
-            "users", {"id": user_id}, {"$set": {"token_version": new_version}}
-        )
+        await db.update_one("users", {"id": user_id}, {"$set": {"token_version": new_version}})
     except Exception as e:
         logger.error(
             f"logout-all: could not bump token_version for {user_id}: {e}",
@@ -1128,9 +1092,7 @@ async def logout_all(
             exc_info=True,
         )
 
-    logger.info(
-        f"logout-all: user={user_id} token_version→{new_version} revoked_refresh={revoked}"
-    )
+    logger.info(f"logout-all: user={user_id} token_version→{new_version} revoked_refresh={revoked}")
 
     # P3: Clear HTTP-only cookies
     try:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -532,7 +532,8 @@ async def update_my_driver(body: UpdateDriverProfileRequest, current_user: dict 
             **updates,
         }
         await db_supabase.insert_one("drivers", new_driver)
-        # Also flip the user role to 'driver' if not already
+        # Mark as driver; is_rider is intentionally left unchanged so a
+        # driver who was already riding keeps both flags (dual-role).
         await db_supabase.update_one("users", {"id": current_user["id"]}, {"role": "driver", "is_driver": True})
         return serialize_doc(new_driver)
 
@@ -710,12 +711,9 @@ async def register_driver(
     }
     await db_supabase.insert_one("drivers", await _encrypt_driver_pii(new_driver))
 
-    # Canonicalize the identity: if the user's role is still 'rider' flip
-    # it to 'driver' so admin lists, login resolution, and role-gated code
-    # all agree (see migration 31 for the one-shot backfill of legacy
-    # rows). Only updates when needed so we don't churn updated_at on
-    # users who are already tagged correctly.
-    if current_user.get("role") != "driver" or not current_user.get("is_driver"):
+    # Canonicalize is_driver flag. is_rider is intentionally NOT cleared here
+    # so that a driver who already has is_rider=true keeps dual-role status.
+    if not current_user.get("is_driver"):
         try:
             # users table has no updated_at column (supabase_schema.sql).
             await db_supabase.update_one(

--- a/backend/routes/safety.py
+++ b/backend/routes/safety.py
@@ -57,7 +57,7 @@ async def submit_safety_report(
 ):
     """Record a safety incident submitted by a driver or rider."""
     user_id = current_user.get("id")
-    user_role = current_user.get("role") or "rider"
+    user_role = "driver" if current_user.get("is_driver") else "rider"
 
     incident_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc).isoformat()

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -31,21 +31,15 @@ async def get_profile(current_user: dict = Depends(get_current_user)):
 
 
 @api_router.post("/profile", response_model=UserProfile)
-async def create_profile(
-    request: CreateProfileRequest, current_user: dict = Depends(get_current_user)
-):
+async def create_profile(request: CreateProfileRequest, current_user: dict = Depends(get_current_user)):
     valid_genders = ["Male", "Female", "Other"]
     if request.gender not in valid_genders:
-        raise HTTPException(
-            status_code=400, detail=f"Gender must be one of: {', '.join(valid_genders)}"
-        )
+        raise HTTPException(status_code=400, detail=f"Gender must be one of: {', '.join(valid_genders)}")
 
     # GAP FIX: Check for duplicate email across users
     email_lower = request.email.strip().lower()
     existing_email_user = (lambda _r: _r[0] if _r else None)(
-        await db_supabase.get_rows(
-            "users", {"email": email_lower, "id": {"$ne": current_user["id"]}}, limit=1
-        )
+        await db_supabase.get_rows("users", {"email": email_lower, "id": {"$ne": current_user["id"]}}, limit=1)
     )
     if existing_email_user:
         raise HTTPException(
@@ -60,9 +54,15 @@ async def create_profile(
         "gender": request.gender,
         "profile_complete": True,
     }
-    # Allow driver app to set role='driver' so onboarding status is computed
-    if request.role and request.role in ("driver", "rider"):
-        update_data["role"] = request.role
+    # Allow driver app to hint the role so onboarding status is computed.
+    # We write the flag (is_driver / is_rider) rather than the role column so
+    # that a user who starts driver onboarding keeps is_rider=true (dual-role).
+    if request.role == "driver":
+        update_data["role"] = "driver"
+        update_data["is_driver"] = True
+        # is_rider intentionally left unchanged
+    elif request.role == "rider":
+        update_data["is_rider"] = True
 
     await db_supabase.update_one("users", {"id": current_user["id"]}, update_data)
     updated_user = await db_supabase.get_user_by_id(current_user["id"])
@@ -85,9 +85,7 @@ async def request_data_export(current_user: dict = Depends(get_current_user)):
     request_id = str(uuid.uuid4())
     now = datetime.now(timezone.utc)
     response_due_at = (now + timedelta(days=30)).isoformat()
-    logger.info(
-        f"DSAR submitted for user {user_id} request_id={request_id} due={response_due_at}"
-    )
+    logger.info(f"DSAR submitted for user {user_id} request_id={request_id} due={response_due_at}")
     try:
         export_record = {
             "id": request_id,
@@ -140,15 +138,11 @@ async def _anonymise_rides(user_id: str) -> None:
                 if ride.get(lng_field) is not None:
                     updates[lng_field] = round(float(ride[lng_field]), 2)
             await db_supabase.update_one("rides", {"id": ride["id"]}, updates)
-        logger.info(
-            f"Anonymised {len(rides)} completed rides for deleted user {user_id}"
-        )
+        logger.info(f"Anonymised {len(rides)} completed rides for deleted user {user_id}")
     except Exception as e:
         # Log but don't fail the deletion — ride anonymisation is best-effort;
         # the account is still marked pending_deletion so the purge loop retries.
-        logger.error(
-            f"Ride anonymisation failed for user {user_id}: {e}", exc_info=True
-        )
+        logger.error(f"Ride anonymisation failed for user {user_id}: {e}", exc_info=True)
 
 
 @api_router.delete("/account")
@@ -157,9 +151,7 @@ async def delete_account_pipeda(current_user: dict = Depends(get_current_user)):
     user_id = current_user["id"]
     logger.info(f"Account deletion (PIPEDA) requested for user {user_id}")
 
-    grace_period_end = (
-        datetime.now(timezone.utc).replace(microsecond=0) + timedelta(days=30)
-    ).isoformat()
+    grace_period_end = (datetime.now(timezone.utc).replace(microsecond=0) + timedelta(days=30)).isoformat()
     now = datetime.now(timezone.utc).isoformat()
     try:
         await db_supabase.update_one(
@@ -171,9 +163,7 @@ async def delete_account_pipeda(current_user: dict = Depends(get_current_user)):
                 "status": "pending_deletion",
             },
         )
-        await db_supabase.update_one(
-            "drivers", {"user_id": user_id}, {"deleted_at": now}
-        )
+        await db_supabase.update_one("drivers", {"user_id": user_id}, {"deleted_at": now})
         # R-P2-46: strip PII from ride records immediately even though the account
         # itself has a 30-day grace period.  Ride rows are retained for SK regulatory
         # retention (7 years) but personal identifiers are removed now.
@@ -185,9 +175,7 @@ async def delete_account_pipeda(current_user: dict = Depends(get_current_user)):
             resource_id=user_id,
             details={"grace_period_end": grace_period_end, "pipeda": True},
         )
-        logger.info(
-            f"Account deletion scheduled for user {user_id} (grace period until {grace_period_end})"
-        )
+        logger.info(f"Account deletion scheduled for user {user_id} (grace period until {grace_period_end})")
         return {
             "success": True,
             "message": "Account deletion scheduled. Your account will be permanently deleted after 30 days.",
@@ -209,9 +197,7 @@ async def delete_account(current_user: dict = Depends(get_current_user)):
     now = datetime.now(timezone.utc).isoformat()
     try:
         # Soft-delete driver record (preserves audit trail)
-        await db_supabase.update_one(
-            "drivers", {"user_id": user_id}, {"deleted_at": now}
-        )
+        await db_supabase.update_one("drivers", {"user_id": user_id}, {"deleted_at": now})
         # Hard-delete non-sensitive ancillary data (no soft-delete column)
         await db_supabase.delete_many("driver_documents", {"driver_id": user_id})
         await db_supabase.delete_many("emergency_contacts", {"user_id": user_id})
@@ -231,9 +217,7 @@ async def delete_account(current_user: dict = Depends(get_current_user)):
         return {"success": True, "message": "Account permanently deleted"}
     except Exception as e:
         logger.error(f"Account deletion failed for user {user_id}: {e}")
-        raise HTTPException(
-            status_code=500, detail="Failed to delete account. Please contact support."
-        ) from e
+        raise HTTPException(status_code=500, detail="Failed to delete account. Please contact support.") from e
 
 
 from pydantic import BaseModel  # type: ignore  # noqa: E402
@@ -244,9 +228,7 @@ class UpdatePhoneRequest(BaseModel):
 
 
 @api_router.patch("/profile/phone", response_model=UserProfile)
-async def update_phone(
-    request: UpdatePhoneRequest, current_user: dict = Depends(get_current_user)
-):
+async def update_phone(request: UpdatePhoneRequest, current_user: dict = Depends(get_current_user)):
     """Update the current user's phone number."""
     phone = request.phone.strip()
     if len(phone) < 10:
@@ -254,9 +236,7 @@ async def update_phone(
 
     # Check if phone is already in use by another user
     existing = (lambda _r: _r[0] if _r else None)(
-        await db_supabase.get_rows(
-            "users", {"phone": phone, "id": {"$ne": current_user["id"]}}, limit=1
-        )
+        await db_supabase.get_rows("users", {"phone": phone, "id": {"$ne": current_user["id"]}}, limit=1)
     )
     if existing:
         raise HTTPException(status_code=400, detail="Phone number already in use")
@@ -274,25 +254,17 @@ async def update_phone(
 
 
 @api_router.put("/profile-image", response_model=UserProfile)
-async def upload_profile_image(
-    file: UploadFile = File(...), current_user: dict = Depends(get_current_user)
-):
+async def upload_profile_image(file: UploadFile = File(...), current_user: dict = Depends(get_current_user)):
     """Upload a profile image for the current user (stored as base64 in database)."""
     # Validate file type
     allowed_types = ["image/jpeg", "image/png", "image/webp", "image/gif"]
     if file.content_type not in allowed_types:
-        raise HTTPException(
-            status_code=400, detail="File must be an image (JPEG, PNG, WebP, or GIF)"
-        )
+        raise HTTPException(status_code=400, detail="File must be an image (JPEG, PNG, WebP, or GIF)")
 
     # Validate file size (max 5MB)
     content = await file.read()
     if not isinstance(content, bytes):
-        content = (
-            bytes(content)
-            if hasattr(content, "__bytes__")
-            else str(content).encode("utf-8")
-        )
+        content = bytes(content) if hasattr(content, "__bytes__") else str(content).encode("utf-8")
 
     if len(content) > 5 * 1024 * 1024:
         raise HTTPException(status_code=400, detail="Image must be smaller than 5MB")
@@ -326,15 +298,11 @@ class LinkCorporateRequest(BaseModel):
 
 
 @api_router.patch("/profile/corporate", response_model=UserProfile)
-async def link_corporate_account(
-    request: LinkCorporateRequest, current_user: dict = Depends(get_current_user)
-):
+async def link_corporate_account(request: LinkCorporateRequest, current_user: dict = Depends(get_current_user)):
     """Link or unlink a corporate account to the user profile."""
     if request.corporate_account_id:
         account = (lambda _r: _r[0] if _r else None)(
-            await db_supabase.get_rows(
-                "corporate_accounts", {"id": request.corporate_account_id}, limit=1
-            )
+            await db_supabase.get_rows("corporate_accounts", {"id": request.corporate_account_id}, limit=1)
         )
         if not account:
             raise HTTPException(status_code=404, detail="Corporate account not found")
@@ -347,9 +315,7 @@ async def link_corporate_account(
 
     updated_user = await db_supabase.get_user_by_id(current_user["id"])
     if not updated_user:
-        raise HTTPException(
-            status_code=500, detail="Could not retrieve updated profile."
-        )
+        raise HTTPException(status_code=500, detail="Could not retrieve updated profile.")
 
     return UserProfile(**updated_user)
 
@@ -377,13 +343,9 @@ class EmergencyContactResponse(BaseModel):
 async def get_emergency_contacts(current_user: dict = Depends(get_current_user)):
     """Get the user's emergency contacts."""
     try:
-        contacts_cursor = db_supabase.get_rows(
-            "emergency_contacts", {"user_id": current_user["id"]}, limit=100
-        )
+        contacts_cursor = db_supabase.get_rows("emergency_contacts", {"user_id": current_user["id"]}, limit=100)
         contacts = (
-            await contacts_cursor.to_list(length=10)
-            if hasattr(contacts_cursor, "to_list")
-            else list(contacts_cursor)
+            await contacts_cursor.to_list(length=10) if hasattr(contacts_cursor, "to_list") else list(contacts_cursor)
         )
     except Exception as e:
         logger.error(
@@ -395,18 +357,12 @@ async def get_emergency_contacts(current_user: dict = Depends(get_current_user))
 
 
 @api_router.post("/emergency-contacts")
-async def add_emergency_contact(
-    contact: EmergencyContactCreate, current_user: dict = Depends(get_current_user)
-):
+async def add_emergency_contact(contact: EmergencyContactCreate, current_user: dict = Depends(get_current_user)):
     """Add an emergency contact (max 3 contacts per user, matching Uber/Lyft)."""
     try:
-        existing_cursor = db_supabase.get_rows(
-            "emergency_contacts", {"user_id": current_user["id"]}, limit=100
-        )
+        existing_cursor = db_supabase.get_rows("emergency_contacts", {"user_id": current_user["id"]}, limit=100)
         existing = (
-            await existing_cursor.to_list(length=10)
-            if hasattr(existing_cursor, "to_list")
-            else list(existing_cursor)
+            await existing_cursor.to_list(length=10) if hasattr(existing_cursor, "to_list") else list(existing_cursor)
         )
     except Exception:
         existing = []
@@ -420,9 +376,7 @@ async def add_emergency_contact(
 
     phone = contact.phone.strip()
     if len(phone) < 10:
-        raise HTTPException(
-            status_code=400, detail="Invalid phone number for emergency contact"
-        )
+        raise HTTPException(status_code=400, detail="Invalid phone number for emergency contact")
 
     contact_doc = {
         "id": str(uuid.uuid4()),
@@ -437,9 +391,7 @@ async def add_emergency_contact(
 
 
 @api_router.delete("/emergency-contacts/{contact_id}")
-async def delete_emergency_contact(
-    contact_id: str, current_user: dict = Depends(get_current_user)
-):
+async def delete_emergency_contact(contact_id: str, current_user: dict = Depends(get_current_user)):
     """Remove an emergency contact."""
     contact = (lambda _r: _r[0] if _r else None)(
         await db_supabase.get_rows(

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -290,7 +290,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           let driverData: Driver | null = null;
           const looksLikeDriver =
             !!userData.is_driver ||
-            userData.role === 'driver' ||
             !!userData.driver_onboarding_status;
           if (looksLikeDriver) {
             try {
@@ -402,7 +401,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // button stays disabled because `driver` is null in the store.
       const looksLikeDriver =
         !!userData?.is_driver ||
-        userData?.role === 'driver' ||
         !!userData?.driver_onboarding_status;
       if (looksLikeDriver) {
         try {
@@ -434,7 +432,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       set({ isLoading: true, error: null });
       const response = await api.post<Driver>('/drivers/register', data);
       const user = get().user;
-      const updatedUser = user ? { ...user, role: 'driver', is_driver: true } : user;
+      const updatedUser = user ? { ...user, role: 'driver', is_driver: true, is_rider: user.is_rider ?? true } : user;
       set({
         driver: response.data,
         user: updatedUser,

--- a/shared/types/api/user.ts
+++ b/shared/types/api/user.ts
@@ -8,10 +8,11 @@ export interface UserProfile {
   profile_image?: string;
   profile_image_status?: string;
   role: string;
+  is_rider: boolean;
+  is_driver: boolean;
   corporate_account_id?: string;
   created_at: string;
   profile_complete: boolean;
-  is_driver: boolean;
   driver_onboarding_status?: string;
   driver_onboarding_detail?: string;
   driver_onboarding_next_screen?: string;


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`

<!-- spinr-expanded:safety -->
## Tier 5 · Safety details

- **Insurance period derivation correct** (derive from ride state, not UI): `[ ]`
- **`driver_insurance_periods` rows append-only** — no update/delete: `[ ]`
- **SOS never auto-dials 911** — only offers one-tap: `[ ]` or N/A
- **Emergency-contact fan-out tested end-to-end**: `[ ]` or N/A
