### PR TITLE
fix(driver-app): remove dangling car/carNav import left by the g4rb4g…

### DIFF
--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -25,7 +25,6 @@ import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useAuthStore } from '@shared/store/authStore';
 import { useLocationStore } from '@shared/store/locationStore';
 import { useDriverStore } from '../store/driverStore';
-import { initCarNav } from '../car/carNav';
 import SpinrConfig from '@shared/config/spinr.config';
 import { ErrorBoundary } from '@shared/components/ErrorBoundary';
 import { OfflineBanner } from '@shared/components/OfflineBanner';
@@ -356,17 +355,9 @@ export default function RootLayout() {
     }
   }, []);
 
-  // ── CarPlay in-dash route map, iOS only ──
-  // iOS CarPlay shares the phone app's JS context, so it's driven from here.
-  // Android Auto runs in its OWN JS root (car/androidAutoEntry, imported above)
-  // — calling initCarNav here too would double-init on Android, hence the iOS
-  // guard. No-op unless the native module is present (CarPlay wiring is gated off
-  // by default — see plugins/withCarIntegration.js). See docs/carplay-android-auto.md.
-  useEffect(() => {
-    if (Platform.OS !== 'ios') return;
-    const cleanup = initCarNav();
-    return cleanup;
-  }, []);
+  // Android Auto is registered at JS bundle load in index.js (registerAutoPlay,
+  // @iternio/react-native-auto-play) — nothing for the phone layout to do here.
+  // iOS CarPlay is dormant (needs an Apple entitlement + scene wiring not present).
 
   // ── Cold-start init: auth, location, Firebase native modules, Android channel ──
   useEffect(() => {

--- a/driver-app/lib/androidAuto/carRoute.ts
+++ b/driver-app/lib/androidAuto/carRoute.ts
@@ -150,8 +150,10 @@ export function defaultNavButtons(os: string): NavButton[] {
  * static (Google + Waze). On CarPlay we only advertise apps the driver actually
  * has — Apple Maps is always present; Google Maps and Waze are added only when
  * `canOpen` confirms their scheme resolves (requires the schemes in
- * LSApplicationQueriesSchemes — see withCarIntegration.js). This is why a driver
- * with Google Maps on CarPlay gets a Google button and one without it does not.
+ * LSApplicationQueriesSchemes, to be added when iOS CarPlay is wired up). This is
+ * why a driver with Google Maps on CarPlay gets a Google button, one without does
+ * not. Android-only today (register.ts uses the static defaultNavButtons); kept
+ * for the dormant iOS CarPlay path.
  */
 export async function resolveNavButtons(
   os: string,


### PR DESCRIPTION
…3 removal

app/_layout.tsx still imported initCarNav from ../car/carNav (deleted in the @iternio switch) and called it in an iOS-only useEffect — a dead import that would break the Metro bundle. With @iternio, Android Auto is registered at JS bundle load in index.js (registerAutoPlay), so the phone layout needs nothing; iOS CarPlay is dormant. Also drops a stale withCarIntegration.js reference in a carRoute.ts comment.

Verified no other dangling references to the removed car/ files or the config plugin. The 29 lib/androidAuto unit tests pass; the 4 unrelated component/store suites that fail in this sandbox were confirmed pre-existing on the pre-merge state e3bc6fc (identical coverage 40.68/42.15/30.18) — not introduced here.

https://claude.ai/code/session_01P6AN9cpmWFit6NVbuWgQH8

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
