### PR TITLE
feat(support): add Zoho Desk OAuth config table + API service

### DIFF
--- a/admin-dashboard/src/app/dashboard/staff/page.tsx
+++ b/admin-dashboard/src/app/dashboard/staff/page.tsx
@@ -31,12 +31,13 @@ const ALL_MODULES = [
   { key: "heatmap", label: "Heat Map" },
   { key: "staff", label: "Staff Management" },
   { key: "audit", label: "Audit Logs" },
+  { key: "support_tickets", label: "Help Desk (Zoho)" },
 ];
 
 const ROLE_PRESETS: Record<string, string[]> = {
   super_admin: ALL_MODULES.map((m) => m.key),
   operations: ["dashboard", "rides", "drivers", "surge", "service_areas", "vehicle_types", "heatmap"],
-  support: ["dashboard", "support", "disputes", "notifications", "users"],
+  support: ["dashboard", "support", "support_tickets", "disputes", "notifications", "users"],
   finance: ["dashboard", "earnings", "promotions", "corporate_accounts", "pricing", "audit"],
 };
 

--- a/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
@@ -192,9 +192,11 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
                             Generate a self-client refresh token in the Zoho API console with the
                             <code className="mx-1">Desk.tickets.ALL</code>,
                             <code className="mx-1">Desk.search.READ</code>,
+                            <code className="mx-1">Desk.agents.READ</code>,
                             <code className="mx-1">Desk.settings.READ</code> and
                             <code className="mx-1">Desk.basic.READ</code> scopes.
-                            <code className="ml-1">Desk.search.READ</code> is required for the dashboard ticket counts.
+                            <code className="ml-1">Desk.search.READ</code> powers the dashboard counts and
+                            <code className="mx-1">Desk.agents.READ</code> the assignee filters/assignment controls.
                         </p>
                     </div>
                 </div>

