### PR TITLE
fix(payments): re-drive stuck wallet 'processing' immediately, not on…

### DIFF
--- a/backend/migrations/107_wallet_pay_idempotent.sql
+++ b/backend/migrations/107_wallet_pay_idempotent.sql
@@ -12,9 +12,10 @@
 -- debit. This adds an explicit paid-guard so recovery of a stuck 'processing'
 -- ride (see routes/rides.py process_payment) is double-charge-proof.
 --
--- Idempotency: if the ride is already 'paid', return the current balance
--- unchanged without debiting. Lock ordering preserved (wallet row first, then
--- ride row) to match wallet_transfer and avoid deadlocks.
+-- Idempotency: if the ride is already 'paid', return NULL (not the current
+-- balance) so the caller can distinguish a no-op from a real debit and skip
+-- the wallet_transactions ledger write. Lock ordering preserved (wallet row
+-- first, then ride row) to match wallet_transfer and avoid deadlocks.
 --
 -- Forward-compatible: CREATE OR REPLACE only; no schema change, no data
 -- migration, safe to run against live traffic.
@@ -58,7 +59,7 @@ BEGIN
        FOR UPDATE;
 
     IF v_status = 'paid' THEN
-        RETURN v_balance;
+        RETURN NULL;  -- NULL signals caller: ride already paid, no money moved
     END IF;
 
     IF v_balance < p_amount THEN

--- a/backend/repositories/wallet_repo.py
+++ b/backend/repositories/wallet_repo.py
@@ -5,7 +5,7 @@ Extracted from db_supabase.py (Phase 4 of god-object decomposition).
 
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from loguru import logger
 
@@ -48,8 +48,12 @@ async def wallet_increment_balance(wallet_id: str, amount: "Decimal") -> "Decima
     return await run_sync(_fn)
 
 
