### PR TITLE
fix(payments): recover stale wallet 'processing' rides; idempotent wa…

### DIFF
--- a/backend/migrations/107_wallet_pay_idempotent.sql
+++ b/backend/migrations/107_wallet_pay_idempotent.sql
@@ -1,0 +1,82 @@
+-- 107_wallet_pay_idempotent.sql
+--
+-- Make wallet_pay_for_ride idempotent so a retry or concurrent re-drive of the
+-- same ride can never debit the rider's wallet twice.
+--
+-- Background: migration 50 introduced wallet_pay_for_ride as an atomic
+-- (debit + mark-paid) transaction, but it debited UNCONDITIONALLY — it never
+-- checked whether the ride was already paid. The only thing preventing a
+-- double debit was the process_payment 'pending' -> 'processing' claim. When a
+-- ride got stuck in 'processing' (a settle crash/timeout between the claim and
+-- this RPC), there was no safe way to re-drive it: re-running risked a double
+-- debit. This adds an explicit paid-guard so recovery of a stuck 'processing'
+-- ride (see routes/rides.py process_payment) is double-charge-proof.
+--
+-- Idempotency: if the ride is already 'paid', return the current balance
+-- unchanged without debiting. Lock ordering preserved (wallet row first, then
+-- ride row) to match wallet_transfer and avoid deadlocks.
+--
+-- Forward-compatible: CREATE OR REPLACE only; no schema change, no data
+-- migration, safe to run against live traffic.
+--
+-- Rollback: re-apply migration 50's body of wallet_pay_for_ride (the version
+-- without the v_status paid-guard).
+
+CREATE OR REPLACE FUNCTION wallet_pay_for_ride(
+    p_wallet_id UUID,
+    p_ride_id   UUID,
+    p_amount    NUMERIC
+)
+RETURNS NUMERIC
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_balance     NUMERIC;
+    v_new_balance NUMERIC;
+    v_status      TEXT;
+BEGIN
+    -- Lock the wallet row first (same order as wallet_transfer).
+    SELECT balance INTO v_balance
+      FROM wallets
+     WHERE id = p_wallet_id
+       AND is_active = TRUE
+       FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'wallet not found or suspended: %', p_wallet_id
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    -- Idempotency guard: if this ride has already been paid, do NOT debit
+    -- again. Return the (unchanged) wallet balance. Lock the ride row so a
+    -- concurrent caller serializes behind us.
+    SELECT payment_status INTO v_status
+      FROM rides
+     WHERE id = p_ride_id
+       FOR UPDATE;
+
+    IF v_status = 'paid' THEN
+        RETURN v_balance;
+    END IF;
+
+    IF v_balance < p_amount THEN
+        RAISE EXCEPTION 'insufficient_funds'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE wallets
+       SET balance    = balance - p_amount,
+           updated_at = NOW()
+     WHERE id = p_wallet_id
+    RETURNING balance INTO v_new_balance;
+
+    UPDATE rides
+       SET payment_status = 'paid',
+           updated_at     = NOW()
+     WHERE id = p_ride_id;
+
+    RETURN v_new_balance;
+END;
+$$;

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import secrets
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from datetime import timezone as _tz
 from decimal import ROUND_HALF_UP, Decimal
 from typing import List, Optional
