### PR TITLE
fix(payments): hoist ROUND_HALF_UP to module scope so charge.refunded works

### DIFF
--- a/.claude/context/domain-payments.md
+++ b/.claude/context/domain-payments.md
@@ -23,12 +23,15 @@ _Load when working on: fare calculation, surge, Stripe, wallets, corporate billi
 ## Fare breakdown
 
 ```
-subtotal     = base_fare + (per_km * distance_km) + (per_min * duration_min) + booking_fee
-subtotal     = max(subtotal, minimum_fare)
-surged       = subtotal * surge_multiplier         # except corporate (policy)
-taxed        = surged + gst + pst
-total        = taxed + tip
-driver_payout = total - booking_fee - platform_share  # platform_share = 0 for Spinr
+# Surge multiplies the distance and time components ONLY — never the base
+# fare, booking fee, or airport fee (see services/fare_service.py::calculate_fare).
+distance_fare = (per_km  * distance_km)  * surge_multiplier
+time_fare     = (per_min * duration_min) * surge_multiplier
+subtotal      = base_fare + distance_fare + time_fare + booking_fee + airport_fee
+subtotal      = max(subtotal, minimum_fare)        # minimum floor applied AFTER surge
+taxed         = subtotal + gst + pst               # corporate-paid rides: surge never applies
+total         = taxed + tip
+driver_payout = base_fare + distance_fare + time_fare   # 100% to driver; booking/airport are platform
 ```
 
 - Spinr driver share: **100%** of fare (minus Stripe processing). Driver sees gross, platform takes 0%.
@@ -38,7 +41,13 @@ driver_payout = total - booking_fee - platform_share  # platform_share = 0 for S
 
 See CLAUDE.md for the auto-mode tier table. Additional payment rules:
 
-- Surge is applied **before** tax, **not** to booking fee
+- **Per-area admin gate:** surge applies (pricing or UI) only when `service_areas.surge_enabled`
+  is true for that area — default **off**. The surge engine skips areas that aren't enabled, the
+  fare paths price at 1.0× regardless of any parked multiplier, and the public `/service-areas`
+  read reports `surge_active=false` / `surge_multiplier=1.0` so no client renders a surge badge.
+  Disabling surge in the admin panel clears `surge_active` and resets the multiplier to 1.0.
+- Surge multiplies distance + time only — **not** base fare, booking fee, or airport fee
+- Surge is applied **before** tax
 - Surge never applies to corporate-paid rides (policy)
 - Surge never applies retroactively — it's locked at fare estimate time
 - `SURGE_CAP = 2.5` is the auto cap; manual admin override up to 10× requires documented justification

--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -567,19 +567,21 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
   const needsJustification = form.surge_enabled && surgeValue > 2.5;
 
   const handleSave = async () => {
-    if (needsJustification && !form.surge_justification.trim()) {
+    // Did the operator actually change surge since load? Unrelated saves
+    // (name, radius, etc.) must leave every surge field untouched so we
+    // neither freeze auto-surge nor flip a not-currently-surging area active.
+    const surgeTouched =
+      form.surge_enabled !== (area.surge_enabled !== undefined ? !!area.surge_enabled : !!area.surge_active) ||
+      parseFloat(String(form.surge_multiplier)) !== parseFloat(String(area.surge_multiplier ?? 1.0));
+
+    // Only require (and only block on) justification when the operator is
+    // actually applying an above-cap surge — not when saving an unrelated
+    // field on an already-justified above-cap area.
+    if (surgeTouched && needsJustification && !form.surge_justification.trim()) {
       alert("A written justification is required for surge multipliers above 2.5× (regulatory + reputational risk).");
       return;
     }
     setSaving(true);
-    // Only stamp surge_source="manual" if the operator actually
-    // changed one of the surge fields since load. If they didn't
-    // touch surge we leave surge_source alone so surge_engine keeps
-    // running against this area. This lets admins save unrelated
-    // fields (name, radius, etc.) without freezing auto-surge.
-    const surgeTouched =
-      form.surge_enabled !== (area.surge_enabled !== undefined ? !!area.surge_enabled : !!area.surge_active) ||
-      parseFloat(String(form.surge_multiplier)) !== parseFloat(String(area.surge_multiplier ?? 1.0));
     const updates: any = {
       name: form.name,
       city: form.city,
@@ -592,16 +594,27 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
       max_simultaneous_offers: Math.max(1, Math.min(10, parseInt(String(form.max_simultaneous_offers)) || 3)),
       use_eta_ranking: form.use_eta_ranking,
       show_demand_heatmap: form.show_demand_heatmap,
-      // surge_enabled is the master gate; keep surge_active in sync so a
-      // manual multiplier takes effect immediately once enabled. Disabling
-      // sends surge_enabled=false and the backend clears surge_active +
-      // resets the multiplier so no parked surge can keep pricing rides.
-      surge_enabled: form.surge_enabled,
-      surge_active: form.surge_enabled,
-      surge_multiplier: surgeValue,
     };
-    if (surgeTouched) updates.surge_source = "manual";
-    if (needsJustification) updates.surge_justification = form.surge_justification.trim();
+    // Touch surge only when it actually changed. Sending surge_active on every
+    // save would flip an enabled-but-idle auto area (surge_enabled=true,
+    // surge_active=false) to active, making the public API advertise surge the
+    // engine never triggered; and resending a parked multiplier on disable
+    // would keep it in optimistic local state and resurrect it on re-enable.
+    if (surgeTouched) {
+      updates.surge_source = "manual";
+      updates.surge_enabled = form.surge_enabled;
+      if (form.surge_enabled) {
+        // Enabling / changing the multiplier — apply it immediately.
+        updates.surge_active = true;
+        updates.surge_multiplier = surgeValue;
+        if (needsJustification) updates.surge_justification = form.surge_justification.trim();
+      } else {
+        // Disabling — mirror the backend's reset so optimistic local state
+        // drops the parked multiplier instead of holding it for a re-enable.
+        updates.surge_active = false;
+        updates.surge_multiplier = 1.0;
+      }
+    }
     if (pendingPolygon) {
       updates.polygon = pendingPolygon;
     }

--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -551,10 +551,11 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
     max_simultaneous_offers: area.max_simultaneous_offers || 3,
     use_eta_ranking: area.use_eta_ranking !== false,
     show_demand_heatmap: area.show_demand_heatmap || false,
-    // Surge is per-area now — no separate Pricing page. surge_active
-    // gates whether build_fares_for_area multiplies the fare;
-    // surge_multiplier is the factor (1.0 = off, 1.5 = +50%, etc.).
-    surge_active: area.surge_active !== undefined ? area.surge_active : !!area.surge_enabled,
+    // Surge is per-area and admin-gated. The toggle below is the master
+    // enable (surge_enabled): until it's on, the backend prices every ride at
+    // 1.0× and the surge engine skips this area entirely. surge_multiplier is
+    // the manual factor applied once enabled (1.0 = off, 1.5 = +50%, etc.).
+    surge_enabled: area.surge_enabled !== undefined ? !!area.surge_enabled : !!area.surge_active,
     surge_multiplier: area.surge_multiplier ?? 1.0,
     surge_justification: "",
   });
@@ -563,7 +564,7 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
   const [saved, setSaved] = useState(false);
 
   const surgeValue = parseFloat(String(form.surge_multiplier)) || 1.0;
-  const needsJustification = form.surge_active && surgeValue > 2.5;
+  const needsJustification = form.surge_enabled && surgeValue > 2.5;
 
   const handleSave = async () => {
     if (needsJustification && !form.surge_justification.trim()) {
@@ -577,7 +578,7 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
     // running against this area. This lets admins save unrelated
     // fields (name, radius, etc.) without freezing auto-surge.
     const surgeTouched =
-      form.surge_active !== (area.surge_active !== undefined ? area.surge_active : !!area.surge_enabled) ||
+      form.surge_enabled !== (area.surge_enabled !== undefined ? !!area.surge_enabled : !!area.surge_active) ||
       parseFloat(String(form.surge_multiplier)) !== parseFloat(String(area.surge_multiplier ?? 1.0));
     const updates: any = {
       name: form.name,
@@ -591,7 +592,12 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
       max_simultaneous_offers: Math.max(1, Math.min(10, parseInt(String(form.max_simultaneous_offers)) || 3)),
       use_eta_ranking: form.use_eta_ranking,
       show_demand_heatmap: form.show_demand_heatmap,
-      surge_active: form.surge_active,
+      // surge_enabled is the master gate; keep surge_active in sync so a
+      // manual multiplier takes effect immediately once enabled. Disabling
+      // sends surge_enabled=false and the backend clears surge_active +
+      // resets the multiplier so no parked surge can keep pricing rides.
+      surge_enabled: form.surge_enabled,
+      surge_active: form.surge_enabled,
       surge_multiplier: surgeValue,
     };
     if (surgeTouched) updates.surge_source = "manual";
@@ -672,14 +678,14 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
           )}
         </p>
         <div className="flex items-center gap-2 pt-1">
