### PR TITLE
feat: send driver ride offer push notifications

### DIFF
--- a/backend/features.py
+++ b/backend/features.py
@@ -1285,7 +1285,7 @@ async def send_push_notification(
         try:
             from utils.push_retry import enqueue_push
 
-            await enqueue_push(user_id, title, body, data, priority=priority)
+            await enqueue_push(user_id, title, body, data, priority=priority, target_app=target_app)
             return True
         except Exception:
             logger.error("push enqueue failed, falling back to direct send", exc_info=True)

--- a/backend/migrations/117_push_retry_target_app.sql
+++ b/backend/migrations/117_push_retry_target_app.sql
@@ -1,0 +1,9 @@
+-- Migration: 117_push_retry_target_app.sql
+-- Rollback: ALTER TABLE push_retry_queue DROP COLUMN IF EXISTS target_app;
+
+-- Queue rows can now preserve which app surface should receive the push.
+-- This matters for dual-role users who can have separate rider and driver
+-- FCM tokens; dispatch ride offers must target the driver app token.
+ALTER TABLE push_retry_queue
+    ADD COLUMN IF NOT EXISTS target_app text
+        CHECK (target_app IS NULL OR target_app IN ('rider', 'driver'));

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -908,12 +908,22 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
                     if k not in _FCM_SPATIAL_EXCLUDE
                 }
                 fcm_data["deeplink"] = "/driver/"
+                fcm_data["booking_id"] = str(ride_id)
+
+                pickup_label = ride.get("pickup_address") or "Nearby pickup"
+                dropoff_label = ride.get("dropoff_address") or "destination"
+                try:
+                    earnings_label = f"${float(ride.get('driver_earnings') or 0):.2f}"
+                except (TypeError, ValueError):
+                    earnings_label = "New fare"
+
                 await send_push_notification(
                     driver["user_id"],
-                    "New ride request",
-                    f"{ride.get('pickup_address') or 'Nearby pickup'} → {ride.get('dropoff_address') or 'destination'}",
+                    f"{earnings_label} ride offer",
+                    f"Booking {ride_id} • {pickup_label} → {dropoff_label}",
                     fcm_data,
                     priority="dispatch",
+                    target_app="driver",
                 )
             except Exception as e:
                 logger.error(f"[DISPATCH] push failed for driver {driver['user_id']}: {e}", exc_info=True)