-async def wallet_pay_for_ride(wallet_id: str, ride_id: str, amount: "Decimal") -> "Decimal":
-    """Atomically debit wallet and mark ride paid. Returns the new balance.
+async def wallet_pay_for_ride(wallet_id: str, ride_id: str, amount: "Decimal") -> "Optional[Decimal]":
+    """Atomically debit wallet and mark ride paid.
+
+    Returns the new balance after debit, or None if the ride was already paid
+    (idempotent no-op — the RPC returned NULL, no money moved, no ledger entry
+    should be written by the caller).
 
     Raises ValueError('insufficient_funds') if balance < amount.
     """
@@ -58,7 +62,7 @@ async def wallet_pay_for_ride(wallet_id: str, ride_id: str, amount: "Decimal") -
     if not supabase:
         raise DatabaseError(details={"original": "supabase not initialised"})
 
-    def _fn():
+    def _fn() -> "Optional[_Decimal]":
         try:
             res = supabase.rpc(
                 "wallet_pay_for_ride",
@@ -73,7 +77,8 @@ async def wallet_pay_for_ride(wallet_id: str, ride_id: str, amount: "Decimal") -
             raise
         data = getattr(res, "data", None)
         if data is None:
-            raise DatabaseError(details={"original": "wallet_pay_for_ride: no data returned"})
+            # NULL from the RPC means ride already paid — idempotent no-op.
+            return None
         return _Decimal(str(data))
 
     return await run_sync(_fn)

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2738,9 +2738,27 @@ async def process_payment(
     # idempotent RPC is the double-charge guard). We do NOT gate this on
     # updated_at — /rate bumps updated_at immediately before /process-payment,
     # so an age filter never fires and the ride stays stuck forever.
+    _wallet_redrive_lock_key: str | None = None
     _claim_states = ["pending", "failed"]
     if _pmethod == "wallet":
         _claim_states.append("processing")
+        if _pstatus == "processing":
+            # 'processing → processing' UPDATE is not exclusive: both concurrent
+            # re-drives match the WHERE clause and both enter settlement. The
+            # idempotent RPC prevents the double-debit but post-RPC side effects
+            # (ledger write, receipt email) would still run twice. Acquire a
+            # short-lived Redis NX lock so only one re-drive proceeds at a time.
+            try:
+                from ..utils.redis_client import redis_delete as _redis_del
+                from ..utils.redis_client import redis_set_nx as _redis_nx
+            except ImportError:
+                from utils.redis_client import redis_set_nx as _redis_nx  # type: ignore
+            _wallet_redrive_lock_key = f"spinr:wallet_settle:{ride_id}"
+            if not await _redis_nx(_wallet_redrive_lock_key, "1", 30):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Payment retry already in progress. Please try again in a moment.",
+                )
     guard_row = await db_supabase.update_one(
         "rides",
         {"id": ride_id, "payment_status": {"$in": _claim_states}},
@@ -2828,7 +2846,21 @@ async def process_payment(
                 detail.update(result.extra)
         raise HTTPException(status_code=result.status_code, detail=detail)
 
-    email_sent = await send_ride_receipt(ride, current_user["id"], tip_amount)
+    # Release the wallet re-drive lock now that settlement is complete so any
+    # subsequent legitimate retry sees the paid status immediately rather than
+    # waiting 30 s for the TTL to expire.
+    if _wallet_redrive_lock_key:
+        try:
+            await _redis_del(_wallet_redrive_lock_key)
+        except Exception as _lock_err:
+            logger.debug("wallet redrive lock release failed (TTL will expire): %s", _lock_err)
+
+    # Skip receipt on already_paid — a previous attempt already paid and
+    # (presumably) sent a receipt; we avoid the duplicate without losing the
+    # financial record (ledger write was also skipped by settle_wallet).
+    email_sent = False
+    if not result.already_paid:
+        email_sent = await send_ride_receipt(ride, current_user["id"], tip_amount)
     return {
         "success": True,
         "charged_amount": _money_str(result.charged_amount),

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2699,14 +2699,6 @@ async def process_payment(
             detail=f"Ride is in status '{_ride_status}'; payment requires completed state.",
         )
 
-    # A wallet ride stuck in 'processing' for longer than this is treated as a
-    # crashed settlement and recovered. Wallet settlement is a single atomic RPC
-    # (wallet_pay_for_ride debits AND marks paid in one txn, migration 50/107),
-    # so a wallet ride still at 'processing' was provably NEVER debited — safe to
-    # re-drive. Kept short so the rider isn't stuck in a "complete → pay" loop,
-    # but long enough that a genuinely in-flight settle on another replica wins.
-    _STALE_PROCESSING_SECONDS = 90
-
     def _charged(r: dict) -> str:
         _g = r.get("grand_total")
         if _g is None:
@@ -2723,8 +2715,12 @@ async def process_payment(
     # 'processing' for a CARD/corporate ride may mean the charge was CAPTURED
     # with the DB write lost (settle_card's captured-but-unconfirmed path), so
     # reporting already-paid avoids a double charge; the reconcile/retry loop
-    # reconciles the truth. WALLET 'processing' is never a captured state (see
-    # above) and falls through to the stale-recovery claim below.
+    # reconciles the truth. WALLET 'processing' is different: settlement is a
+    # single atomic RPC (wallet_pay_for_ride debits AND marks paid in one txn,
+    # migration 50/107), so a wallet ride still at 'processing' was provably
+    # NEVER debited — it's a crashed/timed-out settle that must be RE-DRIVEN,
+    # not reported as paid. The RPC is idempotent (107: no-op if already paid),
+    # so re-driving cannot double-charge even under a concurrent retry.
     if _pstatus == "processing" and _pmethod != "wallet":
         logger.info(f"[PAYMENT] Ride {ride_id} processing ({_pmethod}) — skipping duplicate charge")
         return {"success": True, "charged_amount": _charged(ride), "already_paid": True}
@@ -2736,39 +2732,31 @@ async def process_payment(
     if tip_amount > 500:
         raise HTTPException(status_code=400, detail="Tip amount exceeds maximum ($500)")
 
-    # Atomic claim. Allow re-driving a previously FAILED charge (e.g. the rider
-    # updated a declined card and retried), not just a fresh 'pending'. Without
-    # 'failed' here, a retry after a decline fell through to the guard-None
-    # branch below and was wrongly reported as already-paid — leaving the fare
-    # uncollected while the rider saw "Paid".
+    # Atomic claim. 'pending' is the normal first payment; 'failed' lets a retry
+    # after a decline re-drive; for WALLET we also re-claim 'processing' so a
+    # crashed/stuck settlement is recovered on the rider's next attempt (the
+    # idempotent RPC is the double-charge guard). We do NOT gate this on
+    # updated_at — /rate bumps updated_at immediately before /process-payment,
+    # so an age filter never fires and the ride stays stuck forever.
+    _claim_states = ["pending", "failed"]
+    if _pmethod == "wallet":
+        _claim_states.append("processing")
     guard_row = await db_supabase.update_one(
         "rides",
-        {"id": ride_id, "payment_status": {"$in": ["pending", "failed"]}},
+        {"id": ride_id, "payment_status": {"$in": _claim_states}},
         {
             "payment_status": "processing",
             "updated_at": datetime.now(timezone.utc).isoformat(),
         },
     )
-
-    # Stale wallet-'processing' recovery: a crashed settlement left the ride
-    # claimed but never debited. Reclaim atomically on the updated_at age filter
-    # so only one replica wins the recovery (and wallet_pay_for_ride is
-    # idempotent, so even a lost race cannot double-debit).
-    if guard_row is None and _pstatus == "processing" and _pmethod == "wallet":
-        _stale_before = (datetime.now(timezone.utc) - timedelta(seconds=_STALE_PROCESSING_SECONDS)).isoformat()
-        guard_row = await db_supabase.update_one(
-            "rides",
-            {"id": ride_id, "payment_status": "processing", "updated_at": {"$lt": _stale_before}},
-            {"payment_status": "processing", "updated_at": datetime.now(timezone.utc).isoformat()},
-        )
-        if guard_row is not None:
-            logger.warning(f"[PAYMENT] Recovered stale wallet 'processing' ride {ride_id} for re-settlement")
+    if guard_row is not None and _pstatus == "processing":
+        logger.warning(f"[PAYMENT] Re-driving stuck wallet 'processing' ride {ride_id} for re-settlement")
 
     if guard_row is None:
-        # Lost the claim race (concurrent attempt grabbed it). Re-read to see
-        # the real state — only report already-paid when the ride is genuinely
-        # paid. A still-processing state is reported as a retryable 409 (the
-        # client backs off and retries) rather than a false "Paid".
+        # Couldn't claim. Re-read the real state — only report already-paid when
+        # the ride is genuinely paid (or a captured-card 'processing'); a wallet
+        # state we couldn't claim returns a retryable 409 rather than a false
+        # "Paid".
         fresh = await db_supabase.get_ride(ride_id) or ride
         if fresh.get("payment_status") == "paid":
             return {"success": True, "already_paid": True, "charged_amount": _charged(fresh)}

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -170,6 +170,13 @@ async def settle_wallet(
             )
         logger.error("settle_wallet: wallet_pay_for_ride failed for ride %s: %s", ride_id, exc, exc_info=True)
         return PaymentResult(success=False, error="Wallet payment failed", status_code=400)
+
+    # None means the RPC fired its idempotent no-op (ride already paid in a
+    # previous attempt). No money moved, so we must NOT append a ledger row.
+    if new_balance is None:
+        logger.info("settle_wallet: ride %s already paid — idempotent no-op, skipping ledger write", ride_id)
+        return PaymentResult(success=True, already_paid=True, charged_amount=_money_str(total_charge))
+
     grand_total = _round(_d(ride.get("grand_total") or ride.get("total_fare", 0) or 0))
     ride_fare = _round(
         _d(ride.get("base_fare") or 0) + _d(ride.get("distance_fare") or 0) + _d(ride.get("time_fare") or 0)


### PR DESCRIPTION
… updated_at age

The 90s staleness gate from the prior fix never fired: the rider app calls POST /rides/{id}/rate immediately before /process-payment, and rate_driver calls update_ride() which bumps the ride's updated_at to now. So the "updated_at < now - 90s" recovery filter never matched and a stuck wallet ride returned 409 forever — the rider loops on the payment screen.

Fix: for wallet payments, include 'processing' directly in the atomic claim states ({pending, failed, processing}) so a crashed/interrupted settlement is re-driven on the rider's very next attempt — no time gate. Wallet settlement is one atomic, idempotent RPC (wallet_pay_for_ride; migration 107 makes it a no-op when the ride is already paid), so re-driving cannot double-charge even under a concurrent retry. Card/corporate 'processing' still returns already_paid (a card charge may have been captured with the DB write lost).

Root cause of the original stuck state: a container restart/redeploy interrupted the settlement between the 'processing' claim and the wallet RPC (the logs show Stopping/Starting Container around the stuck ride).

REQUIRES migration 107 applied for the idempotent-RPC double-charge guard.

https://claude.ai/code/session_01UhdcxVFzb1CZxCsHr4Ezrq

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