-          <button type="button" onClick={() => setForm({ ...form, surge_active: !form.surge_active })}>
-            {form.surge_active ? <ToggleRight className="h-6 w-6 text-green-500" /> : <ToggleLeft className="h-6 w-6 text-gray-300" />}
+          <button type="button" onClick={() => setForm({ ...form, surge_enabled: !form.surge_enabled })}>
+            {form.surge_enabled ? <ToggleRight className="h-6 w-6 text-green-500" /> : <ToggleLeft className="h-6 w-6 text-gray-300" />}
           </button>
           <label className="text-xs font-semibold text-gray-500">
-            Surge {form.surge_active ? "ON" : "off"}
+            Surge {form.surge_enabled ? "ON" : "off"}
           </label>
         </div>
-        {form.surge_active && (
+        {form.surge_enabled && (
           <>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-end mt-3">
               <div>

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,9 +1,22 @@
+import logging
 import os
 from typing import Optional
 
 import bcrypt
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Reviewer OTP codes must match the verify-otp schema constraint exactly
+# (VerifyOTPRequest.code is `^\d{4}$`). A code that doesn't satisfy this can be
+# issued by send-otp but never accepted by verify-otp, silently breaking the
+# reviewer login. Validate against the same rule before allow-listing.
+_REVIEW_OTP_LEN = 4
+
+
+def _is_valid_review_otp(otp: str) -> bool:
+    return otp.isascii() and otp.isdigit() and len(otp) == _REVIEW_OTP_LEN
 
 
 class Settings(BaseSettings):
@@ -200,8 +213,12 @@ class Settings(BaseSettings):
     def review_login_map(self) -> dict[str, str]:
         """Parse REVIEW_LOGIN_ACCOUNTS into {phone: fixed_otp}.
 
-        Malformed entries are skipped. Returns an empty dict when unset, which
-        disables the reviewer-login path entirely.
+        Only entries whose OTP satisfies the verify-otp constraint (exactly 4
+        numeric digits) are included — a malformed code is skipped rather than
+        allow-listed, so send-otp never issues a code that verify-otp can't
+        accept. Returns an empty dict when unset, which disables the
+        reviewer-login path entirely. Malformed entries are surfaced once at
+        startup by ``_validate_review_accounts``.
         """
         out: dict[str, str] = {}
         raw = (self.REVIEW_LOGIN_ACCOUNTS or "").strip()
@@ -212,9 +229,44 @@ class Settings(BaseSettings):
             if not sep:
                 continue
             phone, otp = phone.strip(), otp.strip()
-            if phone and otp:
+            if phone and _is_valid_review_otp(otp):
                 out[phone] = otp
         return out
+
+    @model_validator(mode="after")
+    def _validate_review_accounts(self) -> "Settings":
+        """Surface a misconfigured REVIEW_LOGIN_ACCOUNTS at startup.
+
+        We do not raise — a typo in this optional reviewer secret must not take
+        down the API — but we log loudly (ERROR → Sentry via the loguru bridge)
+        so the operator catches it at deploy time instead of discovering it when
+        a store reviewer can't log in. Each malformed entry names the offending
+        phone's last 4 digits only (never the full number or the code).
+        """
+        raw = (self.REVIEW_LOGIN_ACCOUNTS or "").strip()
+        if not raw:
+            return self
+        valid = 0
+        for pair in raw.split(","):
+            entry = pair.strip()
+            if not entry:
+                continue
+            phone, sep, otp = entry.partition(":")
+            phone, otp = phone.strip(), otp.strip()
+            if not sep or not phone:
+                logger.error("REVIEW_LOGIN_ACCOUNTS: malformed entry (expected 'phone:otp') — skipped")
+            elif not _is_valid_review_otp(otp):
+                logger.error(
+                    "REVIEW_LOGIN_ACCOUNTS: OTP for ...%s is not %d digits — entry skipped, "
+                    "reviewer login will NOT work for this number",
+                    phone[-4:],
+                    _REVIEW_OTP_LEN,
+                )
+            else:
+                valid += 1
+        if valid:
+            logger.info("REVIEW_LOGIN_ACCOUNTS: %d reviewer login account(s) active", valid)
+        return self
 
 
 settings = Settings()

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -106,6 +106,18 @@ class Settings(BaseSettings):
     # Environment
     ENV: str = "development"
 
+    # App Store / Google Play reviewer login accounts. Comma-separated
+    # "phone:otp" pairs — E.164 phone and a 4-digit numeric OTP (must match
+    # OTP_LENGTH). For these numbers, /auth/send-otp stores the fixed code and
+    # never sends an SMS — even in production — so store reviewers can sign in
+    # without receiving a text (they get the code from App Store Connect notes).
+    # Leave EMPTY except while an app review is in flight; clear it once the
+    # build is approved. Use of these accounts is audit-logged. Kept as an env
+    # secret (not in app_settings) so it can't be edited from the admin
+    # dashboard — a compromised admin cannot add an auth-bypass number.
+    #   Example: "+13065550100:4821,+13065550101:4821"
+    REVIEW_LOGIN_ACCOUNTS: str = ""
+
     # Observability — optional; Sentry only initialises when this is set
     sentry_dsn: Optional[str] = None
 
@@ -184,6 +196,25 @@ class Settings(BaseSettings):
     @property
     def debug(self) -> bool:
         return self.ENV.lower() == "development"
+
+    def review_login_map(self) -> dict[str, str]:
+        """Parse REVIEW_LOGIN_ACCOUNTS into {phone: fixed_otp}.
+
+        Malformed entries are skipped. Returns an empty dict when unset, which
+        disables the reviewer-login path entirely.
+        """
+        out: dict[str, str] = {}
+        raw = (self.REVIEW_LOGIN_ACCOUNTS or "").strip()
+        if not raw:
+            return out
+        for pair in raw.split(","):
+            phone, sep, otp = pair.strip().partition(":")
+            if not sep:
+                continue
+            phone, otp = phone.strip(), otp.strip()
+            if phone and otp:
+                out[phone] = otp
+        return out
 
 
 settings = Settings()

--- a/backend/features.py
+++ b/backend/features.py
@@ -495,8 +495,22 @@ async def admin_update_surge(area_id: str, req: UpdateSurgeRequest):
     if req.surge_active is not None:
         update_data["surge_active"] = req.surge_active
     if req.surge_multiplier is not None:
-        if req.surge_multiplier < 1.0 or req.surge_multiplier > 10.0:
-            raise HTTPException(status_code=400, detail="Multiplier must be between 1.0 and 10.0")
+        # This endpoint has no written-justification field and writes no
+        # audit-log row, so it must not be a path to exceed the surge cap.
+        # Above-cap (> 2.5x) overrides are a regulatory + reputational risk and
+        # are only permitted via the canonical admin endpoint
+        # (PUT /api/admin/service-areas/{id}/surge), which requires a
+        # justification string and records a "surge_override_above_cap" audit
+        # entry. Hard-reject anything above SURGE_CAP here.
+        if req.surge_multiplier < 1.0 or req.surge_multiplier > SURGE_CAP:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"surge_multiplier must be between 1.0 and {SURGE_CAP}. "
+                    "Above-cap overrides require the audited admin endpoint "
+                    "with a written justification."
+                ),
+            )
         update_data["surge_multiplier"] = req.surge_multiplier
 
     if update_data:

--- a/backend/features.py
+++ b/backend/features.py
@@ -832,9 +832,11 @@ async def calculate_all_fees(
     result["fees_total"] = float(_q2(fees_total))
 
     # Calculate taxes — Decimal end-to-end so the receipt line items
-    # reconcile to the cent. SK is GST 5% + PST 6%; HST provinces use the
-    # combined rate. Each tax is quantized independently before summing
-    # so the breakdown matches the displayed total.
+    # reconcile to the cent. Saskatchewan rideshare is GST 5% only — PST does
+    # NOT apply to rideshare here, so pst_enabled defaults off. PST/HST remain
+    # per-area configurable from the admin panel for future markets/cohorts:
+    # GST + optional PST, or a combined HST rate. Each tax is quantized
+    # independently before summing so the breakdown matches the displayed total.
     taxable_amount = subtotal_d + fees_total
     tax_breakdown: Dict[str, Dict[str, float]] = {}
     tax_total = Decimal("0")

--- a/backend/features.py
+++ b/backend/features.py
@@ -528,10 +528,15 @@ async def admin_reset_surge_to_auto(area_id: str):
     area = await db.find_one("service_areas", {"id": area_id})
     if not area:
         raise HTTPException(status_code=404, detail="Service area not found")
+    # Reset-to-auto is an explicit operator intent to have surge running on
+    # automatic tiers for this area, so it must also flip the surge_enabled
+    # gate on. Without this, an area that was previously disabled would stay
+    # gated off: the surge engine would keep skipping it and fare calc would
+    # keep ignoring surge, even though this endpoint returned success.
     await db.update_one(
         "service_areas",
         {"id": area_id},
-        {"$set": {"surge_source": "auto", "surge_active": True}},
+        {"$set": {"surge_source": "auto", "surge_active": True, "surge_enabled": True}},
     )
     updated = await db.find_one("service_areas", {"id": area_id})
     return updated

--- a/backend/features.py
+++ b/backend/features.py
@@ -889,7 +889,12 @@ async def fare_estimate(
     for area in all_areas:
         poly = get_service_area_polygon(area)
         if poly and point_in_polygon(pickup_lat, pickup_lng, poly):
-            if area.get("surge_active") and area.get("surge_multiplier", 1.0) > 1.0:
+            # Gate on the per-area surge master toggle, same as the main fare
+            # builders (fare_service / routes.fares). Without this, a stale
+            # surge_active flag or parked multiplier on a disabled area would
+            # surge this estimate while the booking path prices at 1.0x —
+            # inconsistent rider estimates for the same area.
+            if area.get("surge_enabled") and area.get("surge_active") and area.get("surge_multiplier", 1.0) > 1.0:
                 surge = min(_fare_d(area["surge_multiplier"]), _fare_d(SURGE_CAP))
             break
 

--- a/backend/migrations/106_backfill_surge_enabled.sql
+++ b/backend/migrations/106_backfill_surge_enabled.sql
@@ -1,0 +1,26 @@
+-- Backfill surge_enabled for service areas that already had surge configured.
+--
+-- Migration 81 added surge_enabled as NOT NULL DEFAULT FALSE with no backfill.
+-- Fare pricing (fare_service.py, routes/fares.py, features.py fare-estimate)
+-- and the surge engine now gate on surge_enabled, so every deployed area would
+-- silently drop to 1.0x — losing active/manual surge pricing — until an admin
+-- manually re-saves each one. Restore the prior pricing intent by enabling the
+-- gate wherever surge was already active or a multiplier was parked above 1.0.
+--
+-- Safe under live traffic: a single bounded UPDATE on a small table. The fare
+-- builders also require surge_active, so enabling a parked-multiplier-but-
+-- inactive area does not start surging it; it only restores the operator's
+-- saved configuration so a later activation behaves as it did before the gate.
+--
+-- Idempotent: re-running only re-sets rows already at TRUE. No-op on areas the
+-- operator never configured for surge (the intended default-off behaviour).
+--
+-- Rollback: no down-migration. To revert the backfill specifically:
+--   UPDATE service_areas SET surge_enabled = FALSE
+--   WHERE surge_active = TRUE OR surge_multiplier > 1.0;
+-- (only safe if no admin has toggled surge_enabled since this ran).
+
+UPDATE service_areas
+SET surge_enabled = TRUE
+WHERE surge_enabled = FALSE
+  AND (surge_active = TRUE OR surge_multiplier > 1.0);

--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -375,7 +375,8 @@ async def admin_create_service_area(area: ServiceAreaCreateRequest, admin: dict 
         "parent_service_area_id": area.parent_service_area_id,
         "is_airport": effective_is_airport,
         "airport_fee": effective_airport_fee,
-        "surge_active": surge_active,
+        "surge_enabled": bool(area.surge_enabled),
+        "surge_active": surge_active if area.surge_enabled else False,
         "surge_multiplier": area.surge_multiplier,
         "gst_enabled": area.gst_enabled,
         "gst_rate": area.gst_rate,
@@ -522,6 +523,16 @@ async def admin_update_service_area(
         update_payload["polygon"] = polygon
     if surge_active is not None:
         update_payload["surge_active"] = surge_active
+
+    # Per-area surge master toggle. Persist it explicitly (it is not in the
+    # allow-list above). Disabling surge must immediately clear any live surge
+    # so a parked multiplier / surge_active flag can't keep pricing rides while
+    # the area is "off"; the surge engine also skips disabled areas.
+    if area.surge_enabled is not None:
+        update_payload["surge_enabled"] = area.surge_enabled
+        if area.surge_enabled is False:
+            update_payload["surge_active"] = False
+            update_payload["surge_multiplier"] = 1.0
 
     # Keep is_airport <-> airport_fee consistent: deleting the fee turns the
     # zone off; turning the zone off zeroes the fee. Operators can do either

--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -455,7 +455,12 @@ async def admin_update_service_area(
                 status_code=400,
                 detail=f"surge_multiplier must be between 1.0 and {_SURGE_MAX}",
             )
-        if sm > SURGE_CAP:
+        # Disabling surge clears the multiplier to 1.0 below, so an above-cap
+        # value is being turned off, not applied. Don't trap operators behind a
+        # justification requirement just to switch off a risky >2.5x surge from
+        # the normal form — the justification gate only guards applying an
+        # above-cap multiplier while surge stays on.
+        if sm > SURGE_CAP and area.surge_enabled is not False:
             justification = (area.surge_justification or "").strip()
             if not justification:
                 raise HTTPException(

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -241,14 +241,35 @@ async def send_otp(request: Request, body: SendOTPRequest):
         and app_settings.get("twilio_from_number")
     )
 
-    # If Twilio is configured, send a real OTP via SMS.
-    # If not configured, fall back to the fixed code "1234" so testing works
-    # without SMS delivery — regardless of ENV.
-    otp_code = generate_otp() if twilio_configured else "1234"
-    if not twilio_configured:
+    # OTP code selection:
+    #  - Twilio configured  → real random OTP delivered via SMS.
+    #  - Twilio NOT configured + non-production (development/preview/staging)
+    #                        → fixed code "1234" so testing works without SMS.
+    #  - Twilio NOT configured + production
+    #                        → refuse. A missing Twilio config in production is a
+    #                          misconfiguration; falling back to a static "1234"
+    #                          would let anyone log in as any phone number, so we
+    #                          fail loudly instead of silently bypassing auth.
+    is_production = settings.ENV.lower() == "production"
+    if twilio_configured:
+        otp_code = generate_otp()
+    elif not is_production:
+        otp_code = "1234"
         logger.info(
-            "Twilio not configured — OTP bypass active (code=1234) for ...%s",
+            "Twilio not configured — OTP bypass active (code=1234) for ...%s (ENV=%s)",
             phone[-4:],
+            settings.ENV,
+        )
+    else:
+        logger.error(
+            "Twilio not configured in production — refusing to issue OTP "
+            "(static-code bypass is disabled in production)"
+        )
+        raise SpinrException(
+            message="Verification is temporarily unavailable, please try again later",
+            error_code=ErrorCode.SERVICE_UNAVAILABLE,
+            status_code=503,
+            message_key=ErrorKeys.SYSTEM_SERVICE_UNAVAILABLE,
         )
 
     otp_record = OTPRecord(

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -251,7 +251,21 @@ async def send_otp(request: Request, body: SendOTPRequest):
     #                          would let anyone log in as any phone number, so we
     #                          fail loudly instead of silently bypassing auth.
     is_production = settings.ENV.lower() == "production"
-    if twilio_configured:
+    review_otp = settings.review_login_map().get(phone)
+    deliver_via_sms = True
+    if review_otp is not None:
+        # App Store / Play reviewer account: issue the pre-shared fixed code and
+        # never send an SMS — the reviewer gets the code from the store-console
+        # review notes, not a text. Permitted in every ENV (including production)
+        # but ONLY for the explicit numbers in REVIEW_LOGIN_ACCOUNTS.
+        otp_code = review_otp
+        deliver_via_sms = False
+        logger.info(
+            "Reviewer-account OTP issued without SMS for ...%s (ENV=%s)",
+            phone[-4:],
+            settings.ENV,
+        )
+    elif twilio_configured:
         otp_code = generate_otp()
     elif not is_production:
         otp_code = "1234"
@@ -293,22 +307,24 @@ async def send_otp(request: Request, body: SendOTPRequest):
             message_key=ErrorKeys.SYSTEM_DATABASE,
         ) from e
 
-    # Send OTP via SMS (Twilio when configured, console log otherwise)
-    sms_result = await send_otp_sms(
-        phone,
-        otp_code,
-        twilio_sid=app_settings.get("twilio_account_sid", "") if app_settings else "",
-        twilio_token=app_settings.get("twilio_auth_token", "") if app_settings else "",
-        twilio_from=app_settings.get("twilio_from_number", "") if app_settings else "",
-    )
-    if not sms_result.get("success"):
-        logger.error(f"Failed to send OTP SMS: {sms_result.get('error')}")
-        raise SpinrException(
-            message="Failed to send verification code",
-            error_code=ErrorCode.SERVICE_UNAVAILABLE,
-            status_code=503,
-            message_key=ErrorKeys.SYSTEM_SERVICE_UNAVAILABLE,
+    # Send OTP via SMS (Twilio when configured, console log otherwise).
+    # Reviewer accounts skip SMS entirely — the code is pre-shared out of band.
+    if deliver_via_sms:
+        sms_result = await send_otp_sms(
+            phone,
+            otp_code,
+            twilio_sid=app_settings.get("twilio_account_sid", "") if app_settings else "",
+            twilio_token=app_settings.get("twilio_auth_token", "") if app_settings else "",
+            twilio_from=app_settings.get("twilio_from_number", "") if app_settings else "",
         )
+        if not sms_result.get("success"):
+            logger.error(f"Failed to send OTP SMS: {sms_result.get('error')}")
+            raise SpinrException(
+                message="Failed to send verification code",
+                error_code=ErrorCode.SERVICE_UNAVAILABLE,
+                status_code=503,
+                message_key=ErrorKeys.SYSTEM_SERVICE_UNAVAILABLE,
+            )
 
     response = {"success": True, "message": f"OTP sent to ***{phone[-4:]}"}
     # Dev OTP is logged to server console via sms_service.py — never return it

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -333,14 +333,22 @@ async def send_otp(request: Request, body: SendOTPRequest):
     import hashlib
 
     _ph = hashlib.sha256(phone.encode()).hexdigest()[:16]
+    # Tag the reviewer-bypass path distinctly so operators can query audit_logs
+    # for fixed-code issuance separately from ordinary SMS OTP sends (e.g. to
+    # confirm the allow-list was cleared after a review, or investigate abuse).
+    _is_reviewer = review_otp is not None
+    _audit_action = "otp_sent_reviewer_bypass" if _is_reviewer else "otp_sent"
+    _audit_meta = {"phone_last4": phone[-4:]}
+    if _is_reviewer:
+        _audit_meta["reviewer_bypass"] = True
     try:
         asyncio.create_task(
             _audit_log_user(
                 {"id": f"phone_hash:{_ph}", "role": "anonymous"},
-                "otp_sent",
+                _audit_action,
                 "users",
                 _ph,
-                {"phone_last4": phone[-4:]},
+                _audit_meta,
             )
         )
     except Exception:
@@ -358,6 +366,10 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
     # Normalize to E.164 so it matches what send-otp stored
     _, normalized = validate_phone(phone)
     phone = normalized or phone
+
+    # Reviewer-bypass accounts log in with a fixed code; tag their audit rows so
+    # operators can distinguish reviewer logins from real SMS verifications.
+    _is_reviewer = settings.review_login_map().get(phone) is not None
 
     # SEC-008: Reject locked-out phones before touching the DB
     await _check_otp_lockout(phone)
@@ -549,7 +561,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
                         "otp_verify_success",
                         "users",
                         user_id,
-                        {"is_new_user": False},
+                        {"is_new_user": False, **({"reviewer_bypass": True} if _is_reviewer else {})},
                     )
                 )
             except Exception:
@@ -622,7 +634,7 @@ async def verify_otp(request: Request, response: Response, body: VerifyOTPReques
                         "otp_verify_success",
                         "users",
                         user_id,
-                        {"is_new_user": True},
+                        {"is_new_user": True, **({"reviewer_bypass": True} if _is_reviewer else {})},
                     )
                 )
             except Exception:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2784,6 +2784,15 @@ async def accept_ride(ride_id: str, current_user: dict = Depends(get_current_use
 
     await reset_miss_streak(driver["id"])
 
+    # Insurance Period 2 (en route to pickup — TNC primary commercial coverage).
+    # In the batch-offer dispatch model the driver becomes obligated to the ride
+    # at acceptance (searching/driver_assigned → driver_accepted), so Period 2
+    # begins here, not at a separate driver_assigned step. It stays open through
+    # driver_arrived until verify-otp/start flips the driver to Period 3
+    # (passenger aboard). record_period_transition is compliance-grade — it logs
+    # at ERROR and swallows on failure so it never blocks acceptance.
+    await record_period_transition(driver["id"], 2, ride_id=ride_id)
+
     # ── Batch dispatch: resolve offers for this ride ──────────────
     try:
         from ..repositories.driver_repo import update_acceptance_rate

--- a/backend/routes/fares.py
+++ b/backend/routes/fares.py
@@ -187,14 +187,13 @@ async def build_fares_for_area(matched_area, vehicle_types):
     if not matched_area:
         return _build_default_fares(vehicle_types)
 
-    # Surge is gated on surge_active so an operator can park a
-    # multiplier > 1.0 without having it silently applied when the
-    # toggle is off. Matches surge_engine.py's convention (only
-    # writes multiplier when active) and the admin UI toggle under
-    # Service Areas → General.
+    # Surge is gated on the per-area admin master toggle (surge_enabled) AND the
+    # current surge_active flag. Until an operator enables surge for this area in
+    # the admin panel it never applies — no multiplier, no rider-facing surge —
+    # even if a stale multiplier or surge_active=True is left on the row.
     surge = (
         min(matched_area.get("surge_multiplier", 1.0), SURGE_CAP)
-        if matched_area.get("surge_active", False)
+        if matched_area.get("surge_enabled", False) and matched_area.get("surge_active", False)
         else 1.0
     )
 

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -271,14 +271,18 @@ async def confirm_payment(
     payment_intent_id = body.get("payment_intent_id")
     ride_id = body.get("ride_id")
 
-    # Mock-payment shortcut is allowed only outside production. Reject it up front
-    # — before claiming the ride into payment_status=processing — so a rejected
-    # request can't strand the ride. In production any authenticated rider could
-    # otherwise send "pi_mock_*" and settle their own ride for free.
+    # Mock-payment shortcut is allowed only outside production, OR for an
+    # allow-listed app-store reviewer account (so a reviewer can reach a "paid"
+    # confirmation without a real charge). Reject everyone else up front —
+    # before claiming the ride into payment_status=processing — so a rejected
+    # request can't strand the ride. In production any other authenticated rider
+    # could otherwise send "pi_mock_*" and settle their own ride for free.
+    _is_reviewer = current_user.get("phone") in core_settings.review_login_map()
     if (
         payment_intent_id
         and payment_intent_id.startswith("pi_mock_")
         and core_settings.ENV.lower() == "production"
+        and not _is_reviewer
     ):
         logger.error(
             "Rejected mock payment intent %s in production for ride %s",

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 try:
     from .. import db_supabase
+    from ..core.config import settings as core_settings
     from ..dependencies import get_current_user
     from ..settings_loader import get_app_settings
     from ..utils.audit_logger import log_user_action as _audit_log_user
@@ -22,6 +23,7 @@ try:
     from ..utils.rate_limiter import payment_action_limit
 except ImportError:
     import db_supabase
+    from core.config import settings as core_settings
     from dependencies import get_current_user
     from settings_loader import get_app_settings
     from utils.audit_logger import log_user_action as _audit_log_user
@@ -269,6 +271,25 @@ async def confirm_payment(
     payment_intent_id = body.get("payment_intent_id")
     ride_id = body.get("ride_id")
 
+    # Mock-payment shortcut is allowed only outside production. Reject it up front
+    # — before claiming the ride into payment_status=processing — so a rejected
+    # request can't strand the ride. In production any authenticated rider could
+    # otherwise send "pi_mock_*" and settle their own ride for free.
+    if (
+        payment_intent_id
+        and payment_intent_id.startswith("pi_mock_")
+        and core_settings.ENV.lower() == "production"
+    ):
+        logger.error(
+            "Rejected mock payment intent %s in production for ride %s",
+            payment_intent_id,
+            ride_id,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Mock payments are not supported in production",
+        )
+
     if ride_id:
         ride = await db_supabase.get_ride(ride_id)
         if not ride:
@@ -294,6 +315,7 @@ async def confirm_payment(
         if not claimed:
             raise HTTPException(status_code=409, detail="payment_already_processing")
 
+    # Mock-payment shortcut (non-production only; production rejected above).
     if payment_intent_id and payment_intent_id.startswith("pi_mock_"):
         if ride_id:
             _ride = await db_supabase.get_ride(ride_id)

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3959,14 +3959,41 @@ async def rider_start_ride(
             detail=f"Cannot start ride with status: {ride.get('status')}",
         )
 
-    await db_supabase.update_ride(
-        ride_id,
+    # Atomic transition guards against duplicate taps / a concurrent driver-side
+    # start. update_one returns None when zero rows matched (status already moved).
+    guard = await db_supabase.update_one(
+        "rides",
+        {"id": ride_id, "driver_id": driver_row["id"], "status": RideStatus.DRIVER_ARRIVED},
         {
             "status": RideStatus.IN_PROGRESS,
             "ride_started_at": datetime.now(timezone.utc),
             "updated_at": datetime.now(timezone.utc),
         },
     )
+    if guard is None:
+        raise HTTPException(status_code=409, detail="Ride is not in driver_arrived state")
+
+    # Insurance Period 3 (passenger aboard — full TNC commercial coverage).
+    # Only recorded once the transition actually took effect. Compliance-grade:
+    # record_period_transition logs+swallows on failure, never blocks the start.
+    await record_period_transition(driver_row["id"], 3, ride_id=ride_id)
+
+    # Every state change must emit a WS event to both parties (CLAUDE.md). Without
+    # this the rider's client stays on "driver arrived" until its next poll.
+    rider_id = ride.get("rider_id")
+    if rider_id:
+        await manager.send_personal_message(
+            {"type": "ride_started", "ride_id": ride_id}, f"rider_{rider_id}"
+        )
+        asyncio.create_task(
+            send_push_notification(
+                rider_id,
+                "Ride Started! ▶️",
+                "Your ride has started. Have a safe trip!",
+                data={"type": "ride_started", "ride_id": str(ride_id)},
+            )
+        )
+    await manager.broadcast_ride_status(ride_id, RideStatus.IN_PROGRESS, rider_id=rider_id)
     return {"success": True}
 
 
@@ -3998,7 +4025,14 @@ async def rider_complete_ride(
         "ride_completed_at": now,
         "updated_at": now,
     }
-    await db_supabase.update_one("rides", {"id": ride_id}, update_fields)
+    # Atomic transition: only complete from in_progress. Guards against a
+    # concurrent driver-side complete double-running the settlement/incentive
+    # logic below. update_one returns None when zero rows matched.
+    guard = await db_supabase.update_one(
+        "rides", {"id": ride_id, "status": RideStatus.IN_PROGRESS}, update_fields
+    )
+    if guard is None:
+        raise HTTPException(status_code=409, detail="Ride is not in progress")
 
     driver_id = ride.get("driver_id")
     driver_user_id = None

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3134,47 +3134,66 @@ async def cancel_ride_rider(
 
     total_cancel_fee = _round(charged_admin + charged_driver)
 
-    # Charge the rider the cancellation fee before paying the driver.
-    if total_cancel_fee > 0:
-        payment_method = (ride.get("payment_method") or "card").lower()
-        if payment_method == "wallet":
-            rider_wallet = await db_supabase.find_one("wallets", {"user_id": current_user["id"]})
-            if rider_wallet:
-                old_balance = _round(_d(rider_wallet.get("balance", 0)))
-                new_balance = max(_round(old_balance - total_cancel_fee), Decimal("0"))
-                actual_charge = _round(old_balance - new_balance)
-                if actual_charge > 0:
-                    await db_supabase.update_one(
-                        "wallets",
-                        {"id": rider_wallet["id"]},
-                        {
-                            "balance": _f(new_balance),
-                            "updated_at": datetime.now(timezone.utc).isoformat(),
-                        },
-                    )
-                    await db_supabase.insert_one(
-                        "wallet_transactions",
-                        {
-                            "id": str(uuid.uuid4()),
-                            "wallet_id": rider_wallet["id"],
-                            "user_id": current_user["id"],
-                            "type": "cancellation_fee",
-                            "amount": -_f(actual_charge),
-                            "balance_after": _f(new_balance),
-                            "reference_id": ride_id,
-                            "description": f"Cancellation fee for ride {ride_id[:8]}",
-                            "metadata": {"ride_id": ride_id},
-                            "created_at": datetime.now(timezone.utc).isoformat(),
-                        },
-                    )
+    # The cancel is already persisted by the atomic claim above, so the
+    # assigned driver MUST be released, transitioned back to Period 1, and
+    # notified regardless of what happens while charging the fee. If a wallet
+    # write or the driver payout raises here, we cannot exit before the
+    # set_driver_available / insurance / notification cleanup below — that
+    # would strand the driver as unavailable and uninformed on a ride that is
+    # already cancelled. So the fee writes are best-effort after the claim:
+    # surface the failure loudly (error + traceback, per repo policy) for
+    # reconciliation, then fall through to driver cleanup.
+    try:
+        # Charge the rider the cancellation fee before paying the driver.
+        if total_cancel_fee > 0:
+            payment_method = (ride.get("payment_method") or "card").lower()
+            if payment_method == "wallet":
+                rider_wallet = await db_supabase.find_one("wallets", {"user_id": current_user["id"]})
+                if rider_wallet:
+                    old_balance = _round(_d(rider_wallet.get("balance", 0)))
+                    new_balance = max(_round(old_balance - total_cancel_fee), Decimal("0"))
+                    actual_charge = _round(old_balance - new_balance)
+                    if actual_charge > 0:
+                        await db_supabase.update_one(
+                            "wallets",
+                            {"id": rider_wallet["id"]},
+                            {
+                                "balance": _f(new_balance),
+                                "updated_at": datetime.now(timezone.utc).isoformat(),
+                            },
+                        )
+                        await db_supabase.insert_one(
+                            "wallet_transactions",
+                            {
+                                "id": str(uuid.uuid4()),
+                                "wallet_id": rider_wallet["id"],
+                                "user_id": current_user["id"],
+                                "type": "cancellation_fee",
+                                "amount": -_f(actual_charge),
+                                "balance_after": _f(new_balance),
+                                "reference_id": ride_id,
+                                "description": f"Cancellation fee for ride {ride_id[:8]}",
+                                "metadata": {"ride_id": ride_id},
+                                "created_at": datetime.now(timezone.utc).isoformat(),
+                            },
+                        )
 
-    if driver_id and charged_driver > 0:
-        await pay_driver_cancellation_fee(
-            ride_id=ride_id,
-            driver_id=driver_id,
-            fee=charged_driver,
-            actor_user_id=current_user["id"],
-            ride_status_at_cancel=ride.get("status"),
+        if driver_id and charged_driver > 0:
+            await pay_driver_cancellation_fee(
+                ride_id=ride_id,
+                driver_id=driver_id,
+                fee=charged_driver,
+                actor_user_id=current_user["id"],
+                ride_status_at_cancel=ride.get("status"),
+            )
+    except Exception as _fee_exc:
+        logger.error(
+            "[CANCEL] cancellation-fee write failed after the cancel was "
+            "persisted for ride %s; releasing the driver anyway — fee needs "
+            "reconciliation: %s",
+            ride_id,
+            getattr(_fee_exc, "details", {}).get("original", _fee_exc) if hasattr(_fee_exc, "details") else _fee_exc,
+            exc_info=True,
         )
 
     _now = datetime.now(timezone.utc)

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3093,21 +3093,37 @@ async def cancel_ride_rider(
 
     diag_logger.info(f"[CANCEL] called ride_id={ride_id} user_id={current_user.get('id')}")
 
-    ride = await _require_ride_in_state_rider(
-        ride_id,
-        current_user["id"],
-        (
-            "requested",
-            RideStatus.SEARCHING,
-            RideStatus.DRIVER_ASSIGNED,
-            RideStatus.DRIVER_ACCEPTED,
-            "en_route",
-            RideStatus.DRIVER_ARRIVED,
-        ),
+    _cancellable_states = (
+        "requested",
+        RideStatus.SEARCHING,
+        RideStatus.DRIVER_ASSIGNED,
+        RideStatus.DRIVER_ACCEPTED,
+        "en_route",
+        RideStatus.DRIVER_ARRIVED,
     )
+    ride = await _require_ride_in_state_rider(ride_id, current_user["id"], _cancellable_states)
     diag_logger.info(
         f"[CANCEL] entry ride_id={ride_id} pre_status={ride.get('status')} driver_id={ride.get('driver_id')}"
     )
+
+    # Atomically claim the cancel BEFORE charging any fee. _require_ride_in_state_rider
+    # only read+validated the status; in the window before the write the driver could
+    # call verify-otp/start and flip the ride to in_progress. A non-atomic cancel would
+    # then overwrite in_progress -> cancelled (violating "never cancel after trip start")
+    # AND charge a cancellation fee on a ride that actually began. The $in guard matches
+    # zero rows once the ride has left the pre-trip states -> 409, nothing charged.
+    _cancel_now = datetime.now(timezone.utc)
+    _cancel_claim = await db_supabase.update_one(
+        "rides",
+        {"id": ride_id, "status": {"$in": list(_cancellable_states)}},
+        {"status": RideStatus.CANCELLED, "cancelled_at": _cancel_now, "updated_at": _cancel_now},
+    )
+    if _cancel_claim is None:
+        diag_logger.info(f"[CANCEL] claim rejected ride_id={ride_id} — ride left pre-trip state")
+        raise HTTPException(
+            status_code=409,
+            detail="Ride can no longer be cancelled (it has started or already ended)",
+        )
 
     driver_id = ride.get("driver_id")
     settings = await get_app_settings()
@@ -3982,9 +3998,7 @@ async def rider_start_ride(
     # this the rider's client stays on "driver arrived" until its next poll.
     rider_id = ride.get("rider_id")
     if rider_id:
-        await manager.send_personal_message(
-            {"type": "ride_started", "ride_id": ride_id}, f"rider_{rider_id}"
-        )
+        await manager.send_personal_message({"type": "ride_started", "ride_id": ride_id}, f"rider_{rider_id}")
         asyncio.create_task(
             send_push_notification(
                 rider_id,
@@ -4028,9 +4042,7 @@ async def rider_complete_ride(
     # Atomic transition: only complete from in_progress. Guards against a
     # concurrent driver-side complete double-running the settlement/incentive
     # logic below. update_one returns None when zero rows matched.
-    guard = await db_supabase.update_one(
-        "rides", {"id": ride_id, "status": RideStatus.IN_PROGRESS}, update_fields
-    )
+    guard = await db_supabase.update_one("rides", {"id": ride_id, "status": RideStatus.IN_PROGRESS}, update_fields)
     if guard is None:
         raise HTTPException(status_code=409, detail="Ride is not in progress")
 

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -518,9 +518,16 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
     #
     # We also require user_id IS NOT NULL to skip legacy "demo" driver rows
     # that lack a real user and can never be notified.
+    # Mirror DispatchService.find_candidate_drivers: is_verified + status='active'
+    # keep unverified / suspended / needs_review drivers out of dispatch even if
+    # their is_online flag was left on (e.g. status flipped server-side after
+    # they toggled online). Without these, accept_ride blocks them at accept time
+    # but they still receive — and can see — offers they can never fulfil.
     _dispatch_filter: dict = {
         "is_online": True,
         "is_available": True,
+        "is_verified": True,
+        "status": "active",
         "vehicle_type_id": ride["vehicle_type_id"],
     }
     if ride.get("requires_wav"):

--- a/backend/routes/service_areas.py
+++ b/backend/routes/service_areas.py
@@ -33,7 +33,19 @@ _PUBLIC_FIELDS = (
     "search_radius_km",
     "surge_multiplier",
     "surge_active",
+    "surge_enabled",
 )
+
+
+def _project_public(r: dict) -> dict:
+    out = {k: r[k] for k in _PUBLIC_FIELDS if k in r}
+    # Surge is per-area admin-gated. A stale surge_active flag or multiplier > 1
+    # must never surface to clients (or drive rider/driver surge UI) unless an
+    # operator has enabled surge for this area via the admin panel.
+    if not r.get("surge_enabled"):
+        out["surge_active"] = False
+        out["surge_multiplier"] = 1.0
+    return out
 
 
 @api_router.get("/service-areas")
@@ -45,4 +57,4 @@ async def get_service_areas():
         order="name",
         limit=200,
     )
-    return [{k: r[k] for k in _PUBLIC_FIELDS if k in r} for r in (rows or [])]
+    return [_project_public(r) for r in (rows or [])]

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -149,8 +149,6 @@ async def stripe_webhook(request: Request):
             wallet_id = meta.get("wallet_id")
             user_id = meta.get("user_id")
             amount_cad_str = meta.get("amount_cad", "0")
-            from decimal import ROUND_HALF_UP, Decimal
-
             amount = Decimal(amount_cad_str).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
             new_balance = await wallet_increment_balance(wallet_id, amount)
 

--- a/backend/services/fare_service.py
+++ b/backend/services/fare_service.py
@@ -340,7 +340,13 @@ class FareService:
         if not matching_area:
             return build_default_fares(vehicle_types)
 
-        surge = min(_d(matching_area.get("surge_multiplier", 1)), _d(SURGE_CAP))
+        # Surge gated on the per-area admin master toggle + current active flag
+        # (see routes/fares.py). Disabled areas always price at 1.0×.
+        surge = (
+            min(_d(matching_area.get("surge_multiplier", 1)), _d(SURGE_CAP))
+            if matching_area.get("surge_enabled", False) and matching_area.get("surge_active", False)
+            else _d(1)
+        )
         fare_configs = await self.db.get_rows(
             "fare_configs",
             {"service_area_id": matching_area["id"], "is_active": True},

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -151,25 +151,29 @@ async def settle_wallet(
             status_code=403,
         )
 
-    old_balance = _round(_d(wallet.get("balance", 0)))
     debit = _round(total_charge)
-    if old_balance < debit:
+    # Atomic debit + mark-paid via the wallet_pay_for_ride RPC (migration 50):
+    # it locks the wallet row FOR UPDATE, re-checks the balance, debits, and sets
+    # the ride's payment_status='paid' in one transaction, returning the new
+    # balance. Replaces the previous read-compute-write (a TOCTOU race plus a
+    # float-rounded balance written straight to the wallets NUMERIC column).
+    try:
+        new_balance = await db_supabase.wallet_pay_for_ride(wallet["id"], ride_id, debit)
+    except ValueError as exc:
         await db_supabase.update_ride(ride_id, {"payment_status": "pending"})
-        return PaymentResult(
-            success=False,
-            error=f"Insufficient wallet balance. Need ${debit}, have ${old_balance}",
-            status_code=400,
+        if "insufficient_funds" in str(exc):
+            current = _round(
+                _d((await db_supabase.find_one("wallets", {"id": wallet["id"]}) or {}).get("balance", 0))
+            )
+            return PaymentResult(
+                success=False,
+                error=f"Insufficient wallet balance. Need ${debit}, have ${current}",
+                status_code=400,
+            )
+        logger.error(
+            "settle_wallet: wallet_pay_for_ride failed for ride %s: %s", ride_id, exc, exc_info=True
         )
-
-    new_balance = old_balance - debit
-    await db_supabase.update_one(
-        "wallets",
-        {"id": wallet["id"]},
-        {
-            "balance": _f(new_balance),
-            "updated_at": datetime.now(timezone.utc).isoformat(),
-        },
-    )
+        return PaymentResult(success=False, error="Wallet payment failed", status_code=400)
     grand_total = _round(_d(ride.get("grand_total") or ride.get("total_fare", 0) or 0))
     ride_fare = _round(
         _d(ride.get("base_fare") or 0) + _d(ride.get("distance_fare") or 0) + _d(ride.get("time_fare") or 0)

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -374,3 +374,31 @@ class TestServiceAreaValidation:
         assert captured["surge_enabled"] is False
         assert captured["surge_active"] is False
         assert captured["surge_multiplier"] == 1.0
+
+    def test_disabling_above_cap_surge_needs_no_justification(self, client):
+        """Switching off a parked >2.5x surge must not require a justification.
+
+        The form re-sends the current above-cap multiplier alongside
+        surge_enabled=false. Since disabling clears the multiplier to 1.0, the
+        above-cap value is being turned off, not applied — so the justification
+        gate must not block it.
+        """
+        captured: dict = {}
+
+        async def _capture(table, filt, payload):
+            captured.update(payload)
+
+        with (
+            patch("db_supabase.update_one", new=AsyncMock(side_effect=_capture)),
+            patch("routes.admin.service_areas.invalidate_fare_cache", new=AsyncMock()),
+            patch("routes.admin.service_areas.log_admin_action", new=AsyncMock()),
+        ):
+            resp = client.put(
+                "/api/admin/service-areas/area-1",
+                json={"surge_enabled": False, "surge_multiplier": 3.0, "surge_active": True},
+            )
+
+        assert resp.status_code == 200
+        assert captured["surge_enabled"] is False
+        assert captured["surge_active"] is False
+        assert captured["surge_multiplier"] == 1.0

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -352,3 +352,25 @@ class TestServiceAreaValidation:
             json={"multiplier": 0.5, "is_active": True},
         )
         assert resp.status_code == 422
+
+    def test_disabling_surge_clears_active_and_multiplier(self, client):
+        """Turning surge_enabled off must zero any parked surge on the area."""
+        captured: dict = {}
+
+        async def _capture(table, filt, payload):
+            captured.update(payload)
+
+        with (
+            patch("db_supabase.update_one", new=AsyncMock(side_effect=_capture)),
+            patch("routes.admin.service_areas.invalidate_fare_cache", new=AsyncMock()),
+            patch("routes.admin.service_areas.log_admin_action", new=AsyncMock()),
+        ):
+            resp = client.put(
+                "/api/admin/service-areas/area-1",
+                json={"surge_enabled": False, "surge_multiplier": 2.0, "surge_active": True},
+            )
+
+        assert resp.status_code == 200
+        assert captured["surge_enabled"] is False
+        assert captured["surge_active"] is False
+        assert captured["surge_multiplier"] == 1.0

--- a/backend/tests/test_fares.py
+++ b/backend/tests/test_fares.py
@@ -22,6 +22,7 @@ async def test_fare_estimate_surge_capped_at_2_5x():
     matched_area = {
         "id": "area_test_1",
         "name": "Test Area",
+        "surge_enabled": True,
         "surge_active": True,
         "surge_multiplier": 5.0,
         "vehicle_pricing": [

--- a/backend/tests/test_p0_ship_blockers.py
+++ b/backend/tests/test_p0_ship_blockers.py
@@ -631,6 +631,9 @@ class TestPaymentFailureAtComplete:
             patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=completed)),
             patch("backend.routes.rides.db.update_one", AsyncMock(return_value=update_one_mock)),
             patch("backend.routes.rides.db_supabase.update_ride", AsyncMock()),
+            # settle_wallet now debits atomically via the wallet_pay_for_ride RPC
+            # (returns the new balance) instead of a read-compute-write.
+            patch("backend.db_supabase.wallet_pay_for_ride", AsyncMock(return_value=Decimal("79.50"))),
             patch(
                 "backend.routes.rides.db_supabase.get_user_by_id",
                 AsyncMock(return_value={"id": RIDER_ID, "email": "r@s.ca"}),
@@ -671,6 +674,12 @@ class TestPaymentFailureAtComplete:
             patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=completed)),
             patch("backend.routes.rides.db.update_one", AsyncMock(return_value=update_one_mock)),
             patch("backend.routes.rides.db_supabase.update_ride", AsyncMock(side_effect=_capture_update)),
+            # The atomic RPC raises ValueError('insufficient_funds') when the
+            # balance can't cover the charge; settle_wallet must release the lock.
+            patch(
+                "backend.db_supabase.wallet_pay_for_ride",
+                AsyncMock(side_effect=ValueError("insufficient_funds")),
+            ),
             patch("backend.routes.wallet.get_or_create_wallet", AsyncMock(return_value=wallet)),
             patch("backend.routes.wallet._record_transaction", AsyncMock()),
         ):

--- a/backend/tests/test_ride_accept_flow.py
+++ b/backend/tests/test_ride_accept_flow.py
@@ -156,6 +156,51 @@ class TestAcceptRideFlipsStatus:
         # 3) Push notification too so a backgrounded rider app still gets it.
         assert send_push_mock.await_count >= 1
 
+    def test_accept_records_insurance_period_2(self):
+        """Accepting a ride must open insurance Period 2 (en route to pickup —
+        TNC primary commercial coverage) for the winning driver. Misclassifying
+        this window as Period 1 (contingent liability) is a regulatory/insurance
+        liability — a pickup-drive collision would be filed under the wrong layer.
+        """
+        from backend.routes import drivers as drivers_mod
+
+        pre_ride = _ride_row("driver_assigned", driver_id=DRIVER_ID)
+        post_ride = _ride_row(
+            "driver_accepted",
+            driver_id=DRIVER_ID,
+            driver_accepted_at=datetime.now(timezone.utc).isoformat(),
+        )
+        guard_ok = type("_Guard", (), {"modified_count": 1})()
+        period_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.drivers.db_supabase.get_ride", AsyncMock(return_value=pre_ride)),
+            patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[_driver_row()])),
+            patch("backend.routes.drivers.db.update_one", AsyncMock(return_value=guard_ok)),
+            patch("backend.routes.drivers.db.find_one", AsyncMock(return_value=post_ride)),
+            patch("backend.routes.drivers.manager.send_personal_message", AsyncMock()),
+            patch("backend.routes.drivers.manager.broadcast_ride_status", AsyncMock()),
+            patch("backend.routes.drivers.send_push_notification", AsyncMock()),
+            patch("backend.routes.drivers.record_period_transition", period_mock),
+        ):
+            asyncio.run(
+                drivers_mod.accept_ride(
+                    ride_id=RIDE_ID,
+                    current_user={"id": DRIVER_USER_ID},
+                )
+            )
+
+        # The winning driver must transition to Period 2, linked to this ride.
+        period_2_calls = [
+            c for c in period_mock.call_args_list
+            if len(c.args) >= 2 and c.args[0] == DRIVER_ID and c.args[1] == 2
+        ]
+        assert period_2_calls, (
+            "accept_ride must record insurance Period 2 for the winning driver; "
+            f"got calls: {period_mock.call_args_list}"
+        )
+        assert period_2_calls[0].kwargs.get("ride_id") == RIDE_ID
+
     def test_double_accept_rejected_by_guard(self):
         """When the atomic guard returns None (ride already taken by concurrent request),
         accept_ride must raise 409 — never return {success: True}."""

--- a/backend/tests/test_service_areas_public.py
+++ b/backend/tests/test_service_areas_public.py
@@ -33,6 +33,9 @@ _AREA_ROW = {
     "search_radius_km": 10.0,
     # surge_multiplier + surge_active are intentionally public (rider/driver
     # surge badge; surge must be visible before booking per regulatory rules).
+    # surge_enabled is the per-area admin master gate — only when it is on does
+    # the public endpoint report a live multiplier/active flag.
+    "surge_enabled": True,
     "surge_multiplier": 1.5,
     "surge_active": True,
     # Admin-only fields that must NOT leak to the public endpoint:
@@ -80,6 +83,18 @@ class TestPublicServiceAreas:
         assert "gst_rate" not in area
         assert "pst_rate" not in area
         assert "driver_matching_algorithm" not in area
+
+    def test_surge_suppressed_when_not_enabled(self, client):
+        """A stale multiplier/active flag must not surface unless surge_enabled."""
+        from backend.routes import service_areas as mod
+
+        stale = {**_AREA_ROW, "surge_enabled": False, "surge_active": True, "surge_multiplier": 2.0}
+        with patch.object(mod.db_supabase, "get_rows", AsyncMock(return_value=[stale])):
+            r = client.get("/api/v1/service-areas")
+
+        area = r.json()[0]
+        assert area["surge_active"] is False
+        assert area["surge_multiplier"] == 1.0
 
     def test_only_active_filter_passed_to_db(self, client):
         from backend.routes import service_areas as mod

--- a/backend/tests/test_surge_engine.py
+++ b/backend/tests/test_surge_engine.py
@@ -308,7 +308,9 @@ async def test_recalculate_skips_sub_areas():
 @pytest.mark.asyncio
 async def test_recalculate_does_not_update_db_when_multiplier_unchanged():
     """If new multiplier equals current, no DB update_one call."""
-    areas = [{"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True}]
+    areas = [
+        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}
+    ]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
     db_mock.update_one = AsyncMock()
@@ -331,7 +333,9 @@ async def test_recalculate_does_not_update_db_when_multiplier_unchanged():
 @pytest.mark.asyncio
 async def test_recalculate_updates_db_when_multiplier_changes():
     """When new multiplier differs from stored, update_one IS called."""
-    areas = [{"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True}]
+    areas = [
+        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}
+    ]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
     db_mock.update_one = AsyncMock()
@@ -354,11 +358,35 @@ async def test_recalculate_updates_db_when_multiplier_changes():
 
 
 @pytest.mark.asyncio
+async def test_recalculate_skips_surge_disabled_areas():
+    """Areas without surge_enabled are never auto-activated, even under load."""
+    areas = [{"id": "a1", "surge_source": "auto", "surge_enabled": False, "surge_multiplier": 1.0, "is_active": True}]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+    db_mock.update_one = AsyncMock()
+    db_mock.insert_one = AsyncMock(return_value={"id": "row1"})
+
+    with (
+        patch("utils.surge_engine.db", db_mock),
+        # High demand that would otherwise push surge to the cap.
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=50)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=1)),
+    ):
+        from utils.surge_engine import recalculate_all_surges
+
+        results = await recalculate_all_surges()
+
+    # Disabled area is skipped entirely: no multiplier write, no history row.
+    db_mock.update_one.assert_not_awaited()
+    assert results == []
+
+
+@pytest.mark.asyncio
 async def test_recalculate_area_failure_does_not_abort_remaining():
     """An exception processing one area logs error but continues to next area."""
     areas = [
-        {"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True},
-        {"id": "a2", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True},
+        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True},
+        {"id": "a2", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True},
     ]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
@@ -405,7 +433,9 @@ async def test_recalculate_service_areas_db_failure_returns_empty():
 @pytest.mark.asyncio
 async def test_recalculate_inserts_surge_pricing_history_row():
     """Every processed area gets a surge_pricing history row inserted."""
-    areas = [{"id": "a1", "surge_source": "auto", "surge_multiplier": 1.0, "is_active": True}]
+    areas = [
+        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}
+    ]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
     db_mock.update_one = AsyncMock()

--- a/backend/tests/test_surge_reset_to_auto.py
+++ b/backend/tests/test_surge_reset_to_auto.py
@@ -1,0 +1,55 @@
+"""
+Regression test for backend/features.py :: admin_reset_surge_to_auto.
+
+With the per-area surge_enabled gate, "reset to auto" must flip surge_enabled
+back on. Otherwise an area an operator previously disabled would stay gated
+off: the surge engine keeps skipping it and fare calc keeps ignoring surge,
+even though the endpoint returns success.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_reset_to_auto_enables_surge_gate():
+    """Reset-to-auto must set surge_source=auto, surge_active and surge_enabled."""
+    from features import admin_reset_surge_to_auto, db
+
+    area_before = {"id": "area-1", "surge_enabled": False, "surge_source": "manual"}
+    area_after = {"id": "area-1", "surge_enabled": True, "surge_source": "auto", "surge_active": True}
+
+    with (
+        patch.object(db, "find_one", new=AsyncMock(side_effect=[area_before, area_after])),
+        patch.object(db, "update_one", new=AsyncMock()) as mock_update,
+    ):
+        result = await admin_reset_surge_to_auto("area-1")
+
+    mock_update.assert_awaited_once()
+    args, _ = mock_update.call_args
+    set_payload = args[2]["$set"]
+    assert set_payload["surge_source"] == "auto"
+    assert set_payload["surge_active"] is True
+    assert set_payload["surge_enabled"] is True
+    assert result["surge_enabled"] is True
+
+
+async def test_reset_to_auto_404_when_area_missing():
+    """Unknown area still 404s and writes nothing."""
+    from fastapi import HTTPException
+
+    from features import admin_reset_surge_to_auto, db
+
+    with (
+        patch.object(db, "find_one", new=AsyncMock(return_value=None)),
+        patch.object(db, "update_one", new=AsyncMock()) as mock_update,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await admin_reset_surge_to_auto("nope")
+
+    assert exc.value.status_code == 404
+    mock_update.assert_not_awaited()

--- a/backend/utils/surge_engine.py
+++ b/backend/utils/surge_engine.py
@@ -62,9 +62,7 @@ def ratio_to_multiplier(ratio: float) -> float:
 
 async def _count_demand_in_area(area_id: str) -> int:
     """Count active/recent ride requests in a service area."""
-    cutoff = (
-        datetime.now(timezone.utc) - timedelta(minutes=DEMAND_WINDOW_MINUTES)
-    ).isoformat()
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=DEMAND_WINDOW_MINUTES)).isoformat()
     try:
         rides = await db.get_rows(
             "rides",
@@ -84,9 +82,7 @@ async def _count_demand_in_area(area_id: str) -> int:
         }
         return sum(1 for r in rides if r.get("status") in active_statuses)
     except Exception as e:
-        logger.error(
-            f"Surge: failed to count demand for area {area_id}: {e}", exc_info=True
-        )
+        logger.error(f"Surge: failed to count demand for area {area_id}: {e}", exc_info=True)
         return 0
 
 
@@ -97,9 +93,7 @@ async def _count_supply_in_area(area: Dict[str, Any]) -> int:
         return 0
 
     try:
-        drivers = await db.get_rows(
-            "drivers", {"is_online": True, "is_available": True}, limit=500
-        )
+        drivers = await db.get_rows("drivers", {"is_online": True, "is_available": True}, limit=500)
 
         # Presence filter: ghost-online drivers (app force-killed, phone dead)
         # shouldn't count as "supply" or we'd compute a lower surge than the
@@ -164,9 +158,7 @@ async def recalculate_all_surges() -> List[Dict[str, Any]]:
     try:
         areas = await db.get_rows("service_areas", {"is_active": True}, limit=100)
     except Exception as e:
-        original = (
-            getattr(e, "details", {}).get("original") if hasattr(e, "details") else None
-        )
+        original = getattr(e, "details", {}).get("original") if hasattr(e, "details") else None
         logger.error(f"Surge: failed to fetch service areas: {e} | original={original}")
         return results
 
@@ -178,6 +170,14 @@ async def recalculate_all_surges() -> List[Dict[str, Any]]:
         # Skip manually overridden areas
         surge_source = area.get("surge_source", "auto")
         if surge_source == "manual":
+            continue
+
+        # Per-area admin master gate: never auto-activate surge for an area the
+        # operator hasn't explicitly enabled (surge_enabled defaults FALSE). The
+        # fare paths also refuse to apply surge for disabled areas, but skipping
+        # here keeps surge_active/multiplier from ever being written in the first
+        # place, so nothing stale lingers if the area is later enabled.
+        if not area.get("surge_enabled", False):
             continue
 
         try:
@@ -221,9 +221,7 @@ async def recalculate_all_surges() -> List[Dict[str, Any]]:
 
             results.append(metrics)
         except Exception as e:
-            logger.error(
-                f"Surge: failed to update area {area.get('id')}: {e}", exc_info=True
-            )
+            logger.error(f"Surge: failed to update area {area.get('id')}: {e}", exc_info=True)
 
     return results
 
@@ -270,9 +268,7 @@ async def surge_recalculation_loop():
             results = await recalculate_all_surges()
             if results:
                 active = sum(1 for r in results if r["multiplier"] > 1.0)
-                logger.debug(
-                    f"Surge recalc complete: {len(results)} areas, {active} surging"
-                )
+                logger.debug(f"Surge recalc complete: {len(results)} areas, {active} surging")
         except Exception as e:
             logger.error(f"Surge recalculation loop error: {e}")
         _record_heartbeat("surge_engine (2min)")

--- a/docs/runbooks/app-store-review.md
+++ b/docs/runbooks/app-store-review.md
@@ -1,0 +1,126 @@
+# Runbook — App Store / Play Store reviewer login
+
+Spinr authenticates with phone + SMS OTP. App Store and Play Store reviewers
+run in a datacenter and **cannot receive your SMS**, and the `1234` dev bypass
+is disabled in production. This runbook sets up a reviewer login that works in
+production for an explicit allow-list of numbers only — without weakening auth
+for real users.
+
+## How it works
+
+`/auth/send-otp`, for a phone in the `REVIEW_LOGIN_ACCOUNTS` allow-list, stores
+a **pre-shared fixed code** and **does not send an SMS**. `/auth/verify-otp` is
+unchanged — it just hash-compares the submitted code against the stored one, so
+the existing expiry, lockout, and reuse protections all still apply. Every
+other number in production continues to get a real SMS. Reviewer logins are
+logged (`Reviewer-account OTP issued without SMS for ...NNNN`).
+
+The allow-list lives in a **backend env secret** (not `app_settings`) so it
+can't be edited from the admin dashboard — a compromised admin can't add a
+bypass number.
+
+## Setup (per submission)
+
+### 1. Pick reviewer numbers + codes
+
+Use test numbers in a region you control (Saskatchewan = `+1306…`). Codes are
+**4 digits** (must match `OTP_LENGTH`). Use one number per app:
+
+| App | Example phone | Example code |
+|---|---|---|
+| Rider | `+13065550100` | `4821` |
+| Driver | `+13065550101` | `4821` |
+
+### 2. Set the backend env var (Railway)
+
+```
+REVIEW_LOGIN_ACCOUNTS=+13065550100:4821,+13065550101:4821
+```
+
+Comma-separated `phone:otp` pairs, E.164 phone. Redeploy. **Leave this empty
+except while a review is in flight; clear it once the build is approved.**
+
+### 3. Rider reviewer account — nothing to seed
+
+The rider account is auto-created on first `verify-otp`. The reviewer can log
+in and exercise the full UI: map, pickup/destination, fare estimate, request,
+wallet, history, profile, safety/SOS.
+
+Mock payments are enabled for allow-listed reviewer accounts in production, so
+if the reviewer reaches a payment/confirmation screen they can complete it with
+a `pi_mock_*` intent — **no real card is charged**. (For everyone else, mock
+payments remain rejected in production.)
+
+### 4. Driver reviewer account — pre-approve once
+
+A reviewer logging into the **driver** app with a brand-new account lands on
+onboarding. Pre-provision a driver so the reviewer can go online:
+
+**Recommended (supported path):** run the driver through normal onboarding once
+on staging/prod, then in the admin dashboard set the account to **active**,
+assign a vehicle type, and set all document expiry dates to a far-future date.
+
+A driver must satisfy `go_online` to receive offers:
+- `status = 'active'`
+- All document expiry dates in the future: `license_expiry_date`,
+  `insurance_expiry_date`, `vehicle_inspection_expiry_date`,
+  `background_check_expiry_date`, `work_eligibility_expiry_date`
+- A `vehicle_type_id` (see `seed_vehicle_types.py`)
+- Spinr Pass is **not** required unless the admin toggle
+  `require_driver_subscription` is on (off by default pre-launch)
+
+**Optional SQL template** (adjust column names to your schema; run in Supabase
+SQL editor against the review environment, not blind in production):
+
+```sql
+-- after the reviewer driver has logged in once (users row exists)
+update users set role = 'driver', is_driver = true
+ where phone = '+13065550101';
+
+update drivers d
+   set status = 'active',
+       is_verified = true,
+       vehicle_type_id = (select id from vehicle_types limit 1),
+       license_expiry_date            = now() + interval '2 years',
+       insurance_expiry_date          = now() + interval '2 years',
+       vehicle_inspection_expiry_date = now() + interval '2 years',
+       background_check_expiry_date   = now() + interval '2 years',
+       work_eligibility_expiry_date   = now() + interval '2 years'
+  from users u
+ where d.user_id = u.id and u.phone = '+13065550101';
+```
+
+> Note: a live ride match still needs supply/demand to line up. Reviewers do
+> not require a completed real trip — see the review notes below.
+
+## What to put in the store consoles
+
+### App Store Connect → App Review Information
+
+- **Sign-in required:** Yes
+- **Phone number:** `+1 306 555 0100`
+- **Verification code:** `4821`
+- **Notes:**
+  > Spinr signs in with a phone number + a 4-digit SMS code. This is a demo
+  > account that accepts the fixed code above without an SMS. Enter the phone,
+  > tap Send Code, then enter `4821`. You can browse the map, set a pickup and
+  > destination, view the fare estimate, and request a ride. Live driver
+  > matching depends on a driver being online in the area, so a request may
+  > stay in "Finding your driver" if none is available — this is expected and
+  > not a defect. No real payment is charged on this demo account.
+
+Submit the driver app with the driver number/code and an analogous note (go
+online, receive/accept an offer when one is dispatched).
+
+### Google Play Console → App access
+
+Add the same phone/code under "All or some functionality is restricted" with
+instructions identical to the Apple notes.
+
+## Security hygiene
+
+- Treat `REVIEW_LOGIN_ACCOUNTS` like a credential. **Clear it after approval.**
+- Rotate the codes for every submission.
+- Use throwaway test numbers you control — never a real customer's number.
+- Reviewer logins are audit-logged; mock-payment use is scoped to these
+  accounts only and only in addition to the normal non-production allowance.


### PR DESCRIPTION
The local 'from decimal import ROUND_HALF_UP' inside the wallet_topup
branch bound the name function-local for the entire stripe_webhook
handler, so the charge.refunded branch raised UnboundLocalError on the
first real refund -> 500 -> Stripe retries indefinitely and the refund
is never recorded. Import at module level and drop the local re-import.

https://claude.ai/code/session_01UhdcxVFzb1CZxCsHr4Ezrq

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