@@ -2205,7 +2205,6 @@ async def get_rider_stats(
     Timezone is derived from the service area of the rider's most recent completed
     ride so 'today' aligns with the driver's local calendar day, not UTC midnight.
     """
-    from datetime import timedelta
     from zoneinfo import ZoneInfo
 
     _tz_name = "America/Regina"
@@ -2700,15 +2699,35 @@ async def process_payment(
             detail=f"Ride is in status '{_ride_status}'; payment requires completed state.",
         )
 
-    if ride.get("payment_status") in ("paid", "processing"):
-        logger.info(f"[PAYMENT] Ride {ride_id} already {ride['payment_status']} — skipping duplicate charge")
-        return {
-            "success": True,
-            "charged_amount": _money_str(
-                _d(ride.get("grand_total") or ride.get("total_fare", 0) or 0) + _d(ride.get("tip_amount", 0) or 0)
-            ),
-            "already_paid": True,
-        }
+    # A wallet ride stuck in 'processing' for longer than this is treated as a
+    # crashed settlement and recovered. Wallet settlement is a single atomic RPC
+    # (wallet_pay_for_ride debits AND marks paid in one txn, migration 50/107),
+    # so a wallet ride still at 'processing' was provably NEVER debited — safe to
+    # re-drive. Kept short so the rider isn't stuck in a "complete → pay" loop,
+    # but long enough that a genuinely in-flight settle on another replica wins.
+    _STALE_PROCESSING_SECONDS = 90
+
+    def _charged(r: dict) -> str:
+        _g = r.get("grand_total")
+        if _g is None:
+            _g = r.get("total_fare", 0)
+        return _money_str(_d(_g) + _d(r.get("tip_amount", 0) or 0))
+
+    _pstatus = ride.get("payment_status")
+    _pmethod = (ride.get("payment_method") or "card").lower()
+
+    if _pstatus == "paid":
+        logger.info(f"[PAYMENT] Ride {ride_id} already paid — skipping duplicate charge")
+        return {"success": True, "charged_amount": _charged(ride), "already_paid": True}
+
+    # 'processing' for a CARD/corporate ride may mean the charge was CAPTURED
+    # with the DB write lost (settle_card's captured-but-unconfirmed path), so
+    # reporting already-paid avoids a double charge; the reconcile/retry loop
+    # reconciles the truth. WALLET 'processing' is never a captured state (see
+    # above) and falls through to the stale-recovery claim below.
+    if _pstatus == "processing" and _pmethod != "wallet":
+        logger.info(f"[PAYMENT] Ride {ride_id} processing ({_pmethod}) — skipping duplicate charge")
+        return {"success": True, "charged_amount": _charged(ride), "already_paid": True}
 
     # Validate the tip BEFORE the atomic claim — raising after the claim would
     # leave payment_status stuck at 'processing' with no charge ever attempted.
@@ -2730,22 +2749,32 @@ async def process_payment(
             "updated_at": datetime.now(timezone.utc).isoformat(),
         },
     )
+
+    # Stale wallet-'processing' recovery: a crashed settlement left the ride
+    # claimed but never debited. Reclaim atomically on the updated_at age filter
+    # so only one replica wins the recovery (and wallet_pay_for_ride is
+    # idempotent, so even a lost race cannot double-debit).
+    if guard_row is None and _pstatus == "processing" and _pmethod == "wallet":
+        _stale_before = (datetime.now(timezone.utc) - timedelta(seconds=_STALE_PROCESSING_SECONDS)).isoformat()
+        guard_row = await db_supabase.update_one(
+            "rides",
+            {"id": ride_id, "payment_status": "processing", "updated_at": {"$lt": _stale_before}},
+            {"payment_status": "processing", "updated_at": datetime.now(timezone.utc).isoformat()},
+        )
+        if guard_row is not None:
+            logger.warning(f"[PAYMENT] Recovered stale wallet 'processing' ride {ride_id} for re-settlement")
+
     if guard_row is None:
         # Lost the claim race (concurrent attempt grabbed it). Re-read to see
         # the real state — only report already-paid when the ride is genuinely
-        # paid or mid-charge (processing). A still-unpaid state must surface as
-        # a retryable 409, never a false success.
+        # paid. A still-processing state is reported as a retryable 409 (the
+        # client backs off and retries) rather than a false "Paid".
         fresh = await db_supabase.get_ride(ride_id) or ride
-        if fresh.get("payment_status") in ("paid", "processing"):
-            _fresh_grand = fresh.get("grand_total")
-            if _fresh_grand is None:
-                _fresh_grand = fresh.get("total_fare", 0)
-            return {
-                "success": True,
-                "already_paid": True,
-                "charged_amount": _money_str(_d(_fresh_grand) + _d(fresh.get("tip_amount", 0) or 0)),
-            }
-        raise HTTPException(status_code=409, detail="Could not start payment; please retry.")
+        if fresh.get("payment_status") == "paid":
+            return {"success": True, "already_paid": True, "charged_amount": _charged(fresh)}
+        if fresh.get("payment_status") == "processing" and _pmethod != "wallet":
+            return {"success": True, "already_paid": True, "charged_amount": _charged(fresh)}
+        raise HTTPException(status_code=409, detail="Payment is processing; please retry in a moment.")
 
     def _q(v) -> Decimal:
         return Decimal(str(v or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)


### PR DESCRIPTION
…llet RPC

Production bug: a wallet ride whose settlement crashed/timed out between the process_payment 'pending'->'processing' claim and the wallet RPC was stranded in 'processing' forever. Every subsequent process-payment returned already_paid:true (false), while /rides/active still saw it as unpaid — the rider app bounced back to ride-completed in an endless "complete -> pay" loop and the fare was never collected.

Part A (migration 107): make wallet_pay_for_ride idempotent. It previously debited unconditionally; now it short-circuits and returns the unchanged balance if the ride is already 'paid'. Any retry or concurrent re-drive is double-charge-proof. Wallet row locked first (preserves wallet_transfer lock order), then the ride row.

Part B (process_payment): method-aware 'processing' handling + recovery.
- paid -> already_paid (unchanged).
- card/corporate 'processing' -> already_paid (the charge may have been captured with the DB write lost; reconcile/retry loop handles the truth).
- wallet 'processing' -> recoverable: settlement is one atomic RPC, so a wallet ride still at 'processing' was NEVER debited. After a 90s staleness window we reclaim it atomically (updated_at age filter so one replica wins) and re-settle. The idempotent RPC is the backstop against any race.
- guard-None re-read now only reports already_paid for genuinely paid (or captured-card) rides; a still-processing wallet ride returns a retryable 409 instead of a false "Paid".

The stuck ride recovers on the rider's next payment attempt once it's >90s old.

https://claude.ai/code/session_01UhdcxVFzb1CZxCsHr4Ezrq

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
