### PR TITLE
Use polygon fallback for service-area checks in rides (fix geofence false negatives)

### DIFF
--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -226,6 +226,29 @@ async def _fetch_directions_polyline(
         return None
 
 
+async def _get_active_service_area_for_point(
+    lat: float,
+    lng: float,
+    active_areas: List[dict],
+) -> Optional[dict]:
+    """Return an active service area containing a point.
+
+    Prefer the PostGIS RPC when its area geography column is populated, but
+    fall back to the JSON/GeoJSON polygon column used by the admin dashboard.
+    Some production rows have polygon coverage without a synced geography value;
+    the fallback keeps estimate geofence checks aligned with what admins see.
+    """
+    matched_area = await db_supabase.get_service_area_for_point(lat, lng)
+    if matched_area and matched_area.get("is_active", True) is not False:
+        return matched_area
+
+    for area in active_areas or []:
+        poly = get_service_area_polygon(area)
+        if poly and point_in_polygon(lat, lng, poly):
+            return area
+    return None
+
+
 async def _require_ride_in_state_rider(ride_id: str, rider_id: str, allowed_states: tuple) -> dict:
     """Load a rider's ride only if it is in one of allowed_states.
 
@@ -1279,19 +1302,13 @@ async def estimate_ride(
     # so calculate_all_fees doesn't re-fetch service_areas N times.
     _est_all_areas = await db_supabase.get_rows("service_areas", {"is_active": True}, limit=500)
 
-    # Use PostGIS RPC for geofence checks — the capped list above is for fee
-    # resolution only and must not be treated as authoritative for coverage.
-    _est_matched_area = await db_supabase.get_service_area_for_point(body.pickup_lat, body.pickup_lng)
-    if _est_matched_area is None and _est_all_areas:
-        _est_matched_area = next(
-            (
-                a
-                for a in _est_all_areas
-                if get_service_area_polygon(a)
-                and point_in_polygon(body.pickup_lat, body.pickup_lng, get_service_area_polygon(a))
-            ),
-            None,
-        )
+    # Use PostGIS RPC for geofence checks, with a JSON/GeoJSON polygon
+    # fallback for service-area rows whose geography column is not synced.
+    _est_matched_area = await _get_active_service_area_for_point(
+        body.pickup_lat,
+        body.pickup_lng,
+        _est_all_areas,
+    )
     if _est_matched_area:
         logger.info(
             "[estimate] matched service area '%s' for fees",
@@ -1305,10 +1322,9 @@ async def estimate_ride(
         )
 
     # Geofence gates — pickup, dropoff, and every stop must be inside an
-    # active service area before we show prices. Uses PostGIS point lookup
-    # so the check is authoritative regardless of how many areas exist.
-    # Fail-open when the RPC returns None AND no areas are configured (DB
-    # outage or fresh install).
+    # active service area before we show prices. The lookup combines PostGIS
+    # with the admin-visible polygon JSON fallback above. Fail-open when no
+    # active areas are configured (DB outage or fresh install).
     if _est_all_areas:
         if _est_matched_area is None:
             raise HTTPException(
@@ -1321,7 +1337,11 @@ async def estimate_ride(
                     ),
                 },
             )
-        _dropoff_area = await db_supabase.get_service_area_for_point(body.dropoff_lat, body.dropoff_lng)
+        _dropoff_area = await _get_active_service_area_for_point(
+            body.dropoff_lat,
+            body.dropoff_lng,
+            _est_all_areas,
+        )
         if _dropoff_area is None:
             logger.info(
                 "[estimate] reject dropoff=(%.5f,%.5f) — outside service areas",
@@ -1342,7 +1362,7 @@ async def estimate_ride(
             s_lat, s_lng = stop.get("lat"), stop.get("lng")
             if s_lat is None or s_lng is None:
                 continue
-            _stop_area = await db_supabase.get_service_area_for_point(s_lat, s_lng)
+            _stop_area = await _get_active_service_area_for_point(s_lat, s_lng, _est_all_areas)
             if _stop_area is None:
                 logger.info(
                     "[estimate] reject stop[%d]=(%.5f,%.5f) — outside service areas",
@@ -1746,25 +1766,18 @@ async def create_ride(
         logger.error(f"Failed to fetch service areas: {e}", exc_info=True)
 
     # Resolve the pickup service area once and pass the match downstream.
-    matched_area = await db_supabase.get_service_area_for_point(body.pickup_lat, body.pickup_lng)
-    if matched_area is None and all_areas:
-        matched_area = next(
-            (
-                a
-                for a in all_areas
-                if get_service_area_polygon(a)
-                and point_in_polygon(body.pickup_lat, body.pickup_lng, get_service_area_polygon(a))
-            ),
-            None,
-        )
+    matched_area = await _get_active_service_area_for_point(
+        body.pickup_lat,
+        body.pickup_lng,
+        all_areas,
+    )
     service_area_id = matched_area["id"] if matched_area else None
 
     # Geofence gate: pickup must fall inside an active service area. Without
     # this the request silently dispatches against drivers anywhere on the
     # map, which is what produced the "I'm outside the zone but the app is
-    # still searching for drivers" report. Dropoff is intentionally NOT
-    # checked here — riders frequently travel out of town and we don't want
-    # to block that, but we do require their pickup to be inside coverage.
+    # still searching for drivers" report. Dropoff and intermediate stops are
+    # checked below with the same service-area matcher.
     if matched_area is None and all_areas:
         logger.info(
             "[geofence] reject pickup=(%.5f,%.5f) — outside %d active service area(s)",
@@ -1784,9 +1797,13 @@ async def create_ride(
         )
 
     # Geofence gate: dropoff must also fall inside an active service area.
-    # Uses PostGIS RPC so the check is authoritative regardless of list size.
+    # Uses PostGIS plus the admin-visible polygon JSON fallback.
     if all_areas:
-        _dropoff_area = await db_supabase.get_service_area_for_point(body.dropoff_lat, body.dropoff_lng)
+        _dropoff_area = await _get_active_service_area_for_point(
+            body.dropoff_lat,
+            body.dropoff_lng,
+            all_areas,
+        )
         if _dropoff_area is None:
             logger.info(
                 "[geofence] reject dropoff=(%.5f,%.5f) — outside service areas",
@@ -1810,7 +1827,7 @@ async def create_ride(
             s_lat, s_lng = stop.get("lat"), stop.get("lng")
             if s_lat is None or s_lng is None:
                 continue
-            _stop_area = await db_supabase.get_service_area_for_point(s_lat, s_lng)
+            _stop_area = await _get_active_service_area_for_point(s_lat, s_lng, all_areas)
             if _stop_area is None:
                 logger.info(
                     "[geofence] reject stop[%d]=(%.5f,%.5f) — outside service areas",

--- a/backend/tests/test_coverage_rides.py
+++ b/backend/tests/test_coverage_rides.py
@@ -167,6 +167,7 @@ async def test_estimate_ride_returns_estimates():
         patch("backend.routes.rides.get_app_settings", new_callable=AsyncMock, return_value={}),
     ):
         mock_db.get_rows = AsyncMock(return_value=[])
+        mock_db.get_service_area_for_point = AsyncMock(return_value=None)
 
         result = await estimate_ride(
             body=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
@@ -213,6 +214,7 @@ async def test_estimate_ride_includes_nearby_drivers():
         # First get_rows call fetches service_areas (return empty to skip geofence),
         # second fetches nearby drivers.
         mock_db.get_rows = AsyncMock(side_effect=[[], [nearby_driver]])
+        mock_db.get_service_area_for_point = AsyncMock(return_value=None)
 
         result = await estimate_ride(
             body=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
@@ -221,6 +223,59 @@ async def test_estimate_ride_includes_nearby_drivers():
 
     assert result["estimates"][0]["driver_count"] == 1
     assert result["estimates"][0]["available"] is True
+
+
+@pytest.mark.anyio
+async def test_estimate_ride_allows_dropoff_matched_by_polygon_fallback():
+    """Dropoff geofence should use the same polygon fallback as pickup."""
+    from backend.routes.rides import RideEstimateRequest, estimate_ride
+
+    fake_fares = [
+        {
+            "vehicle_type": {"id": "vt-1", "name": "Standard"},
+            "base_fare": "3.00",
+            "per_km_rate": "1.50",
+            "per_minute_rate": "0.30",
+            "booking_fee": "2.00",
+            "surge_multiplier": "1.0",
+            "minimum_fare": "5.00",
+        }
+    ]
+    active_area = {
+        "id": "area-1",
+        "name": "Polygon Area",
+        "is_active": True,
+        "polygon": [
+            {"lat": 52.0, "lng": -107.0},
+            {"lat": 52.0, "lng": -106.0},
+            {"lat": 53.0, "lng": -106.0},
+            {"lat": 53.0, "lng": -107.0},
+        ],
+    }
+
+    with (
+        patch("backend.routes.rides.validate_ride_location"),
+        patch("backend.routes.rides.calculate_distance", return_value=5.0),
+        patch("backend.routes.rides.get_fares_for_location", new_callable=AsyncMock, return_value=fake_fares),
+        patch("backend.routes.rides.db_supabase") as mock_db,
+        patch("backend.routes.rides.calculate_airport_fee", new_callable=AsyncMock, return_value={"airport_fee": 0.0}),
+        patch("backend.routes.rides.calculate_all_fees", new_callable=AsyncMock, return_value={}),
+        patch("backend.routes.rides.sign_estimate_token", return_value="tok"),
+        patch("backend.routes.rides.get_app_settings", new_callable=AsyncMock, return_value={}),
+    ):
+        # Simulates production rows where the PostGIS geography column is empty
+        # or stale even though the admin-visible polygon contains both points.
+        mock_db.get_service_area_for_point = AsyncMock(return_value=None)
+        mock_db.get_rows = AsyncMock(side_effect=[[active_area], []])
+
+        result = await estimate_ride(
+            body=RideEstimateRequest(pickup_lat=52.1, pickup_lng=-106.6, dropoff_lat=52.2, dropoff_lng=-106.7),
+            current_user=_USER,
+        )
+
+    assert len(result["estimates"]) == 1
+    assert result["estimates"][0]["estimate_token"] == "tok"
+    assert mock_db.get_service_area_for_point.await_count == 2
 
 
 # ── get_active_ride ───────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Fix cases where riders inside an admin-defined polygon were rejected as "outside service area" because the PostGIS geography column was empty or out-of-sync. 
- Keep estimate and create/booking geofence behavior consistent with what operators draw in the admin UI so the rider app no longer shows spurious 400s for valid dropoffs.

### Description
- Add a shared helper `async def _get_active_service_area_for_point(lat, lng, active_areas)` in `backend/routes/rides.py` that prefers the PostGIS RPC and falls back to the JSON/GeoJSON polygon via `get_service_area_polygon` + `point_in_polygon` when needed. 
- Replace direct calls to `db_supabase.get_service_area_for_point(...)` in `estimate_ride` and `create_ride` with the new helper so pickup, dropoff, and intermediate stops use the same fallback logic. 
- Update `backend/tests/test_coverage_rides.py` to mock the RPC-miss scenario and add `test_estimate_ride_allows_dropoff_matched_by_polygon_fallback` which verifies estimates still succeed when PostGIS returns no row but the polygon contains the points. 
- Minor doc/log text adjustments to clarify that geofence checks combine PostGIS + admin polygon fallback.

### Testing
- Ran static compilation with `python -m py_compile backend/routes/rides.py backend/tests/test_coverage_rides.py`, which succeeded. 
- Attempted to run the estimate-related unit tests with `python -m pytest backend/tests/test_coverage_rides.py -k 'estimate_ride'`, but test execution was blocked by a missing test dependency (`httpx`) causing an `ImportError`. 
- Attempted to install test dependencies (`python -m pip install -r backend/requirements.txt`), but package installation was blocked by the environment package index/proxy returning `403 Forbidden` so full test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ddfe6d68c833081d2ffb96d9d06bb)