### PR TITLE
Persist received_at and route quality; add OSRM route validation and robust route persistence

### DIFF
--- a/backend/migrations/118_route_quality_received_at.sql
+++ b/backend/migrations/118_route_quality_received_at.sql
@@ -62,3 +62,13 @@ COMMENT ON COLUMN rides.route_geometry_status IS
 
 COMMENT ON COLUMN rides.route_geometry_error IS
     'Last route geometry side-table save error, if saving failed after retries.';
+
+-- Existing databases can already have ride_routes from migration 117. Backfill
+-- the lightweight rides status so admin list views do not report completed
+-- historical rides with saved geometry as still pending.
+UPDATE rides r
+SET route_geometry_status = 'saved',
+    route_geometry_error = NULL
+FROM ride_routes rr
+WHERE rr.ride_id = r.id
+  AND COALESCE(r.route_geometry_status, 'pending') = 'pending';

--- a/backend/migrations/118_route_quality_received_at.sql
+++ b/backend/migrations/118_route_quality_received_at.sql
@@ -1,0 +1,43 @@
+-- 118_route_quality_received_at.sql
+-- Preserve device capture timestamps separately from server receipt time and
+-- persist route quality / route-geometry save status for billing and dispute review.
+
+ALTER TABLE driver_location_history
+    ADD COLUMN IF NOT EXISTS received_at TIMESTAMPTZ DEFAULT NOW();
+
+COMMENT ON COLUMN driver_location_history.timestamp IS
+    'Device GPS capture timestamp when supplied by the client; otherwise server receipt time for legacy clients.';
+
+COMMENT ON COLUMN driver_location_history.received_at IS
+    'Server receipt timestamp for the GPS breadcrumb. Used to compare client capture time vs ingestion time.';
+
+CREATE INDEX IF NOT EXISTS idx_dlh_received_at
+    ON driver_location_history(received_at);
+
+ALTER TABLE ride_routes
+    ADD COLUMN IF NOT EXISTS route_quality JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS save_status TEXT NOT NULL DEFAULT 'saved',
+    ADD COLUMN IF NOT EXISTS save_error TEXT;
+
+COMMENT ON COLUMN ride_routes.route_quality IS
+    'Route quality/confidence metadata captured at settlement: point counts, rejected segment ratio, max GPS gap, distance provider, and road-snap outcome.';
+
+COMMENT ON COLUMN ride_routes.save_status IS
+    'Best-effort route geometry persistence status for admin/dispute review.';
+
+COMMENT ON COLUMN ride_routes.save_error IS
+    'Last route geometry persistence error, truncated by the backend, when save_status is failed.';
+
+ALTER TABLE rides
+    ADD COLUMN IF NOT EXISTS route_quality JSONB NOT NULL DEFAULT '{}'::JSONB,
+    ADD COLUMN IF NOT EXISTS route_geometry_status TEXT NOT NULL DEFAULT 'pending',
+    ADD COLUMN IF NOT EXISTS route_geometry_error TEXT;
+
+COMMENT ON COLUMN rides.route_quality IS
+    'Settlement route quality/confidence summary duplicated from ride_routes for billing/dispute list views.';
+
+COMMENT ON COLUMN rides.route_geometry_status IS
+    'Whether the heavy route geometry side-table was saved at completion: pending/saved/failed.';
+
+COMMENT ON COLUMN rides.route_geometry_error IS
+    'Last route geometry side-table save error, if saving failed after retries.';

--- a/backend/migrations/118_route_quality_received_at.sql
+++ b/backend/migrations/118_route_quality_received_at.sql
@@ -14,6 +14,27 @@ COMMENT ON COLUMN driver_location_history.received_at IS
 CREATE INDEX IF NOT EXISTS idx_dlh_received_at
     ON driver_location_history(received_at);
 
