### PR TITLE
feat: Android Auto + CarPlay route map with nav hand-off

### DIFF
--- a/docs/carplay-android-auto.md
+++ b/docs/carplay-android-auto.md
@@ -1,12 +1,12 @@
 # CarPlay & Android Auto — integration strategy
 
 **Last verified:** 2026-06-02
-**Status:** Spike scaffold + first real surface. Committed: the dependency, the
-`withCarIntegration` config plugin, the JS smoke test (`car/carSpike.ts`), and the
-**Android Auto route map** (`car/carRoute.ts` + `car/carNav.tsx`) — see "Implemented" below.
-It must still be proven by an **EAS dev build** on a CarPlay Simulator / Android Auto DHU
-before anything relies on it; that build is the gate. No release branch should merge this
-until the spike passes.
+**Status:** Spike scaffold + first real surface, on **both** platforms. Committed: the
+dependency, the `withCarIntegration` config plugin, the JS smoke test (`car/carSpike.ts`), and
+the **route map** (`car/carRoute.ts` + `car/carNav.tsx`) wired for Android Auto AND CarPlay —
+see "Implemented" below. It must still be proven by an **EAS dev build** on a CarPlay Simulator
+/ Android Auto DHU before anything relies on it; that build is the gate. No release branch
+should merge this until the spike passes.
 **Decision inputs:** Scope = *driving-task v1, architected for an in-dash-nav phase later*;
 platforms = *CarPlay + Android Auto in parallel*; approach = *`react-native-carplay` fork +
 a custom Expo config plugin* (keep all ride logic in shared TS/Zustand).
@@ -66,20 +66,39 @@ turn-by-turn to the driver's own Google Maps / Waze.
   `Linking.openURL` brings the nav app up on the head unit.
 - **Still unproven on hardware:** map-button icons and the on-surface render need the EAS
   dev build + DHU (checklist steps 3/5/6). The JS contract is covered by 20 unit tests.
-- **Not yet wired:** accept/decline from the car, online toggle, OTP/rating (stay on phone),
-  and the **CarPlay (iOS)** reuse of this same layer (see "CarPlay reuse" below).
+- **Not yet wired:** accept/decline from the car, online toggle, OTP/rating (stay on phone).
 
-### CarPlay (iOS) reuse
+### CarPlay (iOS) — wired, emulator-testable
 
-`carRoute.ts` is platform-agnostic and the fork's `MapTemplate` is cross-platform, so ~90% of
-this carries to CarPlay. What iOS still needs before it can ship:
-1. The Apple CarPlay **navigation entitlement** (the fork only does the *windowed* connect —
-   see the TL;DR caveat). Hard external gate; request early.
-2. iOS hand-off URL schemes in `buildHandoffUrl` (`maps:` / `comgooglemaps://` / `waze://`)
-   instead of the Android `google.navigation:` intent.
-3. Drive `initCarNav()` from `app/_layout.tsx` (CarPlay shares the phone JS context) rather
-   than a separate AppRegistry root, and drop the Android-only gate.
-All of this stays behind `SPINR_CARPLAY_IOS=1`, OFF by default.
+The same route-map layer now runs on CarPlay (shares ~all of `carRoute.ts` + `carNav.tsx`):
+- `initCarNav()` runs on iOS as well as Android; CarPlay is driven from `app/_layout.tsx`
+  (shared phone JS context), Android Auto from its AppRegistry root. No double-init.
+- Hand-off is platform-aware: CarPlay offers **Apple Maps** (`maps://`, CarPlay-native) +
+  **Waze**; Android Auto offers Google + Waze. Map buttons use a bundled placeholder glyph.
+- Entitlement switched to **`com.apple.developer.carplay-maps`** (navigation) — REQUIRED for
+  the windowed `CPMapTemplate`; `driving-task` is windowless and can't show the map.
+  Still gated behind `SPINR_CARPLAY_IOS=1` (OFF by default).
+- **Apple-approval caveat:** Apple may push a rideshare *driver* app to driving-task (no map).
+  The **Simulator doesn't enforce the grant**, so the map is testable now; the production grant
+  is a separate request. If Apple insists on driving-task, swap the map for a list UI.
+
+#### CarPlay Simulator test script (macOS + Xcode)
+
+```bash
+cd driver-app
+SPINR_CARPLAY_IOS=1 npx expo prebuild -p ios --clean   # adds the CarPlay scene + entitlement
+npx expo run:ios                                        # or an EAS dev build
+```
+Then: Simulator running → **Xcode ▸ I/O ▸ External Displays ▸ CarPlay**. Expected:
+1. With **no active ride** → the idle "Spinr — waiting for trips" list on the CarPlay screen.
+2. Set the driver into a trip (a real offer→accept, or `useDriverStore.setState({ rideState:
+   'trip_in_progress', activeRide })` from a dev hook) → the map shows the stored polyline with
+   the dropoff pinned.
+3. Tap **Maps** / **Waze** → Metro logs `[car-nav] hand-off → apple maps://…` (the round-trip
+   reaching JS is the assertion; the Simulator won't actually switch nav apps).
+4. Repeat on the **Android Auto DHU** for the Google/Waze buttons.
+
+Remaining hardware-only unknowns: the on-surface map render fidelity and the map-button glyphs.
 
 ## Integration model (separate vs integrated)
 

--- a/docs/carplay-android-auto.md
+++ b/docs/carplay-android-auto.md
@@ -73,8 +73,11 @@ turn-by-turn to the driver's own Google Maps / Waze.
 The same route-map layer now runs on CarPlay (shares ~all of `carRoute.ts` + `carNav.tsx`):
 - `initCarNav()` runs on iOS as well as Android; CarPlay is driven from `app/_layout.tsx`
   (shared phone JS context), Android Auto from its AppRegistry root. No double-init.
-- Hand-off is platform-aware: CarPlay offers **Apple Maps** (`maps://`, CarPlay-native) +
-  **Waze**; Android Auto offers Google + Waze. Map buttons use a bundled placeholder glyph.
+- Hand-off is platform-aware AND install-aware: Android Auto offers Google + Waze; CarPlay
+  always offers **Apple Maps** (`maps://`, CarPlay-native) and adds **Google Maps**
+  (`comgooglemaps://`, which supports CarPlay) and **Waze** (`waze://`) only when
+  `canOpenURL` confirms the driver has them — so no dead buttons. Requires the schemes in
+  `LSApplicationQueriesSchemes` (added by the plugin, gated). Map buttons use a placeholder glyph.
 - Entitlement switched to **`com.apple.developer.carplay-maps`** (navigation) — REQUIRED for
   the windowed `CPMapTemplate`; `driving-task` is windowless and can't show the map.
   Still gated behind `SPINR_CARPLAY_IOS=1` (OFF by default).

--- a/docs/carplay-android-auto.md
+++ b/docs/carplay-android-auto.md
@@ -1,10 +1,12 @@
 # CarPlay & Android Auto — integration strategy
 
-**Last verified:** 2026-05-30
-**Status:** Spike scaffold committed on branch `claude/sleepy-dijkstra-nTIqn` — the dependency,
-the `withCarIntegration` config plugin, and a JS smoke test (`car/carSpike.ts`). It must still
-be proven by an **EAS dev build** on a CarPlay Simulator / Android Auto DHU before anything
-relies on it; that build is the gate. No release branch should merge this until the spike passes.
+**Last verified:** 2026-06-02
+**Status:** Spike scaffold + first real surface. Committed: the dependency, the
+`withCarIntegration` config plugin, the JS smoke test (`car/carSpike.ts`), and the
+**Android Auto route map** (`car/carRoute.ts` + `car/carNav.tsx`) — see "Implemented" below.
+It must still be proven by an **EAS dev build** on a CarPlay Simulator / Android Auto DHU
+before anything relies on it; that build is the gate. No release branch should merge this
+until the spike passes.
 **Decision inputs:** Scope = *driving-task v1, architected for an in-dash-nav phase later*;
 platforms = *CarPlay + Android Auto in parallel*; approach = *`react-native-carplay` fork +
 a custom Expo config plugin* (keep all ride logic in shared TS/Zustand).
@@ -41,6 +43,43 @@ a custom Expo config plugin* (keep all ride logic in shared TS/Zustand).
   *or* navigation — see caveat) and **Google Play car-app review**. Start both early.
 
 ---
+
+## Implemented: Android Auto route map ("Path B look, Path A cost")
+
+The first real car surface, replacing the smoke-test list on the Android Auto root.
+**Decision:** render the route the driver expects to see (the Uber-style in-dash map),
+but do NOT pay for live navigation — draw the polyline we *already* store and hand
+turn-by-turn to the driver's own Google Maps / Waze.
+
+- **No new maps spend.** It reuses `rides.planned_route_polyline` (migration 100, a decoded
+  `[[lat,lng], …]` line captured once at ride creation). No Routes/Directions/Navigation-SDK
+  calls at all — so the per-ride cost stays $0, same as the existing `openNavigation()` deep link.
+- **Files:**
+  - `car/carRoute.ts` — pure logic: destination by ride state (pickup pre-trip, dropoff
+    in-trip), polyline parse, and the Google/Waze hand-off URLs. Fully unit-tested.
+  - `car/carNav.tsx` — `CarMapSurface` (react-native-maps `MapView`+`Polyline`+`Marker`),
+    `buildNavMapTemplate` (fork `MapTemplate`, surface `component`, two nav buttons), and
+    `initCarNav()` (subscribes `useDriverStore`, leg-debounced root swap, idle `ListTemplate`).
+  - `car/androidAutoEntry.tsx` — the Android Auto root now drives `initCarNav()`.
+- **Interaction model:** Android Auto routes taps through template **map buttons**, not
+  in-surface touchables (driver-distraction rules) — `nav-google` / `nav-waze` →
+  `Linking.openURL` brings the nav app up on the head unit.
+- **Still unproven on hardware:** map-button icons and the on-surface render need the EAS
+  dev build + DHU (checklist steps 3/5/6). The JS contract is covered by 20 unit tests.
+- **Not yet wired:** accept/decline from the car, online toggle, OTP/rating (stay on phone),
+  and the **CarPlay (iOS)** reuse of this same layer (see "CarPlay reuse" below).
+
+### CarPlay (iOS) reuse
+
+`carRoute.ts` is platform-agnostic and the fork's `MapTemplate` is cross-platform, so ~90% of
+this carries to CarPlay. What iOS still needs before it can ship:
+1. The Apple CarPlay **navigation entitlement** (the fork only does the *windowed* connect —
+   see the TL;DR caveat). Hard external gate; request early.
+2. iOS hand-off URL schemes in `buildHandoffUrl` (`maps:` / `comgooglemaps://` / `waze://`)
+   instead of the Android `google.navigation:` intent.
+3. Drive `initCarNav()` from `app/_layout.tsx` (CarPlay shares the phone JS context) rather
+   than a separate AppRegistry root, and drop the Android-only gate.
+All of this stays behind `SPINR_CARPLAY_IOS=1`, OFF by default.
 
 ## Integration model (separate vs integrated)
 

--- a/driver-app/__tests__/androidAutoEntry.test.ts
+++ b/driver-app/__tests__/androidAutoEntry.test.ts
@@ -10,7 +10,7 @@ jest.mock('@g4rb4g3/react-native-carplay/lib/CarPlayHeadlessJsTask', () => ({
 }));
 
 import { AppRegistry, Platform } from 'react-native';
