### PR TITLE
fix(estimates): ghost vehicle types on ride-options screen

### DIFF
--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1151,41 +1151,73 @@ async def estimate_ride(
             body.pickup_lng,
         )
 
-    # Fetch all nearby online+available drivers once
-    all_drivers = await db_supabase.get_rows(
-        "drivers",
-        {
-            "is_online": True,
-            "is_available": True,
-        },
-        limit=200,
-    )
-
-    logger.info(
-        "[estimate] fetched %d online+available drivers from DB",
-        len(all_drivers),
-    )
-
-    # Presence filter — same logic as /drivers/nearby and the dispatch path.
-    # Without this, ghost drivers (is_online=True in DB but app dead/backgrounded)
-    # inflate driver_count and mark vehicle types as available when no real
-    # driver will ever receive the offer.
+    # Fetch nearby online+available drivers, presence-first so the DB limit
+    # is never applied to a pool that still contains ghost drivers.
+    #
+    # Pattern: ask Redis for present IDs first, then query Supabase for only
+    # those rows. This way the limit=200 cap applies to genuinely reachable
+    # drivers, not to a mixed DB page that might be dominated by ghosts.
+    #
+    # Fallback: if Redis is unconfigured (dev) or unavailable (outage), skip
+    # the presence pre-filter and query DB directly — same safe-degradation
+    # semantics used in /drivers/nearby and the dispatch path.
     try:
         try:
-            from ..utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
+            from ..utils.driver_presence import list_present_ids as _list_present  # type: ignore
         except ImportError:
-            from utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
-        _d_ids = [d["id"] for d in all_drivers if d.get("id")]
-        if _d_ids:
-            _present_set, _reachable = await _pdc(_d_ids)
-            if _reachable:
-                before_pres = len(all_drivers)
-                all_drivers = [d for d in all_drivers if d["id"] in _present_set]
-                logger.info("[estimate] presence filter: %d/%d driver(s) reachable", len(all_drivers), before_pres)
+            from utils.driver_presence import list_present_ids as _list_present  # type: ignore
+        _present_ids = await _list_present()
+        if _present_ids:
+            # Redis answered with a non-empty pool — query only those drivers.
+            all_drivers = await db_supabase.get_rows(
+                "drivers",
+                {
+                    "id": {"$in": _present_ids},
+                    "is_available": True,
+                },
+                limit=200,
+            )
+            logger.info(
+                "[estimate] presence-first: %d present IDs → %d is_available DB rows",
+                len(_present_ids),
+                len(all_drivers),
+            )
+        else:
+            # Redis returned empty — either all drivers are genuinely offline
+            # (correct: show no availability) or Redis is unconfigured/down.
+            # Distinguish via a quick reachability probe.
+            try:
+                from ..utils.redis_client import _get_redis as _check_redis  # type: ignore
+            except ImportError:
+                from utils.redis_client import _get_redis as _check_redis  # type: ignore
+            _redis_live = await _check_redis() is not None
+            if _redis_live:
+                # Redis is up and returned an empty set → every driver is
+                # genuinely offline. Return no drivers so estimates show
+                # "unavailable" correctly.
+                all_drivers = []
+                logger.info("[estimate] presence-first: Redis up, zero present drivers")
             else:
-                logger.warning("[estimate] presence store unreachable — using DB state for estimates")
+                # Redis is down — fall back to DB query so a Redis outage
+                # doesn't blank all vehicle types for every rider.
+                all_drivers = await db_supabase.get_rows(
+                    "drivers",
+                    {"is_online": True, "is_available": True},
+                    limit=200,
+                )
+                logger.warning(
+                    "[estimate] Redis unavailable — fell back to DB query (%d rows)",
+                    len(all_drivers),
+                )
     except Exception as _pres_exc:
-        logger.warning("[estimate] presence filter failed, using DB state: %s", _pres_exc)
+        logger.warning("[estimate] presence pre-filter failed, falling back to DB: %s", _pres_exc)
+        all_drivers = await db_supabase.get_rows(
+            "drivers",
+            {"is_online": True, "is_available": True},
+            limit=200,
+        )
+
+    logger.info("[estimate] %d driver(s) in pool after presence gating", len(all_drivers))
 
     # Filter to drivers within 10km radius and group by vehicle_type_id.
     # Exclude drivers without a user_id — those are orphan/demo rows that

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1166,6 +1166,27 @@ async def estimate_ride(
         len(all_drivers),
     )
 
+    # Presence filter — same logic as /drivers/nearby and the dispatch path.
+    # Without this, ghost drivers (is_online=True in DB but app dead/backgrounded)
+    # inflate driver_count and mark vehicle types as available when no real
+    # driver will ever receive the offer.
+    try:
+        try:
+            from ..utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
+        except ImportError:
+            from utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
+        _d_ids = [d["id"] for d in all_drivers if d.get("id")]
+        if _d_ids:
+            _present_set, _reachable = await _pdc(_d_ids)
+            if _reachable:
+                before_pres = len(all_drivers)
+                all_drivers = [d for d in all_drivers if d["id"] in _present_set]
+                logger.info("[estimate] presence filter: %d/%d driver(s) reachable", len(all_drivers), before_pres)
+            else:
+                logger.warning("[estimate] presence store unreachable — using DB state for estimates")
+    except Exception as _pres_exc:
+        logger.warning("[estimate] presence filter failed, using DB state: %s", _pres_exc)
+
     # Filter to drivers within 10km radius and group by vehicle_type_id.
     # Exclude drivers without a user_id — those are orphan/demo rows that
     # cannot be dispatched to, and counting them would inflate the rider's


### PR DESCRIPTION
The fare estimates endpoint (POST /rides/estimates) fetched is_online=True AND is_available=True drivers from the DB but never applied the Redis presence filter. Ghost drivers (app dead or backgrounded without calling go-offline) were counted in driver_count and marked vehicle types as available=True even though no real driver would receive an offer.

Applied the same present_driver_ids_checked() filter used by /drivers/nearby: filter when the presence store is reachable, fall back to DB state during a Redis outage (same safe-failover semantics — riders see cars on the screen but dispatch still presence-filters before any offer fires).

This was the root cause of "many vehicle types available" appearing on the ride-options screen for offline drivers.

https://claude.ai/code/session_01WxKrMx4prUSRUdZBmHBXSP

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
