### PR TITLE
fix(driver-activity): use Saskatchewan timezone for today's earnings boundary

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -6,6 +6,7 @@ import socket
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional, Union
+from zoneinfo import ZoneInfo
 
 import stripe
 from fastapi import (
@@ -913,9 +914,10 @@ async def get_driver_earnings(period: str = Query("week"), current_user: dict = 
     logger.info(f"Fetching earnings for driver {driver['id']} period {period}")
 
     # Calculate date range
-    now = datetime.now(timezone.utc)
-    # 'today' and 'day' both mean since midnight today
-    # 'all' means no date restriction — fetch all-time
+    # Use Saskatchewan time (UTC-6, no DST) for day boundaries so "today" aligns
+    # with the driver's local calendar date, not midnight UTC.
+    _SK_TZ = ZoneInfo("America/Regina")
+    now = datetime.now(_SK_TZ)
     use_date_filter = True
     if period in ("today", "day"):
         start_date = now.replace(hour=0, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
The earnings endpoint was computing "start of today" as midnight UTC, which
is 6 PM yesterday in Saskatchewan (UTC-6, no DST). Drivers who hadn't yet
started their day would see yesterday's evening rides in the "Today" stats,
and the totals mismatched the correctly-filtered ride list (which used the
device's local date).

Fix: compute midnight using America/Regina (ZoneInfo) so the server-side
date boundary matches the driver's calendar day.

https://claude.ai/code/session_01WWFguYpD6y1yXVSrCzVAQV