### PR TITLE
Migrate Places proxy to Google Places API (New) and adapt clients/budgeting

### DIFF
--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -239,13 +239,13 @@ export default function SettingsPage() {
                         <Separator />
                         <CardContent className="pt-4 space-y-4">
                             <p className="text-xs text-muted-foreground">
-                                Used by the backend proxy for Places autocomplete, geocoding, and
-                                route distance/duration, and driver ETA ranking. Restrict the key to
-                                these five APIs in GCP Console: <strong>Maps JavaScript API</strong>,{" "}
-                                <strong>Places API</strong>, <strong>Geocoding API</strong>,{" "}
-                                <strong>Directions API</strong>, and{" "}
-                                <strong>Distance Matrix API</strong>. Omitting Distance Matrix causes
-                                ETA-based driver ranking to fall back to straight-line distance.
+                                Used by the backend proxy for Places autocomplete, geocoding,
+                                route distance/duration, driver ETA ranking, and static map images.
+                                Restrict the key to these APIs in GCP Console: <strong>Places API (New)</strong>,{" "}
+                                <strong>Geocoding API</strong>, <strong>Directions API</strong>,{" "}
+                                <strong>Distance Matrix API</strong>, and <strong>Maps Static API</strong>.
+                                Omitting Distance Matrix causes ETA-based driver ranking to fall back
+                                to straight-line distance.
                             </p>
                             <div className="space-y-2">
                                 <Label>API Key</Label>

--- a/admin-dashboard/src/hooks/usePlacesAutocomplete.ts
+++ b/admin-dashboard/src/hooks/usePlacesAutocomplete.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { adminPlacesAutocomplete, type AdminPlaceBias } from "@/lib/api";
 
 const DEBOUNCE_MS = 300;
-const MIN_QUERY_LEN = 2;
+const MIN_QUERY_LEN = 3;
 
 interface Prediction {
     place_id: string;
@@ -54,7 +54,8 @@ export function usePlacesAutocomplete(
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
-        if (!input || input.length < MIN_QUERY_LEN) {
+        const searchInput = input.trim();
+        if (searchInput.length < MIN_QUERY_LEN) {
             setPredictions([]);
             setLoading(false);
             return;
@@ -65,7 +66,7 @@ export function usePlacesAutocomplete(
         debounceRef.current = setTimeout(async () => {
             setLoading(true);
             try {
-                const data = await adminPlacesAutocomplete(input, sessionToken, bias ?? null);
+                const data = await adminPlacesAutocomplete(searchInput, sessionToken, bias ?? null);
                 if (mySeq !== seqRef.current) return;
                 setPredictions(data?.predictions ?? []);
             } catch {

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -15,6 +15,16 @@ try:
     from ...settings_loader import get_app_settings
     from ...socket_manager import manager
     from ...utils.audit_logger import log_admin_action
+    from ...utils.google_places_new import (
+        PLACES_NEW_AUTOCOMPLETE_FIELD_MASK,
+        PLACES_NEW_AUTOCOMPLETE_URL,
+        PLACES_NEW_DETAILS_FIELD_MASK,
+        build_autocomplete_payload,
+        legacy_details_from_new_response,
+        legacy_predictions_from_new_response,
+        places_new_details_url,
+        places_new_headers,
+    )
     from ...utils.insurance_periods import record_period_transition
     from ...utils.rate_limiter import default_limiter as limiter
 except ImportError:
@@ -25,6 +35,16 @@ except ImportError:
     from settings_loader import get_app_settings
     from socket_manager import manager
     from utils.audit_logger import log_admin_action
+    from utils.google_places_new import (
+        PLACES_NEW_AUTOCOMPLETE_FIELD_MASK,
+        PLACES_NEW_AUTOCOMPLETE_URL,
+        PLACES_NEW_DETAILS_FIELD_MASK,
+        build_autocomplete_payload,
+        legacy_details_from_new_response,
+        legacy_predictions_from_new_response,
+        places_new_details_url,
+        places_new_headers,
+    )
     from utils.insurance_periods import record_period_transition
     from utils.rate_limiter import default_limiter as limiter
 
@@ -448,15 +468,14 @@ async def admin_places_autocomplete(
     radius: int = Query(default=50000, ge=1000, le=100000),
     admin_user: dict = Depends(get_admin_user),
 ):
-    """Proxy Google Maps Places Autocomplete API to avoid exposing key to browser.
+    """Proxy Google Places API (New) Autocomplete to avoid exposing key to browser.
 
-    Pass session_token to bundle N autocomplete + 1 details call into one billing session
-    ($0.017 flat vs per-call). Generate one UUID per user typing session on the client.
+    Pass session_token to group autocomplete calls with the final details call. Generate one UUID per user typing session on the client.
 
-    Pass ``location`` ("lat,lng") + ``radius`` (meters, default 50 km) to bias
+    Pass ``location`` ("lat,lng") + ``radius`` (meters, default 50 km) to restrict
     results to a point — typically the admin's geolocation or the ride's pickup —
-    so a search like "Walmart" returns the nearest stores first instead of
-    matches across Canada. Soft bias: distant well-known places still appear.
+    so a search like "Walmart" returns nearby stores instead of matches across
+    Canada.
     Mirrors ``routes/maps_proxy.py:places_autocomplete``.
     """
     import httpx
@@ -466,30 +485,23 @@ async def admin_places_autocomplete(
     if not api_key:
         raise HTTPException(status_code=503, detail="Google Maps API key not configured")
 
-    url = "https://maps.googleapis.com/maps/api/place/autocomplete/json"
-    params: dict = {
-        "input": input,
-        "key": api_key,
-        "language": "en",
-        "components": "country:ca",
-    }
-    if session_token:
-        params["sessiontoken"] = session_token
-    if location:
-        params["location"] = location
-        params["radius"] = str(radius)
-        params["origin"] = location
+    payload = build_autocomplete_payload(input, session_token, location, radius)
 
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(url, params=params)
+            resp = await client.post(
+                PLACES_NEW_AUTOCOMPLETE_URL,
+                headers=places_new_headers(api_key, PLACES_NEW_AUTOCOMPLETE_FIELD_MASK),
+                json=payload,
+            )
+            resp.raise_for_status()
             data = resp.json()
-            if data.get("status") not in ("OK", "ZERO_RESULTS"):
-                logger.error(f"Places autocomplete API error: {data.get('status')}")
-                raise HTTPException(status_code=502, detail="Places API error")
-            return {"predictions": data.get("predictions", [])}
+            return {"predictions": legacy_predictions_from_new_response(data)}
     except HTTPException:
         raise
+    except httpx.HTTPStatusError as e:
+        logger.error("Places autocomplete(new) API error: %s", e.response.text[:500])
+        raise HTTPException(status_code=502, detail="Places API error") from e
     except Exception as e:
         logger.error(f"Failed to call Places autocomplete API: {e}")
         raise HTTPException(status_code=502, detail="Failed to call Places API") from e
@@ -503,9 +515,9 @@ async def admin_places_details(
     session_token: Optional[str] = None,
     admin_user: dict = Depends(get_admin_user),
 ):
-    """Proxy Google Maps Place Details API to get lat/lng.
+    """Proxy Google Places API (New) Place Details to get lat/lng.
 
-    Pass the same session_token used for autocomplete to close the billing session.
+    Pass the same session_token used for autocomplete to close the session.
     """
     import httpx
 
@@ -514,31 +526,24 @@ async def admin_places_details(
     if not api_key:
         raise HTTPException(status_code=503, detail="Google Maps API key not configured")
 
-    url = "https://maps.googleapis.com/maps/api/place/details/json"
-    params: dict = {
-        "place_id": place_id,
-        "fields": "geometry,formatted_address",
-        "key": api_key,
-    }
+    params: dict = {}
     if session_token:
-        params["sessiontoken"] = session_token
+        params["sessionToken"] = session_token
 
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.get(url, params=params)
-            data = resp.json()
-            if data.get("status") != "OK":
-                logger.error(f"Places details API error: {data.get('status')}")
-                raise HTTPException(status_code=502, detail="Places API error")
-
-            loc = data.get("result", {}).get("geometry", {}).get("location", {})
-            return {
-                "lat": loc.get("lat"),
-                "lng": loc.get("lng"),
-                "formatted_address": data.get("result", {}).get("formatted_address"),
-            }
+            resp = await client.get(
+                places_new_details_url(place_id),
+                headers=places_new_headers(api_key, PLACES_NEW_DETAILS_FIELD_MASK),
+                params=params,
+            )
+            resp.raise_for_status()
+            return legacy_details_from_new_response(resp.json())
     except HTTPException:
         raise
+    except httpx.HTTPStatusError as e:
+        logger.error("Places details(new) API error: %s", e.response.text[:500])
+        raise HTTPException(status_code=502, detail="Places API error") from e
     except Exception as e:
         logger.error(f"Failed to call Places details API: {e}")
         raise HTTPException(status_code=502, detail="Failed to call Places API") from e

--- a/backend/routes/maps_proxy.py
+++ b/backend/routes/maps_proxy.py
@@ -11,7 +11,8 @@ Endpoints (mounted at ``/api/v1/maps/*``):
 - ``GET /maps/places/details?place_id=&session_token=`` — finalise a session
 - ``GET /maps/reverse-geocode?lat=&lng=`` — drop-pin → address
 
-Cost shape: with session tokens, N autocomplete + 1 details = $0.017 flat.
+Cost shape: Places API (New) bills autocomplete requests and the final
+Place Details Essentials call separately when a user selects a prediction.
 Reverse-geocode hits a 24h Redis cache keyed by 4-decimal lat/lng (~11m).
 
 All endpoints require an authenticated rider/driver. The Maps key is read
@@ -30,12 +31,32 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 try:
     from ..dependencies import get_current_user
     from ..settings_loader import get_app_settings
+    from ..utils.google_places_new import (
+        PLACES_NEW_AUTOCOMPLETE_FIELD_MASK,
+        PLACES_NEW_AUTOCOMPLETE_URL,
+        PLACES_NEW_DETAILS_FIELD_MASK,
+        build_autocomplete_payload,
+        legacy_details_from_new_response,
+        legacy_predictions_from_new_response,
+        places_new_details_url,
+        places_new_headers,
+    )
     from ..utils.maps_budget import check_budget, record_call
     from ..utils.rate_limiter import default_limiter as limiter
     from ..utils.redis_client import redis_get, redis_set
 except ImportError:  # pragma: no cover - dual import path
     from dependencies import get_current_user  # type: ignore
     from settings_loader import get_app_settings  # type: ignore
+    from utils.google_places_new import (  # type: ignore
+        PLACES_NEW_AUTOCOMPLETE_FIELD_MASK,
+        PLACES_NEW_AUTOCOMPLETE_URL,
+        PLACES_NEW_DETAILS_FIELD_MASK,
+        build_autocomplete_payload,
+        legacy_details_from_new_response,
+        legacy_predictions_from_new_response,
+        places_new_details_url,
+        places_new_headers,
+    )
     from utils.maps_budget import check_budget, record_call  # type: ignore
     from utils.rate_limiter import default_limiter as limiter  # type: ignore
     from utils.redis_client import redis_get, redis_set  # type: ignore
@@ -82,58 +103,44 @@ async def places_autocomplete(
     radius: int = Query(default=50000, ge=1000, le=100000),
     current_user: dict = Depends(get_current_user),
 ):
-    """Proxy Places Autocomplete. Pass session_token to bundle billing."""
+    """Proxy Places API (New) Autocomplete using session_token when present."""
     await _ensure_budget()
     api_key = await _maps_key()
 
-    params: dict = {
-        "input": input,
-        "key": api_key,
-        "language": "en",
-        "components": "country:ca",
-    }
-    if session_token:
-        params["sessiontoken"] = session_token
-
-    if location:
-        # Strict bias: only return results inside the radius around the rider's
-        # location. For ride-sharing this is what users want — they're searching
-        # for pickup/dropoff in their city, not browsing places nation-wide.
-        # Without strictbounds, brand searches like "Walmart" return matches from
-        # all over Canada ranked above the local store.
-        params["location"] = location
-        params["radius"] = str(radius)
-        params["origin"] = location
-        params["strictbounds"] = "true"
+    payload = build_autocomplete_payload(input, session_token, location, radius)
 
     logger.info(
-        "[maps_proxy] autocomplete input=%r location=%s radius=%s strictbounds=%s",
+        "[maps_proxy] autocomplete(new) input=%r location=%s radius=%s restricted=%s",
         input,
-        params.get("location", "(none)"),
-        params.get("radius", "(none)"),
-        params.get("strictbounds", "false"),
+        location or "(none)",
+        radius if location else "(none)",
+        bool(location),
     )
 
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            resp = await client.get(
-                "https://maps.googleapis.com/maps/api/place/autocomplete/json",
-                params=params,
+            resp = await client.post(
+                PLACES_NEW_AUTOCOMPLETE_URL,
+                headers=places_new_headers(api_key, PLACES_NEW_AUTOCOMPLETE_FIELD_MASK),
+                json=payload,
             )
+            resp.raise_for_status()
             data = resp.json()
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "[maps_proxy] autocomplete(new) API error: %s",
+            e.response.text[:500],
+        )
+        raise HTTPException(status_code=502, detail="Places API error") from e
     except Exception as e:
-        logger.error("[maps_proxy] autocomplete request failed: %s", e)
+        logger.error("[maps_proxy] autocomplete(new) request failed: %s", e)
         raise HTTPException(status_code=502, detail="Failed to call Places API") from e
 
-    status = data.get("status")
-    if status not in ("OK", "ZERO_RESULTS"):
-        logger.error("[maps_proxy] autocomplete API error: %s", status)
-        raise HTTPException(status_code=502, detail="Places API error")
+    # Places API (New) bills autocomplete requests individually for sessions
+    # ending in Place Details Essentials, so record each proxied request.
+    await record_call("autocomplete")
 
-    # Bill as session-priced when client opted in, per-keystroke otherwise.
-    await record_call("autocomplete_session" if session_token else "autocomplete")
-
-    predictions = data.get("predictions", [])
+    predictions = legacy_predictions_from_new_response(data)
 
     logger.info(
         "[maps_proxy] autocomplete results=%d top=%s",
@@ -167,41 +174,29 @@ async def places_details(
     await _ensure_budget()
     api_key = await _maps_key()
 
-    params: dict = {
-        "place_id": place_id,
-        "fields": "geometry,formatted_address",
-        "key": api_key,
-    }
+    params: dict = {}
     if session_token:
-        params["sessiontoken"] = session_token
+        params["sessionToken"] = session_token
 
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
             resp = await client.get(
-                "https://maps.googleapis.com/maps/api/place/details/json",
+                places_new_details_url(place_id),
+                headers=places_new_headers(api_key, PLACES_NEW_DETAILS_FIELD_MASK),
                 params=params,
             )
+            resp.raise_for_status()
             data = resp.json()
+    except httpx.HTTPStatusError as e:
+        logger.error("[maps_proxy] details(new) API error: %s", e.response.text[:500])
+        raise HTTPException(status_code=502, detail="Places API error") from e
     except Exception as e:
-        logger.error("[maps_proxy] details request failed: %s", e)
+        logger.error("[maps_proxy] details(new) request failed: %s", e)
         raise HTTPException(status_code=502, detail="Failed to call Places API") from e
 
-    if data.get("status") != "OK":
-        logger.error("[maps_proxy] details API error: %s", data.get("status"))
-        raise HTTPException(status_code=502, detail="Places API error")
+    await record_call("details")
 
-    # When session_token is set, billing is bundled into the autocomplete_session
-    # tier already recorded — no further record needed. Without a session token
-    # this is a per-call Place Details bill.
-    if not session_token:
-        await record_call("details")
-
-    loc = data.get("result", {}).get("geometry", {}).get("location", {})
-    return {
-        "lat": loc.get("lat"),
-        "lng": loc.get("lng"),
-        "formatted_address": data.get("result", {}).get("formatted_address"),
-    }
+    return legacy_details_from_new_response(data)
 
 
 @api_router.get("/reverse-geocode")

--- a/backend/tests/test_maps_proxy.py
+++ b/backend/tests/test_maps_proxy.py
@@ -1,7 +1,7 @@
 """Tests for the rider-facing Google Maps proxy.
 
 Covers the cost-control contracts that justify the proxy's existence:
-  - session-token aware billing (the May 2026 overage fix)
+  - Places API (New) autocomplete/details billing
   - reverse-geocode Redis cache (avoids paying for repeat lookups)
   - daily-budget circuit breaker (defence in depth on top of GCP budget alerts)
 
@@ -67,24 +67,25 @@ async def test_check_budget_allows_under_threshold(mock_redis, monkeypatch):
     from utils import maps_budget
 
     monkeypatch.setattr(maps_budget, "_daily_budget_usd", lambda: 1.0)
-    await maps_budget.record_call("autocomplete_session")
+    await maps_budget.record_call("details")
 
     allowed, _, _ = await maps_budget.check_budget()
     assert allowed is True
 
 
-# ── route-level: session-token billing ────────────────────────────────────────
+# ── route-level: Places API (New) proxy/billing ──────────────────────────────
 
 
 def _mock_httpx_response(payload: dict) -> MagicMock:
     """Build an httpx-like response object for unit testing."""
     resp = MagicMock()
     resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
     return resp
 
 
 @pytest.mark.anyio
-async def test_autocomplete_records_session_when_token_passed(mock_redis, monkeypatch):
+async def test_autocomplete_uses_new_api_and_records_per_request_when_token_passed(mock_redis, monkeypatch):
     from routes import maps_proxy
     from utils import maps_budget
 
@@ -93,8 +94,24 @@ async def test_autocomplete_records_session_when_token_passed(mock_redis, monkey
     mock_client = MagicMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.get = AsyncMock(
-        return_value=_mock_httpx_response({"status": "OK", "predictions": [{"description": "X"}]})
+    mock_client.post = AsyncMock(
+        return_value=_mock_httpx_response(
+            {
+                "suggestions": [
+                    {
+                        "placePrediction": {
+                            "placeId": "ChIJ_123",
+                            "text": {"text": "123 Main St, Regina, SK, Canada"},
+                            "structuredFormat": {
+                                "mainText": {"text": "123 Main St"},
+                                "secondaryText": {"text": "Regina, SK, Canada"},
+                            },
+                            "distanceMeters": 42,
+                        }
+                    }
+                ]
+            }
+        )
     )
 
     with patch("routes.maps_proxy.httpx.AsyncClient", return_value=mock_client):
@@ -105,10 +122,26 @@ async def test_autocomplete_records_session_when_token_passed(mock_redis, monkey
             current_user={"id": "rider_1"},
         )
 
-    assert result == {"predictions": [{"description": "X"}]}
-    # Cost recorded against the session-priced bucket, not the per-call bucket.
+    assert result == {
+        "predictions": [
+            {
+                "place_id": "ChIJ_123",
+                "description": "123 Main St, Regina, SK, Canada",
+                "structured_formatting": {
+                    "main_text": "123 Main St",
+                    "secondary_text": "Regina, SK, Canada",
+                },
+                "distance_meters": 42,
+            }
+        ]
+    }
+    mock_client.post.assert_awaited_once()
+    _, kwargs = mock_client.post.await_args
+    assert kwargs["json"]["sessionToken"] == "abc-uuid"
+    assert kwargs["headers"]["X-Goog-FieldMask"]
+    # Places API (New) bills this Essentials-terminating flow per autocomplete request.
     spent = await maps_budget.estimate_today_usd()
-    assert spent == pytest.approx(0.017, rel=0.01)
+    assert spent == pytest.approx(0.00283, rel=0.01)
 
 
 @pytest.mark.anyio
@@ -121,7 +154,7 @@ async def test_autocomplete_records_per_call_without_token(mock_redis, monkeypat
     mock_client = MagicMock()
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
-    mock_client.get = AsyncMock(return_value=_mock_httpx_response({"status": "OK", "predictions": []}))
+    mock_client.post = AsyncMock(return_value=_mock_httpx_response({"suggestions": []}))
 
     with patch("routes.maps_proxy.httpx.AsyncClient", return_value=mock_client):
         await maps_proxy.places_autocomplete(
@@ -132,12 +165,12 @@ async def test_autocomplete_records_per_call_without_token(mock_redis, monkeypat
         )
 
     spent = await maps_budget.estimate_today_usd()
-    # Per-call autocomplete is $0.00283; never $0.017.
+    # Per-call autocomplete is $0.00283; never the legacy $0.017 session rate.
     assert spent == pytest.approx(0.00283, rel=0.01)
 
 
 @pytest.mark.anyio
-async def test_details_does_not_double_bill_when_session_token_used(mock_redis, monkeypatch):
+async def test_details_uses_new_api_and_records_essentials_charge(mock_redis, monkeypatch):
     from routes import maps_proxy
     from utils import maps_budget
 
@@ -149,27 +182,27 @@ async def test_details_does_not_double_bill_when_session_token_used(mock_redis, 
     mock_client.get = AsyncMock(
         return_value=_mock_httpx_response(
             {
-                "status": "OK",
-                "result": {
-                    "geometry": {"location": {"lat": 52.1, "lng": -106.6}},
-                    "formatted_address": "123 Main St",
-                },
+                "location": {"latitude": 52.1, "longitude": -106.6},
+                "formattedAddress": "123 Main St",
             }
         )
     )
 
     with patch("routes.maps_proxy.httpx.AsyncClient", return_value=mock_client):
-        await maps_proxy.places_details(
+        result = await maps_proxy.places_details(
             request=_fake_request(),
             place_id="ChIJ_123",
             session_token="abc-uuid",
             current_user={"id": "rider_1"},
         )
 
-    # Session-bundled details are billed via the autocomplete_session line; this
-    # call must not record an additional `details` charge.
+    assert result == {"lat": 52.1, "lng": -106.6, "formatted_address": "123 Main St"}
+    mock_client.get.assert_awaited_once()
+    _, kwargs = mock_client.get.await_args
+    assert kwargs["params"] == {"sessionToken": "abc-uuid"}
+    assert kwargs["headers"]["X-Goog-FieldMask"] == "location,formattedAddress"
     spent = await maps_budget.estimate_today_usd()
-    assert spent == 0.0
+    assert spent == pytest.approx(0.005, rel=0.01)
 
 
 # ── route-level: reverse-geocode caching ──────────────────────────────────────
@@ -240,7 +273,7 @@ async def test_autocomplete_503s_when_budget_exhausted(mock_redis, monkeypatch):
 
     # Pin budget tiny and pre-spend over it.
     monkeypatch.setattr(maps_budget, "_daily_budget_usd", lambda: 0.001)
-    await maps_budget.record_call("autocomplete_session")  # 0.017 spent
+    await maps_budget.record_call("autocomplete")  # 0.00283 spent
 
     monkeypatch.setattr(maps_proxy, "_maps_key", AsyncMock(return_value="dummy_key"))
 

--- a/backend/utils/google_places_new.py
+++ b/backend/utils/google_places_new.py
@@ -1,0 +1,143 @@
+"""Helpers for proxying Google Places API (New) while preserving legacy responses."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import HTTPException
+
+PLACES_NEW_AUTOCOMPLETE_URL = "https://places.googleapis.com/v1/places:autocomplete"
+PLACES_NEW_DETAILS_BASE_URL = "https://places.googleapis.com/v1/places"
+
+# Keep autocomplete in the lower-cost request tier by asking only for fields the
+# mobile/admin UIs already render, then translate those fields back to the legacy
+# response shape expected by the clients.
+PLACES_NEW_AUTOCOMPLETE_FIELD_MASK = ",".join(
+    [
+        "suggestions.placePrediction.placeId",
+        "suggestions.placePrediction.text.text",
+        "suggestions.placePrediction.structuredFormat.mainText.text",
+        "suggestions.placePrediction.structuredFormat.secondaryText.text",
+        "suggestions.placePrediction.types",
+        "suggestions.placePrediction.distanceMeters",
+    ]
+)
+
+# Essentials fields only: enough for our pickup/dropoff coordinates and label.
+PLACES_NEW_DETAILS_FIELD_MASK = "location,formattedAddress"
+
+
+def places_new_headers(api_key: str, field_mask: str) -> dict[str, str]:
+    return {
+        "Content-Type": "application/json",
+        "X-Goog-Api-Key": api_key,
+        "X-Goog-FieldMask": field_mask,
+    }
+
+
+def _parse_location(location: str) -> tuple[float, float]:
+    try:
+        lat_raw, lng_raw = location.split(",", 1)
+        lat = float(lat_raw)
+        lng = float(lng_raw)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail="location must be formatted as 'lat,lng'",
+        ) from exc
+
+    if not (-90 <= lat <= 90 and -180 <= lng <= 180):
+        raise HTTPException(
+            status_code=400,
+            detail="location latitude/longitude out of range",
+        )
+    return lat, lng
+
+
+def build_autocomplete_payload(
+    input_text: str,
+    session_token: Optional[str],
+    location: Optional[str],
+    radius: int,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "input": input_text,
+        "languageCode": "en",
+        "includedRegionCodes": ["ca"],
+    }
+    if session_token:
+        payload["sessionToken"] = session_token
+
+    if location:
+        lat, lng = _parse_location(location)
+        center = {"latitude": lat, "longitude": lng}
+        # Places API (New) caps circular locationRestriction radius at 50km.
+        new_api_radius = min(float(radius), 50000.0)
+        payload["locationRestriction"] = {
+            "circle": {
+                "center": center,
+                "radius": new_api_radius,
+            }
+        }
+        payload["origin"] = center
+
+    return payload
+
+
+def _text_value(value: Any) -> Optional[str]:
+    if isinstance(value, dict):
+        text = value.get("text")
+        return text if isinstance(text, str) and text else None
+    return None
+
+
+def _legacy_prediction(place_prediction: dict[str, Any]) -> Optional[dict[str, Any]]:
+    place_id = place_prediction.get("placeId")
+    if not place_id:
+        return None
+
+    description = _text_value(place_prediction.get("text")) or ""
+    structured = place_prediction.get("structuredFormat") or {}
+    main_text = _text_value(structured.get("mainText")) or description
+    secondary_text = _text_value(structured.get("secondaryText"))
+
+    legacy: dict[str, Any] = {
+        "place_id": place_id,
+        "description": description or main_text,
+        "structured_formatting": {
+            "main_text": main_text,
+        },
+    }
+    if secondary_text:
+        legacy["structured_formatting"]["secondary_text"] = secondary_text
+    if isinstance(place_prediction.get("types"), list):
+        legacy["types"] = place_prediction["types"]
+    if place_prediction.get("distanceMeters") is not None:
+        legacy["distance_meters"] = place_prediction["distanceMeters"]
+    return legacy
+
+
+def legacy_predictions_from_new_response(data: dict[str, Any]) -> list[dict[str, Any]]:
+    predictions: list[dict[str, Any]] = []
+    for suggestion in data.get("suggestions", []):
+        place_prediction = suggestion.get("placePrediction") if isinstance(suggestion, dict) else None
+        if not isinstance(place_prediction, dict):
+            continue
+        legacy = _legacy_prediction(place_prediction)
+        if legacy:
+            predictions.append(legacy)
+    return predictions
+
+
+def places_new_details_url(place_id: str) -> str:
+    normalized = place_id.removeprefix("places/")
+    return f"{PLACES_NEW_DETAILS_BASE_URL}/{normalized}"
+
+
+def legacy_details_from_new_response(data: dict[str, Any]) -> dict[str, Any]:
+    loc = data.get("location") or {}
+    return {
+        "lat": loc.get("latitude"),
+        "lng": loc.get("longitude"),
+        "formatted_address": data.get("formattedAddress"),
+    }

--- a/backend/utils/maps_budget.py
+++ b/backend/utils/maps_budget.py
@@ -37,13 +37,14 @@ logger = logging.getLogger(__name__)
 
 Sku = Literal["autocomplete", "autocomplete_session", "details", "geocode"]
 
-# USD per call. Source: Google Maps Platform pricing 2025.
-# autocomplete_session is the per-session flat rate (covers N autocomplete
-# requests + 1 details call when the same session token is passed).
+# USD per call. Source: Google Maps Platform pricing 2026.
+# Places API (New) charges autocomplete requests separately for sessions that
+# terminate in Place Details Essentials; `autocomplete_session` remains for
+# historical counters that may still exist in today's Redis bucket.
 _PRICE_USD: dict[Sku, float] = {
     "autocomplete": 0.00283,
     "autocomplete_session": 0.017,
-    "details": 0.017,
+    "details": 0.005,
     "geocode": 0.005,
 }
 

--- a/driver-app/app/driver/addresses.tsx
+++ b/driver-app/app/driver/addresses.tsx
@@ -30,8 +30,8 @@ interface AutocompletePrediction {
 }
 
 /** Geocode a free-text address into {lat, lng} via the backend Places proxy.
- *  Uses one Places billing session (autocomplete → details = $0.017 flat)
- *  instead of a direct Geocoding API call. Falls back to null on no result. */
+ *  Uses one Places API (New) autocomplete → details session instead of a
+ *  direct Geocoding API call. Falls back to null on no result. */
 async function geocodeAddress(address: string): Promise<{ lat: number; lng: number } | null> {
     const sessionToken = newPlacesSessionToken();
     try {

--- a/shared/hooks/usePlacesAutocomplete.ts
+++ b/shared/hooks/usePlacesAutocomplete.ts
@@ -21,7 +21,7 @@ import { buildPlacesQuery, type PlaceBias, type PlacePrediction } from '@shared/
 import { newPlacesSessionToken } from '@shared/utils/placesSession';
 
 const DEBOUNCE_MS = 300;
-const MIN_QUERY_LEN = 2;
+const MIN_QUERY_LEN = 3;
 
 export interface UsePlacesAutocompleteResult {
   predictions: PlacePrediction[];
@@ -46,7 +46,8 @@ export function usePlacesAutocomplete(
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (!input || input.length < MIN_QUERY_LEN) {
+    const searchInput = input.trim();
+    if (searchInput.length < MIN_QUERY_LEN) {
       setPredictions([]);
       setLoading(false);
       return;
@@ -58,7 +59,7 @@ export function usePlacesAutocomplete(
     debounceRef.current = setTimeout(async () => {
       setLoading(true);
       try {
-        const query = buildPlacesQuery(input, sessionTokenRef.current, bias ?? null);
+        const query = buildPlacesQuery(searchInput, sessionTokenRef.current, bias ?? null);
         const params = new URLSearchParams();
         params.set('input', query.input);
         params.set('session_token', query.session_token);

--- a/shared/utils/placesSession.ts
+++ b/shared/utils/placesSession.ts
@@ -2,9 +2,9 @@
  * Google Places API session-token helper.
  *
  * One token per "user typing session" — N autocomplete requests + 1 details
- * lookup billed as a single $0.017 session instead of per-call. Regenerate
- * the token after closing a session (i.e. after a successful place details
- * call) to start the next session.
+ * lookup grouped for Google Places API (New) session pricing. Regenerate the
+ * token after closing a session (i.e. after a successful place details call)
+ * to start the next session.
  *
  * Not cryptographically sensitive — Google only requires opacity, not entropy.
  *


### PR DESCRIPTION
### Motivation

- Move Maps proxy and clients to the Google Places API (New) to use the updated endpoints and field-masking model while preserving the legacy response shape for existing callers. 
- Update billing bookkeeping to reflect the Places API (New) pricing and ensure per-request recording for autocomplete/details. 
- Improve client-side behavior by trimming inputs and raising the minimum query length to reduce noisy short queries.

### Description

- Added `backend/utils/google_places_new.py` with helpers to build the new API payloads, translate new responses into the legacy shape, and emit `X-Goog-FieldMask`/API-key headers. 
- Replaced legacy Places REST calls in `backend/routes/maps_proxy.py` and `backend/routes/admin/rides.py` to call the new Places endpoints (POST autocomplete, new details URL) and to use the helpers for payloads, headers, and translation. 
- Updated maps budgeting in `backend/utils/maps_budget.py` to reflect 2026 pricing (`autocomplete` 0.00283, `details` 0.005) and to retain the historical `autocomplete_session` SKU for compatibility. 
- Adjusted recording logic to always `record_call` for proxied requests under the new API semantics and added HTTP status error logging/translation. 
- Tightened client-side hooks and usage: trimmed input and raised `MIN_QUERY_LEN` from 2 to 3 in `shared/hooks/usePlacesAutocomplete.ts` and `admin-dashboard/src/hooks/usePlacesAutocomplete.ts`, and pass trimmed input into backend calls. 
- Minor text updates to admin dashboard and driver app docs to reflect the new API and the addition of static maps mention. 
- Updated `backend/tests/test_maps_proxy.py` to mock the new API shapes, assert header/payload contents, and validate updated budget accounting.

### Testing

- Ran unit tests in `backend/tests/test_maps_proxy.py` which were updated to the new API shapes and assertions, and they passed. 
- Ran the maps budget unit tests (`utils.maps_budget` related tests) and they passed with the adjusted SKU pricing. 
- All modified automated tests completed successfully (no failing tests observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dbf5bb6f48330a19f0f7c19bd2df0)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
