### PR TITLE
Ensure fare estimates include all active vehicle types (fallback to defaults)

### DIFF
--- a/backend/routes/fares.py
+++ b/backend/routes/fares.py
@@ -237,8 +237,20 @@ async def build_fares_for_area(matched_area, vehicle_types):
     for vt in vehicle_types:
         pricing = _pick(vt)
         if not pricing:
+            # Always return every active vehicle type. The rider booking sheet
+            # uses the estimate list as its vehicle-type list, then greys out
+            # types with no nearby drivers. If a service area has partial
+            # pricing (for example only Sedan is configured), skipping the
+            # unpriced types makes the rider app look empty or incomplete
+            # instead of showing those types as unavailable. Use platform
+            # defaults for the missing pricing rows so availability remains a
+            # driver-presence decision, not an admin-pricing-data decision.
             if has_area_pricing:
-                continue
+                logger.warning(
+                    "Fares: missing area pricing for vehicle type %s in service area %s; using defaults",
+                    vt.get("name", vt.get("id")),
+                    matched_area.get("name", matched_area.get("id")),
+                )
             pricing = {
                 "base_fare": DEFAULT_FARE["base_fare"],
                 "per_km_rate": DEFAULT_FARE["per_km_rate"],

--- a/backend/tests/test_fares.py
+++ b/backend/tests/test_fares.py
@@ -48,3 +48,48 @@ async def test_fare_estimate_surge_capped_at_2_5x():
         assert fare["surge_multiplier"] <= 2.5, (
             f"surge_multiplier {fare['surge_multiplier']} exceeds 2.5× cap (vehicle_type={fare.get('vehicle_type')})"
         )
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_build_fares_for_area_includes_unpriced_vehicle_types_with_defaults():
+    """Regression: partial area pricing must not hide vehicle types from booking.
+
+    The rider app renders vehicle cards from /rides/estimate. If a service area
+    has pricing for only one vehicle type, unpriced active types still need a
+    fare row so the app can show them greyed out when no drivers are available.
+    """
+    from backend.routes.fares import build_fares_for_area
+    from backend.services.fare_service import DEFAULT_FARE
+
+    matched_area = {
+        "id": "area_partial_pricing",
+        "name": "Partial Pricing Area",
+        "surge_enabled": False,
+        "surge_active": False,
+        "surge_multiplier": 1.0,
+        "vehicle_pricing": [
+            {
+                "vehicle_type": "Sedan",
+                "base_fare": 4.25,
+                "per_km": 1.75,
+                "per_min": 0.35,
+                "min_fare": 9.00,
+                "booking_fee": 2.50,
+            }
+        ],
+    }
+    vehicle_types = [
+        {"id": "vt_sedan", "name": "Sedan", "is_active": True},
+        {"id": "vt_xl", "name": "XL", "is_active": True},
+    ]
+
+    with patch("backend.routes.fares.db_supabase.get_rows", new_callable=AsyncMock) as mock_get_rows:
+        mock_get_rows.return_value = []
+        fares = await build_fares_for_area(matched_area, vehicle_types)
+
+    assert [fare["vehicle_type"]["id"] for fare in fares] == ["vt_sedan", "vt_xl"]
+    fares_by_id = {fare["vehicle_type"]["id"]: fare for fare in fares}
+    assert fares_by_id["vt_sedan"]["base_fare"] == "4.25"
+    assert fares_by_id["vt_xl"]["base_fare"] == f'{DEFAULT_FARE["base_fare"]:.2f}'
+    assert fares_by_id["vt_xl"]["per_km_rate"] == f'{DEFAULT_FARE["per_km_rate"]:.2f}'


### PR DESCRIPTION
### Motivation
- The rider booking UI was empty when a service area had pricing for only a subset of active vehicle types, preventing the app from showing greyed-out (unavailable) vehicle cards; availability should be determined by driver presence, not admin pricing data. 

### Description
- Change `backend/routes/fares.py` so unpriced active vehicle types are not skipped; when area pricing is partial the code now logs a warning and populates missing rows with `DEFAULT_FARE` values. 
- Keep the existing normalization to string money values via `_money_str` and preserve `surge_multiplier` handling. 
- Add a regression unit test `backend/tests/test_fares.py::test_build_fares_for_area_includes_unpriced_vehicle_types_with_defaults` that asserts both a priced and an unpriced active vehicle type are returned and that the unpriced type uses platform defaults. 

### Testing
- Ran static compile check with `python -m py_compile backend/routes/fares.py backend/tests/test_fares.py`, which succeeded. 
- Added unit test `test_build_fares_for_area_includes_unpriced_vehicle_types_with_defaults`; running `pytest` was attempted but blocked by the local environment missing the `httpx` dependency, so full test execution is pending in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dabcebda0833080b6c7aa78016279)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
