### PR TITLE
fix(users): await get_rows in emergency-contacts routes + migration t…

### DIFF
--- a/backend/migrations/120_ensure_emergency_contacts_and_gps_column.sql
+++ b/backend/migrations/120_ensure_emergency_contacts_and_gps_column.sql
@@ -1,0 +1,87 @@
+-- 120_ensure_emergency_contacts_and_gps_column.sql
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS emergency_contacts;
+--   ALTER TABLE rides DROP COLUMN IF EXISTS gps_anonymized_at;
+--
+-- Problem 1: emergency_contacts table missing on Railway (PGRST205).
+--   The table is defined in 08_complete_schema.sql, but due to string-sort
+--   ordering (100_* sorts before 50_*, which sorts before 08_* on some runners)
+--   combined with a fresh DB, the table may never have been created.
+--   This migration creates it idempotently and applies RLS.
+--
+-- Problem 2: purge_pii_retention() crashes with
+--   'column "gps_anonymized_at" does not exist'.
+--   The column is added by 50_pii_retention_purge.sql, but migration 117
+--   re-creates purge_pii_retention() referencing that column. On a fresh DB
+--   with string-sorted migration application, 117_* runs before 50_*, so the
+--   function compiles fine but fails at runtime because the column isn't there yet.
+--   This migration adds the column idempotently to make the function safe to call
+--   regardless of application order.
+
+-- ── 1. emergency_contacts ─────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS emergency_contacts (
+    id           TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::text,
+    user_id      TEXT        NOT NULL,
+    name         TEXT        NOT NULL,
+    phone        TEXT        NOT NULL,
+    relationship TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_emergency_contacts_user_id ON emergency_contacts (user_id);
+
+ALTER TABLE emergency_contacts ENABLE ROW LEVEL SECURITY;
+
+-- Riders may only see and manage their own contacts.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'emergency_contacts'
+          AND policyname = 'emergency_contacts_owner_select'
+    ) THEN
+        CREATE POLICY emergency_contacts_owner_select
+            ON emergency_contacts FOR SELECT
+            USING (auth.uid()::text = user_id);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'emergency_contacts'
+          AND policyname = 'emergency_contacts_owner_insert'
+    ) THEN
+        CREATE POLICY emergency_contacts_owner_insert
+            ON emergency_contacts FOR INSERT
+            WITH CHECK (auth.uid()::text = user_id);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'emergency_contacts'
+          AND policyname = 'emergency_contacts_owner_delete'
+    ) THEN
+        CREATE POLICY emergency_contacts_owner_delete
+            ON emergency_contacts FOR DELETE
+            USING (auth.uid()::text = user_id);
+    END IF;
+END
+$$;
+
+-- ── 2. rides.gps_anonymized_at ────────────────────────────────────────────────
+ALTER TABLE rides
+    ADD COLUMN IF NOT EXISTS gps_anonymized_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN rides.gps_anonymized_at IS
+    'Set by purge_pii_retention() once pickup/dropoff GPS + polylines are scrubbed (3y). NULL means full GPS still present. Append-only — never reset.';
+
+CREATE INDEX IF NOT EXISTS idx_rides_gps_anonymized_at
+    ON rides (created_at)
+    WHERE gps_anonymized_at IS NULL;
+
+-- Tell PostgREST to reload its schema cache so the new table is immediately
+-- visible without a full restart.
+NOTIFY pgrst, 'reload schema';

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -343,10 +343,7 @@ class EmergencyContactResponse(BaseModel):
 async def get_emergency_contacts(current_user: dict = Depends(get_current_user)):
     """Get the user's emergency contacts."""
     try:
-        contacts_cursor = db_supabase.get_rows("emergency_contacts", {"user_id": current_user["id"]}, limit=100)
-        contacts = (
-            await contacts_cursor.to_list(length=10) if hasattr(contacts_cursor, "to_list") else list(contacts_cursor)
-        )
+        contacts = await db_supabase.get_rows("emergency_contacts", {"user_id": current_user["id"]}, limit=100)
     except Exception as e:
         logger.error(
             f"Could not fetch emergency contacts for user {current_user['id']}: {e}",
@@ -360,10 +357,7 @@ async def get_emergency_contacts(current_user: dict = Depends(get_current_user))
 async def add_emergency_contact(contact: EmergencyContactCreate, current_user: dict = Depends(get_current_user)):
     """Add an emergency contact (max 3 contacts per user, matching Uber/Lyft)."""
     try:
-        existing_cursor = db_supabase.get_rows("emergency_contacts", {"user_id": current_user["id"]}, limit=100)
-        existing = (
-            await existing_cursor.to_list(length=10) if hasattr(existing_cursor, "to_list") else list(existing_cursor)
-        )
+        existing = await db_supabase.get_rows("emergency_contacts", {"user_id": current_user["id"]}, limit=100)
     except Exception:
         existing = []
 


### PR DESCRIPTION
…o create missing table/column

Two production crashes from the same root:

1. Missing `await` on `db_supabase.get_rows()` in GET and POST /users/emergency-contacts — get_rows is async, so the unawaited calls returned a coroutine object. This caused the repeated Railway log "coroutine 'get_rows' was never awaited" warnings and made the 3-contact limit check always pass (existing appeared as an empty list).

2. PGRST205 "Could not find the table 'public.emergency_contacts'" on POST
   + "column 'gps_anonymized_at' does not exist" in purge_pii_retention — both caused by string-sort migration ordering: on a fresh DB the runner applies 100_*/117_* before 08_*/50_*, so the table and column that those later migrations depend on may not exist yet. Migration 120 creates both idempotently (IF NOT EXISTS) and issues NOTIFY pgrst to reload the schema cache immediately.

https://claude.ai/code/session_01BEqGZoYXZikLisc1JCb9ig

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
