### PR TITLE
Deliver dispatch pushes inline, not queued — fixes silent offer drops

### DIFF
--- a/backend/features.py
+++ b/backend/features.py
@@ -1258,55 +1258,21 @@ async def _send_expo_push(token: str, title: str, body: str, data: Dict[str, str
         return False
 
 
-async def send_push_notification(
-    user_id: str,
+async def _deliver_push_now(
+    token: str,
     title: str,
     body: str,
-    data: Dict[str, str] | None = None,
-    priority: str = "normal",
-    target_app: str | None = None,
-):
-    """Send a push notification to a user.
+    data: Dict[str, str] | None,
+    user_id: str,
+    target_app: str | None,
+) -> bool:
+    """Attempt a single, immediate push delivery. Returns True on success.
 
-    Routes automatically: Expo push tokens go via Expo's REST API; all other
-    tokens are assumed to be FCM and sent via Firebase Admin SDK.
-
-    ``target_app`` selects which per-app token column to read:
-      - ``"rider"``  → ``fcm_token_rider``
-      - ``"driver"`` → ``fcm_token_driver``
-      - ``None``     → legacy ``fcm_token`` (backward compat)
-
-    Dispatch and safety priority pushes are written to the push_retry_queue
-    table first so that a transient FCM/Expo outage doesn't silently drop a
-    ride offer or SOS alert.  Normal (informational) pushes continue to use
-    the existing direct-send path.
+    Routes Expo push tokens via Expo's REST API; everything else is treated as
+    an FCM token and sent through the Firebase Admin SDK. A stale FCM token is
+    purged so the next login re-registers. Never raises — returns False on any
+    failure so the caller can decide whether to enqueue a retry.
     """
-    if priority in ("dispatch", "safety"):
-        try:
-            from utils.push_retry import enqueue_push
-
-            await enqueue_push(user_id, title, body, data, priority=priority, target_app=target_app)
-            return True
-        except Exception:
-            logger.error("push enqueue failed, falling back to direct send", exc_info=True)
-
-    user = await db.find_one("users", {"id": user_id})
-    if not user:
-        logger.warning(f"No user found for {user_id} — push dropped")
-        return False
-
-    token: str | None = None
-    if target_app == "rider":
-        token = user.get("fcm_token_rider") or user.get("fcm_token")
-    elif target_app == "driver":
-        token = user.get("fcm_token_driver") or user.get("fcm_token")
-    else:
-        token = user.get("fcm_token")
-
-    if not token:
-        logger.warning(f"No FCM token on file for user {user_id} (target_app={target_app}) — push dropped")
-        return False
-
     if _is_expo_token(token):
         return await _send_expo_push(token, title, body, data)
 
@@ -1346,6 +1312,21 @@ async def send_push_notification(
                     "apns-priority": "10",
                     "apns-push-type": "alert",
                 },
+                # iOS has no full-screen intent — a dispatch offer rides on a
+                # time-sensitive alert payload (custom sound + category for the
+                # Accept/Decline actions). Without this aps block, iOS shows
+                # nothing for an otherwise data-only dispatch message.
+                payload=messaging.APNSPayload(
+                    aps=messaging.Aps(
+                        alert=messaging.ApsAlert(title=title, body=body),
+                        sound="ride_offer.caf" if is_dispatch else "default",
+                        category="ride-offer" if is_dispatch else None,
+                        content_available=True,
+                        mutable_content=True,
+                    ),
+                )
+                if is_dispatch
+                else None,
             ),
         )
         response = await asyncio.to_thread(messaging.send, message)
@@ -1371,6 +1352,73 @@ async def send_push_notification(
     except Exception as e:
         logger.error(f"Failed to send push notification to user {user_id}: {e}", exc_info=True)
         return False
+
+
+async def send_push_notification(
+    user_id: str,
+    title: str,
+    body: str,
+    data: Dict[str, str] | None = None,
+    priority: str = "normal",
+    target_app: str | None = None,
+):
+    """Send a push notification to a user.
+
+    Routes automatically: Expo push tokens go via Expo's REST API; all other
+    tokens are assumed to be FCM and sent via Firebase Admin SDK.
+
+    ``target_app`` selects which per-app token column to read:
+      - ``"rider"``  → ``fcm_token_rider``
+      - ``"driver"`` → ``fcm_token_driver``
+      - ``None``     → legacy ``fcm_token`` (backward compat)
+
+    Delivery is attempted INLINE for every priority. Dispatch (ride offer) and
+    safety (SOS) pushes are time-critical — a ride offer expires in ~15s — so
+    they must never wait on the 30s push_retry loop. Only when the immediate
+    send fails do dispatch/safety pushes fall back to the push_retry_queue, so
+    a transient FCM/Expo outage still doesn't silently drop a ride offer or
+    SOS alert. Normal (informational) pushes are best-effort and not retried.
+    """
+    user = await db.find_one("users", {"id": user_id})
+    if not user:
+        logger.warning(f"No user found for {user_id} — push dropped")
+        return False
+
+    token: str | None = None
+    if target_app == "rider":
+        token = user.get("fcm_token_rider") or user.get("fcm_token")
+    elif target_app == "driver":
+        token = user.get("fcm_token_driver") or user.get("fcm_token")
+    else:
+        token = user.get("fcm_token")
+
+    if not token:
+        logger.warning(f"No FCM token on file for user {user_id} (target_app={target_app}) — push dropped")
+        return False
+
+    # Primary path: deliver right now (≈100–300 ms) so a ride offer reaches the
+    # driver's phone well inside the offer window. A queued-only dispatch would
+    # arrive after the 30s retry tick — long after the offer has expired.
+    delivered = await _deliver_push_now(token, title, body, data, user_id, target_app)
+    if delivered:
+        return True
+
+    # Immediate delivery failed. For time-critical pushes, enqueue for retry
+    # (exponential back-off) so a transient outage doesn't drop a ride offer or
+    # SOS alert. A missing token already returned above, so this only covers
+    # genuine send failures worth retrying.
+    if priority in ("dispatch", "safety"):
+        try:
+            try:
+                from .utils.push_retry import enqueue_push
+            except ImportError:
+                from utils.push_retry import enqueue_push
+
+            await enqueue_push(user_id, title, body, data, priority=priority, target_app=target_app)
+            logger.warning(f"push: immediate send failed for user {user_id} — enqueued {priority} push for retry")
+        except Exception:
+            logger.error("push_retry enqueue (fallback) failed", exc_info=True)
+    return False
 
 
 async def send_email(*, to: str, subject: str, body: str) -> bool:

--- a/backend/features.py
+++ b/backend/features.py
@@ -1374,40 +1374,62 @@ async def send_push_notification(
 
     Delivery is attempted INLINE for every priority. Dispatch (ride offer) and
     safety (SOS) pushes are time-critical — a ride offer expires in ~15s — so
-    they must never wait on the 30s push_retry loop. Only when the immediate
-    send fails do dispatch/safety pushes fall back to the push_retry_queue, so
-    a transient FCM/Expo outage still doesn't silently drop a ride offer or
-    SOS alert. Normal (informational) pushes are best-effort and not retried.
+    they must never wait on the 30s push_retry loop. If the immediate attempt
+    fails for any reason — the FCM/Expo send OR a transient error in the users
+    lookup — dispatch/safety pushes fall back to the push_retry_queue so the
+    offer/SOS is never silently dropped (the retry loop re-reads the user at
+    send time). Normal (informational) pushes are best-effort: a lookup error
+    surfaces to the caller rather than being masked.
     """
-    user = await db.find_one("users", {"id": user_id})
-    if not user:
-        logger.warning(f"No user found for {user_id} — push dropped")
-        return False
+    time_critical = priority in ("dispatch", "safety")
 
-    token: str | None = None
-    if target_app == "rider":
-        token = user.get("fcm_token_rider") or user.get("fcm_token")
-    elif target_app == "driver":
-        token = user.get("fcm_token_driver") or user.get("fcm_token")
-    else:
-        token = user.get("fcm_token")
+    # The whole immediate path (users lookup + token select + send) is guarded:
+    # for a time-critical push a transient Supabase read hiccup must fall back
+    # to the retry queue, NOT escape — dispatch fires this fire-and-forget, so a
+    # raise would vanish and drop the offer (the queued-first path it replaced
+    # could not do that). _deliver_push_now never raises, so a caught exception
+    # here is the lookup path.
+    try:
+        user = await db.find_one("users", {"id": user_id})
+        if not user:
+            logger.warning(f"No user found for {user_id} — push dropped")
+            return False
 
-    if not token:
-        logger.warning(f"No FCM token on file for user {user_id} (target_app={target_app}) — push dropped")
-        return False
+        token: str | None = None
+        if target_app == "rider":
+            token = user.get("fcm_token_rider") or user.get("fcm_token")
+        elif target_app == "driver":
+            token = user.get("fcm_token_driver") or user.get("fcm_token")
+        else:
+            token = user.get("fcm_token")
 
-    # Primary path: deliver right now (≈100–300 ms) so a ride offer reaches the
-    # driver's phone well inside the offer window. A queued-only dispatch would
-    # arrive after the 30s retry tick — long after the offer has expired.
-    delivered = await _deliver_push_now(token, title, body, data, user_id, target_app)
-    if delivered:
-        return True
+        if not token:
+            logger.warning(f"No FCM token on file for user {user_id} (target_app={target_app}) — push dropped")
+            return False
 
-    # Immediate delivery failed. For time-critical pushes, enqueue for retry
-    # (exponential back-off) so a transient outage doesn't drop a ride offer or
-    # SOS alert. A missing token already returned above, so this only covers
-    # genuine send failures worth retrying.
-    if priority in ("dispatch", "safety"):
+        # Primary path: deliver right now (≈100–300 ms) so a ride offer reaches
+        # the driver's phone well inside the offer window. A queued-only dispatch
+        # would arrive after the 30s retry tick — long after the offer expired.
+        delivered = await _deliver_push_now(token, title, body, data, user_id, target_app)
+        if delivered:
+            return True
+    except Exception:
+        logger.error(
+            f"push: immediate send path errored for user {user_id} (priority={priority})",
+            exc_info=True,
+        )
+        if not time_critical:
+            # Informational push: keep the existing best-effort contract and let
+            # the DB error surface to the caller instead of masking it.
+            raise
+        # Time-critical: fall through to the retry-queue enqueue below.
+
+    # Immediate delivery failed (send returned False) or the immediate path
+    # errored for a time-critical push. Enqueue for retry (exponential back-off)
+    # so a transient outage doesn't silently drop a ride offer or SOS alert. The
+    # retry loop re-reads the user/token at send time, so a failed lookup here is
+    # recoverable; a genuinely missing user/token already returned above.
+    if time_critical:
         try:
             try:
                 from .utils.push_retry import enqueue_push

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -917,13 +917,20 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
                 except (TypeError, ValueError):
                     earnings_label = "New fare"
 
-                await send_push_notification(
-                    driver["user_id"],
-                    f"{earnings_label} ride offer",
-                    f"Booking {ride_id} • {pickup_label} → {dropoff_label}",
-                    fcm_data,
-                    priority="dispatch",
-                    target_app="driver",
+                # Fire the push without blocking the per-driver offer loop —
+                # send_push_notification now delivers inline (≈100–300 ms FCM
+                # round-trip), and we don't want N drivers serialized on it.
+                # The WebSocket offer above already reached any foreground app;
+                # this push covers backgrounded / locked / killed devices.
+                asyncio.create_task(
+                    send_push_notification(
+                        driver["user_id"],
+                        f"{earnings_label} ride offer",
+                        f"Booking {ride_id} • {pickup_label} → {dropoff_label}",
+                        fcm_data,
+                        priority="dispatch",
+                        target_app="driver",
+                    )
                 )
             except Exception as e:
                 logger.error(f"[DISPATCH] push failed for driver {driver['user_id']}: {e}", exc_info=True)

--- a/backend/tests/test_p3_push_notifications.py
+++ b/backend/tests/test_p3_push_notifications.py
@@ -419,3 +419,115 @@ class TestNativePushDelivery:
         msg_arg = mock_messaging.Message.call_args
         assert msg_arg is not None
         assert msg_arg.kwargs.get("token") == android_token or (msg_arg.args and android_token in str(msg_arg.args))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dispatch (ride-offer) pushes must be delivered INLINE, not parked on the
+# 30s push_retry loop — a ride offer expires in ~15s, so a queued-only send
+# arrives after the offer is already gone (the "no push when minimized" bug).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestDispatchPushIsImmediate:
+    """Pins send_push_notification's dispatch path.
+
+    Code under test: backend/features.py::send_push_notification, priority="dispatch".
+    """
+
+    async def test_dispatch_push_sent_immediately_not_queued(self):
+        """A dispatch push reaches messaging.send on the request path and is
+        NOT parked on the retry queue when delivery succeeds."""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_messaging = MagicMock()
+        mock_messaging.send = MagicMock(return_value="projects/spinr/messages/ok")
+        mock_firebase = MagicMock()
+        mock_firebase.messaging = mock_messaging
+
+        user_row = {"id": USER_ID, "fcm_token_driver": "android-fcm-driver-token"}
+        enqueued: list = []
+
+        async def _enqueue(*args, **kwargs):  # pragma: no cover - must not run
+            enqueued.append(kwargs or args)
+
+        with (
+            patch.dict(
+                sys.modules,
+                {"firebase_admin": mock_firebase, "firebase_admin.messaging": mock_messaging},
+            ),
+            patch("backend.features.db_supabase.find_one", AsyncMock(return_value=user_row)),
+            patch("backend.utils.push_retry.enqueue_push", AsyncMock(side_effect=_enqueue)),
+        ):
+            from backend import features as features_mod
+
+            result = await features_mod.send_push_notification(
+                user_id=USER_ID,
+                title="$12.50 ride offer",
+                body="Booking r1 • A → B",
+                data={"type": "new_ride_assignment", "ride_id": "r1"},
+                priority="dispatch",
+                target_app="driver",
+            )
+
+        assert result is True
+        mock_messaging.send.assert_called_once()
+        assert enqueued == [], "dispatch push must be sent inline, not parked on the 30s retry queue"
+
+    async def test_dispatch_push_falls_back_to_queue_when_send_fails(self):
+        """If the immediate send fails, the dispatch push is enqueued for retry
+        so a transient FCM outage doesn't silently drop the offer."""
+        user_row = {"id": USER_ID, "fcm_token_driver": "android-fcm-driver-token"}
+        enqueued: list = []
+
+        async def _enqueue(user_id, title, body, data=None, priority="normal", target_app=None):
+            enqueued.append({"user_id": user_id, "priority": priority, "target_app": target_app})
+
+        with (
+            patch("backend.features.db_supabase.find_one", AsyncMock(return_value=user_row)),
+            patch("backend.features._deliver_push_now", AsyncMock(return_value=False)),
+            patch("backend.utils.push_retry.enqueue_push", AsyncMock(side_effect=_enqueue)),
+        ):
+            from backend import features as features_mod
+
+            result = await features_mod.send_push_notification(
+                user_id=USER_ID,
+                title="$12.50 ride offer",
+                body="Booking r1 • A → B",
+                data={"type": "new_ride_assignment", "ride_id": "r1"},
+                priority="dispatch",
+                target_app="driver",
+            )
+
+        assert result is False
+        assert len(enqueued) == 1, "a failed dispatch push must be enqueued for retry"
+        assert enqueued[0]["priority"] == "dispatch"
+        assert enqueued[0]["target_app"] == "driver"
+
+    async def test_missing_token_is_not_queued(self):
+        """No token on file → drop immediately; enqueuing can't fix a missing
+        token and would just churn the retry loop."""
+        user_row = {"id": USER_ID}  # no fcm_token_driver / fcm_token
+        enqueued: list = []
+
+        async def _enqueue(*args, **kwargs):  # pragma: no cover - must not run
+            enqueued.append(kwargs or args)
+
+        with (
+            patch("backend.features.db_supabase.find_one", AsyncMock(return_value=user_row)),
+            patch("backend.utils.push_retry.enqueue_push", AsyncMock(side_effect=_enqueue)),
+        ):
+            from backend import features as features_mod
+
+            result = await features_mod.send_push_notification(
+                user_id=USER_ID,
+                title="$12.50 ride offer",
+                body="Booking r1 • A → B",
+                data={"type": "new_ride_assignment", "ride_id": "r1"},
+                priority="dispatch",
+                target_app="driver",
+            )
+
+        assert result is False
+        assert enqueued == [], "missing-token dispatch must not be enqueued"

--- a/backend/tests/test_p3_push_notifications.py
+++ b/backend/tests/test_p3_push_notifications.py
@@ -531,3 +531,63 @@ class TestDispatchPushIsImmediate:
 
         assert result is False
         assert enqueued == [], "missing-token dispatch must not be enqueued"
+
+    async def test_dispatch_push_enqueued_when_user_lookup_fails(self):
+        """A transient Supabase read failure in the users lookup must NOT drop a
+        time-critical offer — it falls back to the retry queue (the queued-first
+        path this replaced couldn't drop it either)."""
+        enqueued: list = []
+
+        async def _enqueue(user_id, title, body, data=None, priority="normal", target_app=None):
+            enqueued.append({"user_id": user_id, "priority": priority, "target_app": target_app})
+
+        with (
+            patch(
+                "backend.features.db_supabase.find_one",
+                AsyncMock(side_effect=RuntimeError("supabase read timeout")),
+            ),
+            patch("backend.utils.push_retry.enqueue_push", AsyncMock(side_effect=_enqueue)),
+        ):
+            from backend import features as features_mod
+
+            result = await features_mod.send_push_notification(
+                user_id=USER_ID,
+                title="$12.50 ride offer",
+                body="Booking r1 • A → B",
+                data={"type": "new_ride_assignment", "ride_id": "r1"},
+                priority="dispatch",
+                target_app="driver",
+            )
+
+        assert result is False
+        assert len(enqueued) == 1, "a dispatch push must be enqueued when the user lookup fails"
+        assert enqueued[0]["priority"] == "dispatch"
+        assert enqueued[0]["target_app"] == "driver"
+
+    async def test_normal_push_lookup_failure_surfaces_not_masked(self):
+        """A non-time-critical push keeps its best-effort contract: a DB error in
+        the lookup surfaces to the caller and is never silently queued."""
+        enqueued: list = []
+
+        async def _enqueue(*args, **kwargs):  # pragma: no cover - must not run
+            enqueued.append(kwargs or args)
+
+        with (
+            patch(
+                "backend.features.db_supabase.find_one",
+                AsyncMock(side_effect=RuntimeError("db down")),
+            ),
+            patch("backend.utils.push_retry.enqueue_push", AsyncMock(side_effect=_enqueue)),
+        ):
+            from backend import features as features_mod
+
+            with pytest.raises(RuntimeError):
+                await features_mod.send_push_notification(
+                    user_id=USER_ID,
+                    title="Ride completed",
+                    body="Thanks for riding",
+                    data={"type": "ride_completed"},
+                    priority="normal",
+                )
+
+        assert enqueued == [], "normal pushes must not be enqueued for retry"


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Send dispatch (ride-offer) and safety (SOS) pushes immediately on the request path instead of parking them on a 30-second retry queue, eliminating the "no push when minimized" bug where offers expire before the queued push is sent.
- **Type**: `fix`
- **Linked issue**: `none` — reported directly in a Claude Code session (driver saw no ride-offer notification when the app was minimized); no GitHub tracking issue was filed.
- **Risk**: `medium` — Changes the critical path for ride-offer delivery; dispatch pushes now send inline (≈100–300 ms FCM round-trip). Mitigated by firing the push via `asyncio.create_task()` so the per-driver offer loop doesn't serialize on it.
- **User-visible change**: `drivers` — Ride offers now reliably reach backgrounded/locked/killed devices within the ~15 s offer window instead of silently dropping when the app is minimized.
- **Scope contract**: `[x]` This PR matches its stated type — refactors push delivery and adds inline-delivery tests; no unrelated changes.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `single-surface` — Backend push delivery only; no schema, API contract, or config changes.
- **Data schema change**: `none`
- **API contract change**: `none` — `send_push_notification()` signature unchanged; internal refactor only.
- **Background job change**: `modified` — The `push_retry` loop still exists but now only handles *failed* dispatch/safety pushes (fallback path), not all of them.
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — Reverts to queued-only dispatch delivery; old backend re-queues all dispatch pushes. No data cleanup needed.
- **Dependencies / coordination**: `none`
- **Assumptions**: Firebase Admin SDK and Expo push APIs are available and respond within ≈300 ms; transient outages are rare enough that one immediate attempt + exponential-backoff retry is sufficient for dispatch offers.
- **Not changing but considered**: The WebSocket offer dispatch (which reaches foreground apps instantly) is unchanged; this fix only improves backgrounded/locked-device coverage.

## Tier 3 — Compliance flags

- `[x]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — SOS pushes also use the `safety` priority path and now benefit from inline delivery + retry fallback, improving emergency-alert latency.

## Tier 4 — Verification

- **Unit tests**: `added` — three cases in `test_p3_push_notifications.py`:
  1. `test_dispatch_push_sent_immediately_not_queued` — dispatch calls `messaging.send()` directly and does NOT enqueue on success.
  2. `test_dispatch_push_falls_back_to_queue_when_send_fails` — failed dispatch pushes are enqueued for retry.
  3. `test_missing_token_is_not_queued` — missing tokens are dropped immediately (no point retrying).
- **Integration tests**: `not-applicable` — push delivery is mocked; full FCM/Expo paths covered by existing `test_push_delivered_to_{android,ios}_device`.
- **Metrics / logs introduced**: `none` — existing `logger.warning()` / `logger.error()` calls updated with clearer context only.
- **Screenshots / video**: `not-applicable` — no UI files touched.
- **Perf numbers**: Dispatch offer→phone is SLA-critical (<2 s P95). The inline FCM send (≈100–300 ms) is fired via `asyncio.create_task`, so it runs off the per-driver offer loop — loop latency is unchanged vs. the prior queued-insert. Net effect: offer→phone drops from up to ~30 s (next retry-loop tick) to ≈1–2 s. No automated before/after P95 captured (sandbox has no PyPI/DB access; perf harness not run) — reasoned, not measured.

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — not run here: the sandbox blocks PyPI so pytest couldn't execute; CI runs the suite. Logic traced against the new tests.
- [ ] Tested with rider + driver + admin accounts — n/a (single-surface backend; driver dispatch path only).
- [ ] Verified the rollback command actually works — n/a (`risk:medium`; revert is a plain `git revert`, no data migration).
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — n/a (no convention changed).
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics — confirmed: new log lines use `user_id` only.

## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: Dispatch (ride-offer) and safety (SOS) pushes were written to `push_retry_queue` and returned immediately; they were only sent by `push_retry_loop`, which ticks every 30 s. A ride offer expires in ~15 s, so when the driver app was minimized/locked (WebSocket suspended) the queued FCM push — the only channel left — arrived after the offer had already expired, surfacing to the driver as "no notification."
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): When `push_retry_queue` was added, dispatch/safety pushes were routed to enqueue-only in `send_push_notification` with no inline send path. Exact PR unknown — pre-dates this branch's history.
- **Why it was not caught earlier** (missing test / missing alert / dormant path): Unit tests mocked the queue and asserted enqueue happened; none asserted the push is *delivered within the offer window*. The gap only manifests on a real backgrounded device where the WebSocket is suspended.
- **Regression test added that fails without this fix**: `[x]` `test_dispatch_push_sent_immediately_not_queued` — on the old enqueue-only code `messaging.send` is never called, so it fails.
- **Backport needed?**: `none` — this PR targets `main` directly.

https://claude.ai/code/session_01XZnz3Rmusb427wa3JL4eqS

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
