### PR TITLE
Use `ride_completed_at` for admin driver queries; include unpriced vehicle types in fare estimates

### DIFF
--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -728,7 +728,7 @@ async def admin_get_expiring_documents(
             {
                 "driver_id": {"$in": list(affected_driver_ids)},
                 "status": "completed",
-                "completed_at": {"$gte": rides_30d_ago},
+                "ride_completed_at": {"$gte": rides_30d_ago},
             },
             limit=10000,
         )
@@ -1389,7 +1389,7 @@ async def admin_get_driver_payouts_summary(driver_id: str, limit: int = Query(50
         (
             _dec(r.get("driver_earnings"))
             for r in rides
-            if (r.get("completed_at") or r.get("created_at") or "") >= year_start
+            if (r.get("ride_completed_at") or r.get("completed_at") or r.get("created_at") or "") >= year_start
         ),
         Decimal("0"),
     )
@@ -1398,9 +1398,9 @@ async def admin_get_driver_payouts_summary(driver_id: str, limit: int = Query(50
     # days" earnings metric uses (≥1 completed ride on that calendar date).
     thirty_days_ago = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
     recent_dates = {
-        (r.get("completed_at") or r.get("created_at") or "")[:10]
+        (r.get("ride_completed_at") or r.get("completed_at") or r.get("created_at") or "")[:10]
         for r in rides
-        if (r.get("completed_at") or r.get("created_at") or "") >= thirty_days_ago
+        if (r.get("ride_completed_at") or r.get("completed_at") or r.get("created_at") or "") >= thirty_days_ago
     }
     active_days_30d = len([d for d in recent_dates if d])
 

--- a/backend/routes/fares.py
+++ b/backend/routes/fares.py
@@ -237,8 +237,20 @@ async def build_fares_for_area(matched_area, vehicle_types):
     for vt in vehicle_types:
         pricing = _pick(vt)
         if not pricing:
+            # Always return every active vehicle type. The rider booking sheet
+            # uses the estimate list as its vehicle-type list, then greys out
+            # types with no nearby drivers. If a service area has partial
+            # pricing (for example only Sedan is configured), skipping the
+            # unpriced types makes the rider app look empty or incomplete
+            # instead of showing those types as unavailable. Use platform
+            # defaults for the missing pricing rows so availability remains a
+            # driver-presence decision, not an admin-pricing-data decision.
             if has_area_pricing:
-                continue
+                logger.warning(
+                    "Fares: missing area pricing for vehicle type %s in service area %s; using defaults",
+                    vt.get("name", vt.get("id")),
+                    matched_area.get("name", matched_area.get("id")),
+                )
             pricing = {
                 "base_fare": DEFAULT_FARE["base_fare"],
                 "per_km_rate": DEFAULT_FARE["per_km_rate"],

--- a/backend/tests/test_admin_drivers_expiring.py
+++ b/backend/tests/test_admin_drivers_expiring.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_admin_get_expiring_documents_filters_rides_by_ride_completed_at():
+    """The rides table uses ride_completed_at, not completed_at."""
+    from routes.admin import drivers as admin_drivers
+
+    now = datetime.now(timezone.utc)
+    driver = {
+        "id": "driver-1",
+        "user_id": "user-1",
+        "status": "active",
+        "service_area_id": "area-1",
+        "license_expiry_date": (now + timedelta(days=10)).isoformat(),
+    }
+    user = {
+        "id": "user-1",
+        "first_name": "Alex",
+        "last_name": "Driver",
+        "email": "alex@example.test",
+    }
+    area = {"id": "area-1", "name": "Saskatoon"}
+    ride = {
+        "id": "ride-1",
+        "driver_id": "driver-1",
+        "status": "completed",
+        "ride_completed_at": (now - timedelta(days=1)).isoformat(),
+    }
+
+    async def fake_get_rows(table, filters=None, **kwargs):
+        if table == "drivers":
+            return [driver]
+        if table == "users":
+            return [user]
+        if table == "service_areas":
+            return [area]
+        if table == "rides":
+            assert "ride_completed_at" in filters
+            assert "completed_at" not in filters
+            assert filters["ride_completed_at"]["$gte"]
+            return [ride]
+        raise AssertionError(f"unexpected table: {table}")
+
+    with patch.object(admin_drivers.db_supabase, "get_rows", new=AsyncMock(side_effect=fake_get_rows)) as get_rows:
+        result = await admin_drivers.admin_get_expiring_documents(window_days=30)
+
+    assert result["items"][0]["rides_last_30d"] == 1
+    rides_call = next(call for call in get_rows.await_args_list if call.args[0] == "rides")
+    rides_filters = rides_call.args[1]
+    assert rides_filters == {
+        "driver_id": {"$in": ["driver-1"]},
+        "status": "completed",
+        "ride_completed_at": {"$gte": rides_filters["ride_completed_at"]["$gte"]},
+    }

--- a/backend/tests/test_fares.py
+++ b/backend/tests/test_fares.py
@@ -48,3 +48,48 @@ async def test_fare_estimate_surge_capped_at_2_5x():
         assert fare["surge_multiplier"] <= 2.5, (
             f"surge_multiplier {fare['surge_multiplier']} exceeds 2.5× cap (vehicle_type={fare.get('vehicle_type')})"
         )
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_build_fares_for_area_includes_unpriced_vehicle_types_with_defaults():
+    """Regression: partial area pricing must not hide vehicle types from booking.
+
+    The rider app renders vehicle cards from /rides/estimate. If a service area
+    has pricing for only one vehicle type, unpriced active types still need a
+    fare row so the app can show them greyed out when no drivers are available.
+    """
+    from backend.routes.fares import build_fares_for_area
+    from backend.services.fare_service import DEFAULT_FARE
+
+    matched_area = {
+        "id": "area_partial_pricing",
+        "name": "Partial Pricing Area",
+        "surge_enabled": False,
+        "surge_active": False,
+        "surge_multiplier": 1.0,
+        "vehicle_pricing": [
+            {
+                "vehicle_type": "Sedan",
+                "base_fare": 4.25,
+                "per_km": 1.75,
+                "per_min": 0.35,
+                "min_fare": 9.00,
+                "booking_fee": 2.50,
+            }
+        ],
+    }
+    vehicle_types = [
+        {"id": "vt_sedan", "name": "Sedan", "is_active": True},
+        {"id": "vt_xl", "name": "XL", "is_active": True},
+    ]
+
+    with patch("backend.routes.fares.db_supabase.get_rows", new_callable=AsyncMock) as mock_get_rows:
+        mock_get_rows.return_value = []
+        fares = await build_fares_for_area(matched_area, vehicle_types)
+
+    assert [fare["vehicle_type"]["id"] for fare in fares] == ["vt_sedan", "vt_xl"]
+    fares_by_id = {fare["vehicle_type"]["id"]: fare for fare in fares}
+    assert fares_by_id["vt_sedan"]["base_fare"] == "4.25"
+    assert fares_by_id["vt_xl"]["base_fare"] == f'{DEFAULT_FARE["base_fare"]:.2f}'
+    assert fares_by_id["vt_xl"]["per_km_rate"] == f'{DEFAULT_FARE["per_km_rate"]:.2f}'


### PR DESCRIPTION
### Motivation
- Fix a Supabase `42703` error caused by querying the nonexistent `completed_at` column and align admin queries with the canonical `ride_completed_at` column.
- Ensure the rider booking UI is not empty when a service area has partial pricing by returning all active vehicle types so the app can grey out unavailable types.

### Description
- Update `backend/routes/admin/drivers.py` to query `rides` using `ride_completed_at` and to prefer `ride_completed_at` when computing year-to-date and recent-date aggregates while keeping fallbacks to `completed_at` and `created_at` for legacy shapes.
- Change `backend/routes/fares.py` so `build_fares_for_area` always returns every active vehicle type when area pricing is partial, logging a warning and populating missing rows with `DEFAULT_FARE` values instead of skipping them.
- Add `backend/tests/test_admin_drivers_expiring.py` to assert the expiring-documents endpoint filters on `ride_completed_at`, and extend `backend/tests/test_fares.py` with `test_build_fares_for_area_includes_unpriced_vehicle_types_with_defaults` to guard the fare fallback behavior.

### Testing
- Ran python static-check compile: `python -m py_compile backend/routes/admin/drivers.py backend/tests/test_admin_drivers_expiring.py` and `python -m py_compile backend/routes/fares.py backend/tests/test_fares.py`, which succeeded.
- Attempted to run the new tests with `pytest` (for example `cd backend && PYENV_VERSION=3.12.13 python -m pytest tests/test_admin_drivers_expiring.py --no-cov`), but execution was blocked locally by a missing `httpx` dependency in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dabcebda0833080b6c7aa78016279)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