--- a/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
@@ -67,6 +67,7 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
 
     useEffect(() => {
         load();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const save = async () => {

--- a/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
@@ -46,6 +46,7 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
     const [dataCenter, setDataCenter] = useState("ca");
     const [orgId, setOrgId] = useState("");
     const [departmentId, setDepartmentId] = useState("");
+    const [fromEmail, setFromEmail] = useState("");
     const [clientId, setClientId] = useState("");
     const [clientSecret, setClientSecret] = useState("");
     const [refreshToken, setRefreshToken] = useState("");
@@ -58,6 +59,7 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
             setDataCenter(s.data_center || "ca");
             setOrgId(s.org_id || "");
             setDepartmentId(s.default_department_id || "");
+            setFromEmail(s.default_from_email || "");
         } catch {
             toast({ title: "Failed to load Zoho config", variant: "destructive" });
         } finally {
@@ -78,6 +80,7 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
                 data_center: dataCenter,
                 org_id: orgId,
                 default_department_id: departmentId,
+                default_from_email: fromEmail,
             };
             // Only send secrets the admin actually typed.
             if (clientId.trim()) body.client_id = clientId.trim();
@@ -158,6 +161,18 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
                     <div className="space-y-1">
                         <Label>Default Department ID (optional)</Label>
                         <Input value={departmentId} onChange={(e) => setDepartmentId(e.target.value)} />
+                    </div>
+                    <div className="space-y-1">
+                        <Label>Reply-from email</Label>
+                        <Input
+                            type="email"
+                            value={fromEmail}
+                            onChange={(e) => setFromEmail(e.target.value)}
+                            placeholder="support@spinr.ca"
+                        />
+                        <p className="text-xs text-muted-foreground">
+                            Must be a verified support address in your Zoho Desk portal. Required to send email replies.
+                        </p>
                     </div>
                 </div>
 

--- a/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
@@ -175,8 +175,11 @@ export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) =>
                         <Input type="password" value={refreshToken} onChange={(e) => setRefreshToken(e.target.value)} placeholder={status?.has_refresh_token ? "•••••• (unchanged)" : ""} />
                         <p className="text-xs text-muted-foreground">
                             Generate a self-client refresh token in the Zoho API console with the
-                            <code className="mx-1">Desk.tickets.ALL</code> and
+                            <code className="mx-1">Desk.tickets.ALL</code>,
+                            <code className="mx-1">Desk.search.READ</code>,
+                            <code className="mx-1">Desk.settings.READ</code> and
                             <code className="mx-1">Desk.basic.READ</code> scopes.
+                            <code className="ml-1">Desk.search.READ</code> is required for the dashboard ticket counts.
                         </p>
                     </div>
                 </div>

--- a/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+    getZohoConfig,
+    updateZohoConfig,
+    testZohoConnection,
+    ZohoConfigStatus,
+} from "@/lib/api";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { CheckCircle2, XCircle, Plug } from "lucide-react";
+
+const DATA_CENTERS = [
+    { value: "ca", label: "Canada (zohocloud.ca)" },
+    { value: "com", label: "United States (zoho.com)" },
+    { value: "eu", label: "Europe (zoho.eu)" },
+    { value: "in", label: "India (zoho.in)" },
+    { value: "com.au", label: "Australia (zoho.com.au)" },
+    { value: "jp", label: "Japan (zoho.jp)" },
+];
+
+/** Connection + OAuth config for Zoho Desk. Secrets are write-only — the
+ *  backend returns presence flags only, so empty secret inputs mean
+ *  "leave unchanged". */
+export function ZohoConfigCard({ onSaved }: { onSaved?: (s: ZohoConfigStatus) => void }) {
+    const { toast } = useToast();
+    const [status, setStatus] = useState<ZohoConfigStatus | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [testing, setTesting] = useState(false);
+
+    const [enabled, setEnabled] = useState(false);
+    const [dataCenter, setDataCenter] = useState("ca");
+    const [orgId, setOrgId] = useState("");
+    const [departmentId, setDepartmentId] = useState("");
+    const [clientId, setClientId] = useState("");
+    const [clientSecret, setClientSecret] = useState("");
+    const [refreshToken, setRefreshToken] = useState("");
+
+    const load = async () => {
+        try {
+            const s = await getZohoConfig();
+            setStatus(s);
+            setEnabled(s.enabled);
+            setDataCenter(s.data_center || "ca");
+            setOrgId(s.org_id || "");
+            setDepartmentId(s.default_department_id || "");
+        } catch {
+            toast({ title: "Failed to load Zoho config", variant: "destructive" });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const save = async () => {
+        setSaving(true);
+        try {
+            const body: Record<string, unknown> = {
+                enabled,
+                data_center: dataCenter,
+                org_id: orgId,
+                default_department_id: departmentId,
+            };
+            // Only send secrets the admin actually typed.
+            if (clientId.trim()) body.client_id = clientId.trim();
+            if (clientSecret.trim()) body.client_secret = clientSecret.trim();
+            if (refreshToken.trim()) body.refresh_token = refreshToken.trim();
+            const s = await updateZohoConfig(body);
+            setStatus(s);
+            setClientId("");
+            setClientSecret("");
+            setRefreshToken("");
+            toast({ title: "Zoho Desk configuration saved" });
+            onSaved?.(s);
+        } catch (e: any) {
+            toast({ title: "Save failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const test = async () => {
+        setTesting(true);
+        try {
+            const r = await testZohoConnection();
+            toast({
+                title: "Connection OK",
+                description: `${r.departments?.length ?? 0} department(s) reachable`,
+            });
+        } catch (e: any) {
+            toast({ title: "Connection failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    if (loading) return <Card><CardContent className="p-6 text-muted-foreground">Loading…</CardContent></Card>;
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                    <Plug className="h-5 w-5" /> Zoho Desk Connection
+                    {status?.connected ? (
+                        <Badge className="ml-2 bg-emerald-100 text-emerald-800 hover:bg-emerald-100">
+                            <CheckCircle2 className="mr-1 h-3 w-3" /> Connected
+                        </Badge>
+                    ) : (
+                        <Badge variant="secondary" className="ml-2 bg-amber-100 text-amber-800 hover:bg-amber-100">
+                            <XCircle className="mr-1 h-3 w-3" /> Not connected
+                        </Badge>
+                    )}
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div className="flex items-center justify-between rounded-lg border p-3">
+                    <div>
+                        <p className="font-medium">Enable integration</p>
+                        <p className="text-sm text-muted-foreground">Turn the Help Desk on for staff.</p>
+                    </div>
+                    <Switch checked={enabled} onCheckedChange={setEnabled} />
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-1">
+                        <Label>Data center</Label>
+                        <Select value={dataCenter} onValueChange={setDataCenter}>
+                            <SelectTrigger><SelectValue /></SelectTrigger>
+                            <SelectContent>
+                                {DATA_CENTERS.map((d) => (
+                                    <SelectItem key={d.value} value={d.value}>{d.label}</SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                    <div className="space-y-1">
+                        <Label>Org ID</Label>
+                        <Input value={orgId} onChange={(e) => setOrgId(e.target.value)} placeholder="e.g. 700123456" />
+                    </div>
+                    <div className="space-y-1">
+                        <Label>Default Department ID (optional)</Label>
+                        <Input value={departmentId} onChange={(e) => setDepartmentId(e.target.value)} />
+                    </div>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="space-y-1">
+                        <Label>Client ID {status?.has_client_id && <span className="text-xs text-emerald-600">(saved)</span>}</Label>
+                        <Input value={clientId} onChange={(e) => setClientId(e.target.value)} placeholder={status?.has_client_id ? "•••••• (unchanged)" : ""} />
+                    </div>
+                    <div className="space-y-1">
+                        <Label>Client Secret {status?.has_client_secret && <span className="text-xs text-emerald-600">(saved)</span>}</Label>
+                        <Input type="password" value={clientSecret} onChange={(e) => setClientSecret(e.target.value)} placeholder={status?.has_client_secret ? "•••••• (unchanged)" : ""} />
+                    </div>
+                    <div className="space-y-1 sm:col-span-2">
+                        <Label>Refresh Token {status?.has_refresh_token && <span className="text-xs text-emerald-600">(saved)</span>}</Label>
+                        <Input type="password" value={refreshToken} onChange={(e) => setRefreshToken(e.target.value)} placeholder={status?.has_refresh_token ? "•••••• (unchanged)" : ""} />
+                        <p className="text-xs text-muted-foreground">
+                            Generate a self-client refresh token in the Zoho API console with the
+                            <code className="mx-1">Desk.tickets.ALL</code> and
+                            <code className="mx-1">Desk.basic.READ</code> scopes.
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex gap-2">
+                    <Button onClick={save} disabled={saving}>{saving ? "Saving…" : "Save"}</Button>
+                    <Button variant="outline" onClick={test} disabled={testing || !status?.connected}>
+                        {testing ? "Testing…" : "Test connection"}
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ZohoConfigCard } from "./_components/zoho-config-card";
-import { Headphones, Inbox, BarChart3, Settings as SettingsIcon, AlertCircle, Ticket as TicketIcon } from "lucide-react";
+import { Headphones, Inbox, BarChart3, Settings as SettingsIcon, AlertCircle, Info, Ticket as TicketIcon } from "lucide-react";
 
 function statusClass(status: string): string {
     const s = (status || "").toLowerCase();
@@ -94,23 +94,46 @@ export default function HelpDeskPage() {
             {!loading && connected && data && (
                 <>
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        {/* Only `total` is an exact account-wide count. The open/status
+                            figures are derived from the latest sample, so label them
+                            as such rather than presenting them as account-wide totals. */}
                         <StatCard label="Total tickets" value={data.total} />
-                        <StatCard label="Open / active" value={data.open} accent />
+                        <StatCard
+                            label="Open / active"
+                            value={data.open}
+                            accent
+                            sub={data.approximate ? `of latest ${data.sample_size}` : undefined}
+                        />
                         {Object.entries(data.by_status).slice(0, 2).map(([k, v]) => (
-                            <StatCard key={k} label={k} value={v} />
+                            <StatCard
+                                key={k}
+                                label={k}
+                                value={v}
+                                sub={data.approximate ? `of latest ${data.sample_size}` : undefined}
+                            />
                         ))}
                     </div>
 
-                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                        {Object.entries(data.by_status).map(([k, v]) => (
-                            <Card key={k}>
-                                <CardContent className="flex items-center justify-between p-4">
+                    <Card>
+                        <CardHeader className="pb-2">
+                            <CardTitle className="flex items-center gap-2 text-base">
+                                Status breakdown
+                                {data.approximate && (
+                                    <span className="flex items-center gap-1 text-xs font-normal text-muted-foreground">
+                                        <Info className="h-3 w-3" /> latest {data.sample_size} tickets (sample)
+                                    </span>
+                                )}
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                            {Object.entries(data.by_status).map(([k, v]) => (
+                                <div key={k} className="flex items-center justify-between rounded-lg border p-4">
                                     <Badge variant="secondary" className={statusClass(k)}>{k}</Badge>
                                     <span className="text-xl font-semibold">{v}</span>
-                                </CardContent>
-                            </Card>
-                        ))}
-                    </div>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
 
                     <Card>
                         <CardHeader><CardTitle className="text-base">Recent tickets</CardTitle></CardHeader>
@@ -144,12 +167,13 @@ export default function HelpDeskPage() {
     );
 }
 
-function StatCard({ label, value, accent }: { label: string; value: number; accent?: boolean }) {
+function StatCard({ label, value, accent, sub }: { label: string; value: number; accent?: boolean; sub?: string }) {
     return (
         <Card>
             <CardHeader className="pb-2"><CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle></CardHeader>
             <CardContent>
                 <div className={`text-2xl font-bold ${accent ? "text-blue-600" : ""}`}>{value}</div>
+                {sub && <p className="mt-1 text-xs text-muted-foreground">{sub}</p>}
             </CardContent>
         </Card>
     );

--- a/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { getZohoConfig, getTicketDashboard, ZohoDashboard } from "@/lib/api";
+import { getZohoConfig, getDeskDashboard, ZohoDashboard } from "@/lib/api";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -34,7 +34,7 @@ export default function HelpDeskPage() {
             const cfg = await getZohoConfig();
             setConnected(cfg.connected);
             if (cfg.connected) {
-                setData(await getTicketDashboard());
+                setData(await getDeskDashboard());
             }
         } catch (e: any) {
             setError(e?.message || "Failed to load");

--- a/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getZohoConfig, getTicketDashboard, ZohoDashboard } from "@/lib/api";
+import { useRequireModule } from "@/hooks/useRequireModule";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ZohoConfigCard } from "./_components/zoho-config-card";
+import { Headphones, Inbox, BarChart3, Settings as SettingsIcon, AlertCircle, Ticket as TicketIcon } from "lucide-react";
+
+function statusClass(status: string): string {
+    const s = (status || "").toLowerCase();
+    if (s.includes("open")) return "bg-blue-100 text-blue-800 hover:bg-blue-100";
+    if (s.includes("hold")) return "bg-amber-100 text-amber-800 hover:bg-amber-100";
+    if (s.includes("escal")) return "bg-red-100 text-red-800 hover:bg-red-100";
+    if (s.includes("closed")) return "bg-gray-200 text-gray-700 hover:bg-gray-200";
+    return "bg-slate-100 text-slate-700 hover:bg-slate-100";
+}
+
+export default function HelpDeskPage() {
+    const { allowed } = useRequireModule("support_tickets");
+    const [connected, setConnected] = useState<boolean | null>(null);
+    const [data, setData] = useState<ZohoDashboard | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [showSettings, setShowSettings] = useState(false);
+
+    const loadDashboard = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const cfg = await getZohoConfig();
+            setConnected(cfg.connected);
+            if (cfg.connected) {
+                setData(await getTicketDashboard());
+            }
+        } catch (e: any) {
+            setError(e?.message || "Failed to load");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (allowed) loadDashboard();
+    }, [allowed]);
+
+    if (!allowed) return null;
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="flex items-center gap-2 text-2xl font-bold">
+                        <Headphones className="h-6 w-6" /> Help Desk
+                    </h1>
+                    <p className="text-sm text-muted-foreground">Zoho Desk support tickets</p>
+                </div>
+                <div className="flex gap-2">
+                    <Button asChild variant="outline">
+                        <Link href="/dashboard/support-tickets/tickets"><Inbox className="mr-2 h-4 w-4" /> Tickets</Link>
+                    </Button>
+                    <Button asChild variant="outline">
+                        <Link href="/dashboard/support-tickets/trends"><BarChart3 className="mr-2 h-4 w-4" /> Trends</Link>
+                    </Button>
+                    <Button variant="ghost" onClick={() => setShowSettings((v) => !v)}>
+                        <SettingsIcon className="mr-2 h-4 w-4" /> Settings
+                    </Button>
+                </div>
+            </div>
+
+            {loading && <Card><CardContent className="p-6 text-muted-foreground">Loading…</CardContent></Card>}
+
+            {!loading && connected === false && (
+                <>
+                    <Card>
+                        <CardContent className="flex items-center gap-3 p-4 text-sm text-amber-700">
+                            <AlertCircle className="h-5 w-5" />
+                            Zoho Desk is not connected yet. Add your credentials below to enable the Help Desk.
+                        </CardContent>
+                    </Card>
+                    <ZohoConfigCard onSaved={() => loadDashboard()} />
+                </>
+            )}
+
+            {!loading && connected && showSettings && <ZohoConfigCard onSaved={() => loadDashboard()} />}
+
+            {!loading && connected && error && (
+                <Card><CardContent className="p-4 text-sm text-red-600">{error}</CardContent></Card>
+            )}
+
+            {!loading && connected && data && (
+                <>
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        <StatCard label="Total tickets" value={data.total} />
+                        <StatCard label="Open / active" value={data.open} accent />
+                        {Object.entries(data.by_status).slice(0, 2).map(([k, v]) => (
+                            <StatCard key={k} label={k} value={v} />
+                        ))}
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                        {Object.entries(data.by_status).map(([k, v]) => (
+                            <Card key={k}>
+                                <CardContent className="flex items-center justify-between p-4">
+                                    <Badge variant="secondary" className={statusClass(k)}>{k}</Badge>
+                                    <span className="text-xl font-semibold">{v}</span>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
+
+                    <Card>
+                        <CardHeader><CardTitle className="text-base">Recent tickets</CardTitle></CardHeader>
+                        <CardContent className="space-y-2">
+                            {data.recent.length === 0 && (
+                                <p className="text-sm text-muted-foreground">No recent tickets.</p>
+                            )}
+                            {data.recent.map((t: any) => (
+                                <Link
+                                    key={t.id}
+                                    href={`/dashboard/support-tickets/tickets/${t.id}`}
+                                    className="flex items-center justify-between rounded-lg border p-3 hover:bg-muted/50"
+                                >
+                                    <div className="flex min-w-0 items-center gap-3">
+                                        <TicketIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                        <div className="min-w-0">
+                                            <p className="truncate font-medium">{t.subject || "(no subject)"}</p>
+                                            <p className="truncate text-xs text-muted-foreground">
+                                                #{t.ticketNumber} · {t.contact?.email || t.email || "—"}
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <Badge variant="secondary" className={statusClass(t.status)}>{t.status}</Badge>
+                                </Link>
+                            ))}
+                        </CardContent>
+                    </Card>
+                </>
+            )}
+        </div>
+    );
+}
+
+function StatCard({ label, value, accent }: { label: string; value: number; accent?: boolean }) {
+    return (
+        <Card>
+            <CardHeader className="pb-2"><CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle></CardHeader>
+            <CardContent>
+                <div className={`text-2xl font-bold ${accent ? "text-blue-600" : ""}`}>{value}</div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/support-tickets/tickets/[id]/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/tickets/[id]/page.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import {
+    getDeskTicket,
+    getDeskTicketThreads,
+    getDeskAgents,
+    replyDeskTicket,
+    commentDeskTicket,
+    updateDeskTicket,
+} from "@/lib/api";
+import { useRequireModule } from "@/hooks/useRequireModule";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/components/ui/use-toast";
+import { ArrowLeft, Send, StickyNote, User, Mail } from "lucide-react";
+
+const STATUSES = ["Open", "On Hold", "Escalated", "Closed"];
+const PRIORITIES = ["Low", "Medium", "High", "Urgent"];
+
+function statusClass(status: string): string {
+    const s = (status || "").toLowerCase();
+    if (s.includes("open")) return "bg-blue-100 text-blue-800 hover:bg-blue-100";
+    if (s.includes("hold")) return "bg-amber-100 text-amber-800 hover:bg-amber-100";
+    if (s.includes("escal")) return "bg-red-100 text-red-800 hover:bg-red-100";
+    if (s.includes("closed")) return "bg-gray-200 text-gray-700 hover:bg-gray-200";
+    return "bg-slate-100 text-slate-700 hover:bg-slate-100";
+}
+
+/** Strip HTML to plain text. Thread/comment bodies originate from customer
+ *  emails and other agents, so we never inject their HTML into the admin DOM
+ *  (XSS). We render text only. */
+function toText(html: string): string {
+    if (!html) return "";
+    if (typeof document === "undefined") return html.replace(/<[^>]*>/g, "");
+    const el = document.createElement("div");
+    el.innerHTML = html;
+    return el.textContent || el.innerText || "";
+}
+
+export default function TicketDetailPage() {
+    const { allowed } = useRequireModule("support_tickets");
+    const params = useParams();
+    const id = String(params?.id || "");
+    const { toast } = useToast();
+
+    const [ticket, setTicket] = useState<any>(null);
+    const [thread, setThread] = useState<any[]>([]);
+    const [agents, setAgents] = useState<any[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const [reply, setReply] = useState("");
+    const [note, setNote] = useState("");
+    const [sending, setSending] = useState(false);
+    const [savingField, setSavingField] = useState(false);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const [t, th] = await Promise.all([getDeskTicket(id), getDeskTicketThreads(id)]);
+            setTicket(t);
+            setThread(th.data || []);
+        } catch (e: any) {
+            setError(e?.message || "Failed to load ticket");
+        } finally {
+            setLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        if (allowed && id) load();
+    }, [allowed, id, load]);
+
+    useEffect(() => {
+        if (!allowed) return;
+        getDeskAgents().then((r) => setAgents(r.data || [])).catch(() => {});
+    }, [allowed]);
+
+    const patch = async (fields: Record<string, string>, label: string) => {
+        setSavingField(true);
+        try {
+            await updateDeskTicket(id, fields);
+            toast({ title: `${label} updated` });
+            await load();
+        } catch (e: any) {
+            toast({ title: "Update failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setSavingField(false);
+        }
+    };
+
+    const sendReply = async () => {
+        if (!reply.trim()) return;
+        setSending(true);
+        try {
+            await replyDeskTicket(id, { content: reply, to: ticket?.email || ticket?.contact?.email });
+            setReply("");
+            toast({ title: "Reply sent" });
+            await load();
+        } catch (e: any) {
+            toast({ title: "Reply failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setSending(false);
+        }
+    };
+
+    const sendNote = async () => {
+        if (!note.trim()) return;
+        setSending(true);
+        try {
+            await commentDeskTicket(id, { content: note, is_public: false });
+            setNote("");
+            toast({ title: "Internal note added" });
+            await load();
+        } catch (e: any) {
+            toast({ title: "Note failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setSending(false);
+        }
+    };
+
+    if (!allowed) return null;
+
+    return (
+        <div className="space-y-4">
+            <div className="flex items-center justify-between">
+                <Button asChild variant="ghost" size="sm">
+                    <Link href="/dashboard/support-tickets/tickets"><ArrowLeft className="mr-2 h-4 w-4" /> Back to tickets</Link>
+                </Button>
+            </div>
+
+            {loading && <Card><CardContent className="p-6 text-muted-foreground">Loading…</CardContent></Card>}
+            {!loading && error && <Card><CardContent className="p-4 text-sm text-red-600">{error}</CardContent></Card>}
+
+            {!loading && ticket && (
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                    {/* Main column: subject + conversation + reply */}
+                    <div className="space-y-4 lg:col-span-2">
+                        <Card>
+                            <CardHeader>
+                                <div className="flex items-start justify-between gap-2">
+                                    <CardTitle className="text-lg">{ticket.subject || "(no subject)"}</CardTitle>
+                                    <Badge variant="secondary" className={statusClass(ticket.status)}>{ticket.status}</Badge>
+                                </div>
+                                <p className="text-xs text-muted-foreground">
+                                    #{ticket.ticketNumber} · created {ticket.createdTime?.slice(0, 16).replace("T", " ")}
+                                </p>
+                            </CardHeader>
+                            <CardContent>
+                                <p className="whitespace-pre-wrap text-sm">{toText(ticket.description || "")}</p>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">Conversation</CardTitle></CardHeader>
+                            <CardContent className="space-y-3">
+                                {thread.length === 0 && <p className="text-sm text-muted-foreground">No replies yet.</p>}
+                                {thread.map((m: any, i: number) => {
+                                    const isComment = m.type === "comment";
+                                    const author = m.author?.name || m.commenter?.name || m.fromEmailAddress || m.from || "—";
+                                    const when = (m.createdTime || m.commentedTime || m.summary?.time || "").slice(0, 16).replace("T", " ");
+                                    const body = toText(m.content || m.summary || m.plainText || "");
+                                    return (
+                                        <div key={m.id || i} className={`rounded-lg border p-3 ${isComment ? "bg-amber-50 dark:bg-amber-950/20" : ""}`}>
+                                            <div className="mb-1 flex items-center justify-between">
+                                                <span className="flex items-center gap-1 text-sm font-medium">
+                                                    {isComment ? <StickyNote className="h-3 w-3" /> : <Mail className="h-3 w-3" />}
+                                                    {author} {isComment && <span className="text-xs text-amber-700">(internal note)</span>}
+                                                </span>
+                                                <span className="text-xs text-muted-foreground">{when}</span>
+                                            </div>
+                                            <p className="whitespace-pre-wrap text-sm">{body}</p>
+                                        </div>
+                                    );
+                                })}
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">Reply to requester</CardTitle></CardHeader>
+                            <CardContent className="space-y-2">
+                                <Textarea rows={4} value={reply} onChange={(e) => setReply(e.target.value)} placeholder="Type your reply…" />
+                                <div className="flex justify-end">
+                                    <Button onClick={sendReply} disabled={sending || !reply.trim()}>
+                                        <Send className="mr-2 h-4 w-4" /> Send reply
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">Internal note</CardTitle></CardHeader>
+                            <CardContent className="space-y-2">
+                                <Textarea rows={2} value={note} onChange={(e) => setNote(e.target.value)} placeholder="Add a private note (not sent to the requester)…" />
+                                <div className="flex justify-end">
+                                    <Button variant="outline" onClick={sendNote} disabled={sending || !note.trim()}>
+                                        <StickyNote className="mr-2 h-4 w-4" /> Add note
+                                    </Button>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </div>
+
+                    {/* Side column: properties / assign */}
+                    <div className="space-y-4">
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">Requester</CardTitle></CardHeader>
+                            <CardContent className="space-y-1 text-sm">
+                                <p className="flex items-center gap-2"><User className="h-4 w-4" />
+                                    {`${ticket.contact?.firstName || ""} ${ticket.contact?.lastName || ""}`.trim() || "—"}
+                                </p>
+                                <p className="flex items-center gap-2 text-muted-foreground"><Mail className="h-4 w-4" />
+                                    {ticket.contact?.email || ticket.email || "—"}
+                                </p>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">Properties</CardTitle></CardHeader>
+                            <CardContent className="space-y-3">
+                                <div className="space-y-1">
+                                    <Label>Status</Label>
+                                    <Select value={ticket.status} onValueChange={(v) => patch({ status: v }, "Status")} disabled={savingField}>
+                                        <SelectTrigger><SelectValue /></SelectTrigger>
+                                        <SelectContent>
+                                            {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label>Priority</Label>
+                                    <Select value={ticket.priority || ""} onValueChange={(v) => patch({ priority: v }, "Priority")} disabled={savingField}>
+                                        <SelectTrigger><SelectValue placeholder="None" /></SelectTrigger>
+                                        <SelectContent>
+                                            {PRIORITIES.map((p) => <SelectItem key={p} value={p}>{p}</SelectItem>)}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label>Assignee</Label>
+                                    <Select
+                                        value={ticket.assigneeId || ticket.assignee?.id || ""}
+                                        onValueChange={(v) => patch({ assigneeId: v }, "Assignee")}
+                                        disabled={savingField}
+                                    >
+                                        <SelectTrigger><SelectValue placeholder="Unassigned" /></SelectTrigger>
+                                        <SelectContent>
+                                            {agents.map((a) => (
+                                                <SelectItem key={a.id} value={a.id}>
+                                                    {`${a.firstName || ""} ${a.lastName || ""}`.trim() || a.emailId || a.id}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { getDeskTickets, getDeskAgents } from "@/lib/api";
+import { useRequireModule } from "@/hooks/useRequireModule";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { Inbox, ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+
+const PAGE_SIZE = 25;
+const STATUSES = ["All", "Open", "On Hold", "Escalated", "Closed"];
+
+function statusClass(status: string): string {
+    const s = (status || "").toLowerCase();
+    if (s.includes("open")) return "bg-blue-100 text-blue-800 hover:bg-blue-100";
+    if (s.includes("hold")) return "bg-amber-100 text-amber-800 hover:bg-amber-100";
+    if (s.includes("escal")) return "bg-red-100 text-red-800 hover:bg-red-100";
+    if (s.includes("closed")) return "bg-gray-200 text-gray-700 hover:bg-gray-200";
+    return "bg-slate-100 text-slate-700 hover:bg-slate-100";
+}
+
+function priorityClass(p: string): string {
+    const s = (p || "").toLowerCase();
+    if (s === "high" || s === "urgent") return "bg-red-100 text-red-800 hover:bg-red-100";
+    if (s === "medium") return "bg-amber-100 text-amber-800 hover:bg-amber-100";
+    return "bg-slate-100 text-slate-700 hover:bg-slate-100";
+}
+
+export default function TicketListPage() {
+    const { allowed } = useRequireModule("support_tickets");
+    const [tickets, setTickets] = useState<any[]>([]);
+    const [agents, setAgents] = useState<any[]>([]);
+    const [status, setStatus] = useState("All");
+    const [assignee, setAssignee] = useState("all");
+    const [page, setPage] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await getDeskTickets({
+                from: page * PAGE_SIZE + 1,
+                limit: PAGE_SIZE,
+                status: status === "All" ? undefined : status,
+                assigneeId: assignee === "all" ? undefined : assignee,
+            });
+            setTickets(res.data || []);
+        } catch (e: any) {
+            setError(e?.message || "Failed to load tickets");
+            setTickets([]);
+        } finally {
+            setLoading(false);
+        }
+    }, [page, status, assignee]);
+
+    useEffect(() => {
+        if (allowed) load();
+    }, [allowed, load]);
+
+    useEffect(() => {
+        if (!allowed) return;
+        getDeskAgents().then((r) => setAgents(r.data || [])).catch(() => {});
+    }, [allowed]);
+
+    if (!allowed) return null;
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+                <h1 className="flex items-center gap-2 text-2xl font-bold">
+                    <Inbox className="h-6 w-6" /> Tickets
+                </h1>
+                <div className="flex flex-wrap items-center gap-2">
+                    <Select value={status} onValueChange={(v) => { setPage(0); setStatus(v); }}>
+                        <SelectTrigger className="w-36"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                            {STATUSES.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+                        </SelectContent>
+                    </Select>
+                    <Select value={assignee} onValueChange={(v) => { setPage(0); setAssignee(v); }}>
+                        <SelectTrigger className="w-44"><SelectValue placeholder="Assignee" /></SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">All assignees</SelectItem>
+                            {agents.map((a) => (
+                                <SelectItem key={a.id} value={a.id}>
+                                    {a.firstName || ""} {a.lastName || a.emailId || a.id}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                    <Button variant="outline" size="icon" onClick={load} disabled={loading}>
+                        <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+                    </Button>
+                </div>
+            </div>
+
+            {error && <Card><CardContent className="p-4 text-sm text-red-600">{error}</CardContent></Card>}
+
+            <div className="rounded-lg border">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-20">#</TableHead>
+                            <TableHead>Subject</TableHead>
+                            <TableHead>Requester</TableHead>
+                            <TableHead>Priority</TableHead>
+                            <TableHead>Assignee</TableHead>
+                            <TableHead>Status</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {loading && (
+                            <TableRow><TableCell colSpan={6} className="py-8 text-center text-muted-foreground">Loading…</TableCell></TableRow>
+                        )}
+                        {!loading && tickets.length === 0 && (
+                            <TableRow><TableCell colSpan={6} className="py-8 text-center text-muted-foreground">No tickets found.</TableCell></TableRow>
+                        )}
+                        {!loading && tickets.map((t) => (
+                            <TableRow key={t.id} className="cursor-pointer">
+                                <TableCell>
+                                    <Link href={`/dashboard/support-tickets/tickets/${t.id}`} className="font-mono text-sm text-blue-600">
+                                        {t.ticketNumber}
+                                    </Link>
+                                </TableCell>
+                                <TableCell className="max-w-xs">
+                                    <Link href={`/dashboard/support-tickets/tickets/${t.id}`} className="block truncate font-medium hover:underline">
+                                        {t.subject || "(no subject)"}
+                                    </Link>
+                                </TableCell>
+                                <TableCell className="text-sm">{t.contact?.email || t.email || "—"}</TableCell>
+                                <TableCell><Badge variant="secondary" className={priorityClass(t.priority)}>{t.priority || "None"}</Badge></TableCell>
+                                <TableCell className="text-sm">
+                                    {t.assignee ? `${t.assignee.firstName || ""} ${t.assignee.lastName || ""}`.trim() || "—" : "Unassigned"}
+                                </TableCell>
+                                <TableCell><Badge variant="secondary" className={statusClass(t.status)}>{t.status}</Badge></TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
+
+            <div className="flex items-center justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(0, p - 1))} disabled={page === 0 || loading}>
+                    <ChevronLeft className="h-4 w-4" /> Prev
+                </Button>
+                <span className="text-sm text-muted-foreground">Page {page + 1}</span>
+                <Button variant="outline" size="sm" onClick={() => setPage((p) => p + 1)} disabled={tickets.length < PAGE_SIZE || loading}>
+                    Next <ChevronRight className="h-4 w-4" />
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/support-tickets/trends/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/trends/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+    ResponsiveContainer,
+    LineChart,
+    Line,
+    BarChart,
+    Bar,
+    PieChart,
+    Pie,
+    Cell,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Legend,
+} from "recharts";
+import { getTicketTrends, ZohoTrends } from "@/lib/api";
+import { useRequireModule } from "@/hooks/useRequireModule";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import { ArrowLeft, BarChart3, Info } from "lucide-react";
+
+const COLORS = ["#3b82f6", "#f59e0b", "#ef4444", "#10b981", "#8b5cf6", "#64748b"];
+
+function toSeries(rec: Record<string, number>) {
+    return Object.entries(rec).map(([name, value]) => ({ name, value }));
+}
+
+export default function TrendsPage() {
+    const { allowed } = useRequireModule("support_tickets");
+    const [days, setDays] = useState("14");
+    const [data, setData] = useState<ZohoTrends | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            setData(await getTicketTrends({ days: Number(days) }));
+        } catch (e: any) {
+            setError(e?.message || "Failed to load trends");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (allowed) load();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [allowed, days]);
+
+    if (!allowed) return null;
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="flex items-center gap-2 text-2xl font-bold">
+                        <BarChart3 className="h-6 w-6" /> Ticket Trends
+                    </h1>
+                    <p className="text-sm text-muted-foreground">Volume and breakdowns over time</p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <Select value={days} onValueChange={setDays}>
+                        <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="7">Last 7 days</SelectItem>
+                            <SelectItem value="14">Last 14 days</SelectItem>
+                            <SelectItem value="30">Last 30 days</SelectItem>
+                            <SelectItem value="90">Last 90 days</SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <Button asChild variant="outline">
+                        <Link href="/dashboard/support-tickets"><ArrowLeft className="mr-2 h-4 w-4" /> Back</Link>
+                    </Button>
+                </div>
+            </div>
+
+            {loading && <Card><CardContent className="p-6 text-muted-foreground">Loading…</CardContent></Card>}
+            {!loading && error && <Card><CardContent className="p-4 text-sm text-red-600">{error}</CardContent></Card>}
+
+            {!loading && data && (
+                <>
+                    {data.approximate && (
+                        <Card>
+                            <CardContent className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+                                <Info className="h-4 w-4" />
+                                Trends are computed from the latest {data.sample_size} tickets and are approximate at high volume.
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    <Card>
+                        <CardHeader><CardTitle className="text-base">Ticket volume (by day created)</CardTitle></CardHeader>
+                        <CardContent>
+                            <ResponsiveContainer width="100%" height={280}>
+                                <LineChart data={data.volume} margin={{ top: 10, right: 16, left: -8, bottom: 0 }}>
+                                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                                    <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+                                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                                    <Tooltip />
+                                    <Line type="monotone" dataKey="count" stroke="#3b82f6" strokeWidth={2} dot={{ r: 2 }} />
+                                </LineChart>
+                            </ResponsiveContainer>
+                        </CardContent>
+                    </Card>
+
+                    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">By status</CardTitle></CardHeader>
+                            <CardContent>
+                                <ResponsiveContainer width="100%" height={240}>
+                                    <PieChart>
+                                        <Pie data={toSeries(data.by_status)} dataKey="value" nameKey="name" outerRadius={80} label>
+                                            {toSeries(data.by_status).map((_, i) => (
+                                                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                                            ))}
+                                        </Pie>
+                                        <Legend />
+                                        <Tooltip />
+                                    </PieChart>
+                                </ResponsiveContainer>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">By priority</CardTitle></CardHeader>
+                            <CardContent>
+                                <ResponsiveContainer width="100%" height={240}>
+                                    <BarChart data={toSeries(data.by_priority)}>
+                                        <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                                        <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                                        <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                                        <Tooltip />
+                                        <Bar dataKey="value" fill="#f59e0b" />
+                                    </BarChart>
+                                </ResponsiveContainer>
+                            </CardContent>
+                        </Card>
+
+                        <Card>
+                            <CardHeader><CardTitle className="text-base">By channel</CardTitle></CardHeader>
+                            <CardContent>
+                                <ResponsiveContainer width="100%" height={240}>
+                                    <BarChart data={toSeries(data.by_channel)}>
+                                        <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                                        <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                                        <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                                        <Tooltip />
+                                        <Bar dataKey="value" fill="#10b981" />
+                                    </BarChart>
+                                </ResponsiveContainer>
+                            </CardContent>
+                        </Card>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/support-tickets/trends/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/trends/page.tsx
@@ -17,7 +17,7 @@ import {
     Tooltip,
     Legend,
 } from "recharts";
-import { getTicketTrends, ZohoTrends } from "@/lib/api";
+import { getDeskTrends, ZohoTrends } from "@/lib/api";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -47,7 +47,7 @@ export default function TrendsPage() {
         setLoading(true);
         setError(null);
         try {
-            setData(await getTicketTrends({ days: Number(days) }));
+            setData(await getDeskTrends({ days: Number(days) }));
         } catch (e: any) {
             setError(e?.message || "Failed to load trends");
         } finally {

--- a/admin-dashboard/src/components/sidebar.tsx
+++ b/admin-dashboard/src/components/sidebar.tsx
@@ -8,7 +8,7 @@ import {
     Flame, Building2, LifeBuoy, HelpCircle,
     LogOut, Menu, X, ChevronLeft, ChevronRight,
     Sun, Moon, Shield, ShieldAlert, Cloud, Trophy, TrendingUp, Activity,
-    Inbox, Clock,
+    Inbox, Clock, Headphones, BarChart3,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState, useEffect } from "react";
@@ -83,6 +83,16 @@ const NAV_GROUPS: NavGroup[] = [
         title: "Support",
         items: [
             { href: "/dashboard/support", label: "Support & Issues", icon: LifeBuoy, module: "support" },
+            {
+                href: "/dashboard/support-tickets",
+                label: "Help Desk",
+                icon: Headphones,
+                module: "support_tickets",
+                children: [
+                    { href: "/dashboard/support-tickets/tickets", label: "Tickets", icon: Inbox, module: "support_tickets" },
+                    { href: "/dashboard/support-tickets/trends", label: "Trends", icon: BarChart3, module: "support_tickets" },
+                ],
+            },
             { href: "/dashboard/safety", label: "Safety", icon: ShieldAlert, module: "support" },
             { href: "/dashboard/disputes", label: "Disputes & Refunds", icon: Shield, module: "support" },
             { href: "/dashboard/faqs", label: "FAQs", icon: HelpCircle, module: "support" },

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2278,3 +2278,115 @@ export const bulkRetryPayouts = (body: BulkRetryPayoutsRequest) =>
         method: "POST",
         body: JSON.stringify(body),
     });
+
+/* ── Zoho Desk support tickets ──────────────────────────────────────────
+ * Native admin UI proxied to Zoho Desk via the backend. Secrets are
+ * write-only; getZohoConfig returns presence flags only. Gated by the
+ * `support_tickets` RBAC module (config endpoints require any admin).
+ */
+export interface ZohoConfigStatus {
+    enabled: boolean;
+    data_center: string;
+    org_id: string;
+    default_department_id: string;
+    has_client_id: boolean;
+    has_client_secret: boolean;
+    has_refresh_token: boolean;
+    connected: boolean;
+    updated_at?: string | null;
+}
+export interface ZohoConfigUpdate {
+    enabled?: boolean;
+    data_center?: string;
+    org_id?: string;
+    default_department_id?: string;
+    client_id?: string;
+    client_secret?: string;
+    refresh_token?: string;
+}
+export interface ZohoTicketsResponse {
+    data: any[];
+}
+export interface ZohoDashboard {
+    total: number;
+    open: number;
+    by_status: Record<string, number>;
+    recent: any[];
+}
+export interface ZohoTrends {
+    sample_size: number;
+    approximate: boolean;
+    volume: Array<{ date: string; count: number }>;
+    by_status: Record<string, number>;
+    by_priority: Record<string, number>;
+    by_channel: Record<string, number>;
+}
+
+export const getZohoConfig = () =>
+    request<ZohoConfigStatus>("/api/admin/support-tickets/config");
+export const updateZohoConfig = (body: ZohoConfigUpdate) =>
+    request<ZohoConfigStatus>("/api/admin/support-tickets/config", {
+        method: "PUT",
+        body: JSON.stringify(body),
+    });
+export const testZohoConnection = () =>
+    request<{ ok: boolean; departments: any[] }>("/api/admin/support-tickets/config/test", {
+        method: "POST",
+    });
+
+export const getTicketDashboard = (departmentId?: string) => {
+    const qs = departmentId ? `?department_id=${encodeURIComponent(departmentId)}` : "";
+    return request<ZohoDashboard>(`/api/admin/support-tickets/dashboard${qs}`);
+};
+export const getTicketTrends = (opts?: { days?: number; departmentId?: string }) => {
+    const sp = new URLSearchParams();
+    if (opts?.days) sp.set("days", String(opts.days));
+    if (opts?.departmentId) sp.set("department_id", opts.departmentId);
+    const qs = sp.toString();
+    return request<ZohoTrends>(`/api/admin/support-tickets/trends${qs ? `?${qs}` : ""}`);
+};
+
+export const getTickets = (opts?: {
+    from?: number;
+    limit?: number;
+    status?: string;
+    departmentId?: string;
+    assigneeId?: string;
+    sortBy?: string;
+}) => {
+    const sp = new URLSearchParams();
+    if (opts?.from) sp.set("from", String(opts.from));
+    if (opts?.limit) sp.set("limit", String(opts.limit));
+    if (opts?.status) sp.set("status", opts.status);
+    if (opts?.departmentId) sp.set("department_id", opts.departmentId);
+    if (opts?.assigneeId) sp.set("assignee_id", opts.assigneeId);
+    if (opts?.sortBy) sp.set("sort_by", opts.sortBy);
+    const qs = sp.toString();
+    return request<ZohoTicketsResponse>(`/api/admin/support-tickets/tickets${qs ? `?${qs}` : ""}`);
+};
+export const getTicket = (id: string) =>
+    request<any>(`/api/admin/support-tickets/tickets/${id}`);
+export const getTicketThreads = (id: string) =>
+    request<ZohoTicketsResponse>(`/api/admin/support-tickets/tickets/${id}/threads`);
+export const replyTicket = (id: string, body: { content: string; to?: string; channel?: string }) =>
+    request<any>(`/api/admin/support-tickets/tickets/${id}/reply`, {
+        method: "POST",
+        body: JSON.stringify(body),
+    });
+export const commentTicket = (id: string, body: { content: string; is_public?: boolean }) =>
+    request<any>(`/api/admin/support-tickets/tickets/${id}/comment`, {
+        method: "POST",
+        body: JSON.stringify(body),
+    });
+export const updateTicket = (
+    id: string,
+    body: { status?: string; priority?: string; assigneeId?: string; departmentId?: string },
+) =>
+    request<any>(`/api/admin/support-tickets/tickets/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+    });
+export const getTicketAgents = () =>
+    request<ZohoTicketsResponse>("/api/admin/support-tickets/agents");
+export const getTicketDepartments = () =>
+    request<ZohoTicketsResponse>("/api/admin/support-tickets/departments");

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2314,6 +2314,8 @@ export interface ZohoDashboard {
     open: number;
     by_status: Record<string, number>;
     recent: any[];
+    sample_size: number;
+    approximate: boolean;
 }
 export interface ZohoTrends {
     sample_size: number;

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2289,6 +2289,7 @@ export interface ZohoConfigStatus {
     data_center: string;
     org_id: string;
     default_department_id: string;
+    default_from_email: string;
     has_client_id: boolean;
     has_client_secret: boolean;
     has_refresh_token: boolean;
@@ -2300,6 +2301,7 @@ export interface ZohoConfigUpdate {
     data_center?: string;
     org_id?: string;
     default_department_id?: string;
+    default_from_email?: string;
     client_id?: string;
     client_secret?: string;
     refresh_token?: string;

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2334,11 +2334,11 @@ export const testZohoConnection = () =>
         method: "POST",
     });
 
-export const getTicketDashboard = (departmentId?: string) => {
+export const getDeskDashboard = (departmentId?: string) => {
     const qs = departmentId ? `?department_id=${encodeURIComponent(departmentId)}` : "";
     return request<ZohoDashboard>(`/api/admin/support-tickets/dashboard${qs}`);
 };
-export const getTicketTrends = (opts?: { days?: number; departmentId?: string }) => {
+export const getDeskTrends = (opts?: { days?: number; departmentId?: string }) => {
     const sp = new URLSearchParams();
     if (opts?.days) sp.set("days", String(opts.days));
     if (opts?.departmentId) sp.set("department_id", opts.departmentId);
@@ -2346,7 +2346,7 @@ export const getTicketTrends = (opts?: { days?: number; departmentId?: string })
     return request<ZohoTrends>(`/api/admin/support-tickets/trends${qs ? `?${qs}` : ""}`);
 };
 
-export const getTickets = (opts?: {
+export const getDeskTickets = (opts?: {
     from?: number;
     limit?: number;
     status?: string;
@@ -2364,21 +2364,21 @@ export const getTickets = (opts?: {
     const qs = sp.toString();
     return request<ZohoTicketsResponse>(`/api/admin/support-tickets/tickets${qs ? `?${qs}` : ""}`);
 };
-export const getTicket = (id: string) =>
+export const getDeskTicket = (id: string) =>
     request<any>(`/api/admin/support-tickets/tickets/${id}`);
-export const getTicketThreads = (id: string) =>
+export const getDeskTicketThreads = (id: string) =>
     request<ZohoTicketsResponse>(`/api/admin/support-tickets/tickets/${id}/threads`);
-export const replyTicket = (id: string, body: { content: string; to?: string; channel?: string }) =>
+export const replyDeskTicket = (id: string, body: { content: string; to?: string; channel?: string }) =>
     request<any>(`/api/admin/support-tickets/tickets/${id}/reply`, {
         method: "POST",
         body: JSON.stringify(body),
     });
-export const commentTicket = (id: string, body: { content: string; is_public?: boolean }) =>
+export const commentDeskTicket = (id: string, body: { content: string; is_public?: boolean }) =>
     request<any>(`/api/admin/support-tickets/tickets/${id}/comment`, {
         method: "POST",
         body: JSON.stringify(body),
     });
-export const updateTicket = (
+export const updateDeskTicket = (
     id: string,
     body: { status?: string; priority?: string; assigneeId?: string; departmentId?: string },
 ) =>
@@ -2386,7 +2386,7 @@ export const updateTicket = (
         method: "PATCH",
         body: JSON.stringify(body),
     });
-export const getTicketAgents = () =>
+export const getDeskAgents = () =>
     request<ZohoTicketsResponse>("/api/admin/support-tickets/agents");
-export const getTicketDepartments = () =>
+export const getDeskDepartments = () =>
     request<ZohoTicketsResponse>("/api/admin/support-tickets/departments");

--- a/backend/migrations/121_zoho_desk_integration.sql
+++ b/backend/migrations/121_zoho_desk_integration.sql
@@ -1,0 +1,50 @@
+-- 121_zoho_desk_integration.sql
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS zoho_desk_config;
+--
+-- Purpose: Zoho Desk admin integration. Stores the single-row OAuth2
+-- connection config + cached access token for the Zoho Desk REST API.
+-- Tickets are NOT mirrored locally — the admin panel proxies the Zoho
+-- Desk API live through the backend. Only the OAuth connection state
+-- lives here so it survives restarts and is shared across replicas.
+--
+-- Security: this table holds OAuth client secrets + refresh/access tokens.
+-- It is backend-only. RLS is ENABLED with NO policies, so the anon and
+-- authenticated PostgREST roles are denied all access; the backend's
+-- service-role key bypasses RLS by design (same model as other
+-- credential-bearing tables). Never expose this table to the frontend.
+--
+-- Forward-compatible: single-row table, created idempotently. Safe to run
+-- against live traffic (no locks on existing hot tables).
+
+CREATE TABLE IF NOT EXISTS zoho_desk_config (
+    -- Single logical row; pinned id so upserts are deterministic.
+    id                       TEXT        PRIMARY KEY DEFAULT 'default',
+    enabled                  BOOLEAN     NOT NULL DEFAULT FALSE,
+    -- Zoho data center code: 'com' (US), 'ca' (Canada), 'eu', 'in',
+    -- 'com.au', 'jp'. Selects the accounts + desk API domains. Spinr is
+    -- Canadian, so 'ca' (zohocloud.ca) is the expected production value.
+    data_center              TEXT        NOT NULL DEFAULT 'ca',
+    org_id                   TEXT,
+    default_department_id    TEXT,
+    -- OAuth2 self-client / refresh-token credentials (admin-managed).
+    client_id                TEXT,
+    client_secret            TEXT,
+    refresh_token            TEXT,
+    -- Cached short-lived access token (refreshed on demand by the backend).
+    access_token             TEXT,
+    access_token_expires_at  TIMESTAMPTZ,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Seed the single row so the backend always has a config to read/update.
+INSERT INTO zoho_desk_config (id)
+VALUES ('default')
+ON CONFLICT (id) DO NOTHING;
+
+-- Backend-only table: deny anon/authenticated, service role bypasses RLS.
+ALTER TABLE zoho_desk_config ENABLE ROW LEVEL SECURITY;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/122_zoho_desk_default_from_email.sql
+++ b/backend/migrations/122_zoho_desk_default_from_email.sql
@@ -1,0 +1,16 @@
+-- 122_zoho_desk_default_from_email.sql
+--
+-- Rollback:
+--   ALTER TABLE zoho_desk_config DROP COLUMN IF EXISTS default_from_email;
+--
+-- Purpose: Zoho Desk's sendReply (EMAIL channel) requires `fromEmailAddress`
+-- to be one of the portal's configured support addresses, otherwise the reply
+-- is rejected upstream. Store the admin-chosen reply-from address on the
+-- single-row config so the backend can attach it to every email reply.
+--
+-- Backend-only table (RLS already enabled in migration 121); this is a plain
+-- additive column, safe against in-flight traffic.
+
+ALTER TABLE zoho_desk_config ADD COLUMN IF NOT EXISTS default_from_email TEXT;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/routes/admin/__init__.py
+++ b/backend/routes/admin/__init__.py
@@ -72,6 +72,7 @@ from .settings import router as settings_router
 from .staff import router as staff_router
 from .subscriptions import router as subscriptions_router
 from .support import router as support_router
+from .support_tickets import router as support_tickets_router
 from .users import router as users_router
 from .vehicle_fleet import router as vehicle_fleet_router
 from .wallet import router as wallet_router
@@ -99,6 +100,10 @@ admin_router.include_router(rides_router, dependencies=[Depends(require_module("
 admin_router.include_router(users_router, dependencies=[Depends(require_module("users"))])
 admin_router.include_router(promotions_router, dependencies=[Depends(require_module("promotions"))])
 admin_router.include_router(support_router, dependencies=[Depends(require_module("support"))])
+# support_tickets sub-router enforces require_module("support_tickets") per-handler
+# (the dashboard/trends/ticket routes carry it explicitly); config routes use
+# get_admin_user so any admin can connect the integration.
+admin_router.include_router(support_tickets_router)
 admin_router.include_router(safety_router, dependencies=[Depends(require_module("support"))])
 admin_router.include_router(faqs_router, dependencies=[Depends(require_module("support"))])
 admin_router.include_router(legal_documents_router, dependencies=[Depends(require_module("documents"))])

--- a/backend/routes/admin/auth.py
+++ b/backend/routes/admin/auth.py
@@ -123,6 +123,7 @@ ALL_MODULES = [
     "heatmap",
     "staff",
     "audit",
+    "support_tickets",
 ]
 
 # Auth sub-router — mounted at /admin/auth by server.py directly

--- a/backend/routes/admin/staff.py
+++ b/backend/routes/admin/staff.py
@@ -65,6 +65,7 @@ AVAILABLE_MODULES = [
     "heatmap",
     "staff",  # Only super_admin can access this
     "audit",
+    "support_tickets",
 ]
 
 ROLE_PRESETS = {
@@ -78,7 +79,7 @@ ROLE_PRESETS = {
         "vehicle_types",
         "heatmap",
     ],
-    "support": ["dashboard", "support", "disputes", "notifications", "users"],
+    "support": ["dashboard", "support", "support_tickets", "disputes", "notifications", "users"],
     "finance": ["dashboard", "earnings", "promotions", "corporate_accounts", "pricing", "audit"],
 }
 

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -80,6 +80,7 @@ class ZohoConfigUpdate(BaseModel):
     data_center: Optional[str] = None
     org_id: Optional[str] = None
     default_department_id: Optional[str] = None
+    default_from_email: Optional[str] = None
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     refresh_token: Optional[str] = None
@@ -96,6 +97,7 @@ def _config_status(cfg: Dict[str, Any]) -> Dict[str, Any]:
         "data_center": cfg.get("data_center") or "ca",
         "org_id": cfg.get("org_id") or "",
         "default_department_id": cfg.get("default_department_id") or "",
+        "default_from_email": cfg.get("default_from_email") or "",
         "has_client_id": _has("client_id"),
         "has_client_secret": _has("client_secret"),
         "has_refresh_token": _has("refresh_token"),
@@ -274,7 +276,7 @@ async def tickets(
     status: Optional[str] = Query(None),
     department_id: Optional[str] = Query(None),
     assignee_id: Optional[str] = Query(None),
-    sort_by: str = Query("-modifiedTime"),
+    sort_by: str = Query("-createdTime"),
     admin: dict = Depends(require_module("support_tickets")),
 ):
     dept = await _resolve_department(department_id)
@@ -319,8 +321,22 @@ async def reply_ticket(
     payload: ReplyRequest,
     admin: dict = Depends(require_module("support_tickets")),
 ):
+    # EMAIL replies need a configured portal from-address or Zoho rejects them.
+    cfg = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID}) or {}
+    from_email = (cfg.get("default_from_email") or "").strip() or None
+    if payload.channel.upper() == "EMAIL" and not from_email:
+        raise HTTPException(
+            status_code=400,
+            detail="No reply-from email configured. Set a default reply-from address in Help Desk settings.",
+        )
     try:
-        result = await zoho.send_reply(ticket_id, content=payload.content, to=payload.to, channel=payload.channel)
+        result = await zoho.send_reply(
+            ticket_id,
+            content=payload.content,
+            to=payload.to,
+            from_email=from_email,
+            channel=payload.channel,
+        )
     except ZohoDeskError as e:
         raise _err(e) from e
     await log_admin_action(admin, "zoho_desk_ticket_reply", "zoho_desk_ticket", ticket_id, {"channel": payload.channel})

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -14,7 +14,7 @@ GET /config returns presence flags, never the secrets themselves.
 
 import logging
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -37,17 +37,37 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/support-tickets", tags=["Admin Support Tickets"])
 
-# Default Zoho Desk status buckets surfaced on the dashboard. Zoho statuses
-# are configurable per-account; these are the out-of-the-box values and the
-# dashboard tolerates extras (they show up under by_status).
-_DASHBOARD_STATUSES = ["Open", "On Hold", "Escalated", "Closed"]
-
 _CONFIG_TABLE = "zoho_desk_config"
 _CONFIG_ID = "default"
 
 
 def _err(e: ZohoDeskError) -> HTTPException:
     return HTTPException(status_code=e.status, detail=str(e.message))
+
+
+async def _resolve_department(department_id: Optional[str]) -> Optional[str]:
+    """Fall back to the admin-configured default department when the caller
+    does not pass one explicitly, so a saved default actually scopes the
+    dashboard / trends / ticket list in multi-department accounts."""
+    if department_id:
+        return department_id
+    cfg = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID}) or {}
+    dep = (cfg.get("default_department_id") or "").strip()
+    return dep or None
+
+
+def _parse_zoho_time(value: str):
+    """Parse a Zoho ISO timestamp (e.g. '2026-06-01T12:00:00.000Z') to an
+    aware datetime, or None if unparseable."""
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 # --------------------------------------------------------------------------
@@ -148,21 +168,30 @@ async def dashboard(
     department_id: Optional[str] = Query(None),
     admin: dict = Depends(require_module("support_tickets")),
 ):
+    dept = await _resolve_department(department_id)
     try:
-        total = await zoho.ticket_count(department_id=department_id)
-        by_status: Dict[str, int] = {}
-        for status in _DASHBOARD_STATUSES:
-            by_status[status] = await zoho.ticket_count(status=status, department_id=department_id)
-        recent = await zoho.list_tickets(limit=10, department_id=department_id, sort_by="-createdTime")
+        # `total` is an accurate count from Zoho's /ticketsCount. The
+        # per-status breakdown is derived from a recent sample because
+        # /ticketsCount does not support a `status` filter and the REST tier
+        # has no generic group-by endpoint we can rely on across accounts.
+        total = await zoho.ticket_count(department_id=dept)
+        sample = await zoho.list_tickets(limit=100, department_id=dept, sort_by="-createdTime")
     except ZohoDeskError as e:
         raise _err(e) from e
 
-    open_count = by_status.get("Open", 0) + by_status.get("Escalated", 0) + by_status.get("On Hold", 0)
+    tickets: List[Dict[str, Any]] = (sample or {}).get("data", [])
+    by_status: Counter = Counter()
+    for t in tickets:
+        by_status[t.get("status") or "Unknown"] += 1
+
+    open_count = sum(c for s, c in by_status.items() if "closed" not in s.lower())
     return {
         "total": total,
         "open": open_count,
-        "by_status": by_status,
-        "recent": (recent or {}).get("data", []),
+        "by_status": dict(by_status),
+        "recent": tickets[:10],
+        "sample_size": len(tickets),
+        "approximate": len(tickets) >= 100,
     }
 
 
@@ -175,16 +204,22 @@ async def trends(
     """Time-series + breakdowns derived from the most recent tickets.
 
     Zoho's API does not expose a generic aggregate report endpoint on the
-    REST tier, so we aggregate the latest page of tickets client-side. This
-    is approximate for very high volumes (capped at 100 tickets) and is
-    clearly labelled as such in the UI.
+    REST tier, so we aggregate the latest page of tickets client-side, keeping
+    only those created within the selected window. This is approximate when
+    more than 100 tickets fall inside the window, and is labelled as such.
     """
+    dept = await _resolve_department(department_id)
     try:
-        page = await zoho.list_tickets(limit=100, department_id=department_id, sort_by="-createdTime")
+        page = await zoho.list_tickets(limit=100, department_id=dept, sort_by="-createdTime")
     except ZohoDeskError as e:
         raise _err(e) from e
 
-    tickets: List[Dict[str, Any]] = (page or {}).get("data", [])
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    raw: List[Dict[str, Any]] = (page or {}).get("data", [])
+    # Honor the requested window: drop tickets created before the cutoff so
+    # the Last 7/14/30/90-day selector produces the report it promises.
+    tickets = [t for t in raw if (_parse_zoho_time(t.get("createdTime") or "") or cutoff) >= cutoff]
+
     by_day: Counter = Counter()
     by_status: Counter = Counter()
     by_priority: Counter = Counter()
@@ -201,7 +236,9 @@ async def trends(
     volume = [{"date": d, "count": c} for d, c in sorted(by_day.items()) if d != "unknown"]
     return {
         "sample_size": len(tickets),
-        "approximate": len(tickets) >= 100,
+        # Approximate when the raw page was capped AND everything we fetched is
+        # inside the window (i.e. there may be more we didn't see).
+        "approximate": len(raw) >= 100 and len(tickets) == len(raw),
         "volume": volume,
         "by_status": dict(by_status),
         "by_priority": dict(by_priority),
@@ -240,12 +277,13 @@ async def tickets(
     sort_by: str = Query("-modifiedTime"),
     admin: dict = Depends(require_module("support_tickets")),
 ):
+    dept = await _resolve_department(department_id)
     try:
         return await zoho.list_tickets(
             from_index=from_index,
             limit=limit,
             status=status,
-            department_id=department_id,
+            department_id=dept,
             assignee_id=assignee_id,
             sort_by=sort_by,
         )

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -134,7 +134,7 @@ async def test_connection(admin: dict = Depends(get_admin_user)):
     try:
         depts = await zoho.list_departments()
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
     return {"ok": True, "departments": (depts or {}).get("data", [])}
 
 
@@ -155,7 +155,7 @@ async def dashboard(
             by_status[status] = await zoho.ticket_count(status=status, department_id=department_id)
         recent = await zoho.list_tickets(limit=10, department_id=department_id, sort_by="-createdTime")
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
     open_count = by_status.get("Open", 0) + by_status.get("Escalated", 0) + by_status.get("On Hold", 0)
     return {
@@ -182,7 +182,7 @@ async def trends(
     try:
         page = await zoho.list_tickets(limit=100, department_id=department_id, sort_by="-createdTime")
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
     tickets: List[Dict[str, Any]] = (page or {}).get("data", [])
     by_day: Counter = Counter()
@@ -219,7 +219,7 @@ async def agents(admin: dict = Depends(require_module("support_tickets"))):
     try:
         return await zoho.list_agents()
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
 
 @router.get("/departments")
@@ -227,7 +227,7 @@ async def departments(admin: dict = Depends(require_module("support_tickets"))):
     try:
         return await zoho.list_departments()
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
 
 @router.get("/tickets")
@@ -250,7 +250,7 @@ async def tickets(
             sort_by=sort_by,
         )
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
 
 @router.get("/tickets/{ticket_id}")
@@ -258,7 +258,7 @@ async def ticket_detail(ticket_id: str, admin: dict = Depends(require_module("su
     try:
         return await zoho.get_ticket(ticket_id)
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
 
 @router.get("/tickets/{ticket_id}/threads")
@@ -266,7 +266,7 @@ async def ticket_threads(ticket_id: str, admin: dict = Depends(require_module("s
     try:
         return await zoho.get_ticket_threads(ticket_id)
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
 
 
 class ReplyRequest(BaseModel):
@@ -284,7 +284,7 @@ async def reply_ticket(
     try:
         result = await zoho.send_reply(ticket_id, content=payload.content, to=payload.to, channel=payload.channel)
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
     await log_admin_action(admin, "zoho_desk_ticket_reply", "zoho_desk_ticket", ticket_id, {"channel": payload.channel})
     return result
 
@@ -303,7 +303,7 @@ async def comment_ticket(
     try:
         result = await zoho.add_comment(ticket_id, content=payload.content, is_public=payload.is_public)
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
     await log_admin_action(admin, "zoho_desk_ticket_comment", "zoho_desk_ticket", ticket_id, None)
     return result
 
@@ -327,6 +327,6 @@ async def patch_ticket(
     try:
         result = await zoho.update_ticket(ticket_id, fields)
     except ZohoDeskError as e:
-        raise _err(e)
+        raise _err(e) from e
     await log_admin_action(admin, "zoho_desk_ticket_updated", "zoho_desk_ticket", ticket_id, {"fields": list(fields)})
     return result

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -1,0 +1,332 @@
+"""
+Admin support-tickets routes — Zoho Desk proxy.
+
+Mounted under /api/admin/support-tickets and gated by the
+``support_tickets`` RBAC module (see routes/admin/__init__.py). Staff with
+that module can view the ticket dashboard/trends, open and reply to
+tickets, change status/priority, and (re)assign to agents — all proxied
+live to Zoho Desk via services/zoho_desk_service.py.
+
+Connection config (OAuth client id/secret, refresh token, org, data
+center) is managed here too, but the secret values are write-only:
+GET /config returns presence flags, never the secrets themselves.
+"""
+
+import logging
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+try:
+    from ... import db_supabase
+    from ...dependencies import get_admin_user, require_module
+    from ...services import zoho_desk_service as zoho
+    from ...services.zoho_desk_service import ZohoDeskError
+    from ...utils.audit_logger import log_admin_action
+except ImportError:  # pragma: no cover - direct module import in tests
+    import db_supabase
+    from dependencies import get_admin_user, require_module
+    from services import zoho_desk_service as zoho
+    from services.zoho_desk_service import ZohoDeskError
+    from utils.audit_logger import log_admin_action
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/support-tickets", tags=["Admin Support Tickets"])
+
+# Default Zoho Desk status buckets surfaced on the dashboard. Zoho statuses
+# are configurable per-account; these are the out-of-the-box values and the
+# dashboard tolerates extras (they show up under by_status).
+_DASHBOARD_STATUSES = ["Open", "On Hold", "Escalated", "Closed"]
+
+_CONFIG_TABLE = "zoho_desk_config"
+_CONFIG_ID = "default"
+
+
+def _err(e: ZohoDeskError) -> HTTPException:
+    return HTTPException(status_code=e.status, detail=str(e.message))
+
+
+# --------------------------------------------------------------------------
+# Connection config (secrets are write-only)
+# --------------------------------------------------------------------------
+
+
+class ZohoConfigUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    data_center: Optional[str] = None
+    org_id: Optional[str] = None
+    default_department_id: Optional[str] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+    refresh_token: Optional[str] = None
+
+
+def _config_status(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Presence-only view of the config — never leaks secret values."""
+
+    def _has(key: str) -> bool:
+        return bool((cfg.get(key) or "").strip())
+
+    return {
+        "enabled": bool(cfg.get("enabled")),
+        "data_center": cfg.get("data_center") or "ca",
+        "org_id": cfg.get("org_id") or "",
+        "default_department_id": cfg.get("default_department_id") or "",
+        "has_client_id": _has("client_id"),
+        "has_client_secret": _has("client_secret"),
+        "has_refresh_token": _has("refresh_token"),
+        "connected": bool(
+            cfg.get("enabled")
+            and _has("client_id")
+            and _has("client_secret")
+            and _has("refresh_token")
+            and _has("org_id")
+        ),
+        "updated_at": cfg.get("updated_at"),
+    }
+
+
+@router.get("/config")
+async def get_config(admin: dict = Depends(get_admin_user)):
+    cfg = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID}) or {}
+    return _config_status(cfg)
+
+
+@router.put("/config")
+async def update_config(payload: ZohoConfigUpdate, admin: dict = Depends(get_admin_user)):
+    fields = payload.model_dump(exclude_unset=True)
+    if not fields:
+        raise HTTPException(status_code=400, detail="No fields supplied")
+    # Empty strings for secret fields would wipe a working credential by
+    # accident — drop them so callers must send a real value to change one.
+    for secret in ("client_secret", "refresh_token", "client_id"):
+        if secret in fields and not (fields[secret] or "").strip():
+            fields.pop(secret)
+    if "data_center" in fields:
+        fields["data_center"] = (fields["data_center"] or "ca").strip().lower()
+
+    fields["updated_at"] = datetime.now(timezone.utc).isoformat()
+    # Changing any credential invalidates the cached access token.
+    if {"client_id", "client_secret", "refresh_token", "data_center"} & set(fields):
+        fields["access_token"] = None
+        fields["access_token_expires_at"] = None
+
+    await db_supabase.update_one(_CONFIG_TABLE, {"id": _CONFIG_ID}, fields, upsert=True)
+    await log_admin_action(
+        admin,
+        "zoho_desk_config_updated",
+        "zoho_desk_config",
+        _CONFIG_ID,
+        # Audit which keys changed — never the secret values themselves.
+        {"fields_changed": [k for k in fields if k not in ("updated_at",)]},
+    )
+    cfg = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID}) or {}
+    return _config_status(cfg)
+
+
+@router.post("/config/test")
+async def test_connection(admin: dict = Depends(get_admin_user)):
+    """Verify the stored credentials by making a lightweight Zoho call."""
+    try:
+        depts = await zoho.list_departments()
+    except ZohoDeskError as e:
+        raise _err(e)
+    return {"ok": True, "departments": (depts or {}).get("data", [])}
+
+
+# --------------------------------------------------------------------------
+# Dashboard + trends
+# --------------------------------------------------------------------------
+
+
+@router.get("/dashboard")
+async def dashboard(
+    department_id: Optional[str] = Query(None),
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    try:
+        total = await zoho.ticket_count(department_id=department_id)
+        by_status: Dict[str, int] = {}
+        for status in _DASHBOARD_STATUSES:
+            by_status[status] = await zoho.ticket_count(status=status, department_id=department_id)
+        recent = await zoho.list_tickets(limit=10, department_id=department_id, sort_by="-createdTime")
+    except ZohoDeskError as e:
+        raise _err(e)
+
+    open_count = by_status.get("Open", 0) + by_status.get("Escalated", 0) + by_status.get("On Hold", 0)
+    return {
+        "total": total,
+        "open": open_count,
+        "by_status": by_status,
+        "recent": (recent or {}).get("data", []),
+    }
+
+
+@router.get("/trends")
+async def trends(
+    days: int = Query(14, ge=1, le=90),
+    department_id: Optional[str] = Query(None),
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    """Time-series + breakdowns derived from the most recent tickets.
+
+    Zoho's API does not expose a generic aggregate report endpoint on the
+    REST tier, so we aggregate the latest page of tickets client-side. This
+    is approximate for very high volumes (capped at 100 tickets) and is
+    clearly labelled as such in the UI.
+    """
+    try:
+        page = await zoho.list_tickets(limit=100, department_id=department_id, sort_by="-createdTime")
+    except ZohoDeskError as e:
+        raise _err(e)
+
+    tickets: List[Dict[str, Any]] = (page or {}).get("data", [])
+    by_day: Counter = Counter()
+    by_status: Counter = Counter()
+    by_priority: Counter = Counter()
+    by_channel: Counter = Counter()
+
+    for t in tickets:
+        created = t.get("createdTime") or ""
+        day = created[:10] if len(created) >= 10 else "unknown"
+        by_day[day] += 1
+        by_status[t.get("status") or "Unknown"] += 1
+        by_priority[t.get("priority") or "None"] += 1
+        by_channel[t.get("channel") or "Unknown"] += 1
+
+    volume = [{"date": d, "count": c} for d, c in sorted(by_day.items()) if d != "unknown"]
+    return {
+        "sample_size": len(tickets),
+        "approximate": len(tickets) >= 100,
+        "volume": volume,
+        "by_status": dict(by_status),
+        "by_priority": dict(by_priority),
+        "by_channel": dict(by_channel),
+    }
+
+
+# --------------------------------------------------------------------------
+# Tickets
+# --------------------------------------------------------------------------
+
+
+@router.get("/agents")
+async def agents(admin: dict = Depends(require_module("support_tickets"))):
+    try:
+        return await zoho.list_agents()
+    except ZohoDeskError as e:
+        raise _err(e)
+
+
+@router.get("/departments")
+async def departments(admin: dict = Depends(require_module("support_tickets"))):
+    try:
+        return await zoho.list_departments()
+    except ZohoDeskError as e:
+        raise _err(e)
+
+
+@router.get("/tickets")
+async def tickets(
+    from_index: int = Query(1, ge=1, alias="from"),
+    limit: int = Query(50, ge=1, le=100),
+    status: Optional[str] = Query(None),
+    department_id: Optional[str] = Query(None),
+    assignee_id: Optional[str] = Query(None),
+    sort_by: str = Query("-modifiedTime"),
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    try:
+        return await zoho.list_tickets(
+            from_index=from_index,
+            limit=limit,
+            status=status,
+            department_id=department_id,
+            assignee_id=assignee_id,
+            sort_by=sort_by,
+        )
+    except ZohoDeskError as e:
+        raise _err(e)
+
+
+@router.get("/tickets/{ticket_id}")
+async def ticket_detail(ticket_id: str, admin: dict = Depends(require_module("support_tickets"))):
+    try:
+        return await zoho.get_ticket(ticket_id)
+    except ZohoDeskError as e:
+        raise _err(e)
+
+
+@router.get("/tickets/{ticket_id}/threads")
+async def ticket_threads(ticket_id: str, admin: dict = Depends(require_module("support_tickets"))):
+    try:
+        return await zoho.get_ticket_threads(ticket_id)
+    except ZohoDeskError as e:
+        raise _err(e)
+
+
+class ReplyRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+    to: Optional[str] = None
+    channel: str = "EMAIL"
+
+
+@router.post("/tickets/{ticket_id}/reply")
+async def reply_ticket(
+    ticket_id: str,
+    payload: ReplyRequest,
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    try:
+        result = await zoho.send_reply(ticket_id, content=payload.content, to=payload.to, channel=payload.channel)
+    except ZohoDeskError as e:
+        raise _err(e)
+    await log_admin_action(admin, "zoho_desk_ticket_reply", "zoho_desk_ticket", ticket_id, {"channel": payload.channel})
+    return result
+
+
+class CommentRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+    is_public: bool = False
+
+
+@router.post("/tickets/{ticket_id}/comment")
+async def comment_ticket(
+    ticket_id: str,
+    payload: CommentRequest,
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    try:
+        result = await zoho.add_comment(ticket_id, content=payload.content, is_public=payload.is_public)
+    except ZohoDeskError as e:
+        raise _err(e)
+    await log_admin_action(admin, "zoho_desk_ticket_comment", "zoho_desk_ticket", ticket_id, None)
+    return result
+
+
+class TicketUpdate(BaseModel):
+    status: Optional[str] = None
+    priority: Optional[str] = None
+    assigneeId: Optional[str] = None
+    departmentId: Optional[str] = None
+
+
+@router.patch("/tickets/{ticket_id}")
+async def patch_ticket(
+    ticket_id: str,
+    payload: TicketUpdate,
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    fields = payload.model_dump(exclude_unset=True, exclude_none=True)
+    if not fields:
+        raise HTTPException(status_code=400, detail="No fields supplied")
+    try:
+        result = await zoho.update_ticket(ticket_id, fields)
+    except ZohoDeskError as e:
+        raise _err(e)
+    await log_admin_action(admin, "zoho_desk_ticket_updated", "zoho_desk_ticket", ticket_id, {"fields": list(fields)})
+    return result

--- a/backend/services/zoho_desk_service.py
+++ b/backend/services/zoho_desk_service.py
@@ -24,7 +24,7 @@ References: https://desk.zoho.com/DeskAPIDocument
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import httpx
 

--- a/backend/services/zoho_desk_service.py
+++ b/backend/services/zoho_desk_service.py
@@ -72,8 +72,7 @@ def _dc_domains(data_center: str) -> Dict[str, str]:
     dc = (data_center or "ca").strip().lower()
     if dc not in _DATA_CENTERS:
         raise ZohoDeskError(
-            f"Unknown Zoho data center '{data_center}'. Expected one of: "
-            f"{', '.join(sorted(_DATA_CENTERS))}.",
+            f"Unknown Zoho data center '{data_center}'. Expected one of: {', '.join(sorted(_DATA_CENTERS))}.",
             status=503,
         )
     return _DATA_CENTERS[dc]
@@ -92,10 +91,7 @@ async def _load_config() -> Dict[str, Any]:
 def _require_connected(cfg: Dict[str, Any]) -> None:
     if not cfg.get("enabled"):
         raise ZohoDeskError("Zoho Desk integration is disabled.", status=503)
-    missing = [
-        k for k in ("client_id", "client_secret", "refresh_token", "org_id")
-        if not (cfg.get(k) or "").strip()
-    ]
+    missing = [k for k in ("client_id", "client_secret", "refresh_token", "org_id") if not (cfg.get(k) or "").strip()]
     if missing:
         raise ZohoDeskError(
             f"Zoho Desk is not fully configured (missing: {', '.join(missing)}).",
@@ -236,6 +232,7 @@ async def _request(
 # Public API used by routes/admin/support_tickets.py
 # --------------------------------------------------------------------------
 
+
 async def list_tickets(
     *,
     from_index: int = 1,
@@ -243,7 +240,7 @@ async def list_tickets(
     status: Optional[str] = None,
     department_id: Optional[str] = None,
     assignee_id: Optional[str] = None,
-    sort_by: str = "-modifiedTime",
+    sort_by: str = "-createdTime",
 ) -> Dict[str, Any]:
     params: Dict[str, Any] = {
         "from": max(1, from_index),
@@ -254,7 +251,10 @@ async def list_tickets(
     if status:
         params["status"] = status
     if department_id:
-        params["departmentId"] = department_id
+        # The List Tickets endpoint filters by `departmentIds` (plural,
+        # comma-separated) — `departmentId` (singular) is silently ignored
+        # here (it's only valid on the count endpoints).
+        params["departmentIds"] = department_id
     if assignee_id:
         params["assignee"] = assignee_id
     data = await _request("GET", "/api/v1/tickets", params=params)
@@ -262,16 +262,12 @@ async def list_tickets(
 
 
 async def get_ticket(ticket_id: str) -> Dict[str, Any]:
-    return await _request(
-        "GET", f"/api/v1/tickets/{ticket_id}", params={"include": "contacts,assignee,team"}
-    )
+    return await _request("GET", f"/api/v1/tickets/{ticket_id}", params={"include": "contacts,assignee,team"})
 
 
 async def get_ticket_threads(ticket_id: str) -> Dict[str, Any]:
     """Conversation thread (replies + comments) for a ticket."""
-    data = await _request(
-        "GET", f"/api/v1/tickets/{ticket_id}/conversations", params={"limit": 100}
-    )
+    data = await _request("GET", f"/api/v1/tickets/{ticket_id}/conversations", params={"limit": 100})
     return data or {"data": []}
 
 
@@ -280,8 +276,8 @@ async def send_reply(
     *,
     content: str,
     to: Optional[str] = None,
+    from_email: Optional[str] = None,
     channel: str = "EMAIL",
-    is_public: bool = True,
 ) -> Dict[str, Any]:
     body: Dict[str, Any] = {
         "channel": channel,
@@ -291,6 +287,10 @@ async def send_reply(
     }
     if to:
         body["to"] = to
+    # EMAIL replies require `fromEmailAddress` to be one of the portal's
+    # configured support addresses, or Zoho rejects the reply.
+    if from_email:
+        body["fromEmailAddress"] = from_email
     return await _request("POST", f"/api/v1/tickets/{ticket_id}/sendReply", json_body=body)
 
 

--- a/backend/services/zoho_desk_service.py
+++ b/backend/services/zoho_desk_service.py
@@ -1,0 +1,334 @@
+"""
+ZohoDeskService — thin async proxy over the Zoho Desk REST API.
+
+The admin panel does NOT mirror tickets locally; it proxies the Zoho Desk
+API live through the backend so staff always see current state. This module
+owns:
+
+  * the OAuth2 refresh-token grant (exchange refresh_token -> access_token),
+  * an in-DB cache of the short-lived access token (zoho_desk_config row),
+  * a generic authenticated request helper that refreshes-and-retries once
+    on a 401, and
+  * the small set of endpoints the admin pages need (tickets, threads,
+    replies, status/assignee updates, agents, departments, counts).
+
+Config + tokens live in the single-row ``zoho_desk_config`` table
+(migration 121). The backend's service-role key bypasses RLS; the table
+is never exposed to the frontend.
+
+Zoho data centers expose different domains. ``data_center`` in the config
+selects them. Spinr is Canadian, so the default is the Canada DC.
+
+References: https://desk.zoho.com/DeskAPIDocument
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+try:
+    from .. import db_supabase
+except ImportError:  # pragma: no cover - allow direct module imports in tests
+    import db_supabase
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_TABLE = "zoho_desk_config"
+_CONFIG_ID = "default"
+_HTTP_TIMEOUT = 15.0
+# Refresh the access token this many seconds before its real expiry so an
+# in-flight request never races the boundary.
+_EXPIRY_SKEW_SECONDS = 60
+
+# data_center code -> (accounts base, desk API base). Zoho hosts each region
+# on a distinct domain; using the wrong one yields INVALID_OAUTH errors.
+_DATA_CENTERS: Dict[str, Dict[str, str]] = {
+    "com": {"accounts": "https://accounts.zoho.com", "desk": "https://desk.zoho.com"},
+    "ca": {"accounts": "https://accounts.zohocloud.ca", "desk": "https://desk.zohocloud.ca"},
+    "eu": {"accounts": "https://accounts.zoho.eu", "desk": "https://desk.zoho.eu"},
+    "in": {"accounts": "https://accounts.zoho.in", "desk": "https://desk.zoho.in"},
+    "com.au": {"accounts": "https://accounts.zoho.com.au", "desk": "https://desk.zoho.com.au"},
+    "jp": {"accounts": "https://accounts.zoho.jp", "desk": "https://desk.zoho.jp"},
+}
+
+
+class ZohoDeskError(Exception):
+    """Raised when Zoho Desk is misconfigured or returns an error.
+
+    ``status`` is the HTTP status the route layer should surface (502 for
+    upstream failures, 503 when the integration is not configured).
+    """
+
+    def __init__(self, message: str, status: int = 502, details: Optional[Any] = None):
+        super().__init__(message)
+        self.message = message
+        self.status = status
+        self.details = details
+
+
+def _dc_domains(data_center: str) -> Dict[str, str]:
+    dc = (data_center or "ca").strip().lower()
+    if dc not in _DATA_CENTERS:
+        raise ZohoDeskError(
+            f"Unknown Zoho data center '{data_center}'. Expected one of: "
+            f"{', '.join(sorted(_DATA_CENTERS))}.",
+            status=503,
+        )
+    return _DATA_CENTERS[dc]
+
+
+async def _load_config() -> Dict[str, Any]:
+    row = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID})
+    if not row:
+        raise ZohoDeskError(
+            "Zoho Desk is not configured. Connect it from the admin panel first.",
+            status=503,
+        )
+    return row
+
+
+def _require_connected(cfg: Dict[str, Any]) -> None:
+    if not cfg.get("enabled"):
+        raise ZohoDeskError("Zoho Desk integration is disabled.", status=503)
+    missing = [
+        k for k in ("client_id", "client_secret", "refresh_token", "org_id")
+        if not (cfg.get(k) or "").strip()
+    ]
+    if missing:
+        raise ZohoDeskError(
+            f"Zoho Desk is not fully configured (missing: {', '.join(missing)}).",
+            status=503,
+        )
+
+
+def _token_is_fresh(cfg: Dict[str, Any]) -> bool:
+    token = (cfg.get("access_token") or "").strip()
+    if not token:
+        return False
+    expires_at = cfg.get("access_token_expires_at")
+    if not expires_at:
+        return False
+    try:
+        if isinstance(expires_at, str):
+            exp = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+        else:
+            exp = expires_at
+        if exp.tzinfo is None:
+            exp = exp.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return False
+    return datetime.now(timezone.utc) < exp
+
+
+async def _refresh_access_token(cfg: Dict[str, Any]) -> str:
+    """Exchange the stored refresh token for a new access token and persist it.
+
+    Zoho refresh tokens are long-lived; access tokens expire in ~1h. We store
+    the new access token + expiry back on the config row so other replicas and
+    later requests reuse it instead of refreshing on every call.
+    """
+    domains = _dc_domains(cfg.get("data_center", "ca"))
+    params = {
+        "refresh_token": cfg["refresh_token"],
+        "client_id": cfg["client_id"],
+        "client_secret": cfg["client_secret"],
+        "grant_type": "refresh_token",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.post(f"{domains['accounts']}/oauth/v2/token", params=params)
+    except httpx.HTTPError as e:
+        logger.error("Zoho Desk token refresh transport error: %s", e)
+        raise ZohoDeskError("Could not reach Zoho accounts to refresh token.", status=502) from e
+
+    data: Dict[str, Any] = {}
+    try:
+        data = resp.json()
+    except ValueError:
+        pass
+
+    access_token = data.get("access_token")
+    if resp.status_code != 200 or not access_token:
+        # Zoho returns 200 with an {"error": ...} body for bad grants.
+        err = data.get("error") or resp.text
+        logger.error("Zoho Desk token refresh failed (%s): %s", resp.status_code, err)
+        raise ZohoDeskError(f"Zoho token refresh failed: {err}", status=502, details=err)
+
+    expires_in = int(data.get("expires_in", 3600))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=max(60, expires_in - _EXPIRY_SKEW_SECONDS))
+
+    await db_supabase.update_one(
+        _CONFIG_TABLE,
+        {"id": _CONFIG_ID},
+        {
+            "access_token": access_token,
+            "access_token_expires_at": expires_at.isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    cfg["access_token"] = access_token
+    cfg["access_token_expires_at"] = expires_at.isoformat()
+    return access_token
+
+
+async def _get_access_token(cfg: Dict[str, Any], force: bool = False) -> str:
+    if not force and _token_is_fresh(cfg):
+        return cfg["access_token"]
+    return await _refresh_access_token(cfg)
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: Optional[Dict[str, Any]] = None,
+    json_body: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Authenticated Zoho Desk request. Refreshes the token and retries once
+    on a 401 (expired/revoked access token)."""
+    cfg = await _load_config()
+    _require_connected(cfg)
+    domains = _dc_domains(cfg.get("data_center", "ca"))
+    url = f"{domains['desk']}{path}"
+
+    async def _do(token: str) -> httpx.Response:
+        headers = {
+            "Authorization": f"Zoho-oauthtoken {token}",
+            "orgId": str(cfg["org_id"]),
+        }
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            return await client.request(method, url, params=params, json=json_body, headers=headers)
+
+    token = await _get_access_token(cfg)
+    try:
+        resp = await _do(token)
+        if resp.status_code == 401:
+            # Access token expired/revoked mid-flight — refresh once and retry.
+            token = await _get_access_token(cfg, force=True)
+            resp = await _do(token)
+    except httpx.HTTPError as e:
+        logger.error("Zoho Desk request transport error (%s %s): %s", method, path, e)
+        raise ZohoDeskError("Could not reach Zoho Desk.", status=502) from e
+
+    if resp.status_code == 204:
+        return None
+    if resp.status_code >= 400:
+        body: Any = resp.text
+        try:
+            body = resp.json()
+        except ValueError:
+            pass
+        logger.error("Zoho Desk API error (%s %s) -> %s: %s", method, path, resp.status_code, body)
+        raise ZohoDeskError(
+            f"Zoho Desk returned {resp.status_code}.",
+            status=502,
+            details=body,
+        )
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+# --------------------------------------------------------------------------
+# Public API used by routes/admin/support_tickets.py
+# --------------------------------------------------------------------------
+
+async def list_tickets(
+    *,
+    from_index: int = 1,
+    limit: int = 50,
+    status: Optional[str] = None,
+    department_id: Optional[str] = None,
+    assignee_id: Optional[str] = None,
+    sort_by: str = "-modifiedTime",
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "from": max(1, from_index),
+        "limit": min(max(1, limit), 100),
+        "sortBy": sort_by,
+        "include": "contacts,assignee",
+    }
+    if status:
+        params["status"] = status
+    if department_id:
+        params["departmentId"] = department_id
+    if assignee_id:
+        params["assignee"] = assignee_id
+    data = await _request("GET", "/api/v1/tickets", params=params)
+    return data or {"data": []}
+
+
+async def get_ticket(ticket_id: str) -> Dict[str, Any]:
+    return await _request(
+        "GET", f"/api/v1/tickets/{ticket_id}", params={"include": "contacts,assignee,team"}
+    )
+
+
+async def get_ticket_threads(ticket_id: str) -> Dict[str, Any]:
+    """Conversation thread (replies + comments) for a ticket."""
+    data = await _request(
+        "GET", f"/api/v1/tickets/{ticket_id}/conversations", params={"limit": 100}
+    )
+    return data or {"data": []}
+
+
+async def send_reply(
+    ticket_id: str,
+    *,
+    content: str,
+    to: Optional[str] = None,
+    channel: str = "EMAIL",
+    is_public: bool = True,
+) -> Dict[str, Any]:
+    body: Dict[str, Any] = {
+        "channel": channel,
+        "content": content,
+        "contentType": "html",
+        "isForward": False,
+    }
+    if to:
+        body["to"] = to
+    return await _request("POST", f"/api/v1/tickets/{ticket_id}/sendReply", json_body=body)
+
+
+async def add_comment(ticket_id: str, *, content: str, is_public: bool = False) -> Dict[str, Any]:
+    body = {"content": content, "contentType": "html", "isPublic": is_public}
+    return await _request("POST", f"/api/v1/tickets/{ticket_id}/comments", json_body=body)
+
+
+async def update_ticket(ticket_id: str, fields: Dict[str, Any]) -> Dict[str, Any]:
+    """PATCH a ticket. Callers pass only the Zoho fields they want changed
+    (status, priority, assigneeId, departmentId, etc.)."""
+    allowed = {"status", "priority", "assigneeId", "departmentId", "category", "subCategory"}
+    payload = {k: v for k, v in fields.items() if k in allowed and v is not None}
+    if not payload:
+        raise ZohoDeskError("No updatable ticket fields supplied.", status=400)
+    return await _request("PATCH", f"/api/v1/tickets/{ticket_id}", json_body=payload)
+
+
+async def list_agents(limit: int = 100) -> Dict[str, Any]:
+    data = await _request("GET", "/api/v1/agents", params={"limit": min(max(1, limit), 200)})
+    return data or {"data": []}
+
+
+async def list_departments() -> Dict[str, Any]:
+    data = await _request("GET", "/api/v1/departments", params={"isEnabled": "true"})
+    return data or {"data": []}
+
+
+async def ticket_count(
+    *, status: Optional[str] = None, department_id: Optional[str] = None
+) -> int:
+    params: Dict[str, Any] = {}
+    if status:
+        params["status"] = status
+    if department_id:
+        params["departmentId"] = department_id
+    data = await _request("GET", "/api/v1/ticketsCount", params=params)
+    try:
+        return int((data or {}).get("count", 0))
+    except (TypeError, ValueError):
+        return 0

--- a/backend/services/zoho_desk_service.py
+++ b/backend/services/zoho_desk_service.py
@@ -319,12 +319,15 @@ async def list_departments() -> Dict[str, Any]:
     return data or {"data": []}
 
 
-async def ticket_count(
-    *, status: Optional[str] = None, department_id: Optional[str] = None
-) -> int:
+async def ticket_count(*, department_id: Optional[str] = None) -> int:
+    """Total ticket count via Zoho's /ticketsCount.
+
+    Note: /ticketsCount filters by department/assignee/contact/date — NOT by
+    `status` (status is not a supported filter there). Per-status breakdowns
+    are derived from a recent-ticket sample in the route layer instead.
+    Requires the ``Desk.search.READ`` OAuth scope.
+    """
     params: Dict[str, Any] = {}
-    if status:
-        params["status"] = status
     if department_id:
         params["departmentId"] = department_id
     data = await _request("GET", "/api/v1/ticketsCount", params=params)

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for the Zoho Desk integration (services/zoho_desk_service.py).
+
+Covers the contract that matters for production safety:
+  - not-configured / disabled -> ZohoDeskError(503), never a silent fallback
+  - unknown data center -> 503
+  - on-demand token refresh + persistence of the new access token
+  - 401 mid-flight -> refresh once and retry
+  - upstream error body surfaced as ZohoDeskError(502)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import services.zoho_desk_service as zoho
+from services.zoho_desk_service import ZohoDeskError
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, json_data=None, text=""):
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("no json")
+        return self._json
+
+
+class _FakeClient:
+    """Async-context-manager stand-in for httpx.AsyncClient. ``handler`` is a
+    callable (method, url, kwargs) -> _FakeResponse."""
+
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, **kwargs):
+        return self._handler("POST", url, kwargs)
+
+    async def request(self, method, url, **kwargs):
+        return self._handler(method, url, kwargs)
+
+
+def _connected_config(**overrides):
+    cfg = {
+        "id": "default",
+        "enabled": True,
+        "data_center": "ca",
+        "org_id": "700123",
+        "client_id": "cid",
+        "client_secret": "secret",
+        "refresh_token": "rtok",
+        "access_token": "",
+        "access_token_expires_at": None,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _patch_db(monkeypatch, row):
+    fake_db = MagicMock()
+    fake_db.find_one = AsyncMock(return_value=row)
+    fake_db.update_one = AsyncMock(return_value=None)
+    monkeypatch.setattr(zoho, "db_supabase", fake_db)
+    return fake_db
+
+
+def _patch_http(monkeypatch, handler):
+    monkeypatch.setattr(zoho.httpx, "AsyncClient", lambda *a, **k: _FakeClient(handler))
+
+
+@pytest.mark.anyio
+async def test_not_configured_raises_503(monkeypatch):
+    _patch_db(monkeypatch, None)
+    with pytest.raises(ZohoDeskError) as ei:
+        await zoho.list_tickets()
+    assert ei.value.status == 503
+
+
+@pytest.mark.anyio
+async def test_disabled_raises_503(monkeypatch):
+    _patch_db(monkeypatch, _connected_config(enabled=False))
+    with pytest.raises(ZohoDeskError) as ei:
+        await zoho.list_tickets()
+    assert ei.value.status == 503
+
+
+@pytest.mark.anyio
+async def test_unknown_data_center_raises_503(monkeypatch):
+    _patch_db(monkeypatch, _connected_config(data_center="mars"))
+    with pytest.raises(ZohoDeskError) as ei:
+        await zoho.list_tickets()
+    assert ei.value.status == 503
+
+
+@pytest.mark.anyio
+async def test_refresh_and_request_persists_token(monkeypatch):
+    db = _patch_db(monkeypatch, _connected_config())
+    calls = []
+
+    def handler(method, url, kwargs):
+        calls.append((method, url))
+        if "/oauth/v2/token" in url:
+            return _FakeResponse(200, {"access_token": "AT1", "expires_in": 3600})
+        # Must use Canada DC domain and the bearer header scheme.
+        assert "desk.zohocloud.ca" in url
+        assert kwargs["headers"]["Authorization"] == "Zoho-oauthtoken AT1"
+        assert kwargs["headers"]["orgId"] == "700123"
+        return _FakeResponse(200, {"data": [{"id": "1", "subject": "hi"}]})
+
+    _patch_http(monkeypatch, handler)
+    out = await zoho.list_tickets(limit=10)
+    assert out["data"][0]["id"] == "1"
+    # token refresh happened and was persisted
+    assert any("/oauth/v2/token" in u for _, u in calls)
+    db.update_one.assert_awaited()
+    persisted = db.update_one.call_args.args[2]
+    assert persisted["access_token"] == "AT1"
+    assert persisted["access_token_expires_at"] is not None
+
+
+@pytest.mark.anyio
+async def test_401_triggers_single_refresh_retry(monkeypatch):
+    # Start with a "fresh" token so the first call uses it and gets a 401.
+    _patch_db(
+        monkeypatch,
+        _connected_config(
+            access_token="STALE",
+            access_token_expires_at="2999-01-01T00:00:00+00:00",
+        ),
+    )
+    seq = {"n": 0}
+
+    def handler(method, url, kwargs):
+        if "/oauth/v2/token" in url:
+            return _FakeResponse(200, {"access_token": "FRESH", "expires_in": 3600})
+        seq["n"] += 1
+        if seq["n"] == 1:
+            return _FakeResponse(401, {"error": "expired"})
+        assert kwargs["headers"]["Authorization"] == "Zoho-oauthtoken FRESH"
+        return _FakeResponse(200, {"data": []})
+
+    _patch_http(monkeypatch, handler)
+    out = await zoho.list_tickets()
+    assert out == {"data": []}
+    assert seq["n"] == 2  # original + one retry
+
+
+@pytest.mark.anyio
+async def test_refresh_failure_raises_502(monkeypatch):
+    _patch_db(monkeypatch, _connected_config())
+
+    def handler(method, url, kwargs):
+        if "/oauth/v2/token" in url:
+            # Zoho returns 200 with an error body for bad grants.
+            return _FakeResponse(200, {"error": "invalid_code"})
+        return _FakeResponse(200, {"data": []})
+
+    _patch_http(monkeypatch, handler)
+    with pytest.raises(ZohoDeskError) as ei:
+        await zoho.list_tickets()
+    assert ei.value.status == 502
+
+
+@pytest.mark.anyio
+async def test_upstream_error_surfaced_502(monkeypatch):
+    _patch_db(
+        monkeypatch,
+        _connected_config(
+            access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"
+        ),
+    )
+
+    def handler(method, url, kwargs):
+        return _FakeResponse(500, {"errorCode": "INTERNAL_ERROR"}, text="boom")
+
+    _patch_http(monkeypatch, handler)
+    with pytest.raises(ZohoDeskError) as ei:
+        await zoho.get_ticket("123")
+    assert ei.value.status == 502
+
+
+@pytest.mark.anyio
+async def test_update_ticket_rejects_empty(monkeypatch):
+    _patch_db(monkeypatch, _connected_config())
+    with pytest.raises(ZohoDeskError) as ei:
+        await zoho.update_ticket("1", {"unknown_field": "x"})
+    assert ei.value.status == 400

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -176,9 +176,7 @@ async def test_refresh_failure_raises_502(monkeypatch):
 async def test_upstream_error_surfaced_502(monkeypatch):
     _patch_db(
         monkeypatch,
-        _connected_config(
-            access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"
-        ),
+        _connected_config(access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"),
     )
 
     def handler(method, url, kwargs):
@@ -204,9 +202,7 @@ async def test_ticket_count_omits_status_param(monkeypatch):
     # only ever send departmentId there (status breakdown is sampled instead).
     _patch_db(
         monkeypatch,
-        _connected_config(
-            access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"
-        ),
+        _connected_config(access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"),
     )
     seen = {}
 
@@ -221,6 +217,46 @@ async def test_ticket_count_omits_status_param(monkeypatch):
     assert "ticketsCount" in seen["url"]
     assert "status" not in seen["params"]
     assert seen["params"].get("departmentId") == "dep1"
+
+
+@pytest.mark.anyio
+async def test_list_tickets_uses_departmentids_and_created_sort(monkeypatch):
+    # Codex P2: List Tickets filters by `departmentIds` (plural); singular is
+    # ignored. Default sort must be a supported field (`-createdTime`).
+    _patch_db(
+        monkeypatch,
+        _connected_config(access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"),
+    )
+    seen = {}
+
+    def handler(method, url, kwargs):
+        seen["params"] = kwargs.get("params") or {}
+        return _FakeResponse(200, {"data": []})
+
+    _patch_http(monkeypatch, handler)
+    await zoho.list_tickets(department_id="dep1")
+    assert seen["params"].get("departmentIds") == "dep1"
+    assert "departmentId" not in seen["params"]
+    assert seen["params"].get("sortBy") == "-createdTime"
+
+
+@pytest.mark.anyio
+async def test_send_reply_includes_from_email(monkeypatch):
+    # Codex P2: EMAIL replies must carry `fromEmailAddress` or Zoho rejects them.
+    _patch_db(
+        monkeypatch,
+        _connected_config(access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"),
+    )
+    seen = {}
+
+    def handler(method, url, kwargs):
+        seen["body"] = kwargs.get("json") or {}
+        return _FakeResponse(200, {"id": "r1"})
+
+    _patch_http(monkeypatch, handler)
+    await zoho.send_reply("t1", content="hi", to="x@y.ca", from_email="support@spinr.ca")
+    assert seen["body"]["fromEmailAddress"] == "support@spinr.ca"
+    assert seen["body"]["to"] == "x@y.ca"
 
 
 def test_parse_zoho_time_window():

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -196,3 +196,39 @@ async def test_update_ticket_rejects_empty(monkeypatch):
     with pytest.raises(ZohoDeskError) as ei:
         await zoho.update_ticket("1", {"unknown_field": "x"})
     assert ei.value.status == 400
+
+
+@pytest.mark.anyio
+async def test_ticket_count_omits_status_param(monkeypatch):
+    # Codex P2: /ticketsCount does not support a `status` filter. Ensure we
+    # only ever send departmentId there (status breakdown is sampled instead).
+    _patch_db(
+        monkeypatch,
+        _connected_config(
+            access_token="AT", access_token_expires_at="2999-01-01T00:00:00+00:00"
+        ),
+    )
+    seen = {}
+
+    def handler(method, url, kwargs):
+        seen["url"] = url
+        seen["params"] = kwargs.get("params") or {}
+        return _FakeResponse(200, {"count": 42})
+
+    _patch_http(monkeypatch, handler)
+    out = await zoho.ticket_count(department_id="dep1")
+    assert out == 42
+    assert "ticketsCount" in seen["url"]
+    assert "status" not in seen["params"]
+    assert seen["params"].get("departmentId") == "dep1"
+
+
+def test_parse_zoho_time_window():
+    # Codex P2: the trends `days` selector must actually filter by created
+    # time. The route helper parses Zoho timestamps; unparseable -> None.
+    from routes.admin.support_tickets import _parse_zoho_time
+
+    dt = _parse_zoho_time("2026-06-01T12:00:00.000Z")
+    assert dt is not None and dt.tzinfo is not None
+    assert _parse_zoho_time("") is None
+    assert _parse_zoho_time("not-a-date") is None


### PR DESCRIPTION
- migration 121: single-row zoho_desk_config (backend-only, RLS deny-all)
- zoho_desk_service: refresh-token OAuth, token cache, list/get/reply/
  update tickets, agents, departments, counts; 401 refresh-and-retry

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
