### PR TITLE
fix: add missing item_category column to lost_and_found

### DIFF
--- a/admin-dashboard/src/__tests__/dashboard/pages.smoke.test.tsx
+++ b/admin-dashboard/src/__tests__/dashboard/pages.smoke.test.tsx
@@ -34,15 +34,19 @@ vi.mock("next/image", () => ({
   default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
 }));
 
-vi.mock("@/store/authStore", () => ({
-  useAuthStore: () => ({
+vi.mock("@/store/authStore", () => {
+  const state = {
     token: "fake-token",
     user: { id: "admin-001", email: "admin@spinr.ca", role: "super_admin", modules: ["dashboard"] },
     setToken: vi.fn(),
     setUser: vi.fn(),
     logout: vi.fn(),
-  }),
-}));
+  };
+  return {
+    useAuthStore: (selector?: (s: typeof state) => unknown) =>
+      typeof selector === "function" ? selector(state) : state,
+  };
+});
 
 // Stub every API function to avoid real network calls.
 // importOriginal enumerates the real module's exports so Vitest 4 strict-ESM

--- a/backend/migrations/114_lost_and_found_add_item_category.sql
+++ b/backend/migrations/114_lost_and_found_add_item_category.sql
@@ -1,0 +1,25 @@
+-- 114_lost_and_found_add_item_category.sql
+--
+-- Production repair: adds the item_category column to lost_and_found on
+-- environments where the table pre-dated the migration runner (or where
+-- migration 69 / 69a ran as a no-op against the legacy schema).
+--
+-- Symptom: PGRST204 "Could not find the 'item_category' column of
+-- 'lost_and_found' in the schema cache" — every POST /lost-and-found
+-- returns 503 until this migration runs.
+--
+-- The CHECK constraint matches the valid values enforced in rides.py.
+-- The NOTIFY forces PostgREST to reload its schema cache immediately.
+--
+-- Forward-compatible: ADD COLUMN IF NOT EXISTS is a no-op when the column
+-- already exists (environments where 69a ran successfully).
+--
+-- Rollback:
+--   ALTER TABLE lost_and_found DROP COLUMN IF EXISTS item_category;
+--   NOTIFY pgrst, 'reload schema';
+
+ALTER TABLE lost_and_found
+    ADD COLUMN IF NOT EXISTS item_category TEXT
+        CHECK (item_category IN ('electronics', 'clothing', 'bag', 'document', 'keys', 'other'));
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/115_lost_and_found_chat.sql
+++ b/backend/migrations/115_lost_and_found_chat.sql
@@ -1,0 +1,95 @@
+-- 115_lost_and_found_chat.sql
+--
+-- Adds per-case chat to the lost_and_found feature.
+-- Creates lost_and_found_messages and extends lost_and_found with
+-- reporter_type so driver- and admin-initiated cases are distinguished.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS lost_and_found_messages CASCADE;
+--   ALTER TABLE lost_and_found DROP COLUMN IF EXISTS reporter_type;
+--   ALTER TABLE lost_and_found DROP CONSTRAINT IF EXISTS lost_and_found_status_check;
+--   ALTER TABLE lost_and_found ADD CONSTRAINT lost_and_found_status_check
+--       CHECK (status IN ('reported','driver_notified','found','returned','unclaimed','resolved','unresolved'));
+--   NOTIFY pgrst, 'reload schema';
+
+-- 1. reporter_type: who opened the case
+ALTER TABLE lost_and_found
+    ADD COLUMN IF NOT EXISTS reporter_type TEXT DEFAULT 'rider'
+        CHECK (reporter_type IN ('rider', 'driver', 'admin'));
+
+-- 2. Extend status values to cover driver-initiated and full lifecycle
+ALTER TABLE lost_and_found DROP CONSTRAINT IF EXISTS lost_and_found_status_check;
+
+ALTER TABLE lost_and_found
+    ADD CONSTRAINT lost_and_found_status_check
+        CHECK (status IN (
+            'reported',        -- rider filed; driver not yet responded
+            'driver_found',    -- driver filed; item in hand
+            'admin_created',   -- admin opened on behalf of either party
+            'driver_notified', -- push sent to driver after rider report
+            'found',           -- driver confirmed item is in vehicle
+            'not_found',       -- driver confirmed item not in vehicle
+            'returned',        -- item physically returned to rider
+            'unclaimed',       -- driver gave up waiting; handed to admin
+            'resolved',        -- generic closed-happy
+            'unresolved',      -- kept from prior constraint; admin resolve endpoint writes this
+            'closed'           -- admin closed without resolution
+        ));
+
+-- 3. Per-case chat thread
+CREATE TABLE IF NOT EXISTS lost_and_found_messages (
+    id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    lost_and_found_id TEXT        NOT NULL REFERENCES lost_and_found(id) ON DELETE CASCADE,
+    sender_id         TEXT,
+    sender_role       TEXT        NOT NULL
+                                      CHECK (sender_role IN ('rider', 'driver', 'admin', 'system')),
+    message           TEXT        NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS lfm_case_time_idx
+    ON lost_and_found_messages (lost_and_found_id, created_at);
+
+ALTER TABLE lost_and_found_messages ENABLE ROW LEVEL SECURITY;
+
+-- Rider or driver on the case can read messages
+DROP POLICY IF EXISTS lfm_select ON lost_and_found_messages;
+CREATE POLICY lfm_select ON lost_and_found_messages
+    FOR SELECT USING (
+        EXISTS (
+            SELECT 1 FROM lost_and_found lf
+            WHERE lf.id = lost_and_found_id
+              AND (
+                  auth.uid()::text = lf.reporter_id::text
+               OR auth.uid()::text = lf.driver_id::text
+              )
+        )
+    );
+
+-- Participants can insert their own messages (not system messages)
+DROP POLICY IF EXISTS lfm_insert ON lost_and_found_messages;
+CREATE POLICY lfm_insert ON lost_and_found_messages
+    FOR INSERT WITH CHECK (
+        sender_id IS NOT NULL
+        AND auth.uid()::text = sender_id::text
+        AND sender_role != 'system'
+        AND EXISTS (
+            SELECT 1 FROM lost_and_found lf
+            WHERE lf.id = lost_and_found_id
+              AND (
+                  auth.uid()::text = lf.reporter_id::text
+               OR auth.uid()::text = lf.driver_id::text
+              )
+        )
+    );
+
+-- Messages are append-only; only service role (backend) may mutate or delete
+DROP POLICY IF EXISTS lfm_update ON lost_and_found_messages;
+CREATE POLICY lfm_update ON lost_and_found_messages
+    FOR UPDATE USING (false);
+
+DROP POLICY IF EXISTS lfm_delete ON lost_and_found_messages;
+CREATE POLICY lfm_delete ON lost_and_found_messages
+    FOR DELETE USING (false);
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/115_lost_and_found_chat.sql
+++ b/backend/migrations/115_lost_and_found_chat.sql
@@ -58,7 +58,7 @@ CREATE POLICY lfm_select ON lost_and_found_messages
     FOR SELECT USING (
         EXISTS (
             SELECT 1 FROM lost_and_found lf
-            WHERE lf.id = lost_and_found_id
+            WHERE lf.id::text = lost_and_found_id
               AND (
                   auth.uid()::text = lf.reporter_id::text
                OR auth.uid()::text = lf.driver_id::text
@@ -75,7 +75,7 @@ CREATE POLICY lfm_insert ON lost_and_found_messages
         AND sender_role != 'system'
         AND EXISTS (
             SELECT 1 FROM lost_and_found lf
-            WHERE lf.id = lost_and_found_id
+            WHERE lf.id::text = lost_and_found_id
               AND (
                   auth.uid()::text = lf.reporter_id::text
                OR auth.uid()::text = lf.driver_id::text

--- a/backend/migrations/115_lost_and_found_chat.sql
+++ b/backend/migrations/115_lost_and_found_chat.sql
@@ -39,7 +39,7 @@ ALTER TABLE lost_and_found
 -- 3. Per-case chat thread
 CREATE TABLE IF NOT EXISTS lost_and_found_messages (
     id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-    lost_and_found_id TEXT        NOT NULL REFERENCES lost_and_found(id) ON DELETE CASCADE,
+    lost_and_found_id TEXT        NOT NULL,
     sender_id         TEXT,
     sender_role       TEXT        NOT NULL
                                       CHECK (sender_role IN ('rider', 'driver', 'admin', 'system')),

--- a/backend/migrations/116_lost_and_found_rider_user_id.sql
+++ b/backend/migrations/116_lost_and_found_rider_user_id.sql
@@ -1,0 +1,20 @@
+-- 116_lost_and_found_rider_user_id.sql
+--
+-- Adds rider_user_id to lost_and_found so the rider on a driver-initiated
+-- case can be identified without a JOIN through rides. This allows the list
+-- endpoint to return all cases a user is party to with simple single-column
+-- filters (reporter_id for rider-reported, rider_user_id for driver-reported,
+-- driver_id for driver-side view).
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS lost_and_found_rider_user_id_idx;
+--   ALTER TABLE lost_and_found DROP COLUMN IF EXISTS rider_user_id;
+--   NOTIFY pgrst, 'reload schema';
+
+ALTER TABLE lost_and_found
+    ADD COLUMN IF NOT EXISTS rider_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS lost_and_found_rider_user_id_idx
+    ON lost_and_found (rider_user_id);
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/116_lost_and_found_rider_user_id.sql
+++ b/backend/migrations/116_lost_and_found_rider_user_id.sql
@@ -12,7 +12,7 @@
 --   NOTIFY pgrst, 'reload schema';
 
 ALTER TABLE lost_and_found
-    ADD COLUMN IF NOT EXISTS rider_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+    ADD COLUMN IF NOT EXISTS rider_user_id TEXT;
 
 CREATE INDEX IF NOT EXISTS lost_and_found_rider_user_id_idx
     ON lost_and_found (rider_user_id);

--- a/backend/routes/admin/vehicle_fleet.py
+++ b/backend/routes/admin/vehicle_fleet.py
@@ -472,7 +472,21 @@ async def admin_list_lost_and_found(
     return items
 
 
-_VALID_STATUSES = frozenset({"reported", "driver_notified", "found", "returned", "unclaimed", "resolved", "unresolved"})
+_VALID_STATUSES = frozenset(
+    {
+        "reported",
+        "driver_notified",
+        "driver_found",
+        "admin_created",
+        "found",
+        "not_found",
+        "returned",
+        "unclaimed",
+        "resolved",
+        "unresolved",
+        "closed",
+    }
+)
 
 
 @router.put("/lost-and-found/{item_id}")

--- a/backend/routes/lost_and_found.py
+++ b/backend/routes/lost_and_found.py
@@ -302,6 +302,8 @@ async def list_messages(
     await _require_participant(case_id, current_user["id"], driver["id"] if driver else None)
 
     filters: dict = {"lost_and_found_id": case_id}
+    if before:
+        filters["created_at"] = {"$lt": before}
     # Fetch newest `limit` messages, then reverse so clients receive them
     # in ascending (oldest-first) order for display.
     rows = await db_supabase.get_rows(
@@ -328,7 +330,7 @@ async def send_message(
     driver = await _driver_for_user(user_id)
     case = await _require_participant(case_id, user_id, driver["id"] if driver else None)
 
-    if case.get("status") in ("not_found", "returned", "resolved", "closed"):
+    if case.get("status") in ("not_found", "returned", "resolved", "unresolved", "closed"):
         raise HTTPException(status_code=400, detail="This case is closed")
 
     is_driver_sender = driver and case.get("driver_id") == driver["id"]

--- a/backend/routes/lost_and_found.py
+++ b/backend/routes/lost_and_found.py
@@ -302,14 +302,16 @@ async def list_messages(
     await _require_participant(case_id, current_user["id"], driver["id"] if driver else None)
 
     filters: dict = {"lost_and_found_id": case_id}
-    messages = await db_supabase.get_rows(
+    # Fetch newest `limit` messages, then reverse so clients receive them
+    # in ascending (oldest-first) order for display.
+    rows = await db_supabase.get_rows(
         "lost_and_found_messages",
         filters,
         order="created_at",
-        desc=False,
+        desc=True,
         limit=limit,
     )
-    return {"messages": messages}
+    return {"messages": list(reversed(rows))}
 
 
 class SendMessageRequest(BaseModel):

--- a/backend/routes/lost_and_found.py
+++ b/backend/routes/lost_and_found.py
@@ -1,0 +1,373 @@
+"""Lost & Found route.
+
+Cases can be opened by a rider (left something), a driver (found something),
+or admin on behalf of either party. Each case has its own chat thread.
+
+Endpoints:
+    GET  /lost-and-found                    — list cases the caller is party to
+    POST /lost-and-found/driver-report      — driver reports a found item
+    GET  /lost-and-found/{case_id}          — single case detail
+    PUT  /lost-and-found/{case_id}/respond  — driver marks found / not_found
+    GET  /lost-and-found/{case_id}/messages — fetch chat messages
+    POST /lost-and-found/{case_id}/messages — send a chat message
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from loguru import logger
+from pydantic import BaseModel, Field
+
+try:
+    from .. import db_supabase
+    from ..dependencies import get_current_user
+    from ..features import send_push_notification
+except ImportError:
+    import db_supabase  # type: ignore
+    from dependencies import get_current_user  # type: ignore
+    from features import send_push_notification  # type: ignore
+
+api_router = APIRouter(prefix="/lost-and-found", tags=["Lost & Found"])
+
+_VALID_CATEGORIES = {"electronics", "clothing", "bag", "document", "keys", "other"}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+async def _driver_for_user(user_id: str) -> Optional[dict]:
+    rows = await db_supabase.get_rows("drivers", {"user_id": user_id}, limit=1)
+    return rows[0] if rows else None
+
+
+async def _require_participant(case_id: str, user_id: str, driver_id: Optional[str] = None) -> dict:
+    """Return the case or raise 403/404."""
+    case = await db_supabase.find_one("lost_and_found", {"id": case_id})
+    if not case:
+        raise HTTPException(status_code=404, detail="Case not found")
+    is_reporter = case.get("reporter_id") == user_id
+    is_rider = case.get("rider_user_id") == user_id
+    is_driver = driver_id is not None and case.get("driver_id") == driver_id
+    if not (is_reporter or is_rider or is_driver):
+        raise HTTPException(status_code=403, detail="Not a participant in this case")
+    return case
+
+
+async def _insert_system_message(case_id: str, text: str) -> None:
+    await db_supabase.insert_one(
+        "lost_and_found_messages",
+        {
+            "id": str(uuid.uuid4()),
+            "lost_and_found_id": case_id,
+            "sender_id": None,
+            "sender_role": "system",
+            "message": text,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+
+async def _push_safe(user_id: str, title: str, body: str, data: dict, target_app: str) -> None:
+    try:
+        await send_push_notification(user_id, title, body, data, target_app=target_app)
+    except Exception:
+        logger.error(
+            "lost_and_found push failed user=%s target_app=%s",
+            user_id,
+            target_app,
+            exc_info=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+@api_router.get("")
+async def list_cases(
+    status: Optional[str] = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return all open cases the caller is party to (as rider or driver)."""
+    user_id = current_user["id"]
+    driver = await _driver_for_user(user_id)
+
+    reporter_filters: dict = {"reporter_id": user_id}
+    rider_filters: dict = {"rider_user_id": user_id}
+    if status:
+        reporter_filters["status"] = status
+        rider_filters["status"] = status
+
+    as_reporter = await db_supabase.get_rows(
+        "lost_and_found",
+        reporter_filters,
+        order="created_at",
+        desc=True,
+        limit=50,
+    )
+    as_rider = await db_supabase.get_rows(
+        "lost_and_found",
+        rider_filters,
+        order="created_at",
+        desc=True,
+        limit=50,
+    )
+
+    as_driver: list = []
+    if driver:
+        driver_filters: dict = {"driver_id": driver["id"]}
+        if status:
+            driver_filters["status"] = status
+        as_driver = await db_supabase.get_rows(
+            "lost_and_found",
+            driver_filters,
+            order="created_at",
+            desc=True,
+            limit=50,
+        )
+
+    seen: set = set()
+    merged: list = []
+    for case in sorted(
+        as_reporter + as_rider + as_driver,
+        key=lambda c: c.get("created_at", ""),
+        reverse=True,
+    ):
+        if case["id"] not in seen:
+            seen.add(case["id"])
+            merged.append(case)
+
+    return {"cases": merged[:50]}
+
+
+# ---------------------------------------------------------------------------
+# Single case
+# ---------------------------------------------------------------------------
+
+
+@api_router.get("/{case_id}")
+async def get_case(case_id: str, current_user: dict = Depends(get_current_user)):
+    driver = await _driver_for_user(current_user["id"])
+    case = await _require_participant(case_id, current_user["id"], driver["id"] if driver else None)
+    return {"case": case}
+
+
+# ---------------------------------------------------------------------------
+# Driver reports a found item
+# ---------------------------------------------------------------------------
+
+
+class DriverReportRequest(BaseModel):
+    ride_id: str
+    item_description: str = Field(..., min_length=3, max_length=500)
+    item_category: str = Field(default="other")
+
+
+@api_router.post("/driver-report")
+async def driver_report_found_item(
+    req: DriverReportRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Driver opens a case after finding an unclaimed item in their vehicle."""
+    driver = await _driver_for_user(current_user["id"])
+    if not driver:
+        raise HTTPException(status_code=403, detail="Driver profile not found")
+
+    ride = await db_supabase.get_ride(req.ride_id)
+    if not ride:
+        raise HTTPException(status_code=404, detail="Ride not found")
+    if ride.get("driver_id") != driver["id"]:
+        raise HTTPException(status_code=403, detail="You were not the driver on this ride")
+    if ride.get("status") != "completed":
+        raise HTTPException(status_code=400, detail="Can only report items for completed rides")
+
+    category = req.item_category if req.item_category in _VALID_CATEGORIES else "other"
+    rider_user_id: Optional[str] = ride.get("rider_id")
+
+    case = await db_supabase.insert_one(
+        "lost_and_found",
+        {
+            "id": str(uuid.uuid4()),
+            "ride_id": req.ride_id,
+            "reporter_id": current_user["id"],
+            "rider_user_id": rider_user_id,
+            "driver_id": driver["id"],
+            "reporter_type": "driver",
+            "item_description": req.item_description,
+            "item_category": category,
+            "status": "driver_found",
+            "contact_method": "in_app",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+    await _insert_system_message(
+        case["id"],
+        f'Driver reported finding an item: "{req.item_description}". They will coordinate return through this chat.',
+    )
+
+    if rider_user_id:
+        await _push_safe(
+            rider_user_id,
+            "Item Found in Your Recent Ride",
+            f"Your driver found an item that may be yours: {req.item_description}. "
+            "Open Lost & Found to coordinate the return.",
+            {"type": "lost_and_found", "case_id": case["id"]},
+            target_app="rider",
+        )
+
+    return {"success": True, "case": case}
+
+
+# ---------------------------------------------------------------------------
+# Driver responds to a rider report (found / not found)
+# ---------------------------------------------------------------------------
+
+
+class RespondRequest(BaseModel):
+    found: bool
+
+
+@api_router.put("/{case_id}/respond")
+async def driver_respond(
+    case_id: str,
+    req: RespondRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Driver confirms whether the reported item is in their vehicle."""
+    driver = await _driver_for_user(current_user["id"])
+    if not driver:
+        raise HTTPException(status_code=403, detail="Driver profile not found")
+
+    case = await db_supabase.find_one("lost_and_found", {"id": case_id})
+    if not case:
+        raise HTTPException(status_code=404, detail="Case not found")
+    if case.get("driver_id") != driver["id"]:
+        raise HTTPException(status_code=403, detail="Not the driver on this case")
+    if case.get("status") not in ("reported", "driver_notified"):
+        raise HTTPException(status_code=400, detail="Case is not awaiting driver response")
+
+    new_status = "found" if req.found else "not_found"
+    system_text = (
+        "Driver confirmed: item is in the vehicle. Use this chat to arrange return."
+        if req.found
+        else "Driver confirmed: item was not found in the vehicle. Contact support if you need further help."
+    )
+
+    await db_supabase.update_one(
+        "lost_and_found",
+        {"id": case_id},
+        {"status": new_status, "updated_at": datetime.now(timezone.utc).isoformat()},
+    )
+    await _insert_system_message(case_id, system_text)
+
+    rider_user_id = case.get("rider_user_id") or case.get("reporter_id")
+    if rider_user_id:
+        push_title = "Your Lost Item: Update" if req.found else "Lost Item Report Update"
+        push_body = (
+            "Good news — your driver has the item. Open Lost & Found to arrange return."
+            if req.found
+            else "Your driver checked and the item was not found. Contact support for help."
+        )
+        await _push_safe(
+            rider_user_id,
+            push_title,
+            push_body,
+            {"type": "lost_and_found", "case_id": case_id},
+            target_app="rider",
+        )
+
+    return {"success": True, "status": new_status}
+
+
+# ---------------------------------------------------------------------------
+# Chat messages
+# ---------------------------------------------------------------------------
+
+
+@api_router.get("/{case_id}/messages")
+async def list_messages(
+    case_id: str,
+    limit: int = Query(50, ge=1, le=100),
+    before: Optional[str] = Query(None, description="ISO timestamp cursor for pagination"),
+    current_user: dict = Depends(get_current_user),
+):
+    driver = await _driver_for_user(current_user["id"])
+    await _require_participant(case_id, current_user["id"], driver["id"] if driver else None)
+
+    filters: dict = {"lost_and_found_id": case_id}
+    messages = await db_supabase.get_rows(
+        "lost_and_found_messages",
+        filters,
+        order="created_at",
+        desc=False,
+        limit=limit,
+    )
+    return {"messages": messages}
+
+
+class SendMessageRequest(BaseModel):
+    message: str = Field(..., min_length=1, max_length=1000)
+
+
+@api_router.post("/{case_id}/messages")
+async def send_message(
+    case_id: str,
+    req: SendMessageRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    user_id = current_user["id"]
+    driver = await _driver_for_user(user_id)
+    case = await _require_participant(case_id, user_id, driver["id"] if driver else None)
+
+    if case.get("status") in ("not_found", "returned", "resolved", "closed"):
+        raise HTTPException(status_code=400, detail="This case is closed")
+
+    is_driver_sender = driver and case.get("driver_id") == driver["id"]
+    sender_role = "driver" if is_driver_sender else "rider"
+
+    msg = await db_supabase.insert_one(
+        "lost_and_found_messages",
+        {
+            "id": str(uuid.uuid4()),
+            "lost_and_found_id": case_id,
+            "sender_id": user_id,
+            "sender_role": sender_role,
+            "message": req.message.strip(),
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+
+    # Push the other party
+    if is_driver_sender:
+        notify_id = case.get("rider_user_id") or case.get("reporter_id")
+        if notify_id:
+            await _push_safe(
+                notify_id,
+                "Lost & Found",
+                req.message.strip(),
+                {"type": "lost_and_found_message", "case_id": case_id},
+                target_app="rider",
+            )
+    else:
+        driver_user_id = None
+        if case.get("driver_id"):
+            d = await db_supabase.get_rows("drivers", {"id": case["driver_id"]}, limit=1)
+            if d:
+                driver_user_id = d[0].get("user_id")
+        if driver_user_id:
+            await _push_safe(
+                driver_user_id,
+                "Lost & Found",
+                req.message.strip(),
+                {"type": "lost_and_found_message", "case_id": case_id},
+                target_app="driver",
+            )
+
+    return {"success": True, "message": msg}

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -4502,7 +4502,9 @@ async def rider_report_lost_item(
         "id": str(uuid.uuid4()),
         "ride_id": ride_id,
         "reporter_id": current_user["id"],
+        "rider_user_id": current_user["id"],
         "driver_id": driver_id,
+        "reporter_type": "rider",
         "item_description": req.item_description,
         "item_category": category,
         "status": "reported",
@@ -4516,15 +4518,12 @@ async def rider_report_lost_item(
         if driver and driver.get("user_id"):
             driver_user = await db_supabase.get_user_by_id(driver["user_id"])
             if driver_user:
-                try:
-                    from ..features import send_push_notification
-                except ImportError:
-                    from features import send_push_notification  # type: ignore
                 await send_push_notification(
                     driver_user["id"],
                     "Lost Item Report",
                     f"A rider reported a lost item: {req.item_description}. Please check your vehicle.",
-                    {"type": "lost_and_found", "ride_id": ride_id},
+                    {"type": "lost_and_found", "case_id": item["id"], "ride_id": ride_id},
+                    target_app="driver",
                 )
                 await db_supabase.update_lost_and_found(
                     item["id"],

--- a/backend/server.py
+++ b/backend/server.py
@@ -245,6 +245,7 @@ register_exception_handlers(app)
 # Create v1 API router
 v1_api_router = APIRouter()
 v1_api_router.include_router(rides_router)
+v1_api_router.include_router(lost_and_found_router)
 # documents_router MUST be included before drivers_router so that its specific
 # paths (/drivers/requirements, /drivers/documents) are matched before the
 # catch-all wildcard GET /drivers/{driver_id} in drivers_router.

--- a/backend/server.py
+++ b/backend/server.py
@@ -124,6 +124,7 @@ from routes.fare_split import api_router as fare_split_router
 from routes.fares import api_router as fares_router
 from routes.favorites import api_router as favorites_router
 from routes.legal_documents import api_router as legal_documents_router
+from routes.lost_and_found import api_router as lost_and_found_router
 from routes.loyalty import api_router as loyalty_router
 from routes.maps_proxy import api_router as maps_router
 from routes.notifications import api_router as notifications_router

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -243,6 +243,8 @@ function usePushNotificationRouter() {
           router.push('/driver/' as any);
         } else if (data?.type === 'chat_message' && data?.ride_id) {
           router.push(`/driver/chat?rideId=${data.ride_id}` as any);
+        } else if ((data?.type === 'lost_and_found' || data?.type === 'lost_and_found_message') && data?.case_id) {
+          router.push({ pathname: '/driver/lost-and-found-chat', params: { caseId: data.case_id } } as any);
         } else {
           router.push('/driver/notifications');
         }
@@ -299,6 +301,8 @@ function usePushNotificationRouter() {
               router.push('/driver/' as any);
             } else if (data?.type === 'chat_message' && data?.ride_id) {
               router.push(`/driver/chat?rideId=${data.ride_id}` as any);
+            } else if ((data?.type === 'lost_and_found' || data?.type === 'lost_and_found_message') && data?.case_id) {
+              router.push({ pathname: '/driver/lost-and-found-chat', params: { caseId: data.case_id } } as any);
             } else {
               router.push('/driver/notifications' as any);
             }

--- a/driver-app/app/driver/(tabs)/profile.tsx
+++ b/driver-app/app/driver/(tabs)/profile.tsx
@@ -522,10 +522,18 @@ export default function ProfileScreen() {
             </TouchableOpacity>
             </View>
 
-            {/* Quick Actions */}
+            {/* Support */}
             <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Settings</Text>
+            <Text style={styles.sectionTitle}>Support</Text>
             <View style={styles.card}>
+                <TouchableOpacity style={styles.actionRow} activeOpacity={0.7} onPress={() => router.push('/driver/lost-and-found' as any)}>
+                    <View style={[styles.iconBox, { backgroundColor: 'rgba(249, 115, 22, 0.1)' }]}>
+                        <Ionicons name="bag-handle" size={18} color="#F97316" />
+                    </View>
+                    <Text style={styles.actionText}>Lost & Found</Text>
+                    <Ionicons name="chevron-forward" size={18} color="#D1D5DB" />
+                </TouchableOpacity>
+                <View style={styles.cardDivider} />
                 <TouchableOpacity style={styles.actionRow} activeOpacity={0.7} onPress={() => router.push('/driver/notifications' as any)}>
                     <View style={[styles.iconBox, { backgroundColor: colors.surfaceLight }]}>
                         <Ionicons name="help-circle" size={18} color={colors.textDim} />

--- a/driver-app/app/driver/lost-and-found-chat.tsx
+++ b/driver-app/app/driver/lost-and-found-chat.tsx
@@ -26,7 +26,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import api from '@shared/api/client';
-import { showToast } from '../../../store/toastStore';
+import { showToast } from '../../../hooks/useToast';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
 
@@ -93,7 +93,7 @@ export default function DriverLostAndFoundChatScreen() {
       setLostCase(caseRes.data?.case ?? null);
       setMessages(msgRes.data?.messages ?? []);
     } catch {
-      showToast('Error', 'Could not load case.', 'danger');
+      showToast('error', 'Could not load case.', 'Pull to refresh.');
     } finally {
       setLoading(false);
     }
@@ -126,7 +126,7 @@ export default function DriverLostAndFoundChatScreen() {
         await loadCase(newCase.id);
       }
     } catch (e: any) {
-      showToast('Error', e?.response?.data?.detail || 'Could not submit report.', 'danger');
+      showToast('error', 'Submit Failed', e?.response?.data?.detail || 'Could not submit report.');
     } finally {
       setSubmitting(false);
     }
@@ -149,7 +149,7 @@ export default function DriverLostAndFoundChatScreen() {
               await api.put(`/lost-and-found/${lostCase.id}/respond`, { found });
               await loadCase(lostCase.id);
             } catch (e: any) {
-              showToast('Error', e?.response?.data?.detail || 'Could not update status.', 'danger');
+              showToast('error', 'Update Failed', e?.response?.data?.detail || 'Could not update status.');
             } finally {
               setResponding(false);
             }
@@ -185,7 +185,7 @@ export default function DriverLostAndFoundChatScreen() {
     } catch (e: any) {
       setMessages(prev => prev.filter(m => m.id !== optimistic.id));
       setText(trimmed);
-      showToast('Send Failed', e?.response?.data?.detail || 'Could not send message.', 'danger');
+      showToast('error', 'Send Failed', e?.response?.data?.detail || 'Could not send message.');
     } finally {
       setSending(false);
     }

--- a/driver-app/app/driver/lost-and-found-chat.tsx
+++ b/driver-app/app/driver/lost-and-found-chat.tsx
@@ -26,7 +26,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import api from '@shared/api/client';
-import { showToast } from '../../../hooks/useToast';
+import { showToast } from '../../hooks/useToast';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
 

--- a/driver-app/app/driver/lost-and-found-chat.tsx
+++ b/driver-app/app/driver/lost-and-found-chat.tsx
@@ -1,0 +1,550 @@
+/**
+ * Driver Lost & Found chat screen.
+ *
+ * Two modes:
+ *   caseId  — open an existing case (rider-reported or admin-created)
+ *   rideId  — start a new case (driver found something in the vehicle)
+ *
+ * When opening an existing case that is in 'reported' or 'driver_notified'
+ * status, the found/not-found response buttons are shown above the chat.
+ * Once responded they collapse and normal chat resumes.
+ */
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import api from '@shared/api/client';
+import { showToast } from '../../../store/toastStore';
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+
+interface LostFoundCase {
+  id: string;
+  item_description: string;
+  item_category?: string;
+  status: string;
+  reporter_type: string;
+}
+
+interface Message {
+  id: string;
+  lost_and_found_id: string;
+  sender_id: string | null;
+  sender_role: 'rider' | 'driver' | 'admin' | 'system';
+  message: string;
+  created_at: string;
+}
+
+const VALID_CATEGORIES = ['electronics', 'clothing', 'bag', 'document', 'keys', 'other'] as const;
+type Category = (typeof VALID_CATEGORIES)[number];
+
+const CATEGORY_LABELS: Record<Category, string> = {
+  electronics: 'Electronics',
+  clothing: 'Clothing',
+  bag: 'Bag',
+  document: 'Document',
+  keys: 'Keys',
+  other: 'Other',
+};
+
+const AWAITING_RESPONSE = new Set(['reported', 'driver_notified']);
+const CLOSED = new Set(['not_found', 'returned', 'resolved', 'closed']);
+
+export default function DriverLostAndFoundChatScreen() {
+  const router = useRouter();
+  const { caseId, rideId } = useLocalSearchParams<{ caseId?: string; rideId?: string }>();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  // Existing-case state
+  const [lostCase, setLostCase] = useState<LostFoundCase | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(!!caseId);
+  const [responding, setResponding] = useState(false);
+
+  // New-case (driver report) state
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<Category>('other');
+  const [submitting, setSubmitting] = useState(false);
+
+  // Chat state
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+  const flatRef = useRef<FlatList>(null);
+
+  const loadCase = useCallback(async (id: string) => {
+    try {
+      const [caseRes, msgRes] = await Promise.all([
+        api.get<{ case: LostFoundCase }>(`/lost-and-found/${id}`),
+        api.get<{ messages: Message[] }>(`/lost-and-found/${id}/messages`),
+      ]);
+      setLostCase(caseRes.data?.case ?? null);
+      setMessages(msgRes.data?.messages ?? []);
+    } catch {
+      showToast('Error', 'Could not load case.', 'danger');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (caseId) loadCase(caseId);
+  }, [caseId, loadCase]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      setTimeout(() => flatRef.current?.scrollToEnd({ animated: true }), 100);
+    }
+  }, [messages.length]);
+
+  // Submit a new driver-found case
+  const submitReport = async () => {
+    if (!description.trim() || !rideId || submitting) return;
+    setSubmitting(true);
+    try {
+      const res = await api.post<{ case: LostFoundCase }>('/lost-and-found/driver-report', {
+        ride_id: rideId,
+        item_description: description.trim(),
+        item_category: category,
+      });
+      const newCase = res.data?.case;
+      if (newCase) {
+        setLostCase(newCase);
+        setLoading(true);
+        await loadCase(newCase.id);
+      }
+    } catch (e: any) {
+      showToast('Error', e?.response?.data?.detail || 'Could not submit report.', 'danger');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Driver responds found / not_found on a rider-reported case
+  const respond = async (found: boolean) => {
+    if (!lostCase || responding) return;
+    const label = found ? 'confirm the item is in your vehicle' : 'mark it as not found';
+    Alert.alert(
+      found ? 'Confirm Item Found' : 'Item Not Found',
+      `Are you sure you want to ${label}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Yes',
+          onPress: async () => {
+            setResponding(true);
+            try {
+              await api.put(`/lost-and-found/${lostCase.id}/respond`, { found });
+              await loadCase(lostCase.id);
+            } catch (e: any) {
+              showToast('Error', e?.response?.data?.detail || 'Could not update status.', 'danger');
+            } finally {
+              setResponding(false);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const sendMessage = async () => {
+    const trimmed = text.trim();
+    if (!trimmed || sending || !lostCase) return;
+    setSending(true);
+    setText('');
+
+    const optimistic: Message = {
+      id: `local-${Date.now()}`,
+      lost_and_found_id: lostCase.id,
+      sender_id: 'me',
+      sender_role: 'driver',
+      message: trimmed,
+      created_at: new Date().toISOString(),
+    };
+    setMessages(prev => [...prev, optimistic]);
+
+    try {
+      const res = await api.post<{ message: Message }>(`/lost-and-found/${lostCase.id}/messages`, {
+        message: trimmed,
+      });
+      if (res.data?.message) {
+        setMessages(prev => prev.filter(m => m.id !== optimistic.id).concat(res.data.message));
+      }
+    } catch (e: any) {
+      setMessages(prev => prev.filter(m => m.id !== optimistic.id));
+      setText(trimmed);
+      showToast('Send Failed', e?.response?.data?.detail || 'Could not send message.', 'danger');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const renderMessage = ({ item }: { item: Message }) => {
+    const isSystem = item.sender_role === 'system' || item.sender_role === 'admin';
+    const isMe = item.sender_role === 'driver';
+
+    if (isSystem) {
+      return (
+        <View style={styles.systemRow}>
+          <Text style={styles.systemText}>{item.message}</Text>
+        </View>
+      );
+    }
+
+    const time = new Date(item.created_at).toLocaleTimeString([], {
+      hour: 'numeric', minute: '2-digit',
+    });
+
+    return (
+      <View style={[styles.msgRow, isMe && styles.msgRowMe]}>
+        {!isMe && (
+          <View style={styles.avatar}>
+            <Ionicons name="person" size={14} color={colors.textDim} />
+          </View>
+        )}
+        <View style={[styles.bubble, isMe ? styles.bubbleMe : styles.bubbleThem]}>
+          <Text style={[styles.bubbleText, isMe && styles.bubbleTextMe]}>{item.message}</Text>
+          <Text style={[styles.timeText, isMe && styles.timeTextMe]}>{time}</Text>
+        </View>
+      </View>
+    );
+  };
+
+  // — New case report form (rideId mode, no case yet) —
+  if (rideId && !lostCase) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+            <Ionicons name="chevron-back" size={28} color={colors.text} />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>Report Found Item</Text>
+          <View style={{ width: 44 }} />
+        </View>
+
+        <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+          <FlatList
+            data={[]}
+            renderItem={null}
+            ListHeaderComponent={
+              <View style={styles.reportForm}>
+                <Text style={styles.formLabel}>What did you find?</Text>
+                <TextInput
+                  style={styles.formInput}
+                  value={description}
+                  onChangeText={setDescription}
+                  placeholder="e.g. Black iPhone with cracked screen"
+                  placeholderTextColor={colors.textDim}
+                  multiline
+                  maxLength={500}
+                />
+
+                <Text style={styles.formLabel}>Category</Text>
+                <View style={styles.catGrid}>
+                  {VALID_CATEGORIES.map(cat => (
+                    <TouchableOpacity
+                      key={cat}
+                      style={[styles.catPill, category === cat && styles.catPillSelected]}
+                      onPress={() => setCategory(cat)}
+                    >
+                      <Text style={[styles.catText, category === cat && styles.catTextSelected]}>
+                        {CATEGORY_LABELS[cat]}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+
+                <TouchableOpacity
+                  style={[styles.submitBtn, { opacity: !description.trim() || submitting ? 0.5 : 1 }]}
+                  onPress={submitReport}
+                  disabled={!description.trim() || submitting}
+                >
+                  {submitting
+                    ? <ActivityIndicator size="small" color="#fff" />
+                    : <Text style={styles.submitBtnText}>Submit & Open Chat</Text>}
+                </TouchableOpacity>
+              </View>
+            }
+          />
+        </KeyboardAvoidingView>
+      </SafeAreaView>
+    );
+  }
+
+  const awaitingResponse = lostCase ? AWAITING_RESPONSE.has(lostCase.status) : false;
+  const isClosed = lostCase ? CLOSED.has(lostCase.status) : false;
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <View style={styles.headerInfo}>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {lostCase?.item_description ?? 'Lost & Found'}
+          </Text>
+          <Text style={styles.headerStatus}>{lostCase?.status ?? ''}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : (
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          keyboardVerticalOffset={0}
+        >
+          {/* Found / Not Found response prompt */}
+          {awaitingResponse && (
+            <View style={styles.respondBanner}>
+              <Text style={styles.respondQuestion}>
+                Is this item in your vehicle?
+              </Text>
+              <View style={styles.respondBtns}>
+                <TouchableOpacity
+                  style={[styles.respondBtn, styles.respondBtnYes]}
+                  onPress={() => respond(true)}
+                  disabled={responding}
+                >
+                  {responding
+                    ? <ActivityIndicator size="small" color="#fff" />
+                    : <Text style={styles.respondBtnText}>Yes, I have it</Text>}
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.respondBtn, styles.respondBtnNo]}
+                  onPress={() => respond(false)}
+                  disabled={responding}
+                >
+                  <Text style={[styles.respondBtnText, { color: '#EF4444' }]}>Not in my vehicle</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          )}
+
+          <FlatList
+            ref={flatRef}
+            data={messages}
+            keyExtractor={m => m.id}
+            renderItem={renderMessage}
+            contentContainerStyle={styles.msgList}
+            showsVerticalScrollIndicator={false}
+            ListEmptyComponent={
+              <View style={styles.center}>
+                <Text style={styles.emptyText}>
+                  {awaitingResponse
+                    ? 'Respond above, then you can chat with the rider.'
+                    : 'No messages yet.'}
+                </Text>
+              </View>
+            }
+          />
+
+          {isClosed ? (
+            <View style={styles.closedBanner}>
+              <Text style={styles.closedText}>This case is closed.</Text>
+            </View>
+          ) : (
+            <View style={styles.inputRow}>
+              <TextInput
+                style={styles.input}
+                value={text}
+                onChangeText={setText}
+                placeholder="Type a message…"
+                placeholderTextColor={colors.textDim}
+                multiline
+                maxLength={1000}
+                returnKeyType="send"
+                onSubmitEditing={sendMessage}
+              />
+              <TouchableOpacity
+                style={[styles.sendBtn, { opacity: !text.trim() || sending ? 0.4 : 1 }]}
+                onPress={sendMessage}
+                disabled={!text.trim() || sending}
+              >
+                {sending
+                  ? <ActivityIndicator size="small" color="#fff" />
+                  : <Ionicons name="send" size={18} color="#fff" />}
+              </TouchableOpacity>
+            </View>
+          )}
+        </KeyboardAvoidingView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.background },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+      gap: 8,
+    },
+    back: { padding: 4 },
+    headerInfo: { flex: 1 },
+    headerTitle: { fontSize: 16, fontFamily: 'PlusJakartaSans_600SemiBold', color: colors.text },
+    headerStatus: { fontSize: 12, color: colors.textDim, marginTop: 1, textTransform: 'capitalize' },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+    emptyText: { fontSize: 14, color: colors.textDim, textAlign: 'center', lineHeight: 20 },
+
+    // Report form
+    reportForm: { padding: 20, gap: 12 },
+    formLabel: {
+      fontSize: 14,
+      fontFamily: 'PlusJakartaSans_600SemiBold',
+      color: colors.text,
+      marginBottom: 4,
+    },
+    formInput: {
+      backgroundColor: colors.surface,
+      borderRadius: 12,
+      padding: 14,
+      fontSize: 15,
+      color: colors.text,
+      minHeight: 80,
+      borderWidth: 1,
+      borderColor: colors.border,
+      textAlignVertical: 'top',
+    },
+    catGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+    catPill: {
+      paddingHorizontal: 14,
+      paddingVertical: 8,
+      borderRadius: 20,
+      borderWidth: 1,
+      borderColor: colors.border,
+      backgroundColor: colors.surface,
+    },
+    catPillSelected: { borderColor: colors.primary, backgroundColor: `${colors.primary}18` },
+    catText: { fontSize: 13, color: colors.textDim },
+    catTextSelected: { color: colors.primary, fontFamily: 'PlusJakartaSans_600SemiBold' },
+    submitBtn: {
+      backgroundColor: colors.primary,
+      borderRadius: 14,
+      padding: 16,
+      alignItems: 'center',
+      marginTop: 8,
+    },
+    submitBtnText: { color: '#fff', fontSize: 15, fontFamily: 'PlusJakartaSans_600SemiBold' },
+
+    // Respond banner
+    respondBanner: {
+      padding: 16,
+      backgroundColor: 'rgba(245, 158, 11, 0.08)',
+      borderBottomWidth: 1,
+      borderBottomColor: 'rgba(245, 158, 11, 0.3)',
+      gap: 10,
+    },
+    respondQuestion: {
+      fontSize: 15,
+      fontFamily: 'PlusJakartaSans_600SemiBold',
+      color: colors.text,
+      textAlign: 'center',
+    },
+    respondBtns: { flexDirection: 'row', gap: 10 },
+    respondBtn: {
+      flex: 1,
+      paddingVertical: 12,
+      borderRadius: 12,
+      alignItems: 'center',
+      borderWidth: 1,
+    },
+    respondBtnYes: { backgroundColor: '#10B981', borderColor: '#10B981' },
+    respondBtnNo: { backgroundColor: colors.surface, borderColor: '#EF4444' },
+    respondBtnText: { fontSize: 14, fontFamily: 'PlusJakartaSans_600SemiBold', color: '#fff' },
+
+    // Chat
+    msgList: { padding: 16, gap: 8, flexGrow: 1 },
+    systemRow: { alignItems: 'center', marginVertical: 8 },
+    systemText: {
+      fontSize: 12,
+      color: colors.textDim,
+      backgroundColor: colors.surfaceLight,
+      paddingHorizontal: 12,
+      paddingVertical: 4,
+      borderRadius: 12,
+      textAlign: 'center',
+    },
+    msgRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 6, marginVertical: 3 },
+    msgRowMe: { flexDirection: 'row-reverse' },
+    avatar: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: colors.surfaceLight,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    bubble: { maxWidth: '75%', borderRadius: 16, padding: 10, gap: 2 },
+    bubbleMe: { backgroundColor: colors.primary, borderBottomRightRadius: 4 },
+    bubbleThem: {
+      backgroundColor: colors.surface,
+      borderBottomLeftRadius: 4,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    bubbleText: { fontSize: 15, color: colors.text, lineHeight: 21 },
+    bubbleTextMe: { color: '#fff' },
+    timeText: { fontSize: 10, color: colors.textDim, alignSelf: 'flex-end' },
+    timeTextMe: { color: 'rgba(255,255,255,0.6)' },
+    closedBanner: {
+      padding: 14,
+      backgroundColor: colors.surfaceLight,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      alignItems: 'center',
+    },
+    closedText: { fontSize: 13, color: colors.textDim },
+    inputRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-end',
+      padding: 10,
+      gap: 8,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      backgroundColor: colors.surface,
+    },
+    input: {
+      flex: 1,
+      backgroundColor: colors.background,
+      borderRadius: 20,
+      paddingHorizontal: 14,
+      paddingVertical: 10,
+      fontSize: 15,
+      color: colors.text,
+      maxHeight: 100,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    sendBtn: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+  });
+}

--- a/driver-app/app/driver/lost-and-found-chat.tsx
+++ b/driver-app/app/driver/lost-and-found-chat.tsx
@@ -60,7 +60,7 @@ const CATEGORY_LABELS: Record<Category, string> = {
 };
 
 const AWAITING_RESPONSE = new Set(['reported', 'driver_notified']);
-const CLOSED = new Set(['not_found', 'returned', 'resolved', 'closed']);
+const CLOSED = new Set(['not_found', 'returned', 'resolved', 'unresolved', 'closed']);
 
 export default function DriverLostAndFoundChatScreen() {
   const router = useRouter();

--- a/driver-app/app/driver/lost-and-found.tsx
+++ b/driver-app/app/driver/lost-and-found.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import api from '@shared/api/client';
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+
+interface LostFoundCase {
+  id: string;
+  ride_id?: string;
+  item_description: string;
+  item_category?: string;
+  status: string;
+  reporter_type: string;
+  created_at: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  reported: 'Rider Filed — Awaiting Your Response',
+  driver_notified: 'Awaiting Your Response',
+  driver_found: 'You Reported Found',
+  found: 'Confirmed Found',
+  not_found: 'Not Found',
+  returned: 'Returned',
+  unclaimed: 'Unclaimed',
+  resolved: 'Resolved',
+  closed: 'Closed',
+  admin_created: 'Admin Created',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  reported: '#F59E0B',
+  driver_notified: '#F59E0B',
+  driver_found: '#10B981',
+  found: '#10B981',
+  not_found: '#EF4444',
+  returned: '#6B7280',
+  unclaimed: '#6B7280',
+  resolved: '#6B7280',
+  closed: '#6B7280',
+  admin_created: '#8B5CF6',
+};
+
+const CATEGORY_ICONS: Record<string, string> = {
+  electronics: 'phone-portrait',
+  clothing: 'shirt',
+  bag: 'bag',
+  document: 'document-text',
+  keys: 'key',
+  other: 'help-circle',
+};
+
+export default function DriverLostAndFoundScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const [cases, setCases] = useState<LostFoundCase[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await api.get<{ cases: LostFoundCase[] }>('/lost-and-found');
+      setCases(res.data?.cases ?? []);
+    } catch {
+      // keep stale data
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(useCallback(() => { load(); }, [load]));
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    load();
+  }, [load]);
+
+  const needsAction = (status: string) => status === 'reported' || status === 'driver_notified';
+
+  const renderCase = ({ item }: { item: LostFoundCase }) => {
+    const statusColor = STATUS_COLORS[item.status] ?? '#6B7280';
+    const statusLabel = STATUS_LABELS[item.status] ?? item.status;
+    const icon = (CATEGORY_ICONS[item.item_category ?? ''] ?? 'help-circle') as any;
+    const date = new Date(item.created_at).toLocaleDateString('en-CA', {
+      month: 'short', day: 'numeric', year: 'numeric',
+    });
+    const actionNeeded = needsAction(item.status);
+
+    return (
+      <TouchableOpacity
+        style={[styles.card, actionNeeded && styles.cardUrgent]}
+        onPress={() => router.push({
+          pathname: '/driver/lost-and-found-chat',
+          params: { caseId: item.id },
+        } as any)}
+        activeOpacity={0.7}
+      >
+        {actionNeeded && (
+          <View style={styles.urgentDot} />
+        )}
+        <View style={[styles.iconBadge, { backgroundColor: `${statusColor}18` }]}>
+          <Ionicons name={icon} size={22} color={statusColor} />
+        </View>
+        <View style={styles.cardBody}>
+          <View style={styles.cardRow}>
+            <Text style={styles.description} numberOfLines={1}>{item.item_description}</Text>
+            <View style={[styles.statusPill, { backgroundColor: `${statusColor}18` }]}>
+              <Text style={[styles.statusText, { color: statusColor }]}>
+                {actionNeeded ? 'Action Needed' : statusLabel}
+              </Text>
+            </View>
+          </View>
+          <Text style={styles.meta}>{date}</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={18} color={colors.textDim} />
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Lost & Found</Text>
+        <View style={{ width: 44 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : cases.length === 0 ? (
+        <View style={styles.center}>
+          <Ionicons name="bag-handle-outline" size={56} color={colors.textDim} />
+          <Text style={styles.emptyTitle}>No cases yet</Text>
+          <Text style={styles.emptyHint}>
+            If you find something in your vehicle, open the ride from your Rides tab and tap
+            "Found an item on this ride?"
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={cases}
+          keyExtractor={c => c.id}
+          renderItem={renderCase}
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+          refreshControl={
+            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />
+          }
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.background },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    back: { padding: 4 },
+    title: { fontSize: 18, fontFamily: 'PlusJakartaSans_700Bold', color: colors.text },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
+    emptyTitle: { fontSize: 16, fontFamily: 'PlusJakartaSans_600SemiBold', color: colors.text },
+    emptyHint: { fontSize: 14, color: colors.textDim, textAlign: 'center', lineHeight: 20 },
+    list: { padding: 16, gap: 12 },
+    card: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderRadius: 14,
+      padding: 14,
+      gap: 12,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    cardUrgent: { borderColor: '#F59E0B' },
+    urgentDot: {
+      position: 'absolute',
+      top: 10,
+      right: 10,
+      width: 8,
+      height: 8,
+      borderRadius: 4,
+      backgroundColor: '#F59E0B',
+    },
+    iconBadge: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cardBody: { flex: 1, gap: 4 },
+    cardRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    description: {
+      flex: 1,
+      fontSize: 15,
+      fontFamily: 'PlusJakartaSans_600SemiBold',
+      color: colors.text,
+    },
+    statusPill: { borderRadius: 8, paddingHorizontal: 8, paddingVertical: 2 },
+    statusText: { fontSize: 11, fontFamily: 'PlusJakartaSans_600SemiBold' },
+    meta: { fontSize: 13, color: colors.textDim },
+  });
+}

--- a/driver-app/app/driver/ride-detail.tsx
+++ b/driver-app/app/driver/ride-detail.tsx
@@ -487,6 +487,20 @@ export default function RideDetailScreen() {
                         })()}
                     </View>
                 </View>
+                {isCompleted && (
+                    <TouchableOpacity
+                        style={styles.foundItemBtn}
+                        onPress={() => router.push({
+                            pathname: '/driver/lost-and-found-chat',
+                            params: { rideId: id },
+                        } as any)}
+                        activeOpacity={0.7}
+                    >
+                        <Ionicons name="bag-handle-outline" size={18} color="#F97316" />
+                        <Text style={styles.foundItemText}>Found an item on this ride?</Text>
+                        <Ionicons name="chevron-forward" size={16} color="#F97316" />
+                    </TouchableOpacity>
+                )}
             </ScrollView>
         </View>
     );
@@ -495,6 +509,23 @@ export default function RideDetailScreen() {
 function createStyles(colors: ThemeColors) {
     return StyleSheet.create({
         container: { flex: 1, backgroundColor: colors.background },
+        foundItemBtn: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 10,
+            margin: 16,
+            padding: 14,
+            backgroundColor: 'rgba(249, 115, 22, 0.08)',
+            borderRadius: 14,
+            borderWidth: 1,
+            borderColor: 'rgba(249, 115, 22, 0.3)',
+        },
+        foundItemText: {
+            flex: 1,
+            fontSize: 14,
+            fontFamily: 'PlusJakartaSans_600SemiBold',
+            color: '#F97316',
+        },
         mapContainer: { height: 220, position: 'relative' },
         map: { ...StyleSheet.absoluteFill },
         backBtn: {

--- a/rider-app/app/(tabs)/account.tsx
+++ b/rider-app/app/(tabs)/account.tsx
@@ -350,8 +350,10 @@ export default function AccountScreen() {
           </View>
 
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Settings</Text>
+            <Text style={styles.sectionTitle}>Support</Text>
             <View style={styles.card}>
+              <MenuRow styles={styles} colors={colors} icon="bag-handle" iconColor="#F97316" iconBg="rgba(249, 115, 22, 0.1)" label="Lost & Found" onPress={() => router.push('/lost-and-found' as any)} />
+              <View style={styles.cardDivider} />
               <MenuRow styles={styles} colors={colors} icon="help-circle" iconColor="#2563EB" iconBg="rgba(37, 99, 235, 0.1)" label="Help Center" onPress={() => router.push('/support' as any)} />
               <View style={styles.cardDivider} />
               <MenuRow styles={styles} colors={colors} icon="document-text" iconColor={colors.textDim} iconBg={colors.surfaceLight} label="Legal" onPress={() => router.push('/legal?type=tos' as any)} />

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -49,26 +49,28 @@ import Toast from '../components/Toast';
 
 
 function routeFromNotificationData(data: Record<string, string> | undefined) {
-  if (!data?.type || !data?.ride_id) return;
-  const { type, ride_id } = data;
+  if (!data?.type) return;
+  const { type, ride_id, case_id } = data;
   switch (type) {
     case 'driver_accepted':
     case 'driver_arrived':
-      router.push({ pathname: '/driver-arriving', params: { rideId: ride_id } } as any);
+      if (ride_id) router.push({ pathname: '/driver-arriving', params: { rideId: ride_id } } as any);
       break;
     case 'ride_started':
-      router.push({ pathname: '/ride-in-progress', params: { rideId: ride_id } } as any);
+      if (ride_id) router.push({ pathname: '/ride-in-progress', params: { rideId: ride_id } } as any);
       break;
     case 'ride_completed':
-      router.push({ pathname: '/ride-completed', params: { rideId: ride_id } } as any);
+      if (ride_id) router.push({ pathname: '/ride-completed', params: { rideId: ride_id } } as any);
       break;
     case 'ride_cancelled':
       router.replace('/(tabs)' as any);
       break;
     case 'chat_message':
-      if (data?.ride_id) {
-        router.push({ pathname: '/chat-driver', params: { rideId: ride_id } } as any);
-      }
+      if (ride_id) router.push({ pathname: '/chat-driver', params: { rideId: ride_id } } as any);
+      break;
+    case 'lost_and_found':
+    case 'lost_and_found_message':
+      if (case_id) router.push({ pathname: '/lost-and-found-chat', params: { caseId: case_id } } as any);
       break;
     default:
       break;
@@ -609,6 +611,8 @@ function RootLayoutInner({
             <Stack.Screen name="work-profile" />
             <Stack.Screen name="work-allowance-request" />
             <Stack.Screen name="become-driver" />
+            <Stack.Screen name="lost-and-found" />
+            <Stack.Screen name="lost-and-found-chat" />
           </Stack>
           </MaybeStripeProvider>
           </TrackBaseUrlContext.Provider>

--- a/rider-app/app/lost-and-found-chat.tsx
+++ b/rider-app/app/lost-and-found-chat.tsx
@@ -49,7 +49,7 @@ const STATUS_LABELS: Record<string, string> = {
   admin_created: 'Case opened by support',
 };
 
-const CLOSED_STATUSES = new Set(['not_found', 'returned', 'resolved', 'closed']);
+const CLOSED_STATUSES = new Set(['not_found', 'returned', 'resolved', 'unresolved', 'closed']);
 
 export default function LostAndFoundChatScreen() {
   const router = useRouter();

--- a/rider-app/app/lost-and-found-chat.tsx
+++ b/rider-app/app/lost-and-found-chat.tsx
@@ -1,0 +1,324 @@
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import api from '@shared/api/client';
+import { showToast } from '../store/toastStore';
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+
+interface LostFoundCase {
+  id: string;
+  item_description: string;
+  item_category?: string;
+  status: string;
+  reporter_type: string;
+  created_at: string;
+}
+
+interface Message {
+  id: string;
+  lost_and_found_id: string;
+  sender_id: string | null;
+  sender_role: 'rider' | 'driver' | 'admin' | 'system';
+  message: string;
+  created_at: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  reported: 'Awaiting driver response',
+  driver_notified: 'Driver has been notified',
+  driver_found: 'Driver found an item',
+  found: 'Driver confirmed — item found',
+  not_found: 'Driver: item not in vehicle',
+  returned: 'Item returned',
+  unclaimed: 'Unclaimed',
+  resolved: 'Resolved',
+  closed: 'Closed',
+  admin_created: 'Case opened by support',
+};
+
+const CLOSED_STATUSES = new Set(['not_found', 'returned', 'resolved', 'closed']);
+
+export default function LostAndFoundChatScreen() {
+  const router = useRouter();
+  const { caseId } = useLocalSearchParams<{ caseId: string }>();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const [lostCase, setLostCase] = useState<LostFoundCase | null>(null);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [text, setText] = useState('');
+  const [sending, setSending] = useState(false);
+  const flatRef = useRef<FlatList>(null);
+
+  const loadAll = useCallback(async () => {
+    if (!caseId) return;
+    try {
+      const [caseRes, msgRes] = await Promise.all([
+        api.get<{ case: LostFoundCase }>(`/lost-and-found/${caseId}`),
+        api.get<{ messages: Message[] }>(`/lost-and-found/${caseId}/messages`),
+      ]);
+      setLostCase(caseRes.data?.case ?? null);
+      setMessages(msgRes.data?.messages ?? []);
+    } catch {
+      showToast('Error', 'Could not load case. Pull to refresh.', 'danger');
+    } finally {
+      setLoading(false);
+    }
+  }, [caseId]);
+
+  useEffect(() => { loadAll(); }, [loadAll]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      setTimeout(() => flatRef.current?.scrollToEnd({ animated: true }), 100);
+    }
+  }, [messages.length]);
+
+  const sendMessage = async () => {
+    const trimmed = text.trim();
+    if (!trimmed || sending || !caseId) return;
+    setSending(true);
+    setText('');
+
+    const optimistic: Message = {
+      id: `local-${Date.now()}`,
+      lost_and_found_id: caseId,
+      sender_id: 'me',
+      sender_role: 'rider',
+      message: trimmed,
+      created_at: new Date().toISOString(),
+    };
+    setMessages(prev => [...prev, optimistic]);
+
+    try {
+      const res = await api.post<{ message: Message }>(`/lost-and-found/${caseId}/messages`, {
+        message: trimmed,
+      });
+      if (res.data?.message) {
+        setMessages(prev => prev.filter(m => m.id !== optimistic.id).concat(res.data.message));
+      }
+    } catch (e: any) {
+      setMessages(prev => prev.filter(m => m.id !== optimistic.id));
+      setText(trimmed);
+      showToast('Send Failed', e?.response?.data?.detail || 'Could not send message.', 'danger');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const renderMessage = ({ item }: { item: Message }) => {
+    const isSystem = item.sender_role === 'system' || item.sender_role === 'admin';
+    const isMe = item.sender_role === 'rider';
+
+    if (isSystem) {
+      return (
+        <View style={styles.systemRow}>
+          <Text style={styles.systemText}>{item.message}</Text>
+        </View>
+      );
+    }
+
+    const time = new Date(item.created_at).toLocaleTimeString([], {
+      hour: 'numeric', minute: '2-digit',
+    });
+
+    return (
+      <View style={[styles.msgRow, isMe && styles.msgRowMe]}>
+        {!isMe && (
+          <View style={styles.avatar}>
+            <Ionicons name="person" size={14} color={colors.textDim} />
+          </View>
+        )}
+        <View style={[styles.bubble, isMe ? styles.bubbleMe : styles.bubbleThem]}>
+          <Text style={[styles.bubbleText, isMe && styles.bubbleTextMe]}>{item.message}</Text>
+          <Text style={[styles.timeText, isMe && styles.timeTextMe]}>{time}</Text>
+        </View>
+      </View>
+    );
+  };
+
+  const isClosed = lostCase ? CLOSED_STATUSES.has(lostCase.status) : false;
+  const statusLabel = lostCase ? (STATUS_LABELS[lostCase.status] ?? lostCase.status) : '';
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      {/* Header */}
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <View style={styles.headerInfo}>
+          <Text style={styles.headerTitle} numberOfLines={1}>
+            {lostCase?.item_description ?? 'Lost & Found'}
+          </Text>
+          <Text style={styles.headerStatus}>{statusLabel}</Text>
+        </View>
+        <View style={{ width: 44 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : (
+        <KeyboardAvoidingView
+          style={{ flex: 1 }}
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          keyboardVerticalOffset={0}
+        >
+          <FlatList
+            ref={flatRef}
+            data={messages}
+            keyExtractor={m => m.id}
+            renderItem={renderMessage}
+            contentContainerStyle={styles.msgList}
+            showsVerticalScrollIndicator={false}
+            ListEmptyComponent={
+              <View style={styles.center}>
+                <Text style={styles.emptyText}>
+                  {isClosed
+                    ? 'This case is closed.'
+                    : 'Waiting for driver to respond. You can send a message below.'}
+                </Text>
+              </View>
+            }
+          />
+
+          {isClosed ? (
+            <View style={styles.closedBanner}>
+              <Text style={styles.closedText}>This case is closed — messaging is disabled.</Text>
+            </View>
+          ) : (
+            <View style={styles.inputRow}>
+              <TextInput
+                style={styles.input}
+                value={text}
+                onChangeText={setText}
+                placeholder="Type a message…"
+                placeholderTextColor={colors.textDim}
+                multiline
+                maxLength={1000}
+                returnKeyType="send"
+                onSubmitEditing={sendMessage}
+              />
+              <TouchableOpacity
+                style={[styles.sendBtn, { opacity: !text.trim() || sending ? 0.4 : 1 }]}
+                onPress={sendMessage}
+                disabled={!text.trim() || sending}
+              >
+                {sending
+                  ? <ActivityIndicator size="small" color="#fff" />
+                  : <Ionicons name="send" size={18} color="#fff" />}
+              </TouchableOpacity>
+            </View>
+          )}
+        </KeyboardAvoidingView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.background },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+      gap: 8,
+    },
+    back: { padding: 4 },
+    headerInfo: { flex: 1 },
+    headerTitle: { fontSize: 16, fontFamily: 'PlusJakartaSans_600SemiBold', color: colors.text },
+    headerStatus: { fontSize: 12, color: colors.textDim, marginTop: 1 },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
+    emptyText: { fontSize: 14, color: colors.textDim, textAlign: 'center', lineHeight: 20 },
+    msgList: { padding: 16, gap: 8, flexGrow: 1 },
+    systemRow: { alignItems: 'center', marginVertical: 8 },
+    systemText: {
+      fontSize: 12,
+      color: colors.textDim,
+      backgroundColor: colors.surfaceLight,
+      paddingHorizontal: 12,
+      paddingVertical: 4,
+      borderRadius: 12,
+      textAlign: 'center',
+    },
+    msgRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 6, marginVertical: 3 },
+    msgRowMe: { flexDirection: 'row-reverse' },
+    avatar: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: colors.surfaceLight,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    bubble: {
+      maxWidth: '75%',
+      borderRadius: 16,
+      padding: 10,
+      gap: 2,
+    },
+    bubbleMe: { backgroundColor: colors.primary, borderBottomRightRadius: 4 },
+    bubbleThem: { backgroundColor: colors.surface, borderBottomLeftRadius: 4, borderWidth: 1, borderColor: colors.border },
+    bubbleText: { fontSize: 15, color: colors.text, lineHeight: 21 },
+    bubbleTextMe: { color: '#fff' },
+    timeText: { fontSize: 10, color: colors.textDim, alignSelf: 'flex-end' },
+    timeTextMe: { color: 'rgba(255,255,255,0.6)' },
+    closedBanner: {
+      padding: 14,
+      backgroundColor: colors.surfaceLight,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      alignItems: 'center',
+    },
+    closedText: { fontSize: 13, color: colors.textDim },
+    inputRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-end',
+      padding: 10,
+      gap: 8,
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      backgroundColor: colors.surface,
+    },
+    input: {
+      flex: 1,
+      backgroundColor: colors.background,
+      borderRadius: 20,
+      paddingHorizontal: 14,
+      paddingVertical: 10,
+      fontSize: 15,
+      color: colors.text,
+      maxHeight: 100,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    sendBtn: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.primary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+  });
+}

--- a/rider-app/app/lost-and-found.tsx
+++ b/rider-app/app/lost-and-found.tsx
@@ -1,0 +1,212 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useFocusEffect } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import api from '@shared/api/client';
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+
+interface LostFoundCase {
+  id: string;
+  ride_id?: string;
+  item_description: string;
+  item_category?: string;
+  status: string;
+  reporter_type: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  reported: 'Awaiting Driver',
+  driver_notified: 'Driver Notified',
+  driver_found: 'Item Found',
+  found: 'Item Found',
+  not_found: 'Not Found',
+  returned: 'Returned',
+  unclaimed: 'Unclaimed',
+  resolved: 'Resolved',
+  closed: 'Closed',
+  admin_created: 'Under Review',
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  reported: '#F59E0B',
+  driver_notified: '#3B82F6',
+  driver_found: '#10B981',
+  found: '#10B981',
+  not_found: '#EF4444',
+  returned: '#6B7280',
+  unclaimed: '#6B7280',
+  resolved: '#6B7280',
+  closed: '#6B7280',
+  admin_created: '#8B5CF6',
+};
+
+const CATEGORY_ICONS: Record<string, string> = {
+  electronics: 'phone-portrait',
+  clothing: 'shirt',
+  bag: 'bag',
+  document: 'document-text',
+  keys: 'key',
+  other: 'help-circle',
+};
+
+export default function LostAndFoundScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const [cases, setCases] = useState<LostFoundCase[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await api.get<{ cases: LostFoundCase[] }>('/lost-and-found');
+      setCases(res.data?.cases ?? []);
+    } catch {
+      // silently keep stale data on error
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(useCallback(() => { load(); }, [load]));
+
+  const onRefresh = useCallback(() => {
+    setRefreshing(true);
+    load();
+  }, [load]);
+
+  const renderCase = ({ item }: { item: LostFoundCase }) => {
+    const statusColor = STATUS_COLORS[item.status] ?? '#6B7280';
+    const statusLabel = STATUS_LABELS[item.status] ?? item.status;
+    const icon = (CATEGORY_ICONS[item.item_category ?? ''] ?? 'help-circle') as any;
+    const date = new Date(item.created_at).toLocaleDateString('en-CA', {
+      month: 'short', day: 'numeric', year: 'numeric',
+    });
+    const isDriverReported = item.reporter_type === 'driver';
+
+    return (
+      <TouchableOpacity
+        style={styles.card}
+        onPress={() => router.push({ pathname: '/lost-and-found-chat', params: { caseId: item.id } } as any)}
+        activeOpacity={0.7}
+      >
+        <View style={[styles.iconBadge, { backgroundColor: `${statusColor}18` }]}>
+          <Ionicons name={icon} size={22} color={statusColor} />
+        </View>
+
+        <View style={styles.cardBody}>
+          <View style={styles.cardRow}>
+            <Text style={styles.description} numberOfLines={1}>{item.item_description}</Text>
+            <View style={[styles.statusPill, { backgroundColor: `${statusColor}18` }]}>
+              <Text style={[styles.statusText, { color: statusColor }]}>{statusLabel}</Text>
+            </View>
+          </View>
+          <Text style={styles.meta}>
+            {isDriverReported ? 'Driver reported • ' : ''}{date}
+          </Text>
+        </View>
+
+        <Ionicons name="chevron-forward" size={18} color={colors.textDim} />
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.back}>
+          <Ionicons name="chevron-back" size={28} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={styles.title}>Lost & Found</Text>
+        <View style={{ width: 44 }} />
+      </View>
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : cases.length === 0 ? (
+        <View style={styles.center}>
+          <Ionicons name="bag-handle-outline" size={56} color={colors.textDim} />
+          <Text style={styles.emptyTitle}>No cases yet</Text>
+          <Text style={styles.emptyHint}>
+            If you left something in a ride, report it from the ride summary in the Activity tab.
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={cases}
+          keyExtractor={c => c.id}
+          renderItem={renderCase}
+          contentContainerStyle={styles.list}
+          showsVerticalScrollIndicator={false}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={colors.primary} />}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: colors.background },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingHorizontal: 16,
+      paddingVertical: 12,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    back: { padding: 4 },
+    title: { fontSize: 18, fontFamily: 'PlusJakartaSans_700Bold', color: colors.text },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
+    emptyTitle: { fontSize: 16, fontFamily: 'PlusJakartaSans_600SemiBold', color: colors.text },
+    emptyHint: { fontSize: 14, color: colors.textDim, textAlign: 'center', lineHeight: 20 },
+    list: { padding: 16, gap: 12 },
+    card: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.surface,
+      borderRadius: 14,
+      padding: 14,
+      gap: 12,
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    iconBadge: {
+      width: 44,
+      height: 44,
+      borderRadius: 22,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cardBody: { flex: 1, gap: 4 },
+    cardRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    description: {
+      flex: 1,
+      fontSize: 15,
+      fontFamily: 'PlusJakartaSans_600SemiBold',
+      color: colors.text,
+    },
+    statusPill: { borderRadius: 8, paddingHorizontal: 8, paddingVertical: 2 },
+    statusText: { fontSize: 11, fontFamily: 'PlusJakartaSans_600SemiBold' },
+    meta: { fontSize: 13, color: colors.textDim },
+  });
+}

--- a/rider-app/store/__tests__/rideStore.ws.test.ts
+++ b/rider-app/store/__tests__/rideStore.ws.test.ts
@@ -107,22 +107,22 @@ describe('rideStore — WebSocket-driven updates', () => {
 
   describe('addChatMessage', () => {
     it('should append a message', () => {
-      useRideStore.getState().addChatMessage({ id: 'm1', text: 'Hello', sender: 'rider' });
+      useRideStore.getState().addChatMessage({ id: 'm1', ride_id: 'ride_1', text: 'Hello', sender: 'rider', timestamp: '' });
 
       expect(useRideStore.getState().chatMessages).toHaveLength(1);
       expect(useRideStore.getState().chatMessages[0].text).toBe('Hello');
     });
 
     it('should deduplicate by id', () => {
-      useRideStore.getState().addChatMessage({ id: 'm1', text: 'Hello', sender: 'rider' });
-      useRideStore.getState().addChatMessage({ id: 'm1', text: 'Hello', sender: 'rider' });
+      useRideStore.getState().addChatMessage({ id: 'm1', ride_id: 'ride_1', text: 'Hello', sender: 'rider', timestamp: '' });
+      useRideStore.getState().addChatMessage({ id: 'm1', ride_id: 'ride_1', text: 'Hello', sender: 'rider', timestamp: '' });
 
       expect(useRideStore.getState().chatMessages).toHaveLength(1);
     });
 
     it('should allow different ids', () => {
-      useRideStore.getState().addChatMessage({ id: 'm1', text: 'Hello', sender: 'rider' });
-      useRideStore.getState().addChatMessage({ id: 'm2', text: 'Hi back', sender: 'driver' });
+      useRideStore.getState().addChatMessage({ id: 'm1', ride_id: 'ride_1', text: 'Hello', sender: 'rider', timestamp: '' });
+      useRideStore.getState().addChatMessage({ id: 'm2', ride_id: 'ride_1', text: 'Hi back', sender: 'driver', timestamp: '' });
 
       expect(useRideStore.getState().chatMessages).toHaveLength(2);
     });
@@ -132,7 +132,7 @@ describe('rideStore — WebSocket-driven updates', () => {
     it('should clear chatMessages on clearRide', () => {
       useRideStore.setState({
         currentRide: { id: 'ride_1' } as any,
-        chatMessages: [{ id: 'm1', text: 'test', sender: 'rider' }],
+        chatMessages: [{ id: 'm1', ride_id: 'ride_1', text: 'test', sender: 'rider', timestamp: '' }],
       });
 
       useRideStore.getState().clearRide();
@@ -170,7 +170,7 @@ describe('rideStore — WebSocket-driven updates', () => {
       useRideStore.setState({
         currentRide: { id: 'ride_1', status: 'driver_assigned' } as any,
         currentDriver: { id: 'driver_1', name: 'Jane' } as any,
-        chatMessages: [{ id: 'm1', text: 'On my way', sender: 'driver' }],
+        chatMessages: [{ id: 'm1', ride_id: 'ride_1', text: 'On my way', sender: 'driver', timestamp: '' }],
       });
 
       useRideStore.getState().clearRide();

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -155,6 +155,7 @@ export interface User {
   created_at: string;
   profile_complete: boolean;
   is_driver?: boolean;
+  is_rider?: boolean;
   profile_image?: string;  // Base64 data URI
   profile_image_status?: 'pending_review' | 'approved' | 'rejected' | null;
   rating?: number;


### PR DESCRIPTION
Production PGRST204 crash — same root cause as migration 112 (contact_method).
The legacy table pre-dated the migration runner, so migration 69's
CREATE TABLE IF NOT EXISTS was a no-op, leaving item_category absent.
ADD COLUMN IF NOT EXISTS is safe on environments where 69a already ran.

https://claude.ai/code/session_01RgNM8yEWZiocnqPYh584wJ

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
