### PR TITLE
fix(driver): bootstrap auth before reconciling rides in the car root …

### DIFF
--- a/driver-app/__tests__/androidAutoEntry.test.ts
+++ b/driver-app/__tests__/androidAutoEntry.test.ts
@@ -9,6 +9,12 @@ jest.mock('@g4rb4g3/react-native-carplay/lib/CarPlayHeadlessJsTask', () => ({
   default: jest.fn(),
 }));
 
+// androidAutoEntry → carNav statically imports the auth store; this test never
+// runs initCarNav, so a minimal mock just needs to resolve the module.
+jest.mock('@shared/store/authStore', () => ({
+  useAuthStore: { getState: () => ({ token: 'tok', isLoading: false, initialize: () => Promise.resolve() }) },
+}));
+
 import { AppRegistry, Platform } from 'react-native';
 import { registerAndroidAuto, AndroidAutoRoot, AndroidAutoClusterRoot } from '../car/androidAutoEntry';
 

--- a/driver-app/__tests__/carNav.test.ts
+++ b/driver-app/__tests__/carNav.test.ts
@@ -35,8 +35,13 @@ jest.mock('@g4rb4g3/react-native-carplay', () => {
   };
 });
 
+jest.mock('@shared/store/authStore', () => ({
+  useAuthStore: { getState: jest.fn() },
+}));
+
 import { Linking, Platform } from 'react-native';
 import { CarPlay, MapTemplate, ListTemplate } from '@g4rb4g3/react-native-carplay';
+import { useAuthStore } from '@shared/store/authStore';
 import { useDriverStore } from '../store/driverStore';
 import { buildIdleTemplate, buildNavMapTemplate, handoffToNav, initCarNav } from '../car/carNav';
 
@@ -90,6 +95,12 @@ beforeEach(() => {
     activeRide: null,
     hydrateDriverRideState: jest.fn().mockResolvedValue(undefined),
     fetchActiveRide: jest.fn().mockResolvedValue(undefined),
+  });
+  // Default: already authenticated, so the cold-launch auth bootstrap is skipped.
+  (useAuthStore.getState as jest.Mock).mockReturnValue({
+    token: 'tok',
+    isLoading: false,
+    initialize: jest.fn().mockResolvedValue(undefined),
   });
   setOS('android');
 });
