### PR TITLE
fix(tracking): unblock MapLibre worker + fix useless style fallback

### DIFF
--- a/admin-dashboard/src/lib/map/maplibre-base.ts
+++ b/admin-dashboard/src/lib/map/maplibre-base.ts
@@ -43,8 +43,10 @@ export function trackBaseMapStyle(): string {
     return protomapsStyleUrl() ?? MAP_STYLE_POSITRON;
 }
 
-/** Keyless fallback style, used if the primary style fails to load at runtime. */
-export const MAP_STYLE_FALLBACK = MAP_STYLE_POSITRON;
+/** Keyless fallback style, used if the primary style fails to load at runtime.
+ *  Must differ from the primary so the error-handler's `primaryStyle !== MAP_STYLE_FALLBACK`
+ *  guard can actually switch styles on failure. */
+export const MAP_STYLE_FALLBACK = MAP_STYLE_URL; // liberty — different look from positron
 
 // Saskatoon by default — Spinr is a Saskatchewan-first service, so maps
 // should land somewhere operational even before service areas load or

--- a/admin-dashboard/src/middleware.ts
+++ b/admin-dashboard/src/middleware.ts
@@ -55,6 +55,12 @@ function buildCsp(nonce: string): string {
     "img-src 'self' data: blob: https:",
     "font-src 'self'",
     "connect-src 'self' https: wss: ws:",
+    // MapLibre GL (and any map library) instantiates its tile-processing Web
+    // Worker from a blob: URL. Chrome does NOT extend 'self' to cover blob:
+    // workers even though the blob was created in the same origin — it requires
+    // an explicit blob: source in worker-src. Without this the worker is blocked,
+    // vector tiles never decode, and the map canvas stays blank.
+    "worker-src blob: 'self'",
     "frame-ancestors 'none'",
   ].join("; ");
 }


### PR DESCRIPTION
CSP was missing `worker-src blob: 'self'`, so Chrome silently blocked
MapLibre GL's tile-processing Web Worker (created from a blob: URL).
Without the worker vector tiles never decode → blank map. Driver/rider
pin markers also never appeared because map.on('load') never fired.

Also fixes MAP_STYLE_FALLBACK being identical to the primary style
(positron), which made the error-handler's style-switch condition always
false. Now falls back to the liberty style on load failure.

https://claude.ai/code/session_01M69xv5oc5PmZQg4V1UQZRu

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