-import { registerAndroidAuto, AndroidAutoRoot } from '../car/androidAutoEntry';
+import { registerAndroidAuto, AndroidAutoRoot, AndroidAutoClusterRoot } from '../car/androidAutoEntry';
 
 const setOS = (os: string) => {
   (Platform as unknown as { OS: string }).OS = os;
@@ -39,9 +39,16 @@ describe('registerAndroidAuto', () => {
     expect(names).toContain('AndroidAuto');
     expect(names).toContain('AndroidAutoCluster');
 
-    // the registered factory yields our car root
-    const factory = spy.mock.calls.find((c) => c[0] === 'AndroidAuto')?.[1];
-    expect(factory()).toBe(AndroidAutoRoot);
+    // the main car surface yields the nav-driving root
+    const autoFactory = spy.mock.calls.find((c) => c[0] === 'AndroidAuto')?.[1];
+    expect(autoFactory()).toBe(AndroidAutoRoot);
+
+    // the cluster surface yields a SEPARATE no-op root (not AndroidAutoRoot), so
+    // initCarNav doesn't run twice and double-fire nav hand-offs.
+    const clusterFactory = spy.mock.calls.find((c) => c[0] === 'AndroidAutoCluster')?.[1];
+    expect(clusterFactory()).toBe(AndroidAutoClusterRoot);
+    expect(clusterFactory()).not.toBe(AndroidAutoRoot);
+    expect(AndroidAutoClusterRoot()).toBeNull();
   });
 
   it('is a no-op on iOS (the phone tree drives CarPlay there)', () => {

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -92,7 +92,7 @@ describe('buildNavMapTemplate', () => {
     ]);
   });
 
-  it('routes the Waze button to Waze and any other button to Google', () => {
+  it('routes the Waze button to Waze and the primary button to Google (Android)', () => {
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
     const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
     const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
@@ -102,6 +102,27 @@ describe('buildNavMapTemplate', () => {
 
     onPress({ id: 'nav-google' });
     expect(openURL).toHaveBeenLastCalledWith('google.navigation:q=52.2,-106.6');
+  });
+
+  it('offers Apple Maps + Waze and routes them on iOS (CarPlay)', () => {
+    setOS('ios');
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
+    expect((cfg.mapButtons as { id: string }[]).map((b) => b.id)).toEqual([
+      'nav-apple',
+      'nav-waze',
+    ]);
+
+    const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
+    onPress({ id: 'nav-apple' });
+    expect(openURL).toHaveBeenLastCalledWith('maps://?daddr=52.2,-106.6&dirflg=d');
+  });
+
+  it('gives every map button an icon (CarPlay/Android Auto buttons are icons)', () => {
+    const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
+    for (const b of cfg.mapButtons as { image?: unknown }[]) {
+      expect(b.image).toBeDefined();
+    }
   });
 });
 
@@ -128,8 +149,15 @@ describe('handoffToNav', () => {
 });
 
 describe('initCarNav', () => {
-  it('is a no-op on iOS (the phone tree drives CarPlay there)', () => {
+  it('runs on iOS too (CarPlay shares the phone JS context)', () => {
     setOS('ios');
+    const cleanup = initCarNav();
+    expect(CarPlay.registerOnConnect).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('is a no-op off-car (web / Expo Go)', () => {
+    setOS('web');
     const cleanup = initCarNav();
     expect(CarPlay.registerOnConnect).not.toHaveBeenCalled();
     cleanup();

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -67,9 +67,21 @@ const configOf = (t: unknown) => (t as { config: Record<string, unknown> }).conf
 
 let openURL: jest.SpyInstance;
 
+// Default: no extra nav apps installed (detection probes resolve false). Tests
+// that need Google Maps / Waze present override canOpenURL.
+const setCanOpen = (fn: jest.Mock) => {
+  (Linking as unknown as { canOpenURL: jest.Mock }).canOpenURL = fn;
+};
+
+const AND_BUTTONS = [
+  { id: 'nav-google', provider: 'google' },
+  { id: 'nav-waze', provider: 'waze' },
+] as never;
+
 beforeEach(() => {
   jest.clearAllMocks();
   openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as never);
+  setCanOpen(jest.fn().mockResolvedValue(false));
   (CarPlay as unknown as { connected: boolean }).connected = false;
   useDriverStore.setState({ rideState: 'idle', activeRide: null });
   setOS('android');
@@ -80,8 +92,8 @@ afterEach(() => {
 });
 
 describe('buildNavMapTemplate', () => {
-  it('builds a MapTemplate with the surface component + two nav buttons', () => {
-    const t = buildNavMapTemplate(MapTemplate as never);
+  it('builds a MapTemplate with the surface component + the given buttons', () => {
+    const t = buildNavMapTemplate(MapTemplate as never, AND_BUTTONS);
     const cfg = configOf(t);
     expect(t).toBeInstanceOf(MapTemplate);
     expect(cfg.id).toBe('spinr-car-nav');
@@ -92,9 +104,9 @@ describe('buildNavMapTemplate', () => {
     ]);
   });
 
-  it('routes the Waze button to Waze and the primary button to Google (Android)', () => {
+  it('routes each button id to its nav app (Android)', () => {
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
-    const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
+    const cfg = configOf(buildNavMapTemplate(MapTemplate as never, AND_BUTTONS));
     const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
 
     onPress({ id: 'nav-waze' });
@@ -104,22 +116,27 @@ describe('buildNavMapTemplate', () => {
     expect(openURL).toHaveBeenLastCalledWith('google.navigation:q=52.2,-106.6');
   });
 
-  it('offers Apple Maps + Waze and routes them on iOS (CarPlay)', () => {
+  it('routes Apple + Google Maps to their iOS schemes (CarPlay)', () => {
     setOS('ios');
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
-    const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
-    expect((cfg.mapButtons as { id: string }[]).map((b) => b.id)).toEqual([
-      'nav-apple',
-      'nav-waze',
-    ]);
-
+    const iosButtons = [
+      { id: 'nav-apple', provider: 'apple' },
+      { id: 'nav-google', provider: 'google' },
+    ] as never;
+    const cfg = configOf(buildNavMapTemplate(MapTemplate as never, iosButtons));
     const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
+
     onPress({ id: 'nav-apple' });
     expect(openURL).toHaveBeenLastCalledWith('maps://?daddr=52.2,-106.6&dirflg=d');
+
+    onPress({ id: 'nav-google' });
+    expect(openURL).toHaveBeenLastCalledWith(
+      'comgooglemaps://?daddr=52.2,-106.6&directionsmode=driving'
+    );
   });
 
   it('gives every map button an icon (CarPlay/Android Auto buttons are icons)', () => {
-    const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
+    const cfg = configOf(buildNavMapTemplate(MapTemplate as never, AND_BUTTONS));
     for (const b of cfg.mapButtons as { image?: unknown }[]) {
       expect(b.image).toBeDefined();
     }
@@ -139,6 +156,17 @@ describe('handoffToNav', () => {
     useDriverStore.setState({ rideState: 'navigating_to_pickup', activeRide: activeRide() });
     handoffToNav('google');
     expect(openURL).toHaveBeenCalledWith('google.navigation:q=52.13,-106.67');
+  });
+
+  it('uses the iOS schemes on CarPlay (Apple Maps + Google Maps)', () => {
+    setOS('ios');
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    handoffToNav('apple');
+    expect(openURL).toHaveBeenLastCalledWith('maps://?daddr=52.2,-106.6&dirflg=d');
+    handoffToNav('google');
+    expect(openURL).toHaveBeenLastCalledWith(
+      'comgooglemaps://?daddr=52.2,-106.6&directionsmode=driving'
+    );
   });
 
   it('is a no-op when there is no active route', () => {
@@ -207,5 +235,26 @@ describe('initCarNav', () => {
     (CarPlay.setRootTemplate as jest.Mock).mockClear();
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
     expect(CarPlay.setRootTemplate).not.toHaveBeenCalled();
+  });
+
+  it("rebuilds with the driver's installed nav apps once detected (CarPlay)", async () => {
+    setOS('ios');
+    setCanOpen(jest.fn().mockResolvedValue(true)); // driver has Google Maps + Waze
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    (CarPlay as unknown as { connected: boolean }).connected = true;
+
+    const cleanup = initCarNav();
+    // onConnect already drew the map with the seed (Apple Maps only); let the
+    // async install detection resolve, which rebuilds with the full set.
+    await new Promise((r) => setImmediate(r));
+
+    const calls = (CarPlay.setRootTemplate as jest.Mock).mock.calls;
+    const lastCfg = configOf(calls[calls.length - 1][0]);
+    expect((lastCfg.mapButtons as { id: string }[]).map((b) => b.id)).toEqual([
+      'nav-apple',
+      'nav-google',
+      'nav-waze',
+    ]);
+    cleanup();
   });
 });

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -172,6 +172,14 @@ describe('button hand-off via the car emitter', () => {
     expect(openURL).not.toHaveBeenCalled();
     cleanup();
   });
+
+  it('ignores presses for ids that are not current nav buttons', () => {
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    const cleanup = initCarNav();
+    emitterCb('buttonPressed')({ buttonId: 'some-other-car-action' });
+    expect(openURL).not.toHaveBeenCalled();
+    cleanup();
+  });
 });
 
 describe('initCarNav', () => {
@@ -212,6 +220,17 @@ describe('initCarNav', () => {
 
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() }); // → map
     expect(idleTpl.destroy).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
+
+  it('rebuilds when the ride changes even on the same leg', () => {
+    (CarPlay as unknown as { connected: boolean }).connected = true;
+    const cleanup = initCarNav();
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide({ id: 'r1' }) });
+    const before = (CarPlay.setRootTemplate as jest.Mock).mock.calls.length;
+    // Same leg (trip_in_progress) but a DIFFERENT ride id → must rebuild + recenter.
+    useDriverStore.setState({ activeRide: activeRide({ id: 'r2' }) });
+    expect((CarPlay.setRootTemplate as jest.Mock).mock.calls.length).toBe(before + 1);
     cleanup();
   });
 

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -1,21 +1,23 @@
 /**
- * Unit tests for car/carNav.tsx — the Android Auto route-map wiring. The native
- * car module is fully mocked and the real useDriverStore drives state, so these
- * assert the JS contract without a head unit: template selection by ride state,
- * leg-debounced root rebuilds, and the Google/Waze hand-off.
+ * Unit tests for car/carNav.tsx — the cross-platform car route-map wiring. The
+ * native car module is fully mocked and the real useDriverStore drives state, so
+ * these assert the JS contract without a head unit: template selection by ride
+ * state, leg-debounced rebuilds with stale-template teardown, button-press
+ * hand-off via the emitter (Android `buttonPressed` / iOS `mapButtonPressed`),
+ * and installed-app detection.
  */
 
-// Mock the fork: MapTemplate / ListTemplate store their config so we can assert
-// instanceof + shape; CarPlay exposes the connect/root surface.
 jest.mock('@g4rb4g3/react-native-carplay', () => {
   class MapTemplate {
     config: Record<string, unknown>;
+    destroy = jest.fn();
     constructor(config: Record<string, unknown>) {
       this.config = config;
     }
   }
   class ListTemplate {
     config: Record<string, unknown>;
+    destroy = jest.fn();
     constructor(config: Record<string, unknown>) {
       this.config = config;
     }
@@ -26,6 +28,7 @@ jest.mock('@g4rb4g3/react-native-carplay', () => {
       registerOnConnect: jest.fn(),
       unregisterOnConnect: jest.fn(),
       setRootTemplate: jest.fn(),
+      emitter: { addListener: jest.fn(() => ({ remove: jest.fn() })) },
     },
     MapTemplate,
     ListTemplate,
@@ -35,16 +38,23 @@ jest.mock('@g4rb4g3/react-native-carplay', () => {
 import { Linking, Platform } from 'react-native';
 import { CarPlay, MapTemplate, ListTemplate } from '@g4rb4g3/react-native-carplay';
 import { useDriverStore } from '../store/driverStore';
-import {
-  buildIdleTemplate,
-  buildNavMapTemplate,
-  handoffToNav,
-  initCarNav,
-} from '../car/carNav';
+import { buildIdleTemplate, buildNavMapTemplate, handoffToNav, initCarNav } from '../car/carNav';
 
 const setOS = (os: string) => {
   (Platform as unknown as { OS: string }).OS = os;
 };
+const setCanOpen = (fn: jest.Mock) => {
+  (Linking as unknown as { canOpenURL: jest.Mock }).canOpenURL = fn;
+};
+
+// Grab the emitter callback initCarNav registered for a given event.
+const emitterCb = (event: string): ((e: unknown) => void) =>
+  (CarPlay.emitter.addListener as jest.Mock).mock.calls.find((c) => c[0] === event)?.[1];
+
+const AND_BUTTONS = [
+  { id: 'nav-google', provider: 'google' },
+  { id: 'nav-waze', provider: 'waze' },
+] as never;
 
 const activeRide = (over: Record<string, unknown> = {}) =>
   ({
@@ -67,17 +77,6 @@ const configOf = (t: unknown) => (t as { config: Record<string, unknown> }).conf
 
 let openURL: jest.SpyInstance;
 
-// Default: no extra nav apps installed (detection probes resolve false). Tests
-// that need Google Maps / Waze present override canOpenURL.
-const setCanOpen = (fn: jest.Mock) => {
-  (Linking as unknown as { canOpenURL: jest.Mock }).canOpenURL = fn;
-};
-
-const AND_BUTTONS = [
-  { id: 'nav-google', provider: 'google' },
-  { id: 'nav-waze', provider: 'waze' },
-] as never;
-
 beforeEach(() => {
   jest.clearAllMocks();
   openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as never);
@@ -92,54 +91,20 @@ afterEach(() => {
 });
 
 describe('buildNavMapTemplate', () => {
-  it('builds a MapTemplate with the surface component + the given buttons', () => {
+  it('builds a MapTemplate with the surface component + the given buttons (icons)', () => {
     const t = buildNavMapTemplate(MapTemplate as never, AND_BUTTONS);
     const cfg = configOf(t);
     expect(t).toBeInstanceOf(MapTemplate);
     expect(cfg.id).toBe('spinr-car-nav');
     expect(typeof cfg.component).toBe('function');
-    expect((cfg.mapButtons as { id: string }[]).map((b) => b.id)).toEqual([
-      'nav-google',
-      'nav-waze',
-    ]);
+    const btns = cfg.mapButtons as { id: string; image?: unknown }[];
+    expect(btns.map((b) => b.id)).toEqual(['nav-google', 'nav-waze']);
+    btns.forEach((b) => expect(b.image).toBeDefined());
   });
 
-  it('routes each button id to its nav app (Android)', () => {
-    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+  it('does NOT use a config press callback (Android routes via the emitter)', () => {
     const cfg = configOf(buildNavMapTemplate(MapTemplate as never, AND_BUTTONS));
-    const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
-
-    onPress({ id: 'nav-waze' });
-    expect(openURL).toHaveBeenLastCalledWith('https://waze.com/ul?ll=52.2,-106.6&navigate=yes');
-
-    onPress({ id: 'nav-google' });
-    expect(openURL).toHaveBeenLastCalledWith('google.navigation:q=52.2,-106.6');
-  });
-
-  it('routes Apple + Google Maps to their iOS schemes (CarPlay)', () => {
-    setOS('ios');
-    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
-    const iosButtons = [
-      { id: 'nav-apple', provider: 'apple' },
-      { id: 'nav-google', provider: 'google' },
-    ] as never;
-    const cfg = configOf(buildNavMapTemplate(MapTemplate as never, iosButtons));
-    const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
-
-    onPress({ id: 'nav-apple' });
-    expect(openURL).toHaveBeenLastCalledWith('maps://?daddr=52.2,-106.6&dirflg=d');
-
-    onPress({ id: 'nav-google' });
-    expect(openURL).toHaveBeenLastCalledWith(
-      'comgooglemaps://?daddr=52.2,-106.6&directionsmode=driving'
-    );
-  });
-
-  it('gives every map button an icon (CarPlay/Android Auto buttons are icons)', () => {
-    const cfg = configOf(buildNavMapTemplate(MapTemplate as never, AND_BUTTONS));
-    for (const b of cfg.mapButtons as { image?: unknown }[]) {
-      expect(b.image).toBeDefined();
-    }
+    expect(cfg.onMapButtonPressed).toBeUndefined();
   });
 });
 
@@ -152,7 +117,7 @@ describe('buildIdleTemplate', () => {
 });
 
 describe('handoffToNav', () => {
-  it('opens the nav app for the active destination', () => {
+  it('opens the nav app for the active destination (Android)', () => {
     useDriverStore.setState({ rideState: 'navigating_to_pickup', activeRide: activeRide() });
     handoffToNav('google');
     expect(openURL).toHaveBeenCalledWith('google.navigation:q=52.13,-106.67');
@@ -176,14 +141,40 @@ describe('handoffToNav', () => {
   });
 });
 
-describe('initCarNav', () => {
-  it('runs on iOS too (CarPlay shares the phone JS context)', () => {
-    setOS('ios');
+describe('button hand-off via the car emitter', () => {
+  it('routes the Android `buttonPressed` ({buttonId}) event to the nav app', () => {
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
     const cleanup = initCarNav();
-    expect(CarPlay.registerOnConnect).toHaveBeenCalledTimes(1);
+
+    const cb = emitterCb('buttonPressed');
+    expect(typeof cb).toBe('function');
+    cb({ buttonId: 'nav-waze' });
+    expect(openURL).toHaveBeenLastCalledWith('https://waze.com/ul?ll=52.2,-106.6&navigate=yes');
+    cb({ buttonId: 'nav-google' });
+    expect(openURL).toHaveBeenLastCalledWith('google.navigation:q=52.2,-106.6');
     cleanup();
   });
 
+  it('routes the iOS `mapButtonPressed` ({id}) event to the nav app', () => {
+    setOS('ios');
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    const cleanup = initCarNav();
+
+    emitterCb('mapButtonPressed')({ id: 'nav-apple' });
+    expect(openURL).toHaveBeenLastCalledWith('maps://?daddr=52.2,-106.6&dirflg=d');
+    cleanup();
+  });
+
+  it('ignores a press event with no id', () => {
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    const cleanup = initCarNav();
+    emitterCb('buttonPressed')({});
+    expect(openURL).not.toHaveBeenCalled();
+    cleanup();
+  });
+});
+
+describe('initCarNav', () => {
   it('is a no-op off-car (web / Expo Go)', () => {
     setOS('web');
     const cleanup = initCarNav();
@@ -191,46 +182,56 @@ describe('initCarNav', () => {
     cleanup();
   });
 
-  it('sets an idle root on connect, then swaps to the map per leg', () => {
+  it('runs on iOS too (CarPlay shares the phone JS context)', () => {
+    setOS('ios');
     const cleanup = initCarNav();
     expect(CarPlay.registerOnConnect).toHaveBeenCalledTimes(1);
+    cleanup();
+  });
 
-    // Nothing set until the head unit connects.
+  it('sets an idle root on connect, then swaps to the map per leg', () => {
+    const cleanup = initCarNav();
     expect(CarPlay.setRootTemplate).not.toHaveBeenCalled();
 
-    // Connect while idle → idle ListTemplate root.
     const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
     onConnect();
     expect(CarPlay.setRootTemplate).toHaveBeenCalledTimes(1);
     expect((CarPlay.setRootTemplate as jest.Mock).mock.calls[0][0]).toBeInstanceOf(ListTemplate);
 
-    // Trip starts → MapTemplate (dropoff leg). Store change fires the subscriber.
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
     expect(CarPlay.setRootTemplate).toHaveBeenCalledTimes(2);
     expect((CarPlay.setRootTemplate as jest.Mock).mock.calls[1][0]).toBeInstanceOf(MapTemplate);
+    cleanup();
+  });
 
+  it('destroys the previous template when rebuilding the root (no listener leak)', () => {
+    const cleanup = initCarNav();
+    const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
+    onConnect(); // idle ListTemplate
+    const idleTpl = (CarPlay.setRootTemplate as jest.Mock).mock.calls[0][0];
+
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() }); // → map
+    expect(idleTpl.destroy).toHaveBeenCalledTimes(1);
     cleanup();
   });
 
   it('does NOT rebuild the root on same-leg store ticks', () => {
     const cleanup = initCarNav();
     const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
-
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
-    onConnect(); // dropoff leg → 1 build
+    onConnect();
     const calls = (CarPlay.setRootTemplate as jest.Mock).mock.calls.length;
-
-    // A second store tick on the same leg (e.g. a location update) → no rebuild.
     useDriverStore.setState({ countdownSeconds: 1 } as never);
     expect((CarPlay.setRootTemplate as jest.Mock).mock.calls.length).toBe(calls);
-
     cleanup();
   });
 
-  it('cleanup unregisters and stops responding to store changes', () => {
+  it('cleanup unregisters, removes button listeners, and stops responding', () => {
     const cleanup = initCarNav();
+    const sub = (CarPlay.emitter.addListener as jest.Mock).mock.results[0].value;
     cleanup();
     expect(CarPlay.unregisterOnConnect).toHaveBeenCalledTimes(1);
+    expect(sub.remove).toHaveBeenCalled();
 
     (CarPlay.setRootTemplate as jest.Mock).mockClear();
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
@@ -244,8 +245,6 @@ describe('initCarNav', () => {
     (CarPlay as unknown as { connected: boolean }).connected = true;
 
     const cleanup = initCarNav();
-    // onConnect already drew the map with the seed (Apple Maps only); let the
-    // async install detection resolve, which rebuilds with the full set.
     await new Promise((r) => setImmediate(r));
 
     const calls = (CarPlay.setRootTemplate as jest.Mock).mock.calls;

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for car/carNav.tsx — the Android Auto route-map wiring. The native
+ * car module is fully mocked and the real useDriverStore drives state, so these
+ * assert the JS contract without a head unit: template selection by ride state,
+ * leg-debounced root rebuilds, and the Google/Waze hand-off.
+ */
+
+// Mock the fork: MapTemplate / ListTemplate store their config so we can assert
+// instanceof + shape; CarPlay exposes the connect/root surface.
+jest.mock('@g4rb4g3/react-native-carplay', () => {
+  class MapTemplate {
+    config: Record<string, unknown>;
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+    }
+  }
+  class ListTemplate {
+    config: Record<string, unknown>;
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+    }
+  }
+  return {
+    CarPlay: {
+      connected: false,
+      registerOnConnect: jest.fn(),
+      unregisterOnConnect: jest.fn(),
+      setRootTemplate: jest.fn(),
+    },
+    MapTemplate,
+    ListTemplate,
+  };
+});
+
+import { Linking, Platform } from 'react-native';
+import { CarPlay, MapTemplate, ListTemplate } from '@g4rb4g3/react-native-carplay';
+import { useDriverStore } from '../store/driverStore';
+import {
+  buildIdleTemplate,
+  buildNavMapTemplate,
+  handoffToNav,
+  initCarNav,
+} from '../car/carNav';
+
+const setOS = (os: string) => {
+  (Platform as unknown as { OS: string }).OS = os;
+};
+
+const activeRide = (over: Record<string, unknown> = {}) =>
+  ({
+    ride: {
+      id: 'r1',
+      pickup_address: 'Pickup',
+      dropoff_address: 'Dropoff',
+      pickup_lat: 52.13,
+      pickup_lng: -106.67,
+      dropoff_lat: 52.2,
+      dropoff_lng: -106.6,
+      planned_route_polyline: [[52.13, -106.67], [52.2, -106.6]],
+      ...over,
+    },
+    rider: { id: 'rider' },
+    vehicle_type: { id: 'vt', name: 'Standard' },
+  }) as never;
+
+const configOf = (t: unknown) => (t as { config: Record<string, unknown> }).config;
+
+let openURL: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as never);
+  (CarPlay as unknown as { connected: boolean }).connected = false;
+  useDriverStore.setState({ rideState: 'idle', activeRide: null });
+  setOS('android');
+});
+
+afterEach(() => {
+  openURL.mockRestore();
+});
+
+describe('buildNavMapTemplate', () => {
+  it('builds a MapTemplate with the surface component + two nav buttons', () => {
+    const t = buildNavMapTemplate(MapTemplate as never);
+    const cfg = configOf(t);
+    expect(t).toBeInstanceOf(MapTemplate);
+    expect(cfg.id).toBe('spinr-car-nav');
+    expect(typeof cfg.component).toBe('function');
+    expect((cfg.mapButtons as { id: string }[]).map((b) => b.id)).toEqual([
+      'nav-google',
+      'nav-waze',
+    ]);
+  });
+
+  it('routes the Waze button to Waze and any other button to Google', () => {
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    const cfg = configOf(buildNavMapTemplate(MapTemplate as never));
+    const onPress = cfg.onMapButtonPressed as (e: { id: string }) => void;
+
+    onPress({ id: 'nav-waze' });
+    expect(openURL).toHaveBeenLastCalledWith('https://waze.com/ul?ll=52.2,-106.6&navigate=yes');
+
+    onPress({ id: 'nav-google' });
+    expect(openURL).toHaveBeenLastCalledWith('google.navigation:q=52.2,-106.6');
+  });
+});
+
+describe('buildIdleTemplate', () => {
+  it('builds a ListTemplate idle root', () => {
+    const t = buildIdleTemplate(ListTemplate as never);
+    expect(t).toBeInstanceOf(ListTemplate);
+    expect(configOf(t).id).toBe('spinr-car-idle');
+  });
+});
+
+describe('handoffToNav', () => {
+  it('opens the nav app for the active destination', () => {
+    useDriverStore.setState({ rideState: 'navigating_to_pickup', activeRide: activeRide() });
+    handoffToNav('google');
+    expect(openURL).toHaveBeenCalledWith('google.navigation:q=52.13,-106.67');
+  });
+
+  it('is a no-op when there is no active route', () => {
+    useDriverStore.setState({ rideState: 'idle', activeRide: null });
+    handoffToNav('google');
+    expect(openURL).not.toHaveBeenCalled();
+  });
+});
+
+describe('initCarNav', () => {
+  it('is a no-op on iOS (the phone tree drives CarPlay there)', () => {
+    setOS('ios');
+    const cleanup = initCarNav();
+    expect(CarPlay.registerOnConnect).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('sets an idle root on connect, then swaps to the map per leg', () => {
+    const cleanup = initCarNav();
+    expect(CarPlay.registerOnConnect).toHaveBeenCalledTimes(1);
+
+    // Nothing set until the head unit connects.
+    expect(CarPlay.setRootTemplate).not.toHaveBeenCalled();
+
+    // Connect while idle → idle ListTemplate root.
+    const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
+    onConnect();
+    expect(CarPlay.setRootTemplate).toHaveBeenCalledTimes(1);
+    expect((CarPlay.setRootTemplate as jest.Mock).mock.calls[0][0]).toBeInstanceOf(ListTemplate);
+
+    // Trip starts → MapTemplate (dropoff leg). Store change fires the subscriber.
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    expect(CarPlay.setRootTemplate).toHaveBeenCalledTimes(2);
+    expect((CarPlay.setRootTemplate as jest.Mock).mock.calls[1][0]).toBeInstanceOf(MapTemplate);
+
+    cleanup();
+  });
+
+  it('does NOT rebuild the root on same-leg store ticks', () => {
+    const cleanup = initCarNav();
+    const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
+
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    onConnect(); // dropoff leg → 1 build
+    const calls = (CarPlay.setRootTemplate as jest.Mock).mock.calls.length;
+
+    // A second store tick on the same leg (e.g. a location update) → no rebuild.
+    useDriverStore.setState({ countdownSeconds: 1 } as never);
+    expect((CarPlay.setRootTemplate as jest.Mock).mock.calls.length).toBe(calls);
+
+    cleanup();
+  });
+
+  it('cleanup unregisters and stops responding to store changes', () => {
+    const cleanup = initCarNav();
+    cleanup();
+    expect(CarPlay.unregisterOnConnect).toHaveBeenCalledTimes(1);
+
+    (CarPlay.setRootTemplate as jest.Mock).mockClear();
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    expect(CarPlay.setRootTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -82,7 +82,15 @@ beforeEach(() => {
   openURL = jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined as never);
   setCanOpen(jest.fn().mockResolvedValue(false));
   (CarPlay as unknown as { connected: boolean }).connected = false;
-  useDriverStore.setState({ rideState: 'idle', activeRide: null });
+  // Stub the cold-launch reconcile so it doesn't clobber the per-test ride state
+  // (its real behavior is exercised in the store tests). One test below overrides
+  // these to assert initCarNav invokes them.
+  useDriverStore.setState({
+    rideState: 'idle',
+    activeRide: null,
+    hydrateDriverRideState: jest.fn().mockResolvedValue(undefined),
+    fetchActiveRide: jest.fn().mockResolvedValue(undefined),
+  });
   setOS('android');
 });
 
@@ -197,10 +205,39 @@ describe('initCarNav', () => {
     cleanup();
   });
 
+  it('hydrates and reconciles the ride against the server on init (cold launch)', async () => {
+    const hydrate = jest.fn().mockResolvedValue(undefined);
+    const fetch = jest.fn().mockResolvedValue(undefined);
+    useDriverStore.setState({ hydrateDriverRideState: hydrate, fetchActiveRide: fetch });
+    const cleanup = initCarNav();
+    await new Promise((r) => setImmediate(r));
+    expect(hydrate).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('ignores store changes while the car is disconnected', () => {
+    // connected = false (beforeEach). On iOS initCarNav is mounted by the phone
+    // layout with no CarPlay session — store changes must not push templates.
+    const cleanup = initCarNav();
+    useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
+    expect(CarPlay.setRootTemplate).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('uses a MapTemplate idle root on iOS (CarPlay needs a CPMapTemplate)', () => {
+    setOS('ios');
+    (CarPlay as unknown as { connected: boolean }).connected = true;
+    const cleanup = initCarNav(); // connected → auto onConnect → idle root
+    expect((CarPlay.setRootTemplate as jest.Mock).mock.calls[0][0]).toBeInstanceOf(MapTemplate);
+    cleanup();
+  });
+
   it('sets an idle root on connect, then swaps to the map per leg', () => {
     const cleanup = initCarNav();
     expect(CarPlay.setRootTemplate).not.toHaveBeenCalled();
 
+    (CarPlay as unknown as { connected: boolean }).connected = true;
     const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
     onConnect();
     expect(CarPlay.setRootTemplate).toHaveBeenCalledTimes(1);
@@ -213,6 +250,7 @@ describe('initCarNav', () => {
   });
 
   it('destroys the previous template when rebuilding the root (no listener leak)', () => {
+    (CarPlay as unknown as { connected: boolean }).connected = true;
     const cleanup = initCarNav();
     const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
     onConnect(); // idle ListTemplate
@@ -235,10 +273,9 @@ describe('initCarNav', () => {
   });
 
   it('does NOT rebuild the root on same-leg store ticks', () => {
+    (CarPlay as unknown as { connected: boolean }).connected = true;
     const cleanup = initCarNav();
-    const onConnect = (CarPlay.registerOnConnect as jest.Mock).mock.calls[0][0];
     useDriverStore.setState({ rideState: 'trip_in_progress', activeRide: activeRide() });
-    onConnect();
     const calls = (CarPlay.setRootTemplate as jest.Mock).mock.calls.length;
     useDriverStore.setState({ countdownSeconds: 1 } as never);
     expect((CarPlay.setRootTemplate as jest.Mock).mock.calls.length).toBe(calls);
@@ -246,6 +283,7 @@ describe('initCarNav', () => {
   });
 
   it('cleanup unregisters, removes button listeners, and stops responding', () => {
+    (CarPlay as unknown as { connected: boolean }).connected = true;
     const cleanup = initCarNav();
     const sub = (CarPlay.emitter.addListener as jest.Mock).mock.results[0].value;
     cleanup();

--- a/driver-app/__tests__/carRoute.test.ts
+++ b/driver-app/__tests__/carRoute.test.ts
@@ -71,21 +71,24 @@ describe('extractPolyline', () => {
 });
 
 describe('selectCarRoute', () => {
-  it('targets the PICKUP before the trip starts', () => {
+  it('targets the PICKUP before the trip starts, with NO route line drawn', () => {
     for (const s of ['navigating_to_pickup', 'arrived_at_pickup'] as RideState[]) {
       const route = selectCarRoute(s, makeRide());
       expect(route?.leg).toBe('pickup');
       expect(route?.destination).toEqual({ latitude: 52.13, longitude: -106.67 });
       expect(route?.destinationLabel).toBe('101 Pickup St');
-      expect(route?.polyline).toHaveLength(3);
+      // The stored line is pickup→dropoff; it must NOT be drawn on the
+      // driver→pickup leg (it would point away from the pickup hand-off).
+      expect(route?.polyline).toEqual([]);
     }
   });
 
-  it('targets the DROPOFF once in progress', () => {
+  it('targets the DROPOFF once in progress and draws the stored route line', () => {
     const route = selectCarRoute('trip_in_progress', makeRide());
     expect(route?.leg).toBe('dropoff');
     expect(route?.destination).toEqual({ latitude: 52.2, longitude: -106.6 });
     expect(route?.destinationLabel).toBe('202 Dropoff Ave');
+    expect(route?.polyline).toHaveLength(3);
   });
 
   it('returns null for non-nav states and a null ride', () => {

--- a/driver-app/__tests__/carRoute.test.ts
+++ b/driver-app/__tests__/carRoute.test.ts
@@ -7,7 +7,6 @@ import {
   defaultNavButtons,
   extractPolyline,
   isNavState,
-  providerForButton,
   resolveNavButtons,
   selectCarRoute,
 } from '../car/carRoute';
@@ -186,19 +185,3 @@ describe('resolveNavButtons (CarPlay install detection)', () => {
   });
 });
 
-describe('providerForButton', () => {
-  const ios = [
-    { id: 'nav-apple', provider: 'apple' as const },
-    { id: 'nav-google', provider: 'google' as const },
-  ];
-
-  it('round-trips a pressed button id back to its provider', () => {
-    expect(providerForButton(ios, 'nav-google', 'ios')).toBe('google');
-    expect(providerForButton(ios, 'nav-apple', 'ios')).toBe('apple');
-  });
-
-  it('falls back to the platform default for an unknown id', () => {
-    expect(providerForButton(ios, 'mystery', 'ios')).toBe('apple');
-    expect(providerForButton([], 'mystery', 'android')).toBe('google');
-  });
-});

--- a/driver-app/__tests__/carRoute.test.ts
+++ b/driver-app/__tests__/carRoute.test.ts
@@ -4,10 +4,11 @@
  */
 import {
   buildHandoffUrl,
+  defaultNavButtons,
   extractPolyline,
   isNavState,
-  navButtonsForPlatform,
   providerForButton,
+  resolveNavButtons,
   selectCarRoute,
 } from '../car/carRoute';
 import type { ActiveRide, RideState } from '../store/driverStore';
@@ -115,42 +116,86 @@ describe('selectCarRoute', () => {
 describe('buildHandoffUrl', () => {
   const dest = { latitude: 52.2, longitude: -106.6 };
 
-  it('builds the Google turn-by-turn navigation intent (matches openNavigation)', () => {
-    expect(buildHandoffUrl('google', dest)).toBe('google.navigation:q=52.2,-106.6');
+  it('uses the Google navigation intent on Android, comgooglemaps on iOS', () => {
+    expect(buildHandoffUrl('google', dest, 'android')).toBe('google.navigation:q=52.2,-106.6');
+    expect(buildHandoffUrl('google', dest, 'ios')).toBe(
+      'comgooglemaps://?daddr=52.2,-106.6&directionsmode=driving'
+    );
   });
 
   it('builds an Apple Maps driving-directions link (CarPlay)', () => {
-    expect(buildHandoffUrl('apple', dest)).toBe('maps://?daddr=52.2,-106.6&dirflg=d');
+    expect(buildHandoffUrl('apple', dest, 'ios')).toBe('maps://?daddr=52.2,-106.6&dirflg=d');
   });
 
-  it('builds a Waze navigate deep link (both platforms)', () => {
-    expect(buildHandoffUrl('waze', dest)).toBe('https://waze.com/ul?ll=52.2,-106.6&navigate=yes');
+  it('uses the waze:// scheme on iOS and the universal link on Android', () => {
+    expect(buildHandoffUrl('waze', dest, 'ios')).toBe('waze://?ll=52.2,-106.6&navigate=yes');
+    expect(buildHandoffUrl('waze', dest, 'android')).toBe(
+      'https://waze.com/ul?ll=52.2,-106.6&navigate=yes'
+    );
   });
 });
 
-describe('navButtonsForPlatform / providerForButton', () => {
-  it('offers Apple Maps + Waze on iOS (CarPlay)', () => {
-    expect(navButtonsForPlatform('ios')).toEqual([
-      { id: 'nav-apple', provider: 'apple' },
-      { id: 'nav-waze', provider: 'waze' },
-    ]);
-  });
-
-  it('offers Google + Waze on Android (Android Auto)', () => {
-    expect(navButtonsForPlatform('android')).toEqual([
+describe('defaultNavButtons', () => {
+  it('seeds only the guaranteed app per platform (no dead button)', () => {
+    expect(defaultNavButtons('ios')).toEqual([{ id: 'nav-apple', provider: 'apple' }]);
+    expect(defaultNavButtons('android')).toEqual([
       { id: 'nav-google', provider: 'google' },
       { id: 'nav-waze', provider: 'waze' },
     ]);
   });
+});
+
+describe('resolveNavButtons (CarPlay install detection)', () => {
+  it('is static Google + Waze on Android (no probing)', async () => {
+    const canOpen = jest.fn().mockResolvedValue(true);
+    await expect(resolveNavButtons('android', canOpen)).resolves.toEqual([
+      { id: 'nav-google', provider: 'google' },
+      { id: 'nav-waze', provider: 'waze' },
+    ]);
+    expect(canOpen).not.toHaveBeenCalled();
+  });
+
+  it('adds Google Maps + Waze on iOS only when both are installed', async () => {
+    const canOpen = jest.fn().mockResolvedValue(true);
+    const buttons = await resolveNavButtons('ios', canOpen);
+    expect(buttons.map((b) => b.provider)).toEqual(['apple', 'google', 'waze']);
+    expect(canOpen).toHaveBeenCalledWith('comgooglemaps://');
+    expect(canOpen).toHaveBeenCalledWith('waze://');
+  });
+
+  it('shows Google but not Waze when only Google Maps is installed', async () => {
+    const canOpen = jest.fn((url: string) => Promise.resolve(url.startsWith('comgooglemaps')));
+    const buttons = await resolveNavButtons('ios', canOpen);
+    expect(buttons.map((b) => b.provider)).toEqual(['apple', 'google']);
+  });
+
+  it('falls back to Apple Maps only when nothing else is installed', async () => {
+    const canOpen = jest.fn().mockResolvedValue(false);
+    const buttons = await resolveNavButtons('ios', canOpen);
+    expect(buttons.map((b) => b.provider)).toEqual(['apple']);
+  });
+
+  it('treats a canOpen rejection as "not installed" (never throws)', async () => {
+    const canOpen = jest.fn().mockRejectedValue(new Error('blocked scheme'));
+    await expect(resolveNavButtons('ios', canOpen)).resolves.toEqual([
+      { id: 'nav-apple', provider: 'apple' },
+    ]);
+  });
+});
+
+describe('providerForButton', () => {
+  const ios = [
+    { id: 'nav-apple', provider: 'apple' as const },
+    { id: 'nav-google', provider: 'google' as const },
+  ];
 
   it('round-trips a pressed button id back to its provider', () => {
-    expect(providerForButton('ios', 'nav-apple')).toBe('apple');
-    expect(providerForButton('ios', 'nav-waze')).toBe('waze');
-    expect(providerForButton('android', 'nav-google')).toBe('google');
+    expect(providerForButton(ios, 'nav-google', 'ios')).toBe('google');
+    expect(providerForButton(ios, 'nav-apple', 'ios')).toBe('apple');
   });
 
   it('falls back to the platform default for an unknown id', () => {
-    expect(providerForButton('ios', 'mystery')).toBe('apple');
-    expect(providerForButton('android', 'mystery')).toBe('google');
+    expect(providerForButton(ios, 'mystery', 'ios')).toBe('apple');
+    expect(providerForButton([], 'mystery', 'android')).toBe('google');
   });
 });

--- a/driver-app/__tests__/carRoute.test.ts
+++ b/driver-app/__tests__/carRoute.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for car/carRoute.ts — the pure route-selection + hand-off logic
+ * behind the Android Auto map. No native module / head unit required.
+ */
+import {
+  buildHandoffUrl,
+  extractPolyline,
+  isNavState,
+  selectCarRoute,
+} from '../car/carRoute';
+import type { ActiveRide, RideState } from '../store/driverStore';
+
+const makeRide = (overrides: Record<string, unknown> = {}): ActiveRide =>
+  ({
+    ride: {
+      id: 'ride-1',
+      pickup_address: '101 Pickup St',
+      dropoff_address: '202 Dropoff Ave',
+      pickup_lat: 52.13,
+      pickup_lng: -106.67,
+      dropoff_lat: 52.2,
+      dropoff_lng: -106.6,
+      planned_route_polyline: [
+        [52.13, -106.67],
+        [52.16, -106.64],
+        [52.2, -106.6],
+      ],
+      ...overrides,
+    },
+    rider: { id: 'rider-1' },
+    vehicle_type: { id: 'vt-1', name: 'Standard' },
+  }) as unknown as ActiveRide;
+
+describe('isNavState', () => {
+  it('is true only for the three navigation states', () => {
+    const truthy: RideState[] = ['navigating_to_pickup', 'arrived_at_pickup', 'trip_in_progress'];
+    const falsy: RideState[] = ['idle', 'ride_offered', 'trip_completed'];
+    truthy.forEach((s) => expect(isNavState(s)).toBe(true));
+    falsy.forEach((s) => expect(isNavState(s)).toBe(false));
+  });
+});
+
+describe('extractPolyline', () => {
+  it('parses a [[lat,lng], …] line off activeRide.ride', () => {
+    const line = extractPolyline(makeRide());
+    expect(line).toHaveLength(3);
+    expect(line[0]).toEqual({ latitude: 52.13, longitude: -106.67 });
+    expect(line[2]).toEqual({ latitude: 52.2, longitude: -106.6 });
+  });
+
+  it('returns [] for null ride, missing line, or non-array junk', () => {
+    expect(extractPolyline(null)).toEqual([]);
+    expect(extractPolyline(makeRide({ planned_route_polyline: undefined }))).toEqual([]);
+    expect(extractPolyline(makeRide({ planned_route_polyline: 'nope' }))).toEqual([]);
+  });
+
+  it('drops malformed points instead of rendering (0,0)', () => {
+    const line = extractPolyline(
+      makeRide({
+        planned_route_polyline: [[52.1, -106.6], ['x', 1], [1], [52.2, -106.5]],
+      })
+    );
+    expect(line).toEqual([
+      { latitude: 52.1, longitude: -106.6 },
+      { latitude: 52.2, longitude: -106.5 },
+    ]);
+  });
+});
+
+describe('selectCarRoute', () => {
+  it('targets the PICKUP before the trip starts', () => {
+    for (const s of ['navigating_to_pickup', 'arrived_at_pickup'] as RideState[]) {
+      const route = selectCarRoute(s, makeRide());
+      expect(route?.leg).toBe('pickup');
+      expect(route?.destination).toEqual({ latitude: 52.13, longitude: -106.67 });
+      expect(route?.destinationLabel).toBe('101 Pickup St');
+      expect(route?.polyline).toHaveLength(3);
+    }
+  });
+
+  it('targets the DROPOFF once in progress', () => {
+    const route = selectCarRoute('trip_in_progress', makeRide());
+    expect(route?.leg).toBe('dropoff');
+    expect(route?.destination).toEqual({ latitude: 52.2, longitude: -106.6 });
+    expect(route?.destinationLabel).toBe('202 Dropoff Ave');
+  });
+
+  it('returns null for non-nav states and a null ride', () => {
+    expect(selectCarRoute('idle', makeRide())).toBeNull();
+    expect(selectCarRoute('ride_offered', makeRide())).toBeNull();
+    expect(selectCarRoute('trip_completed', makeRide())).toBeNull();
+    expect(selectCarRoute('trip_in_progress', null)).toBeNull();
+  });
+
+  it('returns null when the destination coords are missing (no bogus pin)', () => {
+    const route = selectCarRoute(
+      'trip_in_progress',
+      makeRide({ dropoff_lat: undefined, dropoff_lng: undefined })
+    );
+    expect(route).toBeNull();
+  });
+
+  it('still returns a route when the polyline is absent — marker + handoff only', () => {
+    const route = selectCarRoute(
+      'navigating_to_pickup',
+      makeRide({ planned_route_polyline: undefined })
+    );
+    expect(route).not.toBeNull();
+    expect(route?.polyline).toEqual([]);
+  });
+});
+
+describe('buildHandoffUrl', () => {
+  const dest = { latitude: 52.2, longitude: -106.6 };
+
+  it('builds the Google turn-by-turn navigation intent (matches openNavigation)', () => {
+    expect(buildHandoffUrl('google', dest)).toBe('google.navigation:q=52.2,-106.6');
+  });
+
+  it('builds a Waze navigate deep link', () => {
+    expect(buildHandoffUrl('waze', dest)).toBe('https://waze.com/ul?ll=52.2,-106.6&navigate=yes');
+  });
+});

--- a/driver-app/__tests__/carRoute.test.ts
+++ b/driver-app/__tests__/carRoute.test.ts
@@ -6,6 +6,8 @@ import {
   buildHandoffUrl,
   extractPolyline,
   isNavState,
+  navButtonsForPlatform,
+  providerForButton,
   selectCarRoute,
 } from '../car/carRoute';
 import type { ActiveRide, RideState } from '../store/driverStore';
@@ -117,7 +119,38 @@ describe('buildHandoffUrl', () => {
     expect(buildHandoffUrl('google', dest)).toBe('google.navigation:q=52.2,-106.6');
   });
 
-  it('builds a Waze navigate deep link', () => {
+  it('builds an Apple Maps driving-directions link (CarPlay)', () => {
+    expect(buildHandoffUrl('apple', dest)).toBe('maps://?daddr=52.2,-106.6&dirflg=d');
+  });
+
+  it('builds a Waze navigate deep link (both platforms)', () => {
     expect(buildHandoffUrl('waze', dest)).toBe('https://waze.com/ul?ll=52.2,-106.6&navigate=yes');
+  });
+});
+
+describe('navButtonsForPlatform / providerForButton', () => {
+  it('offers Apple Maps + Waze on iOS (CarPlay)', () => {
+    expect(navButtonsForPlatform('ios')).toEqual([
+      { id: 'nav-apple', provider: 'apple' },
+      { id: 'nav-waze', provider: 'waze' },
+    ]);
+  });
+
+  it('offers Google + Waze on Android (Android Auto)', () => {
+    expect(navButtonsForPlatform('android')).toEqual([
+      { id: 'nav-google', provider: 'google' },
+      { id: 'nav-waze', provider: 'waze' },
+    ]);
+  });
+
+  it('round-trips a pressed button id back to its provider', () => {
+    expect(providerForButton('ios', 'nav-apple')).toBe('apple');
+    expect(providerForButton('ios', 'nav-waze')).toBe('waze');
+    expect(providerForButton('android', 'nav-google')).toBe('google');
+  });
+
+  it('falls back to the platform default for an unknown id', () => {
+    expect(providerForButton('ios', 'mystery')).toBe('apple');
+    expect(providerForButton('android', 'mystery')).toBe('google');
   });
 });

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -25,7 +25,7 @@ import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useAuthStore } from '@shared/store/authStore';
 import { useLocationStore } from '@shared/store/locationStore';
 import { useDriverStore } from '../store/driverStore';
-import { initCarSpike } from '../car/carSpike';
+import { initCarNav } from '../car/carNav';
 import SpinrConfig from '@shared/config/spinr.config';
 import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import { OfflineBanner } from '@shared/components/OfflineBanner';
@@ -356,15 +356,15 @@ export default function RootLayout() {
     }
   }, []);
 
-  // ── CarPlay smoke-test (SPIKE), iOS only ──
+  // ── CarPlay in-dash route map, iOS only ──
   // iOS CarPlay shares the phone app's JS context, so it's driven from here.
-  // Android Auto runs in its OWN JS root and is handled by car/androidAutoEntry
-  // (imported above) — calling initCarSpike here too would double-register on
-  // Android. No-op unless the native module is present (CarPlay wiring is gated
-  // off by default — see plugins/withCarIntegration.js). See docs/carplay-android-auto.md.
+  // Android Auto runs in its OWN JS root (car/androidAutoEntry, imported above)
+  // — calling initCarNav here too would double-init on Android, hence the iOS
+  // guard. No-op unless the native module is present (CarPlay wiring is gated off
+  // by default — see plugins/withCarIntegration.js). See docs/carplay-android-auto.md.
   useEffect(() => {
     if (Platform.OS !== 'ios') return;
-    const cleanup = initCarSpike();
+    const cleanup = initCarNav();
     return cleanup;
   }, []);
 

--- a/driver-app/car/androidAutoEntry.tsx
+++ b/driver-app/car/androidAutoEntry.tsx
@@ -29,15 +29,25 @@ function AndroidAutoRoot(): null {
   return null;
 }
 
-export { AndroidAutoRoot };
+// Instrument-cluster surface: on cluster-equipped vehicles the fork runs a
+// SEPARATE "AndroidAutoCluster" root alongside the main one (CarPlaySession.kt,
+// by displayType). It must NOT call initCarNav — a second instance would
+// double-register the global button-press listeners and fire duplicate nav
+// hand-offs for a single tap. The cluster is guidance-only here, so it's a no-op.
+function AndroidAutoClusterRoot(): null {
+  return null;
+}
+
+export { AndroidAutoRoot, AndroidAutoClusterRoot };
 
 export function registerAndroidAuto(): void {
   if (Platform.OS !== 'android') return;
   try {
     AppRegistry.registerComponent('AndroidAuto', () => AndroidAutoRoot);
     // The fork requests "AndroidAutoCluster" for the instrument-cluster surface;
-    // register the same root so a cluster launch doesn't crash on a missing component.
-    AppRegistry.registerComponent('AndroidAutoCluster', () => AndroidAutoRoot);
+    // register a SEPARATE no-op root (not AndroidAutoRoot) so a cluster launch
+    // doesn't crash AND doesn't run a second initCarNav (duplicate-hand-off fix).
+    AppRegistry.registerComponent('AndroidAutoCluster', () => AndroidAutoClusterRoot);
     // The fork needs its headless task registered so timers keep firing while the
     // screen is off. It is only the default export of a subpath (not the index), so
     // require it defensively — a render still works without it.

--- a/driver-app/car/androidAutoEntry.tsx
+++ b/driver-app/car/androidAutoEntry.tsx
@@ -14,14 +14,16 @@
  */
 import { useEffect } from 'react';
 import { AppRegistry, Platform } from 'react-native';
-import { initCarSpike } from './carSpike';
+import { initCarNav } from './carNav';
 
 // Android Auto renders Google car *templates*, not RN views, so this root renders
-// nothing — it just drives the template layer via initCarSpike() (which sets the
-// root template on connect; the car is already connected when this root mounts).
+// nothing itself — it drives the template layer via initCarNav(), which sets a
+// MapTemplate (the in-dash route map drawn from the stored polyline) as the car
+// root on an active ride and an idle ListTemplate otherwise. The map surface
+// component is rendered separately by the fork onto the car surface.
 function AndroidAutoRoot(): null {
   useEffect(() => {
-    const cleanup = initCarSpike();
+    const cleanup = initCarNav();
     return cleanup;
   }, []);
   return null;

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -1,0 +1,177 @@
+/**
+ * Android Auto in-dash route map (Path B *look*, Path A *cost*).
+ *
+ * On an active ride this sets a Google `MapTemplate` as the car root and draws
+ * the route we already stored (`planned_route_polyline`) onto the head-unit map
+ * surface, with the destination pinned. Tapping a map button hands live
+ * turn-by-turn to Google Maps / Waze — so the driver gets the branded in-dash
+ * look with ZERO live Routes/Navigation-SDK spend.
+ *
+ * The surface `component` is registered by the fork's MapTemplate
+ * (`AppRegistry.registerComponent(this.id, …)`) and rendered onto the car
+ * surface; it reads the SAME `useDriverStore` the phone uses (single source of
+ * truth). Android-only and fully guarded — a no-op on iOS / Expo Go / missing
+ * native module.
+ *
+ * UNPROVEN ON HARDWARE: like the rest of car/, this is validated at the JS level
+ * only. The map button icons and on-surface render must still be confirmed on an
+ * EAS dev build + Android Auto DHU (see docs/carplay-android-auto.md).
+ */
+import React from 'react';
+import { Linking, Platform, StyleSheet, View } from 'react-native';
+import { useDriverStore } from '../store/driverStore';
+import { buildHandoffUrl, selectCarRoute, type NavProvider } from './carRoute';
+
+const NAV_TEMPLATE_ID = 'spinr-car-nav';
+const IDLE_TEMPLATE_ID = 'spinr-car-idle';
+const SPINR_RED = '#ee2b2b';
+
+const log = (...args: unknown[]) => {
+  if (__DEV__) console.log('[car-nav]', ...args);
+};
+const noop = () => {};
+
+// ── Surface component: the branded route map drawn from the stored polyline ──
+// react-native-maps' native view is absent in Expo Go / web / tests, so it is
+// lazy-required and the component degrades to null instead of crashing.
+export function CarMapSurface(): React.ReactElement | null {
+  // Hooks first — unconditional, before any early return (rules-of-hooks).
+  const rideState = useDriverStore((s) => s.rideState);
+  const activeRide = useDriverStore((s) => s.activeRide);
+  const route = selectCarRoute(rideState, activeRide);
+
+  let Maps: typeof import('react-native-maps') | null = null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    Maps = require('react-native-maps');
+  } catch {
+    Maps = null;
+  }
+  if (!Maps || !route) return null;
+
+  const MapView = Maps.default;
+  const { Marker, Polyline } = Maps;
+
+  return (
+    <View style={styles.fill}>
+      <MapView
+        style={styles.fill}
+        // The projected car surface is non-interactive (Android Auto drives
+        // interaction through template buttons, not in-surface touches).
+        pointerEvents="none"
+        initialRegion={{
+          latitude: route.destination.latitude,
+          longitude: route.destination.longitude,
+          latitudeDelta: 0.05,
+          longitudeDelta: 0.05,
+        }}
+      >
+        {route.polyline.length >= 2 && (
+          <Polyline coordinates={route.polyline} strokeColor={SPINR_RED} strokeWidth={6} />
+        )}
+        <Marker coordinate={route.destination} title={route.destinationLabel} />
+      </MapView>
+    </View>
+  );
+}
+
+// ── Hand off live turn-by-turn to the driver's nav app ──
+export function handoffToNav(provider: NavProvider): void {
+  const { rideState, activeRide } = useDriverStore.getState();
+  const route = selectCarRoute(rideState, activeRide);
+  if (!route) {
+    log('hand-off skipped — no active route');
+    return;
+  }
+  const url = buildHandoffUrl(provider, route.destination);
+  Linking.openURL(url).catch((e) => log('hand-off openURL failed:', e));
+}
+
+// ── Template builders (constructors injected → unit-testable w/o native) ──
+type MapCtor = new (cfg: Record<string, unknown>) => object;
+type ListCtor = new (cfg: Record<string, unknown>) => object;
+
+export function buildNavMapTemplate(MapTemplateCtor: MapCtor): object {
+  return new MapTemplateCtor({
+    id: NAV_TEMPLATE_ID,
+    component: CarMapSurface,
+    // Android Auto interaction is via template buttons (driver-distraction
+    // model), not in-surface touchables. Each hands off to a nav app.
+    mapButtons: [{ id: 'nav-google' }, { id: 'nav-waze' }],
+    onMapButtonPressed: (e: { id: string }) => {
+      handoffToNav(e.id === 'nav-waze' ? 'waze' : 'google');
+    },
+  });
+}
+
+export function buildIdleTemplate(ListTemplateCtor: ListCtor): object {
+  const item = { id: 'idle', text: 'Spinr', detailText: "You're online — waiting for trips" };
+  return new ListTemplateCtor({
+    id: IDLE_TEMPLATE_ID,
+    title: 'Spinr',
+    sections: [{ items: [item] }],
+    items: [item],
+  });
+}
+
+// ── Wire it up: drive the car root from the ride state machine ──
+export function initCarNav(): () => void {
+  if (Platform.OS !== 'android') return noop;
+
+  let carplay: typeof import('@g4rb4g3/react-native-carplay');
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    carplay = require('@g4rb4g3/react-native-carplay');
+  } catch (e) {
+    log('native module unavailable — skipping (expected in Expo Go):', e);
+    return noop;
+  }
+  const { CarPlay, MapTemplate, ListTemplate } = carplay;
+
+  // Rebuild the root only when the displayed leg changes (idle → pickup →
+  // dropoff), not on every store tick — location updates fire constantly and
+  // setRootTemplate is comparatively expensive.
+  let lastKey: string | null = null;
+  const apply = () => {
+    const { rideState, activeRide } = useDriverStore.getState();
+    const route = selectCarRoute(rideState, activeRide);
+    const key = route ? route.leg : 'idle';
+    if (key === lastKey) return;
+    lastKey = key;
+    try {
+      CarPlay.setRootTemplate(
+        route
+          ? buildNavMapTemplate(MapTemplate as unknown as MapCtor)
+          : buildIdleTemplate(ListTemplate as unknown as ListCtor)
+      );
+    } catch (e) {
+      log('setRootTemplate failed:', e);
+    }
+  };
+
+  const onConnect = () => {
+    lastKey = null; // force a fresh root on (re)connect
+    apply();
+  };
+
+  let unsub = noop;
+  try {
+    CarPlay.registerOnConnect(onConnect);
+    unsub = useDriverStore.subscribe(apply);
+    if (CarPlay.connected) onConnect();
+  } catch (e) {
+    log('init failed:', e);
+    return noop;
+  }
+
+  return () => {
+    try {
+      CarPlay.unregisterOnConnect(onConnect);
+      unsub();
+    } catch {
+      /* no-op */
+    }
+  };
+}
+
+const styles = StyleSheet.create({ fill: { flex: 1 } });

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -139,11 +139,12 @@ export function initCarNav(): () => void {
     if (key === lastKey) return;
     lastKey = key;
     try {
-      CarPlay.setRootTemplate(
-        route
-          ? buildNavMapTemplate(MapTemplate as unknown as MapCtor)
-          : buildIdleTemplate(ListTemplate as unknown as ListCtor)
-      );
+      const tpl = route
+        ? buildNavMapTemplate(MapTemplate as unknown as MapCtor)
+        : buildIdleTemplate(ListTemplate as unknown as ListCtor);
+      // The fork's setRootTemplate type union omits MapTemplate (its TS types lag
+      // the runtime, which accepts it as a root) — cast to the expected param.
+      CarPlay.setRootTemplate(tpl as Parameters<typeof CarPlay.setRootTemplate>[0]);
     } catch (e) {
       log('setRootTemplate failed:', e);
     }

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -109,15 +109,15 @@ type ListCtor = new (cfg: Record<string, unknown>) => object;
 
 export function buildNavMapTemplate(MapTemplateCtor: MapCtor, buttons: NavButton[]): object {
   // `buttons` is resolved per platform + installed apps (see resolveNavButtons).
-  // Interaction is via template map buttons (driver-distraction model), not
-  // in-surface touches; each hands off to the chosen nav app.
+  // PRESSES are handled by a CarPlay.emitter listener in initCarNav, NOT a config
+  // callback: on Android the fork parses `mapButtons` as an ActionStrip and emits
+  // `buttonPressed` (not the iOS `mapButtonPressed`), so a config `onMapButtonPressed`
+  // would be dead on Android. One emitter listener covers both platforms and avoids
+  // stale per-template callbacks firing after rebuilds.
   return new MapTemplateCtor({
     id: NAV_TEMPLATE_ID,
     component: CarMapSurface,
     mapButtons: buttons.map((b) => ({ id: b.id, image: NAV_ICON })),
-    onMapButtonPressed: (e: { id: string }) => {
-      handoffToNav(providerForButton(buttons, e.id, Platform.OS));
-    },
   });
 }
 
@@ -148,9 +148,19 @@ export function initCarNav(): () => void {
   }
   const { CarPlay, MapTemplate, ListTemplate } = carplay;
 
+  // Cold Android Auto launch runs this separate JS root with the phone dashboard
+  // (and its hydrate + fetchActiveRide) never mounted, so the store would sit at
+  // `idle` and show the idle list instead of the active route. Restore the
+  // persisted ride here. Safe + idempotent: hydrateDriverRideState only fills an
+  // empty store, never clobbers a live ride/offer, and is AsyncStorage-only (no
+  // auth). The store subscription below rebuilds the root once state lands.
+  // (Network reconciliation via fetchActiveRide needs auth bootstrap — deferred.)
+  useDriverStore.getState().hydrateDriverRideState?.().catch(() => {});
+
   // Seed with the guaranteed app; the real set (incl. Google Maps / Waze if the
   // driver has them) is resolved asynchronously below and triggers a rebuild.
   let navButtons = defaultNavButtons(Platform.OS);
+  let currentTemplate: { destroy?: () => void } | null = null;
 
   // Rebuild the root only when the displayed leg changes (idle → pickup →
   // dropoff), not on every store tick — location updates fire constantly and
@@ -169,9 +179,23 @@ export function initCarNav(): () => void {
       // The fork's setRootTemplate type union omits MapTemplate (its TS types lag
       // the runtime, which accepts it as a root) — cast to the expected param.
       CarPlay.setRootTemplate(tpl as Parameters<typeof CarPlay.setRootTemplate>[0]);
+      // Tear down the previous template: the fork registers per-instance emitter
+      // listeners keyed by the (shared) template id, so dropping the old instance
+      // without destroy() leaks listeners that keep firing. (Codex P2)
+      const prev = currentTemplate;
+      currentTemplate = tpl as { destroy?: () => void };
+      prev?.destroy?.();
     } catch (e) {
       log('setRootTemplate failed:', e);
     }
+  };
+
+  // Route head-unit button presses to the nav hand-off via ONE emitter listener
+  // per event: iOS emits `mapButtonPressed` ({id}); Android parses mapButtons as
+  // an ActionStrip and emits `buttonPressed` ({buttonId}). (Codex P1)
+  const onButton = (e: { id?: string; buttonId?: string }) => {
+    const id = e.buttonId ?? e.id;
+    if (id) handoffToNav(providerForButton(navButtons, id, Platform.OS));
   };
 
   const onConnect = () => {
@@ -179,10 +203,13 @@ export function initCarNav(): () => void {
     apply();
   };
 
+  const buttonSubs: Array<{ remove: () => void }> = [];
   let unsub = noop;
   try {
     CarPlay.registerOnConnect(onConnect);
     unsub = useDriverStore.subscribe(apply);
+    buttonSubs.push(CarPlay.emitter.addListener('mapButtonPressed', onButton));
+    buttonSubs.push(CarPlay.emitter.addListener('buttonPressed', onButton));
     if (CarPlay.connected) onConnect();
   } catch (e) {
     log('init failed:', e);
@@ -209,6 +236,8 @@ export function initCarNav(): () => void {
     try {
       CarPlay.unregisterOnConnect(onConnect);
       unsub();
+      buttonSubs.forEach((s) => s.remove());
+      currentTemplate?.destroy?.();
     } catch {
       /* no-op */
     }

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -24,7 +24,6 @@ import { useDriverStore } from '../store/driverStore';
 import {
   buildHandoffUrl,
   defaultNavButtons,
-  providerForButton,
   resolveNavButtons,
   selectCarRoute,
   type NavButton,
@@ -70,6 +69,10 @@ export function CarMapSurface(): React.ReactElement | null {
   return (
     <View style={styles.fill}>
       <MapView
+        // Re-mount (fresh initialRegion) when the destination changes so the
+        // camera re-centers on a leg/ride swap instead of staying on the stale
+        // ride — initialRegion only applies on mount. (Codex P2)
+        key={`${route.destination.latitude},${route.destination.longitude}`}
         style={styles.fill}
         // The projected car surface is non-interactive (Android Auto drives
         // interaction through template buttons, not in-surface touches).
@@ -98,9 +101,16 @@ export function handoffToNav(provider: NavProvider): void {
     log('hand-off skipped — no active route');
     return;
   }
+  const { latitude, longitude } = route.destination;
   const url = buildHandoffUrl(provider, route.destination, Platform.OS);
+  // Universal web Maps URL as a last resort so a missing/disabled nav app never
+  // leaves the button dead — `google.navigation:` throws "No Activity found" with
+  // no Maps app. Mirrors openMapsNavigation in ActiveRidePanel.tsx. (Codex P2)
+  const webFallback = `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}&travelmode=driving`;
   log('hand-off →', provider, url); // visible in Metro when testing on a head unit
-  Linking.openURL(url).catch((e) => log('hand-off openURL failed:', e));
+  Linking.openURL(url).catch(() =>
+    Linking.openURL(webFallback).catch((e) => log('hand-off failed:', e))
+  );
 }
 
 // ── Template builders (constructors injected → unit-testable w/o native) ──
@@ -169,7 +179,11 @@ export function initCarNav(): () => void {
   const apply = () => {
     const { rideState, activeRide } = useDriverStore.getState();
     const route = selectCarRoute(rideState, activeRide);
-    const key = route ? route.leg : 'idle';
+    // Include ride identity in the key so a same-leg ride swap (cached →
+    // fetchActiveRide replaces with a different trip_in_progress ride) still
+    // rebuilds the root + re-centers the map, instead of being suppressed. (Codex P2)
+    const rideId = (activeRide?.ride as { id?: string } | undefined)?.id ?? '';
+    const key = route ? `${route.leg}:${rideId}` : 'idle';
     if (key === lastKey) return;
     lastKey = key;
     try {
@@ -193,9 +207,14 @@ export function initCarNav(): () => void {
   // Route head-unit button presses to the nav hand-off via ONE emitter listener
   // per event: iOS emits `mapButtonPressed` ({id}); Android parses mapButtons as
   // an ActionStrip and emits `buttonPressed` ({buttonId}). (Codex P1)
+  // Only hand off for OUR nav button ids: the Android `buttonPressed` event is
+  // global and carries no template id, so any other car action/alert button id
+  // would otherwise fall through and launch navigation. Strict membership check
+  // — unknown ids are ignored. (Codex P2)
   const onButton = (e: { id?: string; buttonId?: string }) => {
     const id = e.buttonId ?? e.id;
-    if (id) handoffToNav(providerForButton(navButtons, id, Platform.OS));
+    const btn = id ? navButtons.find((b) => b.id === id) : undefined;
+    if (btn) handoffToNav(btn.provider);
   };
 
   const onConnect = () => {

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -23,9 +23,11 @@ import { Linking, Platform, StyleSheet, View } from 'react-native';
 import { useDriverStore } from '../store/driverStore';
 import {
   buildHandoffUrl,
-  navButtonsForPlatform,
+  defaultNavButtons,
   providerForButton,
+  resolveNavButtons,
   selectCarRoute,
+  type NavButton,
   type NavProvider,
 } from './carRoute';
 
@@ -96,7 +98,7 @@ export function handoffToNav(provider: NavProvider): void {
     log('hand-off skipped — no active route');
     return;
   }
-  const url = buildHandoffUrl(provider, route.destination);
+  const url = buildHandoffUrl(provider, route.destination, Platform.OS);
   log('hand-off →', provider, url); // visible in Metro when testing on a head unit
   Linking.openURL(url).catch((e) => log('hand-off openURL failed:', e));
 }
@@ -105,17 +107,16 @@ export function handoffToNav(provider: NavProvider): void {
 type MapCtor = new (cfg: Record<string, unknown>) => object;
 type ListCtor = new (cfg: Record<string, unknown>) => object;
 
-export function buildNavMapTemplate(MapTemplateCtor: MapCtor): object {
-  // Per-platform nav apps: CarPlay → Apple Maps + Waze, Android Auto → Google +
-  // Waze. Interaction is via template map buttons (driver-distraction model),
-  // not in-surface touches; each hands off to the chosen nav app.
-  const buttons = navButtonsForPlatform(Platform.OS);
+export function buildNavMapTemplate(MapTemplateCtor: MapCtor, buttons: NavButton[]): object {
+  // `buttons` is resolved per platform + installed apps (see resolveNavButtons).
+  // Interaction is via template map buttons (driver-distraction model), not
+  // in-surface touches; each hands off to the chosen nav app.
   return new MapTemplateCtor({
     id: NAV_TEMPLATE_ID,
     component: CarMapSurface,
     mapButtons: buttons.map((b) => ({ id: b.id, image: NAV_ICON })),
     onMapButtonPressed: (e: { id: string }) => {
-      handoffToNav(providerForButton(Platform.OS, e.id));
+      handoffToNav(providerForButton(buttons, e.id, Platform.OS));
     },
   });
 }
@@ -147,6 +148,10 @@ export function initCarNav(): () => void {
   }
   const { CarPlay, MapTemplate, ListTemplate } = carplay;
 
+  // Seed with the guaranteed app; the real set (incl. Google Maps / Waze if the
+  // driver has them) is resolved asynchronously below and triggers a rebuild.
+  let navButtons = defaultNavButtons(Platform.OS);
+
   // Rebuild the root only when the displayed leg changes (idle → pickup →
   // dropoff), not on every store tick — location updates fire constantly and
   // setRootTemplate is comparatively expensive.
@@ -159,7 +164,7 @@ export function initCarNav(): () => void {
     lastKey = key;
     try {
       const tpl = route
-        ? buildNavMapTemplate(MapTemplate as unknown as MapCtor)
+        ? buildNavMapTemplate(MapTemplate as unknown as MapCtor, navButtons)
         : buildIdleTemplate(ListTemplate as unknown as ListCtor);
       // The fork's setRootTemplate type union omits MapTemplate (its TS types lag
       // the runtime, which accepts it as a root) — cast to the expected param.
@@ -183,6 +188,22 @@ export function initCarNav(): () => void {
     log('init failed:', e);
     return noop;
   }
+
+  // Detect which nav apps the driver actually has (CarPlay varies — some have
+  // Google Maps, some don't). If the resolved set differs from the seed, rebuild
+  // the current root so the extra buttons appear.
+  resolveNavButtons(Platform.OS, (url) => Linking.canOpenURL(url))
+    .then((resolved) => {
+      const changed =
+        resolved.length !== navButtons.length ||
+        resolved.some((b, i) => b.id !== navButtons[i].id);
+      navButtons = resolved;
+      if (changed && CarPlay.connected) {
+        lastKey = null;
+        apply();
+      }
+    })
+    .catch((e) => log('nav-app detection failed:', e));
 
   return () => {
     try {

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -141,6 +141,12 @@ export function buildIdleTemplate(ListTemplateCtor: ListCtor): object {
   });
 }
 
+// CarPlay idle root: a MapTemplate (no nav buttons) so a navigation-category app
+// always has a CPMapTemplate root, even while waiting for a trip. (Codex P2)
+export function buildIdleMapTemplate(MapTemplateCtor: MapCtor): object {
+  return new MapTemplateCtor({ id: IDLE_TEMPLATE_ID, component: CarMapSurface });
+}
+
 // ── Wire it up: drive the car root from the ride state machine ──
 // Runs on both car platforms: Android Auto calls this from its AppRegistry root
 // (car/androidAutoEntry.tsx); CarPlay calls it from app/_layout.tsx (shared JS
@@ -158,14 +164,27 @@ export function initCarNav(): () => void {
   }
   const { CarPlay, MapTemplate, ListTemplate } = carplay;
 
-  // Cold Android Auto launch runs this separate JS root with the phone dashboard
-  // (and its hydrate + fetchActiveRide) never mounted, so the store would sit at
-  // `idle` and show the idle list instead of the active route. Restore the
-  // persisted ride here. Safe + idempotent: hydrateDriverRideState only fills an
-  // empty store, never clobbers a live ride/offer, and is AsyncStorage-only (no
-  // auth). The store subscription below rebuilds the root once state lands.
-  // (Network reconciliation via fetchActiveRide needs auth bootstrap — deferred.)
-  useDriverStore.getState().hydrateDriverRideState?.().catch(() => {});
+  // Cold car launch runs this separate JS root with the phone dashboard (and its
+  // hydrate + fetchActiveRide) never mounted, so the store would sit at `idle`.
+  // Restore the persisted ride AND reconcile against the server, so a cached ride
+  // that completed/cancelled/changed while the phone UI was unmounted doesn't show
+  // or hand off a stale route. fetchActiveRide is safe here — the api client
+  // resolves the token from SecureStore (shared/api/client.ts), so no in-memory
+  // auth bootstrap is needed. Both are guarded/idempotent; the store subscription
+  // rebuilds the root once state lands. (Codex P2)
+  void (async () => {
+    const store = useDriverStore.getState();
+    try {
+      await store.hydrateDriverRideState?.();
+    } catch {
+      /* cache miss — ignore */
+    }
+    try {
+      await store.fetchActiveRide?.();
+    } catch {
+      /* offline / not authed — keep the cached snapshot */
+    }
+  })();
 
   // Seed with the guaranteed app; the real set (incl. Google Maps / Waze if the
   // driver has them) is resolved asynchronously below and triggers a rebuild.
@@ -177,6 +196,11 @@ export function initCarNav(): () => void {
   // setRootTemplate is comparatively expensive.
   let lastKey: string | null = null;
   const apply = () => {
+    // Only push templates when a car is actually connected. On iOS initCarNav is
+    // mounted by the phone layout even with no CarPlay session, so unguarded
+    // store changes (accept/progress a ride while unplugged) would call
+    // setRootTemplate on a nil interface. onConnect re-applies on connect. (Codex P2)
+    if (!CarPlay.connected) return;
     const { rideState, activeRide } = useDriverStore.getState();
     const route = selectCarRoute(rideState, activeRide);
     // Include ride identity in the key so a same-leg ride swap (cached →
@@ -187,9 +211,15 @@ export function initCarNav(): () => void {
     if (key === lastKey) return;
     lastKey = key;
     try {
+      // CarPlay navigation apps (carplay-maps) require a CPMapTemplate root, so
+      // the iOS idle state is a MapTemplate too — a ListTemplate root can be
+      // rejected by the host. Android Auto's idle ListTemplate is fine for the
+      // NAVIGATION category. (Codex P2)
       const tpl = route
         ? buildNavMapTemplate(MapTemplate as unknown as MapCtor, navButtons)
-        : buildIdleTemplate(ListTemplate as unknown as ListCtor);
+        : Platform.OS === 'ios'
+          ? buildIdleMapTemplate(MapTemplate as unknown as MapCtor)
+          : buildIdleTemplate(ListTemplate as unknown as ListCtor);
       // The fork's setRootTemplate type union omits MapTemplate (its TS types lag
       // the runtime, which accepts it as a root) — cast to the expected param.
       CarPlay.setRootTemplate(tpl as Parameters<typeof CarPlay.setRootTemplate>[0]);

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -10,8 +10,9 @@
  * The surface `component` is registered by the fork's MapTemplate
  * (`AppRegistry.registerComponent(this.id, …)`) and rendered onto the car
  * surface; it reads the SAME `useDriverStore` the phone uses (single source of
- * truth). Android-only and fully guarded — a no-op on iOS / Expo Go / missing
- * native module.
+ * truth). Cross-platform — Android Auto (separate AppRegistry root) and CarPlay
+ * (phone JS context, driven from app/_layout.tsx). Fully guarded: a no-op on
+ * Expo Go / web / missing native module.
  *
  * UNPROVEN ON HARDWARE: like the rest of car/, this is validated at the JS level
  * only. The map button icons and on-surface render must still be confirmed on an
@@ -20,11 +21,23 @@
 import React from 'react';
 import { Linking, Platform, StyleSheet, View } from 'react-native';
 import { useDriverStore } from '../store/driverStore';
-import { buildHandoffUrl, selectCarRoute, type NavProvider } from './carRoute';
+import {
+  buildHandoffUrl,
+  navButtonsForPlatform,
+  providerForButton,
+  selectCarRoute,
+  type NavProvider,
+} from './carRoute';
 
 const NAV_TEMPLATE_ID = 'spinr-car-nav';
 const IDLE_TEMPLATE_ID = 'spinr-car-idle';
 const SPINR_RED = '#ee2b2b';
+
+// Placeholder glyph for the map-button icons (CarPlay/Android Auto map buttons
+// are always icons). Reuses a bundled asset so the buttons render + are tappable
+// in the emulator; swap for proper nav/Waze glyphs before release.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const NAV_ICON = require('../assets/images/car_marker.png');
 
 const log = (...args: unknown[]) => {
   if (__DEV__) console.log('[car-nav]', ...args);
@@ -84,6 +97,7 @@ export function handoffToNav(provider: NavProvider): void {
     return;
   }
   const url = buildHandoffUrl(provider, route.destination);
+  log('hand-off →', provider, url); // visible in Metro when testing on a head unit
   Linking.openURL(url).catch((e) => log('hand-off openURL failed:', e));
 }
 
@@ -92,14 +106,16 @@ type MapCtor = new (cfg: Record<string, unknown>) => object;
 type ListCtor = new (cfg: Record<string, unknown>) => object;
 
 export function buildNavMapTemplate(MapTemplateCtor: MapCtor): object {
+  // Per-platform nav apps: CarPlay → Apple Maps + Waze, Android Auto → Google +
+  // Waze. Interaction is via template map buttons (driver-distraction model),
+  // not in-surface touches; each hands off to the chosen nav app.
+  const buttons = navButtonsForPlatform(Platform.OS);
   return new MapTemplateCtor({
     id: NAV_TEMPLATE_ID,
     component: CarMapSurface,
-    // Android Auto interaction is via template buttons (driver-distraction
-    // model), not in-surface touchables. Each hands off to a nav app.
-    mapButtons: [{ id: 'nav-google' }, { id: 'nav-waze' }],
+    mapButtons: buttons.map((b) => ({ id: b.id, image: NAV_ICON })),
     onMapButtonPressed: (e: { id: string }) => {
-      handoffToNav(e.id === 'nav-waze' ? 'waze' : 'google');
+      handoffToNav(providerForButton(Platform.OS, e.id));
     },
   });
 }
@@ -115,8 +131,11 @@ export function buildIdleTemplate(ListTemplateCtor: ListCtor): object {
 }
 
 // ── Wire it up: drive the car root from the ride state machine ──
+// Runs on both car platforms: Android Auto calls this from its AppRegistry root
+// (car/androidAutoEntry.tsx); CarPlay calls it from app/_layout.tsx (shared JS
+// context). The fork's CarPlay singleton abstracts the platform difference.
 export function initCarNav(): () => void {
-  if (Platform.OS !== 'android') return noop;
+  if (Platform.OS !== 'android' && Platform.OS !== 'ios') return noop;
 
   let carplay: typeof import('@g4rb4g3/react-native-carplay');
   try {

--- a/driver-app/car/carRoute.ts
+++ b/driver-app/car/carRoute.ts
@@ -1,0 +1,112 @@
+/**
+ * Car route selection + nav hand-off (Path B *look*, Path A *cost*).
+ *
+ * The Android Auto map shows the route we ALREADY stored at ride creation
+ * (`rides.planned_route_polyline`, migration 100 — a decoded `[[lat,lng], …]`
+ * line), so there is no live Routes/Directions API spend. Turn-by-turn itself is
+ * handed off to the driver's Google Maps / Waze (free, their account) — mirroring
+ * the existing `openNavigation()` deep link in `hooks/useDriverDashboard.ts`.
+ *
+ * Pure + framework-free so it is fully unit-testable without the native car
+ * module or a head unit (the rendering/template layer lives in car/carNav.tsx).
+ */
+import type { ActiveRide, RideState } from '../store/driverStore';
+
+export type LatLng = { latitude: number; longitude: number };
+export type NavProvider = 'google' | 'waze';
+
+export type CarRoute = {
+  /** Where the driver is currently headed: pickup before the trip, dropoff during it. */
+  destination: LatLng;
+  destinationLabel: string;
+  /** Which marker the destination corresponds to. Also used to debounce template rebuilds. */
+  leg: 'pickup' | 'dropoff';
+  /** Stored pickup→dropoff route line. May be empty if it was never captured. */
+  polyline: LatLng[];
+};
+
+// Ride states during which the car shows a route + a "navigate" hand-off.
+const NAV_STATES = new Set<RideState>([
+  'navigating_to_pickup',
+  'arrived_at_pickup',
+  'trip_in_progress',
+]);
+
+export function isNavState(state: RideState): boolean {
+  return NAV_STATES.has(state);
+}
+
+/**
+ * Pull the stored `[[lat,lng], …]` polyline off the active ride, tolerating the
+ * store's loose typing — it rides along on `res.data` via RideInfo's index
+ * signature, so it isn't on the declared ActiveRide shape. Junk entries are
+ * dropped rather than rendered as (0,0).
+ */
+export function extractPolyline(activeRide: ActiveRide | null): LatLng[] {
+  if (!activeRide) return [];
+  const ride = activeRide.ride as Record<string, unknown> | undefined;
+  const raw =
+    (ride?.planned_route_polyline as unknown) ??
+    ((activeRide as Record<string, unknown>).planned_route_polyline as unknown) ??
+    null;
+  if (!Array.isArray(raw)) return [];
+  const out: LatLng[] = [];
+  for (const p of raw) {
+    if (
+      Array.isArray(p) &&
+      p.length >= 2 &&
+      Number.isFinite(p[0]) &&
+      Number.isFinite(p[1])
+    ) {
+      out.push({ latitude: p[0] as number, longitude: p[1] as number });
+    }
+  }
+  return out;
+}
+
+/**
+ * Decide what the car map should show for the current ride state. Destination is
+ * the pickup before the trip starts and the dropoff once `in_progress`. Returns
+ * null when there is no active ride, it isn't a navigation state, or the
+ * destination coords are missing (surface nothing rather than a bogus pin).
+ */
+export function selectCarRoute(
+  state: RideState,
+  activeRide: ActiveRide | null
+): CarRoute | null {
+  if (!activeRide || !isNavState(state)) return null;
+  const ride = activeRide.ride;
+  if (!ride) return null;
+
+  const toDropoff = state === 'trip_in_progress';
+  const destination: LatLng = toDropoff
+    ? { latitude: ride.dropoff_lat, longitude: ride.dropoff_lng }
+    : { latitude: ride.pickup_lat, longitude: ride.pickup_lng };
+
+  if (!Number.isFinite(destination.latitude) || !Number.isFinite(destination.longitude)) {
+    return null;
+  }
+
+  return {
+    destination,
+    destinationLabel: toDropoff
+      ? ride.dropoff_address || 'Dropoff'
+      : ride.pickup_address || 'Pickup',
+    leg: toDropoff ? 'dropoff' : 'pickup',
+    polyline: extractPolyline(activeRide),
+  };
+}
+
+/**
+ * Deep-link URL that hands live turn-by-turn to the driver's nav app. Android
+ * Auto is the only target, so this mirrors the Android branch of the existing
+ * `openNavigation()` (`google.navigation:q=`) and adds Waze. Launching it while
+ * Android Auto is connected brings the nav app up on the head unit.
+ */
+export function buildHandoffUrl(provider: NavProvider, dest: LatLng): string {
+  const { latitude, longitude } = dest;
+  if (provider === 'waze') {
+    return `https://waze.com/ul?ll=${latitude},${longitude}&navigate=yes`;
+  }
+  return `google.navigation:q=${latitude},${longitude}`;
+}

--- a/driver-app/car/carRoute.ts
+++ b/driver-app/car/carRoute.ts
@@ -94,7 +94,12 @@ export function selectCarRoute(
       ? ride.dropoff_address || 'Dropoff'
       : ride.pickup_address || 'Pickup',
     leg: toDropoff ? 'dropoff' : 'pickup',
-    polyline: extractPolyline(activeRide),
+    // Only draw the stored line on the DROPOFF leg — `planned_route_polyline` is
+    // the pickup→dropoff trip route, captured at creation. Pre-pickup (driver→
+    // pickup) we have no stored line, so drawing it would show a route leaving
+    // the pickup toward the dropoff while the hand-off targets the pickup —
+    // misleading exactly when the driver is heading to the rider. Marker only.
+    polyline: toDropoff ? extractPolyline(activeRide) : [],
   };
 }
 

--- a/driver-app/car/carRoute.ts
+++ b/driver-app/car/carRoute.ts
@@ -13,7 +13,8 @@
 import type { ActiveRide, RideState } from '../store/driverStore';
 
 export type LatLng = { latitude: number; longitude: number };
-export type NavProvider = 'google' | 'waze';
+export type NavProvider = 'google' | 'apple' | 'waze';
+export type NavButton = { id: string; provider: NavProvider };
 
 export type CarRoute = {
   /** Where the driver is currently headed: pickup before the trip, dropoff during it. */
@@ -98,15 +99,47 @@ export function selectCarRoute(
 }
 
 /**
- * Deep-link URL that hands live turn-by-turn to the driver's nav app. Android
- * Auto is the only target, so this mirrors the Android branch of the existing
- * `openNavigation()` (`google.navigation:q=`) and adds Waze. Launching it while
- * Android Auto is connected brings the nav app up on the head unit.
+ * Deep-link URL that hands live turn-by-turn to the driver's nav app. Launching
+ * it while the head unit is connected brings the nav app up on the car screen.
+ *   - google → Android `google.navigation:` intent (mirrors openNavigation())
+ *   - apple  → Apple Maps directions (CarPlay-native, always installed on iOS)
+ *   - waze   → Waze universal link (works on both platforms if installed)
  */
 export function buildHandoffUrl(provider: NavProvider, dest: LatLng): string {
   const { latitude, longitude } = dest;
-  if (provider === 'waze') {
-    return `https://waze.com/ul?ll=${latitude},${longitude}&navigate=yes`;
+  switch (provider) {
+    case 'waze':
+      return `https://waze.com/ul?ll=${latitude},${longitude}&navigate=yes`;
+    case 'apple':
+      return `maps://?daddr=${latitude},${longitude}&dirflg=d`;
+    case 'google':
+    default:
+      return `google.navigation:q=${latitude},${longitude}`;
   }
-  return `google.navigation:q=${latitude},${longitude}`;
+}
+
+/**
+ * The nav hand-off buttons to show on the car map, per platform: Android Auto
+ * offers Google + Waze, CarPlay offers Apple Maps + Waze (Apple Maps is the
+ * CarPlay-native, guaranteed-present option). The button id round-trips through
+ * the head unit's press event back to `providerForButton`.
+ */
+export function navButtonsForPlatform(os: string): NavButton[] {
+  return os === 'ios'
+    ? [
+        { id: 'nav-apple', provider: 'apple' },
+        { id: 'nav-waze', provider: 'waze' },
+      ]
+    : [
+        { id: 'nav-google', provider: 'google' },
+        { id: 'nav-waze', provider: 'waze' },
+      ];
+}
+
+/** Resolve a pressed map-button id back to its nav provider (falls back to the
+ *  platform default if the id is unrecognized). */
+export function providerForButton(os: string, id: string): NavProvider {
+  const found = navButtonsForPlatform(os).find((b) => b.id === id);
+  if (found) return found.provider;
+  return os === 'ios' ? 'apple' : 'google';
 }

--- a/driver-app/car/carRoute.ts
+++ b/driver-app/car/carRoute.ts
@@ -47,7 +47,7 @@ export function extractPolyline(activeRide: ActiveRide | null): LatLng[] {
   const ride = activeRide.ride as Record<string, unknown> | undefined;
   const raw =
     (ride?.planned_route_polyline as unknown) ??
-    ((activeRide as Record<string, unknown>).planned_route_polyline as unknown) ??
+    ((activeRide as unknown as Record<string, unknown>).planned_route_polyline as unknown) ??
     null;
   if (!Array.isArray(raw)) return [];
   const out: LatLng[] = [];

--- a/driver-app/car/carRoute.ts
+++ b/driver-app/car/carRoute.ts
@@ -167,11 +167,3 @@ export async function resolveNavButtons(
   if (hasWaze) buttons.push(BUTTON.waze);
   return buttons;
 }
-
-/** Resolve a pressed map-button id back to its provider, given the active button
- *  set (falls back to the platform default if the id is unrecognized). */
-export function providerForButton(buttons: NavButton[], id: string, os: string): NavProvider {
-  const found = buttons.find((b) => b.id === id);
-  if (found) return found.provider;
-  return os === 'ios' ? 'apple' : 'google';
-}

--- a/driver-app/car/carRoute.ts
+++ b/driver-app/car/carRoute.ts
@@ -101,45 +101,72 @@ export function selectCarRoute(
 /**
  * Deep-link URL that hands live turn-by-turn to the driver's nav app. Launching
  * it while the head unit is connected brings the nav app up on the car screen.
- *   - google → Android `google.navigation:` intent (mirrors openNavigation())
- *   - apple  → Apple Maps directions (CarPlay-native, always installed on iOS)
- *   - waze   → Waze universal link (works on both platforms if installed)
+ * The scheme is per-platform because the SAME app uses different schemes:
+ *   - google → Android `google.navigation:` intent; iOS `comgooglemaps://`
+ *              (Google Maps supports CarPlay — offered when installed)
+ *   - apple  → Apple Maps directions (CarPlay-native, always present on iOS)
+ *   - waze   → `waze://` on iOS, Waze universal link on Android (web fallback)
  */
-export function buildHandoffUrl(provider: NavProvider, dest: LatLng): string {
-  const { latitude, longitude } = dest;
+export function buildHandoffUrl(provider: NavProvider, dest: LatLng, os: string): string {
+  const { latitude: la, longitude: lo } = dest;
+  const ios = os === 'ios';
   switch (provider) {
-    case 'waze':
-      return `https://waze.com/ul?ll=${latitude},${longitude}&navigate=yes`;
     case 'apple':
-      return `maps://?daddr=${latitude},${longitude}&dirflg=d`;
+      return `maps://?daddr=${la},${lo}&dirflg=d`;
     case 'google':
+      return ios
+        ? `comgooglemaps://?daddr=${la},${lo}&directionsmode=driving`
+        : `google.navigation:q=${la},${lo}`;
+    case 'waze':
     default:
-      return `google.navigation:q=${latitude},${longitude}`;
+      return ios
+        ? `waze://?ll=${la},${lo}&navigate=yes`
+        : `https://waze.com/ul?ll=${la},${lo}&navigate=yes`;
   }
 }
 
+const BUTTON: Record<NavProvider, NavButton> = {
+  apple: { id: 'nav-apple', provider: 'apple' },
+  google: { id: 'nav-google', provider: 'google' },
+  waze: { id: 'nav-waze', provider: 'waze' },
+};
+
 /**
- * The nav hand-off buttons to show on the car map, per platform: Android Auto
- * offers Google + Waze, CarPlay offers Apple Maps + Waze (Apple Maps is the
- * CarPlay-native, guaranteed-present option). The button id round-trips through
- * the head unit's press event back to `providerForButton`.
+ * Synchronous fallback button set, shown until `resolveNavButtons` finishes its
+ * install check. Uses only the guaranteed-present app per platform so the car
+ * never shows a dead button: Apple Maps on CarPlay, Google on Android Auto.
  */
-export function navButtonsForPlatform(os: string): NavButton[] {
-  return os === 'ios'
-    ? [
-        { id: 'nav-apple', provider: 'apple' },
-        { id: 'nav-waze', provider: 'waze' },
-      ]
-    : [
-        { id: 'nav-google', provider: 'google' },
-        { id: 'nav-waze', provider: 'waze' },
-      ];
+export function defaultNavButtons(os: string): NavButton[] {
+  return os === 'ios' ? [BUTTON.apple] : [BUTTON.google, BUTTON.waze];
 }
 
-/** Resolve a pressed map-button id back to its nav provider (falls back to the
- *  platform default if the id is unrecognized). */
-export function providerForButton(os: string, id: string): NavProvider {
-  const found = navButtonsForPlatform(os).find((b) => b.id === id);
+/**
+ * The nav hand-off buttons to show on the car map. On Android Auto this is
+ * static (Google + Waze). On CarPlay we only advertise apps the driver actually
+ * has — Apple Maps is always present; Google Maps and Waze are added only when
+ * `canOpen` confirms their scheme resolves (requires the schemes in
+ * LSApplicationQueriesSchemes — see withCarIntegration.js). This is why a driver
+ * with Google Maps on CarPlay gets a Google button and one without it does not.
+ */
+export async function resolveNavButtons(
+  os: string,
+  canOpen: (url: string) => Promise<boolean>
+): Promise<NavButton[]> {
+  if (os !== 'ios') return [BUTTON.google, BUTTON.waze];
+  const buttons: NavButton[] = [BUTTON.apple];
+  const [hasGoogle, hasWaze] = await Promise.all([
+    canOpen('comgooglemaps://').catch(() => false),
+    canOpen('waze://').catch(() => false),
+  ]);
+  if (hasGoogle) buttons.push(BUTTON.google);
+  if (hasWaze) buttons.push(BUTTON.waze);
+  return buttons;
+}
+
+/** Resolve a pressed map-button id back to its provider, given the active button
+ *  set (falls back to the platform default if the id is unrecognized). */
+export function providerForButton(buttons: NavButton[], id: string, os: string): NavProvider {
+  const found = buttons.find((b) => b.id === id);
   if (found) return found.provider;
   return os === 'ios' ? 'apple' : 'google';
 }

--- a/driver-app/plugins/withCarIntegration.js
+++ b/driver-app/plugins/withCarIntegration.js
@@ -35,24 +35,29 @@ const path = require('path');
 //   already declare FOREGROUND_SERVICE).
 // ─────────────────────────────────────────────────────────────────────────────
 
-const CARPLAY_ENTITLEMENT = 'com.apple.developer.carplay-driving-task';
+// Navigation/maps entitlement — REQUIRED because the car UI is a windowed
+// CPMapTemplate (the in-dash route map). The fork's CarSceneDelegate uses the
+// WINDOWED connect (`...didConnect:toWindow:`), which is exactly this maps path;
+// `carplay-driving-task` is windowless (no map) and would NOT render the route
+// map, so it is the wrong category here. See docs/carplay-android-auto.md.
+// TRADE-OFF: Apple scrutinizes the navigation entitlement and may steer a
+// rideshare *driver* app toward driving-task instead — which would force a
+// list/Information UI with no on-car map. The CarPlay *Simulator* does not
+// enforce the grant, so this is testable now; the App Store grant is a separate
+// conversation. Flip back to driving-task only if you also drop the map UI.
+const CARPLAY_ENTITLEMENT = 'com.apple.developer.carplay-maps';
 const CAR_SCENE_DELEGATE = 'CarSceneDelegate';
 
 // The ENTIRE iOS CarPlay wiring is OFF by default and opt-in via
 //   `SPINR_CARPLAY_IOS=1 npx expo prebuild`  (or set it in the EAS profile `env`).
 // Two reasons it must not touch default iOS builds:
-//   1. Signing — the managed `carplay-driving-task` entitlement fails code-signing
-//      until Apple grants it AND the provisioning profile includes it.
+//   1. Signing — the managed `carplay-maps` entitlement fails code-signing
+//      until Apple grants it AND the provisioning profile includes it (the
+//      Simulator is exempt, so emulator testing works before the grant).
 //   2. Phone scene — turning on UIApplicationSceneManifest opts the app into the
 //      UIScene lifecycle; with only a CarPlay scene declared, a normal phone launch
 //      can fail to build its window. Keeping the manifest out of default builds
 //      leaves the existing AppDelegate window path untouched (zero blast radius).
-// NOTE: the CarSceneDelegate uses the WINDOWED connect (`...didConnect:toWindow:`),
-// which is the CarPlay *navigation/maps* entitlement path the fork actually
-// supports. The fork does NOT expose a windowless connect, so the *driving-task*
-// (template-only, no map window) category is unsupported as-is — see
-// docs/carplay-android-auto.md. Android Auto (below) is the fork-supported,
-// no-entitlement path and stays always-on.
 const ENABLE_IOS_CARPLAY = process.env.SPINR_CARPLAY_IOS === '1';
 
 // Android permissions for the car app. The fork's OWN AndroidManifest already

--- a/driver-app/plugins/withCarIntegration.js
+++ b/driver-app/plugins/withCarIntegration.js
@@ -139,6 +139,25 @@ function withCarPlaySceneManifest(config) {
   });
 }
 
+// Without declaring these in LSApplicationQueriesSchemes, iOS makes
+// Linking.canOpenURL() return false for them AND blocks the deep link — so the
+// CarPlay map could never detect or hand off to Google Maps / Waze. Apple Maps
+// (`maps://`) needs no declaration. Gated with the rest of the CarPlay wiring.
+const IOS_NAV_QUERY_SCHEMES = ['comgooglemaps', 'waze'];
+
+function withCarPlayQuerySchemes(config) {
+  return withInfoPlist(config, (cfg) => {
+    const plist = cfg.modResults;
+    const existing = Array.isArray(plist.LSApplicationQueriesSchemes)
+      ? plist.LSApplicationQueriesSchemes
+      : [];
+    const merged = new Set(existing);
+    for (const scheme of IOS_NAV_QUERY_SCHEMES) merged.add(scheme);
+    plist.LSApplicationQueriesSchemes = Array.from(merged);
+    return cfg;
+  });
+}
+
 function withCarSceneDelegateFile(config) {
   return withDangerousMod(config, [
     'ios',
@@ -197,6 +216,7 @@ const withCarIntegration = (config) => {
   if (ENABLE_IOS_CARPLAY) {
     config = withCarPlayEntitlement(config);
     config = withCarPlaySceneManifest(config);
+    config = withCarPlayQuerySchemes(config);
     config = withCarSceneDelegateFile(config);
     config = withCarSceneDelegateInXcode(config);
   }


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Implement the Android Auto in-dash route map (Path B look, Path A cost) — draw the stored polyline and hand off turn-by-turn to Google Maps / Waze, with full CarPlay parity.
- **Type**: `feat`
- **Linked issue**: Refs #<carplay-android-auto-spike> (spike scaffold from branch `claude/sleepy-dijkstra-nTIqn`)
- **Risk**: `medium` — New car surface wired to both Android Auto and CarPlay; unproven on hardware (emulator + DHU testing required before release).
- **User-visible change**: `drivers` — Android Auto and CarPlay now show an in-dash route map with navigation buttons instead of a list template.
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` driver-app  `[x]` shared (via carRoute.ts pure logic)
- **Blast radius**: `single-surface` (driver-app only; carRoute.ts is pure logic with no side effects)
- **Data schema change**: `none` (reuses existing `rides.planned_route_polyline` from migration 100)
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none` (guarded by native module availability; no-op on Expo Go / web)
- **Config / secret change**: `none` (existing `withCarIntegration` plugin updated to use `carplay-maps` entitlement instead of `carplay-driving-task`)
- **Rollback plan**: `git-revert-safe` (new files only; `app/_layout.tsx` and `androidAutoEntry.tsx` swap function names but remain compatible)
- **Dependencies / coordination**: `none` (spike scaffold already merged; this completes the first real surface)
- **Assumptions**: 
  - `rides.planned_route_polyline` is populated at ride creation (migration 100).
  - `react-native-maps` is available in the driver-app build (lazy-required, degrades gracefully if absent).
  - The fork `@g4rb4g3/react-native-carplay` is already integrated (from spike).
  - CarPlay Simulator and Android Auto DHU are available for hardware validation before release.
- **Not changing but considered**: OTP, rating, online toggle, and accept/decline remain phone-only (out of scope for v1).

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** — N/A (no new spend; reuses stored polyline, hands off to free nav apps)
- `[ ]` **PIPEDA-relevant** — N/A (no new PII collection; lat/lng already in ride data)
- `[ ]` **SK Transportation Act** — N/A (no driver eligibility or trip retention changes)
- `[ ]` **Auth / RLS** — N/A (no auth changes; uses existing `useDriverStore`)
- `[ ]` **Safety** — N/A (no SOS or emergency contact changes)
- `[ ]` **Third-party SDK added** — N/A (uses existing `react-native-carplay` fork and `react-native-maps`)
- `[ ]` **Breaking change to `shared/`** — N/A (carRoute.ts is new, not a breaking change)

## Tier 4 — Verification

- **Unit tests**: `added` — 20 new unit tests covering:
  - `carRoute.ts`: route selection by state, polyline parsing, hand-off URL generation, nav-app detection (iOS install probing).
  - `carNav.tsx`: template builders, map-button routing, leg-debounced root rebuilds, cleanup, async nav-app resolution.
  - All tests pass with mocked native module; no head unit required.
- **Integration tests**: `not-applicable` — JS contract validated at unit level; hardware validation (map render, button icons) requires EAS dev build + DHU.
- **

https://claude.ai/code/session_01GTRWGXEHYHVXYnf9gjvPgJ

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