+-- Defensive bootstrap: production databases that missed migration 117 (or ran
+-- this migration manually from the SQL editor) otherwise fail with
+-- `relation "ride_routes" does not exist` before the new quality columns can be
+-- added. Keep this table definition aligned with 117_ride_routes.sql; migration
+-- 117 remains the authoritative migration for RLS/retention-function changes.
+CREATE TABLE IF NOT EXISTS ride_routes (
+    ride_id          text PRIMARY KEY REFERENCES rides(id) ON DELETE CASCADE,
+    phase_distances  jsonb NOT NULL DEFAULT '{}'::jsonb,
+    phase_durations  jsonb NOT NULL DEFAULT '{}'::jsonb,
+    phase_polylines  jsonb NOT NULL DEFAULT '{}'::jsonb,
+    road_polyline    jsonb NOT NULL DEFAULT '[]'::jsonb,
+    gps_points_count integer NOT NULL DEFAULT 0,
+    computed_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE ride_routes IS
+    'Per-ride route detail (per-phase distances/durations/polylines + OSRM road-matched line), 1:1 with rides. Write-once at completion, read-on-demand by the admin map modal. Geometry cleared at 3y by purge_pii_retention; row cascades on the 7y rides delete.';
+
+CREATE INDEX IF NOT EXISTS idx_ride_routes_computed_at ON ride_routes (computed_at);
+ALTER TABLE ride_routes ENABLE ROW LEVEL SECURITY;
+
 ALTER TABLE ride_routes
     ADD COLUMN IF NOT EXISTS route_quality JSONB NOT NULL DEFAULT '{}'::JSONB,
     ADD COLUMN IF NOT EXISTS save_status TEXT NOT NULL DEFAULT 'saved',

--- a/backend/migrations/119_route_tracking_perf_indexes.sql
+++ b/backend/migrations/119_route_tracking_perf_indexes.sql
@@ -1,0 +1,21 @@
+-- 119_route_tracking_perf_indexes.sql
+-- Lightweight read-path indexes for route/admin audit tables.
+-- These match current query patterns and future operational checks without adding
+-- meaningful write overhead: driver_activity_log is append-only event data,
+-- ride_routes is written once per completed ride, and failed route geometry rows
+-- are rare but important for admin/support follow-up.
+
+-- Admin driver activity endpoint filters by driver_id and orders newest-first.
+CREATE INDEX IF NOT EXISTS idx_driver_activity_driver_created
+    ON driver_activity_log(driver_id, created_at DESC);
+
+-- Fast operational lookup for route geometry rows that failed to persist cleanly.
+CREATE INDEX IF NOT EXISTS idx_ride_routes_failed_save
+    ON ride_routes(ride_id)
+    WHERE save_status = 'failed';
+
+-- rides duplicates route_geometry_status for list/dispute views; make failed
+-- geometry checks cheap without indexing every completed/saved ride.
+CREATE INDEX IF NOT EXISTS idx_rides_route_geometry_failed
+    ON rides(id)
+    WHERE route_geometry_status = 'failed';

--- a/backend/repositories/ride_repo.py
+++ b/backend/repositories/ride_repo.py
@@ -291,7 +291,7 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
         return await run_sync(
             lambda rid=ride_id: _rows_from_res(
                 supabase.table("driver_location_history")
-                .select("lat,lng,speed,heading,tracking_phase,timestamp")
+                .select("lat,lng,speed,heading,accuracy,altitude,tracking_phase,timestamp,received_at")
                 .eq("ride_id", rid)
                 .order("timestamp")
                 .limit(5000)
@@ -433,9 +433,11 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
     route = await run_sync(_get_route)
     if route:
         ride["road_polyline"] = route.get("road_polyline") or []
-        for _k in ("phase_polylines", "phase_distances", "phase_durations"):
+        for _k in ("phase_polylines", "phase_distances", "phase_durations", "route_quality"):
             if route.get(_k):
                 ride[_k] = route[_k]
+        ride["route_geometry_status"] = route.get("save_status") or ride.get("route_geometry_status")
+        ride["route_geometry_error"] = route.get("save_error") or ride.get("route_geometry_error")
 
     return ride
 
@@ -519,7 +521,7 @@ async def get_ride_location_trail(ride_id: str) -> List[Dict[str, Any]]:
     return await run_sync(
         lambda: _rows_from_res(
             supabase.table("driver_location_history")
-            .select("lat,lng,speed,heading,tracking_phase,timestamp")
+            .select("lat,lng,speed,heading,accuracy,altitude,tracking_phase,timestamp,received_at")
             .eq("ride_id", ride_id)
             .order("timestamp")
             .limit(5000)

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -3637,6 +3637,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                 upsert=True,
             )
             route_geometry_status = "saved"
+            route_geometry_error = None
             break
         except Exception as exc:
             route_geometry_error = str(exc)[:500]

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -3685,9 +3685,11 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
         "gps_points_count": gps_points_count,
         "route_quality": route_quality,
         "route_geometry_status": route_geometry_status,
+        # Clear any previous failed-save message when a retry/re-completion saves
+        # ride_routes successfully; otherwise admin list/detail can show a stale
+        # error while the status is now "saved".
+        "route_geometry_error": route_geometry_error,
     }
-    if route_geometry_error:
-        update_fields["route_geometry_error"] = route_geometry_error
 
     # Check fare lock setting — when enabled, rider pays the booking-time
     # estimate regardless of actual distance/time (SK regulatory requirement).

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1637,7 +1637,7 @@ async def get_drivers(
     """
     Get all drivers (admin only) or nearby drivers (if lat/lng provided).
     """
-    if lat and lng:
+    if lat is not None and lng is not None:
         # Should rely on RPC or geospatial query
         # For now, simplistic implementation as seen in other parts
         drivers = await db_supabase.get_rows("drivers", {"is_online": True}, limit=100)
@@ -1680,11 +1680,11 @@ async def update_location_batch(batch: Union[List[dict], dict], current_user: di
         return {"success": True}
 
     latest = points[-1]
-    lat = latest.get("latitude") or latest.get("lat")
-    lng = latest.get("longitude") or latest.get("lng")
+    lat = latest.get("latitude") if latest.get("latitude") is not None else latest.get("lat")
+    lng = latest.get("longitude") if latest.get("longitude") is not None else latest.get("lng")
     heading = latest.get("heading")
 
-    if lat and lng:
+    if lat is not None and lng is not None:
         # GPS spoofing check
         driver_rows = await db_supabase.get_rows("drivers", {"user_id": current_user["id"]}, limit=1)
         driver_id = driver_rows[0]["id"] if driver_rows else current_user["id"]
@@ -3369,6 +3369,13 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
     route_polyline = []
     road_polyline: list = []
     gps_points_count = 0
+    trip_points_count = 0
+    rejected_segments = 0
+    max_segment_gap_s = 0
+    road_distance_provider = "haversine_filtered"
+    route_quality: Dict[str, Any] = {"confidence": "low", "reason": "no_gps_breadcrumbs"}
+    route_geometry_status = "pending"
+    route_geometry_error: Optional[str] = None
 
     try:
         # Page through ALL breadcrumbs for the ride (time-ordered). The old
@@ -3399,7 +3406,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
             logger.warning(
                 f"GPS breadcrumbs hit ceiling {_MAX_BREADCRUMBS} for ride {ride_id}; tail beyond this is not summed"
             )
-        all_breadcrumbs = [b for b in all_breadcrumbs if b.get("lat") and b.get("lng")]
+        all_breadcrumbs = [b for b in all_breadcrumbs if b.get("lat") is not None and b.get("lng") is not None]
         all_breadcrumbs.sort(key=lambda b: str(b.get("timestamp", "")))
         gps_points_count = len(all_breadcrumbs)
 
@@ -3426,6 +3433,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
             MAX_SEG_KMH = 150.0
             MAX_SEG_GAP_S = 300
             rejected_segments = 0
+            max_segment_gap_s = 0
             phase_totals: Dict[str, float] = {}
             phase_secs: Dict[str, float] = {}
             for i in range(1, len(all_breadcrumbs)):
@@ -3439,6 +3447,8 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                 delta = None
                 if t_prev and t_curr:
                     delta = (t_curr - t_prev).total_seconds()
+                    if delta is not None and delta > max_segment_gap_s:
+                        max_segment_gap_s = int(round(delta))
 
                 # Reject anomalous segments before adding to phase totals.
                 if seg_km > MAX_SEG_KM:
@@ -3524,6 +3534,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                 hi = max(0.1, actual_distance_km_haversine * 3.0)
                 if lo <= actual_distance_km_road <= hi:
                     actual_distance_km = round(actual_distance_km_road, 2)
+                    road_distance_provider = str(road_result.get("provider") or "road_snapped")
                     # Trusted match → persist the road-snapped geometry (saved to
                     # ride_routes below) for SGI / dispute map review.
                     road_polyline = road_result.get("polyline") or []
@@ -3576,28 +3587,82 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                     for p in sampled
                 ]
 
+            rejected_ratio = rejected_segments / max(1, len(all_breadcrumbs) - 1)
+            if trip_points_count >= 20 and rejected_ratio <= 0.1 and max_segment_gap_s <= 120:
+                confidence = "high"
+            elif trip_points_count >= 5 and rejected_ratio <= 0.25 and max_segment_gap_s <= 300:
+                confidence = "medium"
+            else:
+                confidence = "low"
+            route_quality = {
+                "confidence": confidence,
+                "gps_points_count": gps_points_count,
+                "trip_points_count": trip_points_count,
+                "rejected_segments": rejected_segments,
+                "rejected_segment_ratio": round(rejected_ratio, 3),
+                "max_segment_gap_seconds": max_segment_gap_s,
+                "distance_provider": road_distance_provider,
+                "actual_distance_km_haversine": (
+                    round(float(actual_distance_km_haversine), 3) if actual_distance_km_haversine is not None else None
+                ),
+                "actual_distance_km_road_snapped": (
+                    round(float(actual_distance_km_road), 3) if actual_distance_km_road is not None else None
+                ),
+                "road_snap_accepted": bool(road_polyline),
+            }
+
     except Exception as e:
         logger.error(f"Could not aggregate GPS data for ride {ride_id}: {e}", exc_info=True)
 
     # Persist the heavy route geometry to the ride_routes side-table (1:1),
     # keeping it OFF the hot rides row — written once here, read on-demand by the
     # admin map modal. Best-effort: a settlement must not fail on the side write.
-    try:
-        await db_supabase.update_one(
-            "ride_routes",
-            {"ride_id": ride_id},
-            {
-                "phase_distances": phase_distances,
-                "phase_durations": phase_durations,
-                "phase_polylines": phase_polylines,
-                "road_polyline": road_polyline,
-                "gps_points_count": gps_points_count,
-                "computed_at": datetime.now(timezone.utc),
-            },
-            upsert=True,
-        )
-    except Exception:
-        logger.error(f"Could not persist ride_routes for ride {ride_id}", exc_info=True)
+    route_payload = {
+        "phase_distances": phase_distances,
+        "phase_durations": phase_durations,
+        "phase_polylines": phase_polylines,
+        "road_polyline": road_polyline,
+        "gps_points_count": gps_points_count,
+        "route_quality": route_quality,
+        "save_status": "saved",
+        "save_error": None,
+        "computed_at": datetime.now(timezone.utc),
+    }
+    for attempt in range(1, 4):
+        try:
+            await db_supabase.update_one(
+                "ride_routes",
+                {"ride_id": ride_id},
+                route_payload,
+                upsert=True,
+            )
+            route_geometry_status = "saved"
+            break
+        except Exception as exc:
+            route_geometry_error = str(exc)[:500]
+            route_geometry_status = "failed"
+            logger.error(
+                "Could not persist ride_routes for ride %s (attempt %s/3): %s",
+                ride_id,
+                attempt,
+                route_geometry_error,
+                exc_info=True,
+            )
+            if attempt < 3:
+                await asyncio.sleep(0.2 * attempt)
+    if route_geometry_status != "saved":
+        try:
+            await db_supabase.update_one(
+                "rides",
+                {"id": ride_id},
+                {
+                    "route_geometry_status": route_geometry_status,
+                    "route_geometry_error": route_geometry_error,
+                    "route_quality": route_quality,
+                },
+            )
+        except Exception:
+            logger.error("Could not record ride_routes persistence failure for ride %s", ride_id, exc_info=True)
 
     # ── Build update payload ──
     # P0-5: do NOT write payment_status here. The driver completing the
@@ -3618,7 +3683,11 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
         "phase_distances": phase_distances,
         "phase_durations": phase_durations,
         "gps_points_count": gps_points_count,
+        "route_quality": route_quality,
+        "route_geometry_status": route_geometry_status,
     }
+    if route_geometry_error:
+        update_fields["route_geometry_error"] = route_geometry_error
 
     # Check fare lock setting — when enabled, rider pays the booking-time
     # estimate regardless of actual distance/time (SK regulatory requirement).

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -557,7 +557,7 @@ async def websocket_endpoint(
                 lng = data.get("lng")
                 driver_id = current_driver_id if client_type == "driver" else None
 
-                if driver_id and lat and lng:
+                if driver_id and lat is not None and lng is not None:
                     try:
                         from ..utils.location_integrity import check_location_integrity
                     except ImportError:
@@ -580,12 +580,10 @@ async def websocket_endpoint(
                     # foregrounded, not just that TCP is open.
                     await mark_present(driver_id)
 
-                    # One query covers breadcrumb tagging AND rider fan-out;
-                    # previously we hit the rides table twice per GPS ping.
-                    # `driver_accepted` is included so breadcrumbs are tagged
-                    # navigating_to_pickup during that brief state, but the
-                    # rider fan-out list stays restricted to assigned/
-                    # arrived/in_progress to match the pre-refactor behaviour.
+                    # Resolve active rides for rider fan-out. The shared
+                    # breadcrumb writer below independently derives ride_id and
+                    # phase from server milestones so single pings and buffered
+                    # batches follow the same billing/dispute rules.
                     active_rides = await db_supabase.get_rows(
                         "rides",
                         {
@@ -604,31 +602,17 @@ async def websocket_endpoint(
                     active_ride = active_rides[0] if active_rides else None
                     ride_id = active_ride["id"] if active_ride else None
 
-                    status_map = {
-                        "driver_assigned": "navigating_to_pickup",
-                        "driver_accepted": "navigating_to_pickup",
-                        "driver_arrived": "arrived_at_pickup",
-                        "in_progress": "trip_in_progress",
-                    }
-                    tracking_phase = (
-                        status_map.get(active_ride.get("status", ""), "online_idle") if active_ride else "online_idle"
-                    )
-
-                    breadcrumb = {
-                        "id": str(uuid.uuid4()),
-                        "driver_id": driver_id,
-                        "ride_id": ride_id,
-                        "lat": lat,
-                        "lng": lng,
-                        "speed": data.get("speed"),
-                        "heading": data.get("heading"),
-                        "accuracy": data.get("accuracy"),
-                        "altitude": data.get("altitude"),
-                        "tracking_phase": tracking_phase,
-                        "timestamp": datetime.now(timezone.utc),
-                    }
-
-                    await db_supabase.insert_one("driver_location_history", breadcrumb)
+                    # Persist through the shared breadcrumb path even for a single
+                    # live ping. That path stores the device capture timestamp
+                    # when supplied (captured_at/device_timestamp/recorded_at/
+                    # timestamp), records received_at separately, and derives
+                    # ride phase from server ride milestones instead of trusting
+                    # the client's current message timing or phase tag.
+                    try:
+                        from ..utils.breadcrumbs import persist_ride_breadcrumbs
+                    except ImportError:
+                        from utils.breadcrumbs import persist_ride_breadcrumbs  # type: ignore
+                    await persist_ride_breadcrumbs(driver_id, [data], persist_idle=True)
 
                     # Refresh the Maps API key from DB at most every 60 s.
                     now_mono = asyncio.get_event_loop().time()

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -6,6 +6,9 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from firebase_admin import auth as firebase_auth
 from loguru import logger
 
+from backend.utils.breadcrumbs import persist_ride_breadcrumbs
+from backend.utils.location_integrity import check_location_integrity
+
 try:
     from .. import db_supabase
     from ..core.config import settings
@@ -558,10 +561,6 @@ async def websocket_endpoint(
                 driver_id = current_driver_id if client_type == "driver" else None
 
                 if driver_id and lat is not None and lng is not None:
-                    try:
-                        from ..utils.location_integrity import check_location_integrity
-                    except ImportError:
-                        from utils.location_integrity import check_location_integrity  # type: ignore
                     trusted, reason = await check_location_integrity(
                         driver_id,
                         lat,
@@ -608,10 +607,6 @@ async def websocket_endpoint(
                     # timestamp), records received_at separately, and derives
                     # ride phase from server ride milestones instead of trusting
                     # the client's current message timing or phase tag.
-                    try:
-                        from ..utils.breadcrumbs import persist_ride_breadcrumbs
-                    except ImportError:
-                        from utils.breadcrumbs import persist_ride_breadcrumbs  # type: ignore
                     await persist_ride_breadcrumbs(driver_id, [data], persist_idle=True)
 
                     # Refresh the Maps API key from DB at most every 60 s.
@@ -685,6 +680,9 @@ async def websocket_endpoint(
                 # any client-supplied value.
                 points = data.get("points", [])
                 driver_id = current_driver_id if client_type == "driver" else None
+                if not isinstance(points, list):
+                    await websocket.send_json({"type": "location_batch_ack", "count": 0})
+                    continue
 
                 # Per-USER sliding-window rate limit on total batch points to
                 # prevent a single user from flooding driver_location_history
@@ -731,23 +729,34 @@ async def websocket_endpoint(
                     )
                     continue
 
-                if driver_id and points:
-                    try:
-                        from ..utils.breadcrumbs import persist_ride_breadcrumbs
-                    except ImportError:
-                        from utils.breadcrumbs import persist_ride_breadcrumbs  # type: ignore
+                if driver_id and isinstance(points, list) and points:
+                    dict_points = [p for p in points if isinstance(p, dict)]
+                    if not dict_points:
+                        await websocket.send_json({"type": "location_batch_ack", "count": 0})
+                        continue
                     # Shared persistence with the REST path: server-derived phase
                     # per point (from its own timestamp vs the ride milestones),
                     # stale / other-ride discard, and the 500-point cap. Never
                     # trusts the client's ride_id/tracking_phase.
-                    inserted = await persist_ride_breadcrumbs(driver_id, points)
-                    # Live marker from the most recent point (best-effort).
-                    last_pt = points[-1]
-                    _lat, _lng = last_pt.get("lat"), last_pt.get("lng")
+                    inserted = await persist_ride_breadcrumbs(driver_id, dict_points)
+                    # Live marker from the most recent point (best-effort). Accept
+                    # both compact lat/lng and REST-style latitude/longitude keys.
+                    last_pt = dict_points[-1]
+                    _lat = last_pt.get("latitude") if last_pt.get("latitude") is not None else last_pt.get("lat")
+                    _lng = last_pt.get("longitude") if last_pt.get("longitude") is not None else last_pt.get("lng")
                     if _lat is not None and _lng is not None:
-                        await manager.update_driver_location(driver_id, _lat, _lng)
-                        await db_supabase.update_driver_location(driver_id, _lat, _lng, heading=last_pt.get("heading"))
-                        await mark_present(driver_id)
+                        trusted, _reason = await check_location_integrity(
+                            driver_id,
+                            _lat,
+                            _lng,
+                            speed=last_pt.get("speed"),
+                            accuracy=last_pt.get("accuracy"),
+                            mocked=last_pt.get("mocked"),
+                        )
+                        if trusted:
+                            await manager.update_driver_location(driver_id, _lat, _lng)
+                            await db_supabase.update_driver_location(driver_id, _lat, _lng, heading=last_pt.get("heading"))
+                            await mark_present(driver_id)
                     await websocket.send_json({"type": "location_batch_ack", "count": inserted})
 
             elif data.get("type") == "ride_status_update":

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import uuid
 from datetime import datetime, timezone
 
@@ -64,6 +65,20 @@ _ETA_PICKUP_STATUSES = {"driver_assigned", "driver_accepted", "driver_arrived"}
 # Let's use a router.
 
 router = APIRouter()
+
+
+def _parse_live_coordinate(value):
+    if value is None or value == "":
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _valid_live_coordinates(lat: float, lng: float) -> bool:
+    return -90 <= lat <= 90 and -180 <= lng <= 180 and not (lat == 0 and lng == 0)
 
 # GAP FIX: Heartbeat constants — tightened from 30s to 10s to match
 # Uber's ~4s/7s cadence more closely. A 30s ping meant a dead connection
@@ -556,11 +571,11 @@ async def websocket_endpoint(
                 # we deliberately ignore any driver_id the client sent to
                 # prevent a compromised token from spoofing locations for
                 # another driver.
-                lat = data.get("lat")
-                lng = data.get("lng")
+                lat = _parse_live_coordinate(data.get("lat"))
+                lng = _parse_live_coordinate(data.get("lng"))
                 driver_id = current_driver_id if client_type == "driver" else None
 
-                if driver_id and lat is not None and lng is not None:
+                if driver_id and lat is not None and lng is not None and _valid_live_coordinates(lat, lng):
                     trusted, reason = await check_location_integrity(
                         driver_id,
                         lat,
@@ -607,7 +622,7 @@ async def websocket_endpoint(
                     # timestamp), records received_at separately, and derives
                     # ride phase from server ride milestones instead of trusting
                     # the client's current message timing or phase tag.
-                    await persist_ride_breadcrumbs(driver_id, [data], persist_idle=True)
+                    await persist_ride_breadcrumbs(driver_id, [data], persist_idle=True, active_ride=active_ride)
 
                     # Refresh the Maps API key from DB at most every 60 s.
                     now_mono = asyncio.get_event_loop().time()
@@ -742,9 +757,13 @@ async def websocket_endpoint(
                     # Live marker from the most recent point (best-effort). Accept
                     # both compact lat/lng and REST-style latitude/longitude keys.
                     last_pt = dict_points[-1]
-                    _lat = last_pt.get("latitude") if last_pt.get("latitude") is not None else last_pt.get("lat")
-                    _lng = last_pt.get("longitude") if last_pt.get("longitude") is not None else last_pt.get("lng")
-                    if _lat is not None and _lng is not None:
+                    _lat = _parse_live_coordinate(
+                        last_pt.get("latitude") if last_pt.get("latitude") is not None else last_pt.get("lat")
+                    )
+                    _lng = _parse_live_coordinate(
+                        last_pt.get("longitude") if last_pt.get("longitude") is not None else last_pt.get("lng")
+                    )
+                    if _lat is not None and _lng is not None and _valid_live_coordinates(_lat, _lng):
                         trusted, _reason = await check_location_integrity(
                             driver_id,
                             _lat,

--- a/backend/tests/test_breadcrumb_persistence.py
+++ b/backend/tests/test_breadcrumb_persistence.py
@@ -188,3 +188,20 @@ async def test_batch_capped_to_max():
         n = await persist_ride_breadcrumbs("drv_1", pts)
     assert n == MAX_BREADCRUMB_BATCH, "REST batch must be bounded"
     assert len(cap["docs"]) == MAX_BREADCRUMB_BATCH
+
+
+@pytest.mark.asyncio
+async def test_non_list_and_non_dict_points_are_ignored():
+    insert = AsyncMock()
+
+    async def _get_rows(table, query, **kw):
+        return [_ride()]
+
+    with (
+        patch("backend.utils.breadcrumbs.db_supabase.get_rows", _get_rows),
+        patch("backend.utils.breadcrumbs.db_supabase.insert_many", insert),
+    ):
+        assert await persist_ride_breadcrumbs("drv_1", "not-a-list") == 0
+        assert await persist_ride_breadcrumbs("drv_1", ["not-a-dict"]) == 0
+
+    insert.assert_not_called()

--- a/backend/tests/test_breadcrumb_persistence.py
+++ b/backend/tests/test_breadcrumb_persistence.py
@@ -74,6 +74,7 @@ async def test_persists_all_points_with_trip_phase():
     # ts >= ride_started_at → trip_in_progress, derived server-side
     assert all(d["tracking_phase"] == "trip_in_progress" for d in docs)
     assert all(isinstance(d["timestamp"], datetime) for d in docs)
+    assert all(isinstance(d["received_at"], datetime) for d in docs)
 
 
 @pytest.mark.asyncio
@@ -90,6 +91,35 @@ async def test_no_active_ride_persists_nothing():
         n = await persist_ride_breadcrumbs("drv_1", [_pt(50.45, -104.62, "2026-06-01T23:06:17Z")])
     assert n == 0
     insert.assert_not_called()
+
+
+
+
+@pytest.mark.asyncio
+async def test_no_active_ride_can_persist_idle_for_live_ws_ping():
+    cap = {}
+
+    async def _get_rows(table, query, **kw):
+        return []
+
+    async def _insert_many(table, docs):
+        cap["table"] = table
+        cap["docs"] = docs
+        return docs
+
+    with (
+        patch("backend.utils.breadcrumbs.db_supabase.get_rows", _get_rows),
+        patch("backend.utils.breadcrumbs.db_supabase.insert_many", _insert_many),
+    ):
+        n = await persist_ride_breadcrumbs(
+            "drv_1",
+            [_pt(50.45, -104.62, "2026-06-01T23:06:17Z")],
+            persist_idle=True,
+        )
+
+    assert n == 1
+    assert cap["docs"][0]["ride_id"] is None
+    assert cap["docs"][0]["tracking_phase"] == "online_idle"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_breadcrumb_persistence.py
+++ b/backend/tests/test_breadcrumb_persistence.py
@@ -205,3 +205,59 @@ async def test_non_list_and_non_dict_points_are_ignored():
         assert await persist_ride_breadcrumbs("drv_1", ["not-a-dict"]) == 0
 
     insert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_ride_can_be_reused_without_lookup():
+    cap = {}
+    get_rows = AsyncMock(return_value=[_ride(id="wrong_ride")])
+
+    async def _insert_many(table, docs):
+        cap["docs"] = docs
+        return docs
+
+    with (
+        patch("backend.utils.breadcrumbs.db_supabase.get_rows", get_rows),
+        patch("backend.utils.breadcrumbs.db_supabase.insert_many", _insert_many),
+    ):
+        n = await persist_ride_breadcrumbs(
+            "drv_1",
+            [_pt(50.45, -104.62, "2026-06-01T23:06:17Z")],
+            active_ride=_ride(id="already_loaded"),
+        )
+
+    assert n == 1
+    get_rows.assert_not_called()
+    assert cap["docs"][0]["ride_id"] == "already_loaded"
+
+
+@pytest.mark.asyncio
+async def test_future_capture_time_is_clamped_to_received_at():
+    cap = {}
+    g, i = _patches([_ride()], cap)
+    with g, i:
+        n = await persist_ride_breadcrumbs(
+            "drv_1",
+            [_pt(50.45, -104.62, "2099-01-01T00:00:00Z")],
+        )
+
+    assert n == 1
+    assert cap["docs"][0]["timestamp"] == cap["docs"][0]["received_at"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_coordinate_ranges_and_no_fix_are_skipped():
+    cap = {}
+    g, i = _patches([_ride()], cap)
+    with g, i:
+        n = await persist_ride_breadcrumbs(
+            "drv_1",
+            [
+                _pt(0, 0, "2026-06-01T23:06:00Z"),
+                _pt(91, -104.62, "2026-06-01T23:06:10Z"),
+                _pt(50.45, -104.62, "2026-06-01T23:06:20Z"),
+            ],
+        )
+
+    assert n == 1
+    assert cap["docs"][0]["lat"] == 50.45

--- a/backend/tests/test_route_distance_osrm.py
+++ b/backend/tests/test_route_distance_osrm.py
@@ -166,7 +166,12 @@ async def test_prefers_osrm_and_returns_polyline():
     ):
         result = await rd.compute_road_route(_trip(6))
 
-    assert result == {"distance_km": 7.42, "polyline": [[50.4, -104.6], [50.41, -104.61]]}
+    assert result == {
+        "distance_km": 7.42,
+        "polyline": [[50.4, -104.6], [50.41, -104.61]],
+        "provider": "osrm_match",
+        "input_points_count": 6,
+    }
     assert google_called["n"] == 0, "Google must not be called when OSRM returns a value"
 
 
@@ -190,7 +195,12 @@ async def test_falls_back_to_google_when_osrm_none():
     ):
         result = await rd.compute_road_route(_trip(6))
 
-    assert result == {"distance_km": 5.5, "polyline": [[50.0, -104.0]]}
+    assert result == {
+        "distance_km": 5.5,
+        "polyline": [[50.0, -104.0]],
+        "provider": "google_roads",
+        "input_points_count": 6,
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_route_validation_osrm.py
+++ b/backend/tests/test_route_validation_osrm.py
@@ -51,3 +51,12 @@ async def test_validate_trip_route_prefers_osrm_match():
     assert result["snapped_points"] == 3
     assert result["match_confidence"] == 0.92
     assert result["verdict"] == "suspicious"
+
+
+def test_downsample_preserves_latest_point():
+    points = [{"i": i} for i in range(250)]
+
+    sampled = rv._downsample(points, 100)
+
+    assert len(sampled) == 100
+    assert sampled[-1] == points[-1]

--- a/backend/tests/test_route_validation_osrm.py
+++ b/backend/tests/test_route_validation_osrm.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+import pytest
+
+from backend.utils import route_validation as rv
+
+
+class _FakeResp:
+    status_code = 200
+
+    def json(self):
+        return {
+            "code": "Ok",
+            "tracepoints": [{"matchings_index": 0}, {"matchings_index": 0}, None, {"matchings_index": 0}],
+            "matchings": [{"confidence": 0.92}],
+        }
+
+
+class _FakeClient:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def get(self, *_a, **_kw):
+        return _FakeResp()
+
+
+def _crumb(i):
+    return {
+        "lat": 50.45 + i * 0.001,
+        "lng": -104.62 - i * 0.001,
+        "tracking_phase": "trip_in_progress",
+        "accuracy": 12,
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_trip_route_prefers_osrm_match():
+    async def _settings():
+        return {"osrm_url": "http://osrm:5000", "google_maps_api_key": "unused"}
+
+    with patch.object(rv, "get_app_settings", _settings), patch.object(rv.httpx, "AsyncClient", _FakeClient):
+        result = await rv.validate_trip_route([_crumb(i) for i in range(6)])
+
+    assert result["provider"] == "osrm_match"
+    assert result["snapped_points"] == 3
+    assert result["match_confidence"] == 0.92
+    assert result["verdict"] == "suspicious"

--- a/backend/tests/test_route_validation_osrm.py
+++ b/backend/tests/test_route_validation_osrm.py
@@ -60,3 +60,38 @@ def test_downsample_preserves_latest_point():
 
     assert len(sampled) == 100
     assert sampled[-1] == points[-1]
+
+
+class _FakeNoMatchResp:
+    status_code = 200
+
+    def json(self):
+        return {"code": "NoMatch", "message": "No matchings found"}
+
+
+class _FakeNoMatchClient:
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def get(self, *_a, **_kw):
+        return _FakeNoMatchResp()
+
+
+@pytest.mark.asyncio
+async def test_osrm_no_match_is_likely_spoofed_without_google_fallback():
+    async def _settings():
+        return {"osrm_url": "http://osrm:5000"}
+
+    with patch.object(rv, "get_app_settings", _settings), patch.object(rv.httpx, "AsyncClient", _FakeNoMatchClient):
+        result = await rv.validate_trip_route([_crumb(i) for i in range(6)])
+
+    assert result["provider"] == "osrm_match"
+    assert result["snapped_points"] == 0
+    assert result["deviation_pct"] == 100.0
+    assert result["verdict"] == "likely_spoofed"

--- a/backend/utils/breadcrumbs.py
+++ b/backend/utils/breadcrumbs.py
@@ -67,6 +67,8 @@ async def resolve_active_ride(driver_id: str) -> Optional[Dict[str, Any]]:
     active_rides = await db_supabase.get_rows(
         "rides",
         {"driver_id": driver_id, "status": {"$in": _ACTIVE_STATUSES}},
+        order="created_at",
+        desc=True,
         limit=10,
     )
     return active_rides[0] if active_rides else None
@@ -116,6 +118,13 @@ async def persist_ride_breadcrumbs(
     pings can pass ``persist_idle=True`` to keep the historical online-idle
     breadcrumb behavior when no active ride exists. Returns inserted rows.
     """
+    if not isinstance(points, list):
+        logger.warning("breadcrumb persist received non-list points for driver_id=%s", driver_id)
+        return 0
+    points = [p for p in points if isinstance(p, dict)]
+    if not points:
+        return 0
+
     ride = await resolve_active_ride(driver_id)
 
     ride_id = ride.get("id") if ride else None

--- a/backend/utils/breadcrumbs.py
+++ b/backend/utils/breadcrumbs.py
@@ -101,24 +101,32 @@ def _coord(point: Dict[str, Any], *keys: str) -> Optional[float]:
     return None
 
 
-async def persist_ride_breadcrumbs(driver_id: str, points: List[Dict[str, Any]]) -> int:
-    """Persist a batch of GPS points as ``driver_location_history`` breadcrumbs.
+async def persist_ride_breadcrumbs(
+    driver_id: str,
+    points: List[Dict[str, Any]],
+    *,
+    persist_idle: bool = False,
+) -> int:
+    """Persist GPS points as ``driver_location_history`` breadcrumbs.
 
-    Only writes when the driver currently has an active ride. ride_id + phase
-    are derived/validated server-side per point (see module docstring): stale
-    or other-ride points are discarded, phase comes from each point's own
-    capture timestamp, and the batch is capped at ``MAX_BREADCRUMB_BATCH``.
-    Returns the number of breadcrumbs inserted.
+    When the driver has an active ride, ride_id + phase are derived/validated
+    server-side per point (see module docstring): stale or other-ride points
+    are discarded, phase comes from each point's own capture timestamp, and
+    the batch is capped at ``MAX_BREADCRUMB_BATCH``. Single live WebSocket
+    pings can pass ``persist_idle=True`` to keep the historical online-idle
+    breadcrumb behavior when no active ride exists. Returns inserted rows.
     """
     ride = await resolve_active_ride(driver_id)
-    if not ride:
-        return 0
 
-    ride_id = ride.get("id")
-    current_phase = RIDE_STATUS_TO_PHASE.get(ride.get("status", ""), "online_idle")
+    ride_id = ride.get("id") if ride else None
+    current_phase = RIDE_STATUS_TO_PHASE.get(ride.get("status", ""), "online_idle") if ride else "online_idle"
     # Points captured before the ride was assigned to this driver are stale
     # (previous ride / idle) and must not attach to this trip.
-    window_start = parse_iso_utc(ride.get("driver_accepted_at")) or parse_iso_utc(ride.get("created_at"))
+    window_start = (
+        parse_iso_utc(ride.get("driver_accepted_at")) or parse_iso_utc(ride.get("created_at")) if ride else None
+    )
+    if not ride and not persist_idle:
+        return 0
 
     # Cap before building rows — keep the most recent points if over the bound.
     if len(points) > MAX_BREADCRUMB_BATCH:
@@ -145,9 +153,15 @@ async def persist_ride_breadcrumbs(driver_id: str, points: List[Dict[str, Any]])
         point_ride = p.get("ride_id")
         if point_ride and point_ride != ride_id:
             continue
-        ts = parse_iso_utc(p.get("timestamp"))
+        captured_at = parse_iso_utc(
+            p.get("captured_at")
+            or p.get("device_timestamp")
+            or p.get("recorded_at")
+            or p.get("timestamp")
+        )
+        received_at = datetime.now(timezone.utc)
         # Discard points captured before this ride's window (pre-ride / stale).
-        if ts is not None and window_start is not None and ts < window_start:
+        if captured_at is not None and window_start is not None and captured_at < window_start:
             continue
         rows.append(
             {
@@ -161,8 +175,9 @@ async def persist_ride_breadcrumbs(driver_id: str, points: List[Dict[str, Any]])
                 "accuracy": p.get("accuracy"),
                 "altitude": p.get("altitude"),
                 # Server-authoritative phase from the point's own capture time.
-                "tracking_phase": _phase_for_timestamp(ride, ts, current_phase),
-                "timestamp": ts or datetime.now(timezone.utc),
+                "tracking_phase": _phase_for_timestamp(ride, captured_at, current_phase) if ride else "online_idle",
+                "timestamp": captured_at or received_at,
+                "received_at": received_at,
             }
         )
 

--- a/backend/utils/breadcrumbs.py
+++ b/backend/utils/breadcrumbs.py
@@ -32,8 +32,9 @@ this constant.
 from __future__ import annotations
 
 import logging
+import math
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 try:
@@ -60,6 +61,8 @@ _ACTIVE_STATUSES = list(RIDE_STATUS_TO_PHASE.keys())
 # Mirror the WebSocket batch path's bound so the REST path can't force an
 # arbitrarily large single insert (worker stall + breadcrumb-table bloat).
 MAX_BREADCRUMB_BATCH = 500
+_MAX_CLIENT_CLOCK_SKEW = timedelta(minutes=5)
+_ACTIVE_RIDE_NOT_PROVIDED = object()
 
 
 async def resolve_active_ride(driver_id: str) -> Optional[Dict[str, Any]]:
@@ -97,10 +100,34 @@ def _coord(point: Dict[str, Any], *keys: str) -> Optional[float]:
         v = point.get(k)
         if v is not None:
             try:
-                return float(v)
+                value = float(v)
             except (TypeError, ValueError):
                 return None
+            return value if math.isfinite(value) else None
     return None
+
+
+def _valid_lat_lng(lat: float, lng: float) -> bool:
+    # Reject invalid ranges and the common no-fix/default coordinate.
+    return -90 <= lat <= 90 and -180 <= lng <= 180 and not (lat == 0 and lng == 0)
+
+
+def _bounded_capture_time(captured_at: Optional[datetime], received_at: datetime) -> datetime:
+    """Use device capture time only when it is close enough to server receipt time.
+
+    Future device clocks otherwise create future ``driver_location_history.timestamp``
+    values that evade timestamp-based cleanup jobs until that future date.
+    """
+    if captured_at is None:
+        return received_at
+    if captured_at > received_at + _MAX_CLIENT_CLOCK_SKEW:
+        logger.warning(
+            "breadcrumb capture time is in the future; using received_at captured_at=%s received_at=%s",
+            captured_at.isoformat(),
+            received_at.isoformat(),
+        )
+        return received_at
+    return captured_at
 
 
 async def persist_ride_breadcrumbs(
@@ -108,6 +135,7 @@ async def persist_ride_breadcrumbs(
     points: List[Dict[str, Any]],
     *,
     persist_idle: bool = False,
+    active_ride: Optional[Dict[str, Any]] | object = _ACTIVE_RIDE_NOT_PROVIDED,
 ) -> int:
     """Persist GPS points as ``driver_location_history`` breadcrumbs.
 
@@ -125,16 +153,20 @@ async def persist_ride_breadcrumbs(
     if not points:
         return 0
 
-    ride = await resolve_active_ride(driver_id)
+    ride = (
+        await resolve_active_ride(driver_id)
+        if active_ride is _ACTIVE_RIDE_NOT_PROVIDED
+        else active_ride
+    )
 
-    ride_id = ride.get("id") if ride else None
-    current_phase = RIDE_STATUS_TO_PHASE.get(ride.get("status", ""), "online_idle") if ride else "online_idle"
+    ride_id = ride.get("id") if isinstance(ride, dict) else None
+    current_phase = RIDE_STATUS_TO_PHASE.get(ride.get("status", ""), "online_idle") if isinstance(ride, dict) else "online_idle"
     # Points captured before the ride was assigned to this driver are stale
     # (previous ride / idle) and must not attach to this trip.
     window_start = (
-        parse_iso_utc(ride.get("driver_accepted_at")) or parse_iso_utc(ride.get("created_at")) if ride else None
+        parse_iso_utc(ride.get("driver_accepted_at")) or parse_iso_utc(ride.get("created_at")) if isinstance(ride, dict) else None
     )
-    if not ride and not persist_idle:
+    if not isinstance(ride, dict) and not persist_idle:
         return 0
 
     # Cap before building rows — keep the most recent points if over the bound.
@@ -152,7 +184,7 @@ async def persist_ride_breadcrumbs(
     for p in points:
         lat = _coord(p, "lat", "latitude")
         lng = _coord(p, "lng", "longitude")
-        if lat is None or lng is None:
+        if lat is None or lng is None or not _valid_lat_lng(lat, lng):
             continue
         # Drop obviously spoofed fixes; the heavy anomaly filter (speed /
         # distance / gap caps) runs once at settlement in routes/drivers.py.
@@ -169,8 +201,9 @@ async def persist_ride_breadcrumbs(
             or p.get("timestamp")
         )
         received_at = datetime.now(timezone.utc)
+        bounded_captured_at = _bounded_capture_time(captured_at, received_at)
         # Discard points captured before this ride's window (pre-ride / stale).
-        if captured_at is not None and window_start is not None and captured_at < window_start:
+        if captured_at is not None and window_start is not None and bounded_captured_at < window_start:
             continue
         rows.append(
             {
@@ -184,8 +217,8 @@ async def persist_ride_breadcrumbs(
                 "accuracy": p.get("accuracy"),
                 "altitude": p.get("altitude"),
                 # Server-authoritative phase from the point's own capture time.
-                "tracking_phase": _phase_for_timestamp(ride, captured_at, current_phase) if ride else "online_idle",
-                "timestamp": captured_at or received_at,
+                "tracking_phase": _phase_for_timestamp(ride, bounded_captured_at, current_phase) if isinstance(ride, dict) else "online_idle",
+                "timestamp": bounded_captured_at,
                 "received_at": received_at,
             }
         )

--- a/backend/utils/route_distance.py
+++ b/backend/utils/route_distance.py
@@ -253,22 +253,32 @@ async def compute_road_route(breadcrumbs: list[dict]) -> Optional[dict]:
     app_settings = await get_app_settings() or {}
 
     match: Optional[RoadMatch] = None
+    provider: Optional[str] = None
     # OSRM first when configured. DB override (rotatable via admin) wins over env.
     osrm_url = (app_settings.get("osrm_url") or settings.OSRM_URL or "").strip()
     if osrm_url:
         match = await _compute_via_osrm(trip_points, osrm_url)
-        if match is None:
+        if match is not None:
+            provider = "osrm_match"
+        else:
             logger.info("[route_distance] OSRM produced no value; trying Google Roads fallback")
 
     if match is None:
         api_key = (app_settings.get("google_maps_api_key") or "").strip()
         if api_key:
             match = await _compute_via_google_roads(trip_points, api_key)
+            if match is not None:
+                provider = "google_roads"
 
     if match is None:
         return None
     distance_km, polyline = match
-    return {"distance_km": distance_km, "polyline": polyline}
+    return {
+        "distance_km": distance_km,
+        "polyline": polyline,
+        "provider": provider or "unknown",
+        "input_points_count": len(trip_points),
+    }
 
 
 async def compute_road_distance_km(breadcrumbs: list[dict]) -> Optional[float]:

--- a/backend/utils/route_validation.py
+++ b/backend/utils/route_validation.py
@@ -53,11 +53,16 @@ def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> flo
 
 
 def _downsample(points: list[dict], max_count: int) -> list[dict]:
-    """Evenly downsample points to fit API limit."""
+    """Evenly downsample points to fit API limit, always keeping the last point."""
     if len(points) <= max_count:
         return points
-    step = len(points) / max_count
-    return [points[int(i * step)] for i in range(max_count)]
+    if max_count < 2:
+        return [points[-1]]
+    step = len(points) / (max_count - 1)
+    sampled = [points[int(i * step)] for i in range(max_count - 1)]
+    if sampled[-1] is not points[-1]:
+        sampled.append(points[-1])
+    return sampled
 
 
 def _osrm_radius(point: dict) -> str:

--- a/backend/utils/route_validation.py
+++ b/backend/utils/route_validation.py
@@ -1,9 +1,10 @@
-"""Post-trip GPS route validation via Google Roads API.
+"""Post-trip GPS route validation via OSRM /match, then Google Roads fallback.
 
 After a ride completes, we snap the driver's GPS breadcrumbs to the road
-network and measure how far they deviate. A legitimate trip has low deviation
-(GPS is noisy but stays within ~50m of a road). A spoofed trip has large
-deviation (fake coordinates rarely align with actual roads).
+network and measure match coverage/deviation. A legitimate trip has high road
+match coverage (or low Google snap deviation). A spoofed trip tends to have
+large unmatched/deviating stretches because fake coordinates rarely align with
+actual roads.
 
 This is how Uber/Lyft catch fake trips after the fact — even if the spoofer
 bypasses all client-side checks, the server-side route doesn't match reality.
@@ -27,11 +28,20 @@ try:
 except ImportError:
     from settings_loader import get_app_settings  # type: ignore
 
+try:
+    from ..core.config import settings
+except ImportError:
+    from core.config import settings  # type: ignore
+
 logger = logging.getLogger(__name__)
 
 _SNAP_TO_ROAD_URL = "https://roads.googleapis.com/v1/snapToRoads"
 _MAX_POINTS_PER_REQUEST = 100  # API limit
 _DEVIATION_THRESHOLD_METERS = 50  # beyond 50m from nearest road = suspicious
+_OSRM_RADIUS_MIN_M = 10
+_OSRM_RADIUS_MAX_M = 50
+_OSRM_RADIUS_DEFAULT_M = 20
+_TIMEOUT_S = 10.0
 
 
 def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
@@ -48,6 +58,69 @@ def _downsample(points: list[dict], max_count: int) -> list[dict]:
         return points
     step = len(points) / max_count
     return [points[int(i * step)] for i in range(max_count)]
+
+
+def _osrm_radius(point: dict) -> str:
+    try:
+        accuracy = float(point.get("accuracy")) if point.get("accuracy") is not None else _OSRM_RADIUS_DEFAULT_M
+    except (TypeError, ValueError):
+        accuracy = _OSRM_RADIUS_DEFAULT_M
+    return str(int(max(_OSRM_RADIUS_MIN_M, min(accuracy, _OSRM_RADIUS_MAX_M))))
+
+
+async def _validate_via_osrm(trip_points: list[dict], osrm_url: str) -> Optional[dict]:
+    """Validate a trace with OSRM /match and tracepoint match coverage."""
+    sampled = _downsample(trip_points, _MAX_POINTS_PER_REQUEST)
+    coords = ";".join(f"{p['lng']},{p['lat']}" for p in sampled)
+    url = f"{osrm_url.rstrip('/')}/match/v1/driving/{coords}"
+    params = {
+        "overview": "false",
+        "geometries": "geojson",
+        "steps": "false",
+        "radiuses": ";".join(_osrm_radius(p) for p in sampled),
+        "gaps": "ignore",
+        "tidy": "true",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            resp = await client.get(url, params=params)
+            if resp.status_code != 200:
+                logger.warning("[route_validation] OSRM returned %d", resp.status_code)
+                return None
+            data = resp.json()
+    except Exception as exc:
+        logger.warning("[route_validation] OSRM call failed: %s", exc)
+        return None
+
+    if data.get("code") != "Ok":
+        logger.warning("[route_validation] OSRM code=%s", data.get("code"))
+        return None
+
+    tracepoints = data.get("tracepoints") or []
+    total = len(sampled)
+    matched = sum(1 for tp in tracepoints if tp)
+    unmatched = max(0, total - matched)
+    deviation_pct = (unmatched / total) * 100 if total else 0.0
+    confidences = [float(m.get("confidence")) for m in (data.get("matchings") or []) if m.get("confidence") is not None]
+    avg_confidence = sum(confidences) / len(confidences) if confidences else None
+
+    if deviation_pct > 50 or (avg_confidence is not None and avg_confidence < 0.3):
+        verdict = "likely_spoofed"
+    elif deviation_pct > 20 or (avg_confidence is not None and avg_confidence < 0.6):
+        verdict = "suspicious"
+    else:
+        verdict = "clean"
+
+    return {
+        "provider": "osrm_match",
+        "total_points": total,
+        "snapped_points": matched,
+        "deviation_pct": round(deviation_pct, 1),
+        "avg_deviation_m": None,
+        "max_deviation_m": None,
+        "match_confidence": round(avg_confidence, 3) if avg_confidence is not None else None,
+        "verdict": verdict,
+    }
 
 
 async def validate_trip_route(
@@ -69,16 +142,25 @@ async def validate_trip_route(
     if not breadcrumbs or len(breadcrumbs) < 5:
         return None
 
-    settings = await get_app_settings()
-    api_key = (settings or {}).get("google_maps_api_key", "")
-    if not api_key:
-        return None
+    app_settings = await get_app_settings() or {}
 
     # Filter to trip_in_progress phase only (the actual ride)
     trip_points = [
-        b for b in breadcrumbs if b.get("tracking_phase") == "trip_in_progress" and b.get("lat") and b.get("lng")
+        b
+        for b in breadcrumbs
+        if b.get("tracking_phase") == "trip_in_progress" and b.get("lat") is not None and b.get("lng") is not None
     ]
     if len(trip_points) < 5:
+        return None
+
+    osrm_url = (app_settings.get("osrm_url") or settings.OSRM_URL or "").strip()
+    if osrm_url:
+        osrm_result = await _validate_via_osrm(trip_points, osrm_url)
+        if osrm_result is not None:
+            return osrm_result
+
+    api_key = (app_settings.get("google_maps_api_key") or "").strip()
+    if not api_key:
         return None
 
     sampled = _downsample(trip_points, _MAX_POINTS_PER_REQUEST)
@@ -86,7 +168,7 @@ async def validate_trip_route(
     path_str = "|".join(f"{p['lat']},{p['lng']}" for p in sampled)
 
     try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
             resp = await client.get(
                 _SNAP_TO_ROAD_URL,
                 params={
@@ -106,6 +188,7 @@ async def validate_trip_route(
     snapped_points = data.get("snappedPoints", [])
     if not snapped_points:
         return {
+            "provider": "google_roads",
             "total_points": len(sampled),
             "snapped_points": 0,
             "deviation_pct": 100.0,
@@ -159,6 +242,7 @@ async def validate_trip_route(
         verdict = "clean"
 
     return {
+        "provider": "google_roads",
         "total_points": total,
         "snapped_points": len(snapped_by_idx),
         "deviation_pct": round(deviation_pct, 1),

--- a/backend/utils/route_validation.py
+++ b/backend/utils/route_validation.py
@@ -98,7 +98,20 @@ async def _validate_via_osrm(trip_points: list[dict], osrm_url: str) -> Optional
         return None
 
     if data.get("code") != "Ok":
-        logger.warning("[route_validation] OSRM code=%s", data.get("code"))
+        code = data.get("code")
+        logger.warning("[route_validation] OSRM code=%s", code)
+        if code == "NoMatch":
+            total = len(sampled)
+            return {
+                "provider": "osrm_match",
+                "total_points": total,
+                "snapped_points": 0,
+                "deviation_pct": 100.0,
+                "avg_deviation_m": 999.0,
+                "max_deviation_m": 999.0,
+                "match_confidence": None,
+                "verdict": "likely_spoofed",
+            }
         return None
 
     tracepoints = data.get("tracepoints") or []


### PR DESCRIPTION
### Motivation
- Preserve device capture timestamps separately from server receipt time and surface route quality/geometry persistence status for billing and dispute review.
- Improve breadcrumb ingestion to be server-authoritative about ride phase, support single live WS pings when no active ride, and avoid losing data from dense/long trips.
- Use OSRM /match where available (with Google Roads fallback) for post-trip route validation and record provider/metrics for debugging and confidence.

### Description
- Add migration `backend/migrations/118_route_quality_received_at.sql` to add `received_at` to `driver_location_history`, `route_quality` / `save_status` / `save_error` to `ride_routes`, and `route_quality` / `route_geometry_status` / `route_geometry_error` to `rides`.
- Update breadcrumb writer `persist_ride_breadcrumbs` to accept `persist_idle` (keep old idle behaviour for live WS pings), capture device timestamps from multiple keys (`captured_at`/`device_timestamp`/`recorded_at`/`timestamp`), set `received_at` to server time, and derive `tracking_phase` server-side.
- Wire WebSocket and HTTP location batch paths to the shared breadcrumb persister, and tighten null checks for lat/lng handling in `websocket.py` and `drivers.py`.
- Compute richer route-quality metrics in `complete_ride` (counts, rejected segments, max gap, provider, confidence) and persist heavy geometry to `ride_routes` with retries, writing back `route_geometry_status`/`route_geometry_error` and `route_quality` to the `rides` row on failure.
- Return extra metadata from road-snap utilities: `compute_road_route` now returns `provider` and `input_points_count`, and `route_validation.validate_trip_route` now prefers OSRM `/match` with a Google Roads fallback and reports provider-specific diagnostics.
- Adjust various selects to include `accuracy`, `altitude`, and `received_at` in location trail and enrich ride details with `route_geometry_status`/`route_geometry_error`.
- Update and add tests exercising breadcrumb persistence, OSRM/google route distance behavior, and OSRM-based route validation.

### Testing
- Ran breadcrumb persistence unit tests in `backend/tests/test_breadcrumb_persistence.py` including `test_persists_all_points_with_trip_phase` and `test_no_active_ride_can_persist_idle_for_live_ws_ping`, and they passed.
- Ran route distance tests in `backend/tests/test_route_distance_osrm.py` that verify OSRM preference and Google fallback and they passed.
- Added and ran `backend/tests/test_route_validation_osrm.py::test_validate_trip_route_prefers_osrm_match` to validate OSRM `/match` behaviour, and it passed.
- Overall `pytest` for the modified test modules succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f01587cc08330a4e48216b5aed589)

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
