### PR TITLE
fix(driver): show Notifee offer card from in-JS handlers when backgro…

### DIFF
--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -96,12 +96,47 @@ interface UseDriverDashboardReturn {
 // Lazy-load Notifee helpers; mirrors the gating in _layout.tsx so the
 // dashboard still mounts in Expo Go / web (where the native module is absent).
 let _dismissRideOfferNotification: (() => Promise<void>) | null = null;
+let _displayRideOfferNotification: ((o: any) => Promise<void>) | null = null;
 if (Platform.OS === 'android' || Platform.OS === 'ios') {
   try {
-    _dismissRideOfferNotification = require('../services/notifeeService').dismissRideOfferNotification;
+    const _notifee = require('../services/notifeeService');
+    _dismissRideOfferNotification = _notifee.dismissRideOfferNotification;
+    _displayRideOfferNotification = _notifee.displayRideOfferNotification;
   } catch {
     _dismissRideOfferNotification = null;
+    _displayRideOfferNotification = null;
   }
+}
+
+// Surface the heads-up / lock-screen Notifee card for an incoming offer when
+// the app is NOT foreground-active. While online the foreground service keeps
+// the WebSocket (and the foreground-FCM handler) alive in the background, so
+// the offer is processed in-JS while the in-app panel is hidden — nothing else
+// raises a system notification and the driver only feels the vibration. The FCM
+// background handler in _layout.tsx covers the fully-killed case; Notifee
+// dedupes by notification id, so calling this too never yields a duplicate.
+// Dismissal is handled by the rideState effect inside the hook.
+function _surfaceOfferNotification(data: any): void {
+  const display = _displayRideOfferNotification;
+  if (!display) return;
+  if (AppState.currentState === 'active') return; // in-app panel handles foreground
+  const _num = (v: unknown): number | undefined => {
+    if (v === null || v === undefined || v === '' || v === 'None') return undefined;
+    const n = typeof v === 'number' ? v : parseFloat(String(v));
+    return Number.isFinite(n) ? n : undefined;
+  };
+  display({
+    ride_id: data.ride_id,
+    booking_id: data.booking_id || data.ride_id,
+    pickup_address: data.pickup_address,
+    dropoff_address: data.dropoff_address,
+    fare: _num(data.fare) ?? 0,
+    total_bonus: _num(data.total_bonus),
+    distance_km: _num(data.distance_km),
+    duration_minutes: _num(data.duration_minutes),
+    surge_multiplier: _num(data.surge_multiplier),
+    rider_name: data.rider_name || undefined,
+  }).catch((e: any) => console.warn('[Offer] Notifee surface failed:', e));
 }
 const PENDING_ACTION_KEY = 'spinr_pending_notifee_action';
 
@@ -592,6 +627,10 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
         }
         Vibration.vibrate([0, 500, 200, 500]);
         offerSound.play();
+        // Backgrounded-but-alive: the in-app panel is hidden, so surface the
+        // heads-up Notifee card here — the WS offer is the first, most reliable
+        // trigger. No-op when foreground; deduped against the FCM path by id.
+        _surfaceOfferNotification(data);
         router.replace('/driver/' as any);
         setIncomingRide({
           ride_id: data.ride_id,
@@ -1254,6 +1293,7 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
         if (!isUpdate) {
           Vibration.vibrate([0, 500, 200, 500]);
           offerSound.play();
+          _surfaceOfferNotification(data);
           router.replace('/driver/' as any);
         }
         // FCM values are all strings. Parse JSON for arrays/objects.


### PR DESCRIPTION
…unded

The heads-up / lock-screen ride-offer card was only ever raised by the FCM setBackgroundMessageHandler in _layout.tsx. While the app is backgrounded but still alive — the foreground service keeps the WebSocket connected — the offer is handled in-JS by the WS handler (and the foreground-FCM handler), which vibrate and populate the now-hidden in-app panel but never raise a system notification. Android also doesn't reliably invoke the background handler while the JS runtime is alive, so the driver felt the buzz but saw no card.

Surface the same Notifee card from both in-JS offer handlers whenever the app isn't foreground-active. The WS offer is the first, most reliable trigger while online; Notifee dedupes by notification id so it never doubles the FCM path, and the existing rideState effect still dismisses it on resolution. No-op in the foreground (the in-app panel handles it) and in Expo Go / web.

https://claude.ai/code/session_01XZnz3Rmusb427wa3JL4eqS

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