@@ -213,6 +224,48 @@ describe('initCarNav', () => {
     await new Promise((r) => setImmediate(r));
     expect(hydrate).toHaveBeenCalled();
     expect(fetch).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('bootstraps auth before reconciling when the access token is missing (cold launch)', async () => {
+    // No in-memory access token (memory-only tokens are wiped on process restart);
+    // a successful initialize() registers the refresh callback + restores the token.
+    const initialize = jest.fn(() => {
+      (useAuthStore.getState as jest.Mock).mockReturnValue({ token: 'tok', isLoading: false, initialize });
+      return Promise.resolve();
+    });
+    (useAuthStore.getState as jest.Mock).mockReturnValue({ token: null, isLoading: false, initialize });
+    const fetch = jest.fn().mockResolvedValue(undefined);
+    useDriverStore.setState({ fetchActiveRide: fetch });
+
+    const cleanup = initCarNav();
+    await new Promise((r) => setImmediate(r));
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1); // ran only after auth was restored
+    cleanup();
+  });
+
+  it('skips the auth bootstrap when already authenticated', async () => {
+    const initialize = jest.fn().mockResolvedValue(undefined);
+    (useAuthStore.getState as jest.Mock).mockReturnValue({ token: 'tok', isLoading: false, initialize });
+    const cleanup = initCarNav();
+    await new Promise((r) => setImmediate(r));
+    expect(initialize).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it('does NOT reconcile when still logged out after bootstrap (avoids a pointless 401)', async () => {
+    const initialize = jest.fn().mockResolvedValue(undefined); // refresh failed → still no token
+    (useAuthStore.getState as jest.Mock).mockReturnValue({ token: null, isLoading: false, initialize });
+    const fetch = jest.fn().mockResolvedValue(undefined);
+    useDriverStore.setState({ fetchActiveRide: fetch });
+
+    const cleanup = initCarNav();
+    await new Promise((r) => setImmediate(r));
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
     cleanup();
   });
 

--- a/driver-app/car/carNav.tsx
+++ b/driver-app/car/carNav.tsx
@@ -20,6 +20,7 @@
  */
 import React from 'react';
 import { Linking, Platform, StyleSheet, View } from 'react-native';
+import { useAuthStore } from '@shared/store/authStore';
 import { useDriverStore } from '../store/driverStore';
 import {
   buildHandoffUrl,
@@ -164,25 +165,39 @@ export function initCarNav(): () => void {
   }
   const { CarPlay, MapTemplate, ListTemplate } = carplay;
 
-  // Cold car launch runs this separate JS root with the phone dashboard (and its
-  // hydrate + fetchActiveRide) never mounted, so the store would sit at `idle`.
-  // Restore the persisted ride AND reconcile against the server, so a cached ride
-  // that completed/cancelled/changed while the phone UI was unmounted doesn't show
-  // or hand off a stale route. fetchActiveRide is safe here — the api client
-  // resolves the token from SecureStore (shared/api/client.ts), so no in-memory
-  // auth bootstrap is needed. Both are guarded/idempotent; the store subscription
-  // rebuilds the root once state lands. (Codex P2)
+  // Cold car launch runs this separate JS root with the phone UI never mounted,
+  // so the store sits at `idle` AND auth is unbootstrapped. Restore the persisted
+  // ride (instant, no auth), bootstrap auth, then reconcile against the server.
+  //
+  // Auth bootstrap is REQUIRED before any authed call: access tokens are
+  // memory-only (authStore.setTokens deletes auth_token from SecureStore), and
+  // the phone UI — which registers the silent-refresh callback and refreshes from
+  // the persisted refresh token — hasn't run here. Without it, fetchActiveRide
+  // sends no Authorization, 401s, and (no refresh callback) logs the driver out,
+  // clearing the cached ride. initialize() registers the callback + restores the
+  // access token; guarded so we don't double-init when the phone already did. (Codex)
   void (async () => {
-    const store = useDriverStore.getState();
     try {
-      await store.hydrateDriverRideState?.();
+      await useDriverStore.getState().hydrateDriverRideState?.();
     } catch {
       /* cache miss — ignore */
     }
-    try {
-      await store.fetchActiveRide?.();
-    } catch {
-      /* offline / not authed — keep the cached snapshot */
+    const auth = useAuthStore.getState();
+    if (!auth.token && !auth.isLoading) {
+      try {
+        await auth.initialize?.();
+      } catch {
+        /* refresh failed (transient/expired) — keep the cached snapshot */
+      }
+    }
+    // Only reconcile when authenticated — skip a pointless 401 if genuinely
+    // logged out (a rejected refresh in initialize() clears the session).
+    if (useAuthStore.getState().token) {
+      try {
+        await useDriverStore.getState().fetchActiveRide?.();
+      } catch {
+        /* offline — keep the cached snapshot */
+      }
     }
   })();
 


### PR DESCRIPTION
…(Codex)

My prior fix was wrong: access tokens are memory-only (authStore.setTokens deletes auth_token from SecureStore), so a cold car launch after a process restart has only a refresh token and an unregistered refresh callback. Calling fetchActiveRide there sent no Authorization → 401 → logout → cleared cached ride.

initCarNav now calls useAuthStore.initialize() (registers the silent-refresh callback + restores the access token from the persisted refresh token) before reconciling, guarded by !token && !isLoading so it doesn't double-init when the phone already bootstrapped, and skips fetchActiveRide if still logged out.

https://claude.ai/code/session_01GTRWGXEHYHVXYnf9gjvPgJ

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