--- a/backend/utils/push_retry.py
+++ b/backend/utils/push_retry.py
@@ -32,6 +32,7 @@ async def enqueue_push(
     body: str,
     data: dict | None = None,
     priority: str = "normal",
+    target_app: str | None = None,
 ) -> None:
     """Write a push notification to the retry queue (best-effort).
 
@@ -49,6 +50,7 @@ async def enqueue_push(
                         "body": body,
                         "data": data or {},
                         "priority": priority,
+                        "target_app": target_app,
                     }
                 )
                 .execute()
@@ -80,7 +82,7 @@ async def _tick() -> None:
         resp = await run_sync(
             lambda: (
                 supabase.table("push_retry_queue")
-                .select("*, users!inner(fcm_token)")
+                .select("*, users!inner(fcm_token,fcm_token_rider,fcm_token_driver)")
                 .is_("sent_at", "null")
                 .lte("next_attempt_at", now_iso)
                 .lte("attempts", _MAX_ATTEMPTS - 1)
@@ -110,13 +112,23 @@ async def _process_row(row: dict) -> None:
     body: str = row["body"]
     data: dict = row.get("data") or {}
     attempts: int = row["attempts"]
+    target_app: str | None = row.get("target_app")
 
-    # The join produces a nested dict under the "users" key.
+    # The join produces a nested dict under the "users" key. Prefer the
+    # app-specific token for queued pushes so a dual-role user's driver ride
+    # offer does not get sent to their rider app token (or vice versa).
     user_data = row.get("users") or {}
-    token: str | None = user_data.get("fcm_token") if isinstance(user_data, dict) else None
+    token: str | None = None
+    if isinstance(user_data, dict):
+        if target_app == "driver":
+            token = user_data.get("fcm_token_driver") or user_data.get("fcm_token")
+        elif target_app == "rider":
+            token = user_data.get("fcm_token_rider") or user_data.get("fcm_token")
+        else:
+            token = user_data.get("fcm_token")
 
     if not token:
-        logger.info(f"push_retry: no FCM token for user {user_id!r}, dropping row {row_id}")
+        logger.info(f"push_retry: no FCM token for user {user_id!r} (target_app={target_app!r}), dropping row {row_id}")
         await _delete_row(row_id)
         return
 

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -154,6 +154,7 @@ setBackgroundMessageHandler(async (remoteMessage: any) => {
         PENDING_OFFER_KEY,
         JSON.stringify({
           ride_id: data.ride_id,
+          booking_id: data.booking_id || data.ride_id,
           pickup_address: data.pickup_address || '',
           dropoff_address: data.dropoff_address || '',
           pickup_lat: toNum(data.pickup_lat) ?? 0,
@@ -186,6 +187,7 @@ setBackgroundMessageHandler(async (remoteMessage: any) => {
       try {
         await displayRideOfferNotification({
           ride_id: data.ride_id,
+          booking_id: data.booking_id || data.ride_id,
           pickup_address: data.pickup_address,
           dropoff_address: data.dropoff_address,
           fare,

--- a/driver-app/services/notifeeService.ts
+++ b/driver-app/services/notifeeService.ts
@@ -37,6 +37,7 @@ export type NotifeeAction = 'accept' | 'decline';
 
 export interface RideOfferDisplayData {
     ride_id: string;
+    booking_id?: string;
     pickup_address?: string;
     dropoff_address?: string;
     fare: number;
@@ -94,7 +95,7 @@ export async function ensureNotifeeReady(): Promise<void> {
                     actions: [
                         {
                             id: 'accept',
-                            title: 'Accept',
+                            title: 'Approve',
                             foreground: true,
                             authenticationRequired: false,
                         },
@@ -136,6 +137,7 @@ export async function displayRideOfferNotification(
 
     const title = `$${totalEarnings.toFixed(2)}${surgeBadge} — New ride`;
     const body = [
+        `Booking: ${offer.booking_id || offer.ride_id}`,
         offer.pickup_address ? `From: ${offer.pickup_address}` : null,
         offer.dropoff_address ? `To: ${offer.dropoff_address}` : null,
         offer.distance_km && offer.duration_minutes
@@ -145,6 +147,7 @@ export async function displayRideOfferNotification(
 
     const dataPayload: Record<string, string> = {
         ride_id: offer.ride_id,
+        booking_id: offer.booking_id || offer.ride_id,
         type: 'new_ride_assignment',
     };
 
@@ -173,7 +176,7 @@ export async function displayRideOfferNotification(
             } as any,
             actions: [
                 {
-                    title: '<b><font color="#00D26A">ACCEPT</font></b>',
+                    title: '<b><font color="#00D26A">APPROVE</font></b>',
                     pressAction: { id: 'accept', launchActivity: 'default' },
                 },
                 {


### PR DESCRIPTION
### Motivation
- Ensure drivers receive a rich push notification when a new ride offer arrives even if the app is closed, with action buttons and clear ride details so they can Approve or Decline without opening the app.
- Avoid routing driver ride-offer pushes to the rider app token for dual-role users by preserving which app (driver/rider) the push is intended for.
- Surface booking id, fare, pickup and dropoff in the notification so the driver sees booking context at a glance.

### Description
- Backend: pass a new `target_app` argument through `send_push_notification` and into the retry queue so dispatch/safety pushes are enqueued with `target_app` metadata. 
- Backend: enqueue `target_app` in `push_retry_queue` and select the appropriate per-app token in the retry worker (`fcm_token_driver` / `fcm_token_rider`), falling back to legacy `fcm_token` when needed.
- Backend: include `booking_id`, formatted earnings label and a concise `Booking {id} • {pickup} → {dropoff}` message when sending dispatch pushes from the ride-matching path, and target these pushes at the driver app token.
- DB: add migration `117_push_retry_target_app.sql` to add the `target_app` column to `push_retry_queue` with a `CHECK` constraint.
- Driver app: persist `booking_id` from background FCM payload and include it in Notifee display data; show booking id + fare + pickup/dropoff in the Notifee ride-offer UI and label the positive action as “Approve” while preserving the existing internal action id.

### Testing
- Ran Python compile check: `python3 -m compileall backend/utils/push_retry.py backend/features.py backend/routes/rides.py` (succeeded).
- Static/compile: `cd driver-app && npx tsc --noEmit --pretty false` (failed due to pre-existing/unrelated TypeScript issues in the driver app environment, not introduced by this change).
- Unit tests: `cd driver-app && npx jest store/__tests__/driverStore.test.ts --runInBand` (one existing/unrelated test expectation failed; failure is unrelated to push changes).
- Other checks: `git diff --check` and local lints; created and committed migration and code changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df255e38c8330a54851d49876a007)

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
