### PR TITLE
fix(estimate): apply presence filter so ghost drivers are excluded from driver_count

### DIFF
--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1113,6 +1113,57 @@ class RideEstimateRequest(BaseModel):
     requires_wav: bool = False
 
 
+async def _filter_reachable_drivers(all_drivers: list) -> list:
+    """Drop ghost drivers from a DB-online pool for rider-facing counts.
+
+    A driver is kept iff their Redis presence key is still alive (heartbeat
+    within the TTL) AND their durable intent is online. Mirrors the guard in
+    /drivers/nearby and dispatch so the estimate "X drivers" badge matches
+    what dispatch can actually reach.
+
+    Redis-outage policy (matches /drivers/nearby):
+      * reachable + present set → filter to truly reachable drivers
+      * reachable + empty set   → everyone is offline; an empty result is
+        correct, not a bug
+      * NOT reachable (Redis configured but down) → presence is unknowable,
+        so fall back to DB state (still applying intent_online to catch a
+        stale is_online column). Dispatch presence-filters before any offer,
+        so a ghost that slips through here cannot actually accept a ride.
+
+    Any unexpected error degrades to DB state rather than blanking the count.
+    """
+    try:
+        from ..utils.driver_online import intent_online
+        from ..utils.driver_presence import present_driver_ids_checked
+    except ImportError:  # pragma: no cover - dual import path
+        from utils.driver_online import intent_online  # type: ignore
+        from utils.driver_presence import present_driver_ids_checked  # type: ignore
+
+    driver_ids = [d["id"] for d in all_drivers if d.get("id")]
+    if not driver_ids:
+        return all_drivers
+
+    try:
+        present, reachable = await present_driver_ids_checked(driver_ids)
+    except Exception as exc:
+        logger.warning("[estimate] presence filter error, using DB state: %s", exc)
+        return [d for d in all_drivers if intent_online(d)]
+
+    if reachable:
+        before = len(all_drivers)
+        filtered = [d for d in all_drivers if d.get("id") in present and intent_online(d)]
+        logger.info("[estimate] presence filter: %d/%d driver(s) reachable", len(filtered), before)
+        return filtered
+
+    # Redis configured but unreachable — keep DB state, log warning.
+    filtered = [d for d in all_drivers if intent_online(d)]
+    logger.warning(
+        "[estimate] presence store unreachable, using DB state (%d drivers after intent_online filter)",
+        len(filtered),
+    )
+    return filtered
+
+
 @api_router.post("/estimate")
 @api_rate_limit
 async def estimate_ride(
@@ -1166,40 +1217,9 @@ async def estimate_ride(
     )
 
     # Presence filter: strip drivers whose heartbeat has expired (app crashed /
-    # network lost). Mirrors the same guard in /drivers/nearby and dispatch so
-    # the rider's "X drivers" badge matches what dispatch can actually reach.
-    # On Redis outage (reachable=False) we fall back to DB state rather than
-    # blanking the count entirely — dispatch still presence-filters before any
-    # offer is sent, so a ghost driver that slips through cannot accept a ride.
-    try:
-        try:
-            from ..utils.driver_online import intent_online as _intent_online  # type: ignore
-            from ..utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
-        except ImportError:
-            from utils.driver_online import intent_online as _intent_online  # type: ignore
-            from utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
-
-        _driver_ids = [d["id"] for d in all_drivers if d.get("id")]
-        if _driver_ids:
-            _present, _reachable = await _pdc(_driver_ids)
-            if _reachable:
-                _before = len(all_drivers)
-                all_drivers = [d for d in all_drivers if d.get("id") in _present and _intent_online(d)]
-                logger.info(
-                    "[estimate] presence filter: %d/%d driver(s) reachable",
-                    len(all_drivers),
-                    _before,
-                )
-            else:
-                # Redis configured but unreachable — keep DB state, log warning.
-                # intent_online still applied to catch stale is_online column.
-                all_drivers = [d for d in all_drivers if _intent_online(d)]
-                logger.warning(
-                    "[estimate] presence store unreachable, using DB state (%d drivers after intent_online filter)",
-                    len(all_drivers),
-                )
-    except Exception as _exc:
-        logger.warning("[estimate] presence filter error, using DB state: %s", _exc)
+    # network lost) so the rider's "X drivers" badge matches what dispatch can
+    # actually reach. See _filter_reachable_drivers for the Redis-outage policy.
+    all_drivers = await _filter_reachable_drivers(all_drivers)
 
     # Filter to drivers within 10km radius and group by vehicle_type_id.
     # Exclude drivers without a user_id — those are orphan/demo rows that

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1165,6 +1165,42 @@ async def estimate_ride(
         len(all_drivers),
     )
 
+    # Presence filter: strip drivers whose heartbeat has expired (app crashed /
+    # network lost). Mirrors the same guard in /drivers/nearby and dispatch so
+    # the rider's "X drivers" badge matches what dispatch can actually reach.
+    # On Redis outage (reachable=False) we fall back to DB state rather than
+    # blanking the count entirely — dispatch still presence-filters before any
+    # offer is sent, so a ghost driver that slips through cannot accept a ride.
+    try:
+        try:
+            from ..utils.driver_online import intent_online as _intent_online  # type: ignore
+            from ..utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
+        except ImportError:
+            from utils.driver_online import intent_online as _intent_online  # type: ignore
+            from utils.driver_presence import present_driver_ids_checked as _pdc  # type: ignore
+
+        _driver_ids = [d["id"] for d in all_drivers if d.get("id")]
+        if _driver_ids:
+            _present, _reachable = await _pdc(_driver_ids)
+            if _reachable:
+                _before = len(all_drivers)
+                all_drivers = [d for d in all_drivers if d.get("id") in _present and _intent_online(d)]
+                logger.info(
+                    "[estimate] presence filter: %d/%d driver(s) reachable",
+                    len(all_drivers),
+                    _before,
+                )
+            else:
+                # Redis configured but unreachable — keep DB state, log warning.
+                # intent_online still applied to catch stale is_online column.
+                all_drivers = [d for d in all_drivers if _intent_online(d)]
+                logger.warning(
+                    "[estimate] presence store unreachable, using DB state (%d drivers after intent_online filter)",
+                    len(all_drivers),
+                )
+    except Exception as _exc:
+        logger.warning("[estimate] presence filter error, using DB state: %s", _exc)
+
     # Filter to drivers within 10km radius and group by vehicle_type_id.
     # Exclude drivers without a user_id — those are orphan/demo rows that
     # cannot be dispatched to, and counting them would inflate the rider's

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1201,13 +1201,23 @@ async def estimate_ride(
             body.pickup_lng,
         )
 
-    # Fetch all nearby online+available drivers once
+    # Fetch nearby online+available drivers once. Order by went_online_at DESC
+    # so recently-toggled-online drivers fill the 200-row page first. Ghost
+    # drivers (is_available=True in DB but heartbeat expired) tend to carry
+    # stale went_online_at values and fall toward the tail, so they are less
+    # likely to crowd real drivers out of the cap before the presence filter
+    # below runs. This mitigates — but does not fully eliminate — the
+    # capped-page ghost leak; full elimination needs a geo-index (query by
+    # radius first) or a sweeper that writes is_available=False back on TTL
+    # expiry. Tracked as a follow-up.
     all_drivers = await db_supabase.get_rows(
         "drivers",
         {
             "is_online": True,
             "is_available": True,
         },
+        order="went_online_at",
+        desc=True,
         limit=200,
     )
 

--- a/backend/tests/test_estimate_ghost_driver_filter.py
+++ b/backend/tests/test_estimate_ghost_driver_filter.py
@@ -1,0 +1,101 @@
+"""
+Regression test: ghost driver filter on /rides/estimate.
+
+Before this fix, drivers with is_online=True in the DB but no active
+Redis presence key (app crashed / network lost) were counted in the
+driver_count returned by the estimate endpoint. This produced counts
+like "2 drivers nearby" when only 1 was actually reachable by dispatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+def _make_driver(driver_id: str, vehicle_type_id: str = "economy", lat: float = 52.13, lng: float = -106.67) -> dict:
+    return {
+        "id": driver_id,
+        "user_id": f"user_{driver_id}",
+        "vehicle_type_id": vehicle_type_id,
+        "lat": lat,
+        "lng": lng,
+        "is_online": True,
+        "is_available": True,
+        "went_online_at": "2026-01-01T00:00:00Z",
+        "went_offline_at": None,
+    }
+
+
+PICKUP_LAT, PICKUP_LNG = 52.13, -106.67
+
+
+@pytest.mark.anyio
+async def test_ghost_driver_excluded_when_presence_reachable():
+    """A driver that is DB-online but has no presence key is excluded from the count."""
+    real_driver = _make_driver("d_real")
+    ghost_driver = _make_driver("d_ghost")
+    all_db_drivers = [real_driver, ghost_driver]
+
+    # Only d_real is present in Redis
+    async def _pdc_only_real(candidate_ids):
+        present = {cid for cid in candidate_ids if cid == "d_real"}
+        return present, True  # reachable=True
+
+    with (
+        patch("backend.db_supabase.get_rows", new_callable=AsyncMock) as mock_get_rows,
+        patch("backend.routes.rides.present_driver_ids_checked", new=_pdc_only_real),
+        patch("backend.routes.rides.intent_online", return_value=True),
+    ):
+        # Import inline so the patches are in scope
+        from backend.utils.driver_presence import present_driver_ids_checked as _pdc
+        from backend.utils.driver_online import intent_online
+
+        driver_ids = [d["id"] for d in all_db_drivers if d.get("id")]
+        present, reachable = await _pdc_only_real(driver_ids)
+
+        assert reachable is True
+        # Ghost driver not in present set
+        visible = [d for d in all_db_drivers if d.get("id") in present and intent_online(d)]
+        assert len(visible) == 1
+        assert visible[0]["id"] == "d_real"
+
+
+@pytest.mark.anyio
+async def test_presence_fallback_keeps_db_drivers_when_redis_unreachable():
+    """When Redis is configured but down (reachable=False), DB state is used as fallback."""
+    real_driver = _make_driver("d_real")
+    ghost_driver = _make_driver("d_ghost")
+    all_db_drivers = [real_driver, ghost_driver]
+
+    async def _pdc_redis_down(candidate_ids):
+        return set(), False  # reachable=False → Redis unavailable
+
+    from backend.utils.driver_online import intent_online
+
+    driver_ids = [d["id"] for d in all_db_drivers if d.get("id")]
+    present, reachable = await _pdc_redis_down(driver_ids)
+
+    assert reachable is False
+    # Fall back to DB state — keep both drivers (only intent_online filters)
+    visible = [d for d in all_db_drivers if intent_online(d)]
+    assert len(visible) == 2
+
+
+@pytest.mark.anyio
+async def test_intent_online_filters_stale_is_online_column():
+    """A driver marked is_online=True but went_offline_at > went_online_at is excluded."""
+    from backend.utils.driver_online import intent_online
+
+    # Went online then went offline — is_online column is stale
+    stale_driver = _make_driver("d_stale")
+    stale_driver["went_online_at"] = "2026-01-01T10:00:00Z"
+    stale_driver["went_offline_at"] = "2026-01-01T11:00:00Z"  # offline after online
+
+    # Genuinely online — went_offline_at before went_online_at
+    online_driver = _make_driver("d_online")
+    online_driver["went_online_at"] = "2026-01-01T12:00:00Z"
+    online_driver["went_offline_at"] = "2026-01-01T11:00:00Z"  # offline was earlier
+
+    assert intent_online(stale_driver) is False
+    assert intent_online(online_driver) is True

--- a/backend/tests/test_estimate_ghost_driver_filter.py
+++ b/backend/tests/test_estimate_ghost_driver_filter.py
@@ -5,12 +5,20 @@ Before this fix, drivers with is_online=True in the DB but no active
 Redis presence key (app crashed / network lost) were counted in the
 driver_count returned by the estimate endpoint. This produced counts
 like "2 drivers nearby" when only 1 was actually reachable by dispatch.
+
+These tests exercise the real production helper
+``backend.routes.rides._filter_reachable_drivers``. Only the presence
+store is mocked (at its source module, which the helper's inline import
+resolves to); ``intent_online`` runs for real.
 """
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.routes.rides import _filter_reachable_drivers
 
 
 def _make_driver(driver_id: str, vehicle_type_id: str = "economy", lat: float = 52.13, lng: float = -106.67) -> dict:
@@ -27,75 +35,102 @@ def _make_driver(driver_id: str, vehicle_type_id: str = "economy", lat: float = 
     }
 
 
-PICKUP_LAT, PICKUP_LNG = 52.13, -106.67
+@pytest.mark.anyio
+async def test_ghost_driver_excluded_when_presence_reachable():
+    """A driver that is DB-online but has no presence key is excluded."""
+    all_db_drivers = [_make_driver("d_real"), _make_driver("d_ghost")]
+
+    # Redis reachable; only d_real has a live heartbeat.
+    async def _pdc(candidate_ids):
+        return {cid for cid in candidate_ids if cid == "d_real"}, True
+
+    with patch(
+        "backend.utils.driver_presence.present_driver_ids_checked",
+        new=AsyncMock(side_effect=_pdc),
+    ):
+        result = await _filter_reachable_drivers(all_db_drivers)
+
+    assert [d["id"] for d in result] == ["d_real"]
 
 
 @pytest.mark.anyio
-async def test_ghost_driver_excluded_when_presence_reachable():
-    """A driver that is DB-online but has no presence key is excluded from the count."""
-    real_driver = _make_driver("d_real")
-    ghost_driver = _make_driver("d_ghost")
-    all_db_drivers = [real_driver, ghost_driver]
+async def test_empty_present_set_yields_empty_when_reachable():
+    """Redis reachable but nobody present → empty count is correct, not a bug."""
+    all_db_drivers = [_make_driver("d1"), _make_driver("d2")]
 
-    # Only d_real is present in Redis
-    async def _pdc_only_real(candidate_ids):
-        present = {cid for cid in candidate_ids if cid == "d_real"}
-        return present, True  # reachable=True
+    async def _pdc(candidate_ids):
+        return set(), True
 
-    with (
-        patch("backend.db_supabase.get_rows", new_callable=AsyncMock) as mock_get_rows,
-        patch("backend.routes.rides.present_driver_ids_checked", new=_pdc_only_real),
-        patch("backend.routes.rides.intent_online", return_value=True),
+    with patch(
+        "backend.utils.driver_presence.present_driver_ids_checked",
+        new=AsyncMock(side_effect=_pdc),
     ):
-        # Import inline so the patches are in scope
-        from backend.utils.driver_presence import present_driver_ids_checked as _pdc
-        from backend.utils.driver_online import intent_online
+        result = await _filter_reachable_drivers(all_db_drivers)
 
-        driver_ids = [d["id"] for d in all_db_drivers if d.get("id")]
-        present, reachable = await _pdc_only_real(driver_ids)
-
-        assert reachable is True
-        # Ghost driver not in present set
-        visible = [d for d in all_db_drivers if d.get("id") in present and intent_online(d)]
-        assert len(visible) == 1
-        assert visible[0]["id"] == "d_real"
+    assert result == []
 
 
 @pytest.mark.anyio
 async def test_presence_fallback_keeps_db_drivers_when_redis_unreachable():
-    """When Redis is configured but down (reachable=False), DB state is used as fallback."""
-    real_driver = _make_driver("d_real")
-    ghost_driver = _make_driver("d_ghost")
-    all_db_drivers = [real_driver, ghost_driver]
+    """Redis configured but down (reachable=False) → fall back to DB state."""
+    all_db_drivers = [_make_driver("d_real"), _make_driver("d_ghost")]
 
-    async def _pdc_redis_down(candidate_ids):
-        return set(), False  # reachable=False → Redis unavailable
+    async def _pdc(candidate_ids):
+        return set(), False  # reachable=False
 
-    from backend.utils.driver_online import intent_online
+    with patch(
+        "backend.utils.driver_presence.present_driver_ids_checked",
+        new=AsyncMock(side_effect=_pdc),
+    ):
+        result = await _filter_reachable_drivers(all_db_drivers)
 
-    driver_ids = [d["id"] for d in all_db_drivers if d.get("id")]
-    present, reachable = await _pdc_redis_down(driver_ids)
-
-    assert reachable is False
-    # Fall back to DB state — keep both drivers (only intent_online filters)
-    visible = [d for d in all_db_drivers if intent_online(d)]
-    assert len(visible) == 2
+    # Both kept — only intent_online filters in the fallback path.
+    assert {d["id"] for d in result} == {"d_real", "d_ghost"}
 
 
 @pytest.mark.anyio
-async def test_intent_online_filters_stale_is_online_column():
-    """A driver marked is_online=True but went_offline_at > went_online_at is excluded."""
-    from backend.utils.driver_online import intent_online
+async def test_presence_exception_falls_back_to_db_state():
+    """An unexpected presence error degrades to DB state, never blanks the count."""
+    all_db_drivers = [_make_driver("d1"), _make_driver("d2")]
 
-    # Went online then went offline — is_online column is stale
-    stale_driver = _make_driver("d_stale")
-    stale_driver["went_online_at"] = "2026-01-01T10:00:00Z"
-    stale_driver["went_offline_at"] = "2026-01-01T11:00:00Z"  # offline after online
+    with patch(
+        "backend.utils.driver_presence.present_driver_ids_checked",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = await _filter_reachable_drivers(all_db_drivers)
 
-    # Genuinely online — went_offline_at before went_online_at
-    online_driver = _make_driver("d_online")
-    online_driver["went_online_at"] = "2026-01-01T12:00:00Z"
-    online_driver["went_offline_at"] = "2026-01-01T11:00:00Z"  # offline was earlier
+    assert {d["id"] for d in result} == {"d1", "d2"}
 
-    assert intent_online(stale_driver) is False
-    assert intent_online(online_driver) is True
+
+@pytest.mark.anyio
+async def test_stale_is_online_driver_excluded_even_when_present():
+    """A present driver whose went_offline_at is newer than went_online_at is dropped."""
+    fresh = _make_driver("d_fresh")
+    fresh["went_online_at"] = "2026-01-01T12:00:00Z"
+    fresh["went_offline_at"] = "2026-01-01T11:00:00Z"  # online is more recent → online
+    stale = _make_driver("d_stale")
+    stale["went_online_at"] = "2026-01-01T10:00:00Z"
+    stale["went_offline_at"] = "2026-01-01T11:00:00Z"  # offline is more recent → offline
+
+    async def _pdc(candidate_ids):
+        return set(candidate_ids), True  # both present in Redis
+
+    with patch(
+        "backend.utils.driver_presence.present_driver_ids_checked",
+        new=AsyncMock(side_effect=_pdc),
+    ):
+        result = await _filter_reachable_drivers([fresh, stale])
+
+    assert [d["id"] for d in result] == ["d_fresh"]
+
+
+@pytest.mark.anyio
+async def test_empty_input_short_circuits():
+    """No drivers in → no drivers out, without touching the presence store."""
+    with patch(
+        "backend.utils.driver_presence.present_driver_ids_checked",
+        new=AsyncMock(side_effect=AssertionError("should not be called")),
+    ):
+        result = await _filter_reachable_drivers([])
+
+    assert result == []


### PR DESCRIPTION
/rides/estimate was counting all DB-online drivers (is_online=True,
is_available=True) without consulting the Redis presence store, so a
driver whose app crashed or lost connectivity could stay in the badge
count for up to 30 s after the heartbeat expired. /drivers/nearby and
dispatch both already presence-filter; this brings the estimate path
into line with them.

Three-case handling mirrors /drivers/nearby:
  - Redis reachable + present set → filter to real drivers only
  - Redis reachable + empty set   → zero count is correct (everyone offline)
  - Redis configured but down     → fall back to DB state (dispatch still
    presence-filters before any offer, so a ghost driver cannot accept)

intent_online() is also applied to catch stale is_online column values.

Adds regression tests for all three cases.

https://claude.ai/code/session_01WTd5LLip9sgqgRJ4H1Un3S