### PR TITLE
Claude/zoho desk admin integration zlwu f

### DIFF
--- a/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/page.tsx
@@ -2,13 +2,26 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { getZohoConfig, getDeskDashboard, ZohoDashboard } from "@/lib/api";
+import { getZohoConfig, getDeskDashboard, syncDeskTickets, ZohoDashboard, ZohoConfigStatus } from "@/lib/api";
 import { useRequireModule } from "@/hooks/useRequireModule";
+import { useToast } from "@/components/ui/use-toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ZohoConfigCard } from "./_components/zoho-config-card";
-import { Headphones, Inbox, BarChart3, Settings as SettingsIcon, AlertCircle, Info, Ticket as TicketIcon } from "lucide-react";
+import { Headphones, Inbox, BarChart3, Settings as SettingsIcon, AlertCircle, Info, RefreshCw, Ticket as TicketIcon } from "lucide-react";
+
+function timeAgo(iso?: string | null): string {
+    if (!iso) return "never";
+    const ms = Date.now() - new Date(iso).getTime();
+    if (!isFinite(ms) || ms < 0) return "just now";
+    const m = Math.floor(ms / 60000);
+    if (m < 1) return "just now";
+    if (m < 60) return `${m} min ago`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h ago`;
+    return `${Math.floor(h / 24)}d ago`;
+}
 
 function statusClass(status: string): string {
     const s = (status || "").toLowerCase();
@@ -21,9 +34,12 @@ function statusClass(status: string): string {
 
 export default function HelpDeskPage() {
     const { allowed } = useRequireModule("support_tickets");
+    const { toast } = useToast();
     const [connected, setConnected] = useState<boolean | null>(null);
+    const [cfg, setCfg] = useState<ZohoConfigStatus | null>(null);
     const [data, setData] = useState<ZohoDashboard | null>(null);
     const [loading, setLoading] = useState(true);
+    const [syncing, setSyncing] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [showSettings, setShowSettings] = useState(false);
 
@@ -31,15 +47,32 @@ export default function HelpDeskPage() {
         setLoading(true);
         setError(null);
         try {
-            const cfg = await getZohoConfig();
-            setConnected(cfg.connected);
-            if (cfg.connected) {
+            const c = await getZohoConfig();
+            setCfg(c);
+            setConnected(c.connected);
+            if (c.connected) {
                 setData(await getDeskDashboard());
             }
         } catch (e: any) {
             setError(e?.message || "Failed to load");
         } finally {
             setLoading(false);
+        }
+    };
+
+    const runSync = async () => {
+        setSyncing(true);
+        try {
+            const r = await syncDeskTickets();
+            toast({
+                title: r.skipped ? "Sync skipped" : "Synced",
+                description: r.skipped ? r.skipped : `${r.upserted ?? 0} tickets updated`,
+            });
+            await loadDashboard();
+        } catch (e: any) {
+            toast({ title: "Sync failed", description: e?.message, variant: "destructive" });
+        } finally {
+            setSyncing(false);
         }
     };
 
@@ -63,7 +96,13 @@ export default function HelpDeskPage() {
                     </h1>
                     <p className="text-sm text-muted-foreground">Zoho Desk support tickets</p>
                 </div>
-                <div className="flex gap-2">
+                <div className="flex items-center gap-2">
+                    {connected && (
+                        <Button variant="outline" size="sm" onClick={runSync} disabled={syncing} title={`Last synced ${timeAgo(cfg?.last_synced_at)}`}>
+                            <RefreshCw className={`mr-2 h-4 w-4 ${syncing ? "animate-spin" : ""}`} />
+                            {syncing ? "Syncing…" : `Synced ${timeAgo(cfg?.last_synced_at)}`}
+                        </Button>
+                    )}
                     <Button asChild variant="outline">
                         <Link href="/dashboard/support-tickets/tickets"><Inbox className="mr-2 h-4 w-4" /> Tickets</Link>
                     </Button>

--- a/admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useMemo } from "react";
 import Link from "next/link";
-import { getDeskTickets, getDeskAgents, createDeskTicket, searchDeskTickets } from "@/lib/api";
+import { getDeskTickets, getDeskAgents, getDeskDepartments, createDeskTicket, searchDeskTickets } from "@/lib/api";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -93,7 +93,8 @@ export default function TicketListPage() {
     const { toast } = useToast();
     const [createOpen, setCreateOpen] = useState(false);
     const [creating, setCreating] = useState(false);
-    const [form, setForm] = useState({ subject: "", description: "", email: "", name: "", priority: "Medium" });
+    const [departments, setDepartments] = useState<any[]>([]);
+    const [form, setForm] = useState({ subject: "", description: "", email: "", name: "", priority: "Medium", department: "" });
     const setF = (k: string, v: string) => setForm((f) => ({ ...f, [k]: v }));
 
     const create = async () => {
@@ -109,10 +110,11 @@ export default function TicketListPage() {
                 last_name: rest.join(" ") || undefined,
                 priority: form.priority,
                 channel: "Web",
+                department_id: form.department || undefined,
             });
             toast({ title: "Ticket created" });
             setCreateOpen(false);
-            setForm({ subject: "", description: "", email: "", name: "", priority: "Medium" });
+            setForm({ subject: "", description: "", email: "", name: "", priority: "Medium", department: "" });
             setPage(0);
             load();
         } catch (e: any) {
@@ -162,6 +164,11 @@ export default function TicketListPage() {
     useEffect(() => {
         if (!allowed) return;
         getDeskAgents().then((r) => setAgents(r.data || [])).catch(() => {});
+        getDeskDepartments().then((r) => {
+            const d = r.data || [];
+            setDepartments(d);
+            if (d.length) setForm((f) => ({ ...f, department: f.department || d[0].id }));
+        }).catch(() => {});
     }, [allowed]);
 
     // Created-date range narrows the loaded results (client-side).
@@ -242,12 +249,23 @@ export default function TicketListPage() {
                                 <Input type="email" value={form.email} onChange={(e) => setF("email", e.target.value)} />
                             </div>
                         </div>
-                        <div className="space-y-1">
-                            <Label>Priority</Label>
-                            <Select value={form.priority} onValueChange={(v) => setF("priority", v)}>
-                                <SelectTrigger className="w-40"><SelectValue /></SelectTrigger>
-                                <SelectContent>{PRIORITIES.filter((p) => p !== "All").map((p) => <SelectItem key={p} value={p}>{p}</SelectItem>)}</SelectContent>
-                            </Select>
+                        <div className="grid grid-cols-2 gap-3">
+                            <div className="space-y-1">
+                                <Label>Department</Label>
+                                <Select value={form.department || undefined} onValueChange={(v) => setF("department", v)}>
+                                    <SelectTrigger><SelectValue placeholder={departments.length ? "Select" : "No departments"} /></SelectTrigger>
+                                    <SelectContent>
+                                        {departments.map((d) => <SelectItem key={d.id} value={d.id}>{d.name}</SelectItem>)}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-1">
+                                <Label>Priority</Label>
+                                <Select value={form.priority} onValueChange={(v) => setF("priority", v)}>
+                                    <SelectTrigger><SelectValue /></SelectTrigger>
+                                    <SelectContent>{PRIORITIES.filter((p) => p !== "All").map((p) => <SelectItem key={p} value={p}>{p}</SelectItem>)}</SelectContent>
+                                </Select>
+                            </div>
                         </div>
                     </div>
                     <DialogFooter>

--- a/admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useMemo } from "react";
 import Link from "next/link";
-import { getDeskTickets, getDeskAgents, createDeskTicket } from "@/lib/api";
+import { getDeskTickets, getDeskAgents, createDeskTicket, searchDeskTickets } from "@/lib/api";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -34,7 +34,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
-import { Inbox, ChevronLeft, ChevronRight, RefreshCw, Search, ArrowUp, ArrowDown, Plus } from "lucide-react";
+import { Inbox, ChevronLeft, ChevronRight, RefreshCw, Search, ArrowUp, ArrowDown, Plus, X } from "lucide-react";
 
 const STATUSES = ["All", "Open", "On Hold", "Escalated", "Closed"];
 const PRIORITIES = ["All", "Low", "Medium", "High", "Urgent"];
@@ -80,8 +80,9 @@ export default function TicketListPage() {
     const [pageSize, setPageSize] = useState(25);
     const [page, setPage] = useState(0);
 
-    // Client-side refine (filters the loaded page by contact/category/tag/subject).
+    // Search box (server-side, account-wide) + a created-date refine (client).
     const [refine, setRefine] = useState("");
+    const [searchQ, setSearchQ] = useState("");
     const [fromDate, setFromDate] = useState("");
     const [toDate, setToDate] = useState("");
 
@@ -125,15 +126,26 @@ export default function TicketListPage() {
         setLoading(true);
         setError(null);
         try {
-            const res = await getDeskTickets({
-                from: page * pageSize + 1,
-                limit: pageSize,
-                status: status === "All" ? undefined : status,
-                priority: priority === "All" ? undefined : priority,
-                channel: channel === "All" ? undefined : channel,
-                assigneeId: assignee === "all" ? undefined : assignee,
-                sortBy: `${sortDir === "desc" ? "-" : ""}${sortField}`,
-            });
+            // When a search term is active, query Zoho account-wide; otherwise
+            // page the filtered list.
+            const res = searchQ
+                ? await searchDeskTickets({
+                      q: searchQ,
+                      from: page * pageSize + 1,
+                      limit: pageSize,
+                      status: status === "All" ? undefined : status,
+                      priority: priority === "All" ? undefined : priority,
+                      assigneeId: assignee === "all" ? undefined : assignee,
+                  })
+                : await getDeskTickets({
+                      from: page * pageSize + 1,
+                      limit: pageSize,
+                      status: status === "All" ? undefined : status,
+                      priority: priority === "All" ? undefined : priority,
+                      channel: channel === "All" ? undefined : channel,
+                      assigneeId: assignee === "all" ? undefined : assignee,
+                      sortBy: `${sortDir === "desc" ? "-" : ""}${sortField}`,
+                  });
             setTickets(res.data || []);
         } catch (e: any) {
             setError(e?.message || "Failed to load tickets");
@@ -141,7 +153,7 @@ export default function TicketListPage() {
         } finally {
             setLoading(false);
         }
-    }, [page, pageSize, status, priority, channel, assignee, sortField, sortDir]);
+    }, [page, pageSize, status, priority, channel, assignee, sortField, sortDir, searchQ]);
 
     useEffect(() => {
         if (allowed) load();
@@ -152,32 +164,19 @@ export default function TicketListPage() {
         getDeskAgents().then((r) => setAgents(r.data || [])).catch(() => {});
     }, [allowed]);
 
-    // Client refine across the loaded page (contact, category, tags, subject, #)
-    // plus a created-date range.
+    // Created-date range narrows the loaded results (client-side).
     const shown = useMemo(() => {
-        const q = refine.trim().toLowerCase();
+        if (!fromDate && !toDate) return tickets;
         return tickets.filter((t) => {
-            if (q) {
-                const hay = [
-                    t.subject,
-                    t.ticketNumber,
-                    t.category,
-                    t.contact?.email,
-                    t.email,
-                    `${t.contact?.firstName || ""} ${t.contact?.lastName || ""}`,
-                    tagNames(t),
-                ]
-                    .filter(Boolean)
-                    .join(" ")
-                    .toLowerCase();
-                if (!hay.includes(q)) return false;
-            }
             const created = (t.createdTime || "").slice(0, 10);
             if (fromDate && created && created < fromDate) return false;
             if (toDate && created && created > toDate) return false;
             return true;
         });
-    }, [tickets, refine, fromDate, toDate]);
+    }, [tickets, fromDate, toDate]);
+
+    const runSearch = () => { setPage(0); setSearchQ(refine.trim()); };
+    const clearSearch = () => { setRefine(""); setSearchQ(""); setPage(0); };
 
     const toggleSort = (field: string) => {
         setPage(0);
@@ -285,14 +284,24 @@ export default function TicketListPage() {
                         ))}
                     </SelectContent>
                 </Select>
-                <div className="relative">
-                    <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                    <Input
-                        value={refine}
-                        onChange={(e) => setRefine(e.target.value)}
-                        placeholder="Refine: ticket #, contact, category, tag…"
-                        className="w-64 pl-8"
-                    />
+                <div className="flex items-center gap-1">
+                    <div className="relative">
+                        <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                        <Input
+                            value={refine}
+                            onChange={(e) => setRefine(e.target.value)}
+                            onKeyDown={(e) => { if (e.key === "Enter") runSearch(); }}
+                            placeholder="Search all tickets: # / subject / contact…"
+                            className="w-64 pl-8"
+                        />
+                    </div>
+                    <Button variant="secondary" size="sm" onClick={runSearch} disabled={!refine.trim()}>Search</Button>
+                    {searchQ && (
+                        <Badge variant="secondary" className="gap-1">
+                            “{searchQ}”
+                            <button onClick={clearSearch}><X className="h-3 w-3" /></button>
+                        </Badge>
+                    )}
                 </div>
                 <div className="flex items-center gap-1 text-sm text-muted-foreground">
                     <span>Created</span>

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2294,6 +2294,8 @@ export interface ZohoConfigStatus {
     has_client_secret: boolean;
     has_refresh_token: boolean;
     connected: boolean;
+    last_synced_at?: string | null;
+    last_sync_count?: number | null;
     updated_at?: string | null;
 }
 export interface ZohoConfigUpdate {
@@ -2348,6 +2350,10 @@ export const updateZohoConfig = (body: ZohoConfigUpdate) =>
     });
 export const testZohoConnection = () =>
     request<{ ok: boolean; departments: any[] }>("/api/admin/support-tickets/config/test", {
+        method: "POST",
+    });
+export const syncDeskTickets = () =>
+    request<{ upserted?: number; skipped?: string }>("/api/admin/support-tickets/sync", {
         method: "POST",
     });
 

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2403,6 +2403,25 @@ export const createDeskTicket = (body: CreateDeskTicket) =>
         method: "POST",
         body: JSON.stringify(body),
     });
+export const searchDeskTickets = (opts: {
+    q: string;
+    from?: number;
+    limit?: number;
+    departmentId?: string;
+    status?: string;
+    priority?: string;
+    assigneeId?: string;
+}) => {
+    const sp = new URLSearchParams();
+    sp.set("q", opts.q);
+    if (opts.from) sp.set("from", String(opts.from));
+    if (opts.limit) sp.set("limit", String(opts.limit));
+    if (opts.departmentId) sp.set("department_id", opts.departmentId);
+    if (opts.status) sp.set("status", opts.status);
+    if (opts.priority) sp.set("priority", opts.priority);
+    if (opts.assigneeId) sp.set("assignee_id", opts.assigneeId);
+    return request<ZohoTicketsResponse>(`/api/admin/support-tickets/search?${sp.toString()}`);
+};
 export const getDeskTicket = (id: string) =>
     request<any>(`/api/admin/support-tickets/tickets/${id}`);
 export const getDeskTicketThreads = (id: string) =>

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -316,6 +316,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to import push retry loop: {e}", exc_info=True)
 
+    # Zoho Desk mirror sync — upserts recent tickets into zoho_desk_tickets so
+    # the Help Desk serves lists/dashboards/trends from our DB (saves Zoho API
+    # credits). No-op when the integration is disabled. Replay-safe (upsert).
+    try:
+        from utils.zoho_desk_sync import zoho_desk_sync_loop
+
+        _spawn("zoho_desk_sync (10min)", zoho_desk_sync_loop)
+    except Exception as e:
+        logger.error(f"Failed to import Zoho Desk sync loop: {e}", exc_info=True)
+
     # Loop watchdog — scans heartbeats every 5 minutes and posts a
     # Slack-compatible alert when any loop has gone stale.  No-op when
     # ALERT_WEBHOOK_URL is unset.

--- a/backend/migrations/123_zoho_desk_tickets_mirror.sql
+++ b/backend/migrations/123_zoho_desk_tickets_mirror.sql
@@ -1,0 +1,56 @@
+-- 123_zoho_desk_tickets_mirror.sql
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS zoho_desk_tickets;
+--
+-- Purpose: local mirror of Zoho Desk tickets so the admin Help Desk can serve
+-- lists, dashboards, and trends from our own Postgres instead of hitting the
+-- Zoho REST API on every page view (Zoho enforces a per-day API credit limit).
+-- A background sync loop upserts changed tickets incrementally; reads come from
+-- here. Writes (reply/assign/status/create) still go live to Zoho, then the
+-- next sync reflects them.
+--
+-- Backend-only table (RLS enabled, no policies -> anon/authenticated denied;
+-- the service-role key bypasses RLS). Never exposed to the frontend directly.
+--
+-- Forward-compatible & idempotent; safe against live traffic.
+
+CREATE TABLE IF NOT EXISTS zoho_desk_tickets (
+    zoho_id         TEXT        PRIMARY KEY,            -- Zoho ticket id
+    ticket_number   TEXT,
+    subject         TEXT,
+    status          TEXT,
+    status_type     TEXT,                                -- Open / Closed meta-status
+    priority        TEXT,
+    channel         TEXT,
+    category        TEXT,
+    classification  TEXT,
+    department_id   TEXT,
+    assignee_id     TEXT,
+    assignee_name   TEXT,
+    contact_email   TEXT,
+    contact_name    TEXT,
+    tags            JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    created_time    TIMESTAMPTZ,
+    modified_time   TIMESTAMPTZ,
+    closed_time     TIMESTAMPTZ,
+    due_date        TIMESTAMPTZ,
+    web_url         TEXT,
+    raw             JSONB,                               -- full Zoho payload
+    synced_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index the columns the dashboards/lists/trends filter & sort on.
+CREATE INDEX IF NOT EXISTS idx_zdt_created      ON zoho_desk_tickets (created_time DESC);
+CREATE INDEX IF NOT EXISTS idx_zdt_modified     ON zoho_desk_tickets (modified_time DESC);
+CREATE INDEX IF NOT EXISTS idx_zdt_status       ON zoho_desk_tickets (status);
+CREATE INDEX IF NOT EXISTS idx_zdt_assignee     ON zoho_desk_tickets (assignee_id);
+CREATE INDEX IF NOT EXISTS idx_zdt_department   ON zoho_desk_tickets (department_id);
+
+ALTER TABLE zoho_desk_tickets ENABLE ROW LEVEL SECURITY;
+
+-- Sync cursor lives on the existing single-row config table.
+ALTER TABLE zoho_desk_config ADD COLUMN IF NOT EXISTS last_synced_at TIMESTAMPTZ;
+ALTER TABLE zoho_desk_config ADD COLUMN IF NOT EXISTS last_sync_count INTEGER;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/124_zoho_desk_sync_cursor.sql
+++ b/backend/migrations/124_zoho_desk_sync_cursor.sql
@@ -1,0 +1,16 @@
+-- 124_zoho_desk_sync_cursor.sql
+--
+-- Rollback:
+--   ALTER TABLE zoho_desk_config DROP COLUMN IF EXISTS sync_cursor;
+--
+-- Purpose: high-water mark for the incremental Zoho Desk sync. The sync pulls
+-- tickets sorted by -modifiedTime and stops once it reaches a ticket modified
+-- at or before this cursor, so changes to ANY ticket (including old ones whose
+-- status changed) are captured cheaply. `last_synced_at` remains the run
+-- timestamp used for the "synced N min ago" UI indicator.
+--
+-- Additive column on the backend-only config table; safe against live traffic.
+
+ALTER TABLE zoho_desk_config ADD COLUMN IF NOT EXISTS sync_cursor TIMESTAMPTZ;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/125_lost_and_found_zoho_ticket.sql
+++ b/backend/migrations/125_lost_and_found_zoho_ticket.sql
@@ -1,0 +1,12 @@
+-- 125_lost_and_found_zoho_ticket.sql
+--
+-- Rollback:
+--   ALTER TABLE lost_and_found DROP COLUMN IF EXISTS zoho_ticket_id;
+--
+-- Purpose: link a Lost & Found case to the Zoho Desk ticket auto-created for
+-- it, so the link is idempotent (we only create a ticket when this is null)
+-- and support staff can cross-reference. Additive column; safe in flight.
+
+ALTER TABLE lost_and_found ADD COLUMN IF NOT EXISTS zoho_ticket_id TEXT;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/126_disputes_zoho_ticket.sql
+++ b/backend/migrations/126_disputes_zoho_ticket.sql
@@ -1,0 +1,12 @@
+-- 126_disputes_zoho_ticket.sql
+--
+-- Rollback:
+--   ALTER TABLE disputes DROP COLUMN IF EXISTS zoho_ticket_id;
+--
+-- Purpose: link a payment dispute / refund request to the Zoho Desk ticket
+-- auto-created for it (idempotency + staff cross-reference). Additive column;
+-- safe in flight.
+
+ALTER TABLE disputes ADD COLUMN IF NOT EXISTS zoho_ticket_id TEXT;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 try:
     from ... import db_supabase
     from ...dependencies import get_admin_user, require_module
+    from ...services import zoho_desk_db
     from ...services import zoho_desk_service as zoho
     from ...services.zoho_desk_service import ZohoDeskError
     from ...utils.audit_logger import log_admin_action
@@ -109,6 +110,8 @@ def _config_status(cfg: Dict[str, Any]) -> Dict[str, Any]:
             and _has("refresh_token")
             and _has("org_id")
         ),
+        "last_synced_at": cfg.get("last_synced_at"),
+        "last_sync_count": cfg.get("last_sync_count"),
         "updated_at": cfg.get("updated_at"),
     }
 
@@ -182,75 +185,13 @@ async def test_connection(admin: dict = Depends(get_admin_user)):
 # --------------------------------------------------------------------------
 
 
-@router.get("/dashboard")
-async def dashboard(
-    department_id: Optional[str] = Query(None),
-    admin: dict = Depends(require_module("support_tickets")),
-):
-    dept = await _resolve_department(department_id)
-    # Listing tickets is the core of the dashboard — if this fails, surface it.
-    try:
-        sample = await zoho.list_tickets(limit=100, department_id=dept, sort_by="-createdTime")
-    except ZohoDeskError as e:
-        raise _err(e) from e
-
-    # The exact account-wide total comes from /ticketsCount, which needs the
-    # Desk.search.READ scope. If the connected token lacks it (or the call
-    # otherwise fails), degrade gracefully to the sampled view instead of
-    # 502-ing the whole page — the breakdown below is still useful.
-    total: Optional[int] = None
-    try:
-        total = await zoho.ticket_count(department_id=dept)
-    except ZohoDeskError as e:
-        logger.warning("Zoho ticket_count unavailable (scope/credentials?): %s", e.message)
-
-    tickets: List[Dict[str, Any]] = (sample or {}).get("data", [])
-    by_status: Counter = Counter()
-    for t in tickets:
-        by_status[t.get("status") or "Unknown"] += 1
-
-    open_count = sum(c for s, c in by_status.items() if "closed" not in s.lower())
-    return {
-        "total": total,
-        "total_available": total is not None,
-        "open": open_count,
-        "by_status": dict(by_status),
-        "recent": tickets[:10],
-        "sample_size": len(tickets),
-        "approximate": len(tickets) >= 100,
-    }
+_DASHBOARD_STATUSES = ["Open", "On Hold", "Escalated", "Closed"]
 
 
-@router.get("/trends")
-async def trends(
-    days: int = Query(14, ge=1, le=90),
-    department_id: Optional[str] = Query(None),
-    assignee_id: Optional[str] = Query(None),
-    admin: dict = Depends(require_module("support_tickets")),
-):
-    """Time-series + breakdowns derived from the most recent tickets.
-
-    Zoho's API does not expose a generic aggregate report endpoint on the
-    REST tier, so we aggregate the latest page of tickets client-side, keeping
-    only those created within the selected window. This is approximate when
-    more than 100 tickets fall inside the window, and is labelled as such.
-
-    Includes opened-vs-closed per day and resolution-time stats (computed from
-    closedTime − createdTime on closed tickets in the sample). Optional
-    `assignee_id` scopes everything to one agent.
-    """
-    dept = await _resolve_department(department_id)
-    try:
-        page = await zoho.list_tickets(limit=100, department_id=dept, assignee_id=assignee_id, sort_by="-createdTime")
-    except ZohoDeskError as e:
-        raise _err(e) from e
-
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-    raw: List[Dict[str, Any]] = (page or {}).get("data", [])
-    # Honor the requested window: drop tickets created before the cutoff so
-    # the Last 7/14/30/90-day selector produces the report it promises.
-    tickets = [t for t in raw if (_parse_zoho_time(t.get("createdTime") or "") or cutoff) >= cutoff]
-
+def _aggregate_trends(tickets: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Aggregate a windowed list of Zoho ticket payloads into the trends
+    response (volume, breakdowns, resolution stats). Source-agnostic — used for
+    both the DB mirror (full history) and the live 100-ticket sample."""
     opened_by_day: Counter = Counter()
     closed_by_day: Counter = Counter()
     by_status: Counter = Counter()
@@ -296,18 +237,12 @@ async def trends(
                 if hrs >= 0:
                     resolution_hours.append(hrs)
 
-    # Merge opened+closed into one per-day series for the timeline chart.
     all_days = sorted(d for d in set(opened_by_day) | set(closed_by_day) if d and d != "unknown")
     volume = [{"date": d, "opened": opened_by_day.get(d, 0), "closed": closed_by_day.get(d, 0)} for d in all_days]
-
     avg_res = round(sum(resolution_hours) / len(resolution_hours), 1) if resolution_hours else None
     median_res = round(statistics.median(resolution_hours), 1) if resolution_hours else None
 
     return {
-        "sample_size": len(tickets),
-        # Approximate when the raw page was capped AND everything we fetched is
-        # inside the window (i.e. there may be more we didn't see).
-        "approximate": len(raw) >= 100 and len(tickets) == len(raw),
         "volume": volume,
         "by_status": dict(by_status),
         "by_priority": dict(by_priority),
@@ -315,7 +250,6 @@ async def trends(
         "by_category": dict(by_category),
         "by_classification": dict(by_classification),
         "by_tag": dict(by_tag),
-        # Top requesters by ticket count in the window (max 10).
         "top_contacts": [{"name": n, "count": c} for n, c in by_contact.most_common(10)],
         "stats": {
             "opened": len(tickets),
@@ -326,6 +260,91 @@ async def trends(
             "resolved_sample": len(resolution_hours),
         },
     }
+
+
+@router.get("/dashboard")
+async def dashboard(
+    department_id: Optional[str] = Query(None),
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    dept = await _resolve_department(department_id)
+
+    # Prefer the local mirror — exact counts, no Zoho credits, no sample cap.
+    db = await zoho_desk_db.count_by_status(dept, _DASHBOARD_STATUSES)
+    if db is not None and db[0] > 0:
+        total, by_status = db
+        recent = await zoho_desk_db.list_mirror(limit=10, department_id=dept, sort_by="-createdTime") or []
+        return {
+            "total": total,
+            "total_available": True,
+            "open": total - by_status.get("Closed", 0),
+            "by_status": by_status,
+            "recent": recent,
+            "sample_size": total,
+            "approximate": False,
+            "source": "db",
+        }
+
+    # Live fallback (before the first sync / migration).
+    try:
+        sample = await zoho.list_tickets(limit=100, department_id=dept, sort_by="-createdTime")
+    except ZohoDeskError as e:
+        raise _err(e) from e
+    total = None
+    try:
+        total = await zoho.ticket_count(department_id=dept)
+    except ZohoDeskError as e:
+        logger.warning("Zoho ticket_count unavailable (scope/credentials?): %s", e.message)
+    tickets: List[Dict[str, Any]] = (sample or {}).get("data", [])
+    by_status_c: Counter = Counter()
+    for t in tickets:
+        by_status_c[t.get("status") or "Unknown"] += 1
+    open_count = sum(c for s, c in by_status_c.items() if "closed" not in s.lower())
+    return {
+        "total": total,
+        "total_available": total is not None,
+        "open": open_count,
+        "by_status": dict(by_status_c),
+        "recent": tickets[:10],
+        "sample_size": len(tickets),
+        "approximate": len(tickets) >= 100,
+        "source": "live",
+    }
+
+
+@router.get("/trends")
+async def trends(
+    days: int = Query(14, ge=1, le=90),
+    department_id: Optional[str] = Query(None),
+    assignee_id: Optional[str] = Query(None),
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    """Opened-vs-closed timeline, breakdowns, and resolution stats over the
+    selected window. Served from the local mirror (full history) once synced;
+    otherwise a live 100-ticket sample (flagged approximate)."""
+    dept = await _resolve_department(department_id)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    rows = await zoho_desk_db.fetch_window(since_iso=cutoff.isoformat(), department_id=dept, assignee_id=assignee_id)
+    if rows is not None and len(rows) > 0:
+        result = _aggregate_trends(rows)
+        result["sample_size"] = len(rows)
+        result["approximate"] = False
+        result["source"] = "db"
+        return result
+
+    # Live fallback.
+    try:
+        page = await zoho.list_tickets(limit=100, department_id=dept, assignee_id=assignee_id, sort_by="-createdTime")
+    except ZohoDeskError as e:
+        raise _err(e) from e
+    raw: List[Dict[str, Any]] = (page or {}).get("data", [])
+    tickets = [t for t in raw if (_parse_zoho_time(t.get("createdTime") or "") or cutoff) >= cutoff]
+    result = _aggregate_trends(tickets)
+    result["sample_size"] = len(tickets)
+    result["approximate"] = len(raw) >= 100 and len(tickets) == len(raw)
+    result["source"] = "live"
+    return result
 
 
 # --------------------------------------------------------------------------
@@ -399,6 +418,19 @@ async def tickets(
     admin: dict = Depends(require_module("support_tickets")),
 ):
     dept = await _resolve_department(department_id)
+    # DB-first: serve from the mirror when it has data; else live.
+    rows = await zoho_desk_db.list_mirror(
+        limit=limit,
+        offset=from_index - 1,
+        status=status,
+        priority=priority,
+        channel=channel,
+        assignee_id=assignee_id,
+        department_id=dept,
+        sort_by=sort_by,
+    )
+    if rows is not None and (rows or (await zoho_desk_db.mirror_count() or 0) > 0):
+        return {"data": rows, "source": "db"}
     try:
         return await zoho.list_tickets(
             from_index=from_index,
@@ -425,9 +457,21 @@ async def search(
     assignee_id: Optional[str] = Query(None),
     admin: dict = Depends(require_module("support_tickets")),
 ):
-    """Account-wide ticket search (Zoho /tickets/search). Falls back to the
-    configured default department when none is supplied."""
+    """Account-wide ticket search. Served from the local mirror when synced
+    (fast, no Zoho credits); otherwise Zoho /tickets/search."""
     dept = await _resolve_department(department_id)
+    rows = await zoho_desk_db.list_mirror(
+        limit=limit,
+        offset=from_index - 1,
+        search=q,
+        status=status,
+        priority=priority,
+        assignee_id=assignee_id,
+        department_id=dept,
+        sort_by="-createdTime",
+    )
+    if rows is not None and (rows or (await zoho_desk_db.mirror_count() or 0) > 0):
+        return {"data": rows, "source": "db"}
     try:
         return await zoho.search_tickets(
             query=q,

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -151,6 +151,22 @@ async def update_config(payload: ZohoConfigUpdate, admin: dict = Depends(get_adm
     return _config_status(cfg)
 
 
+@router.post("/sync")
+async def trigger_sync(admin: dict = Depends(require_module("support_tickets"))):
+    """Run a Zoho -> DB mirror sync now (the background loop also runs every
+    ~10 min). Returns how many tickets were upserted."""
+    try:
+        from ...utils.zoho_desk_sync import run_sync
+    except ImportError:
+        from utils.zoho_desk_sync import run_sync
+    try:
+        result = await run_sync()
+    except ZohoDeskError as e:
+        raise _err(e) from e
+    await log_admin_action(admin, "zoho_desk_sync", "zoho_desk_config", _CONFIG_ID, result)
+    return result
+
+
 @router.post("/config/test")
 async def test_connection(admin: dict = Depends(get_admin_user)):
     """Verify the stored credentials by making a lightweight Zoho call."""

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -398,6 +398,34 @@ async def tickets(
         raise _err(e) from e
 
 
+@router.get("/search")
+async def search(
+    q: str = Query(..., min_length=1),
+    from_index: int = Query(1, ge=1, alias="from"),
+    limit: int = Query(50, ge=1, le=100),
+    department_id: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    priority: Optional[str] = Query(None),
+    assignee_id: Optional[str] = Query(None),
+    admin: dict = Depends(require_module("support_tickets")),
+):
+    """Account-wide ticket search (Zoho /tickets/search). Falls back to the
+    configured default department when none is supplied."""
+    dept = await _resolve_department(department_id)
+    try:
+        return await zoho.search_tickets(
+            query=q,
+            from_index=from_index,
+            limit=limit,
+            department_id=dept,
+            status=status,
+            priority=priority,
+            assignee_id=assignee_id,
+        )
+    except ZohoDeskError as e:
+        raise _err(e) from e
+
+
 @router.get("/tickets/{ticket_id}")
 async def ticket_detail(ticket_id: str, admin: dict = Depends(require_module("support_tickets"))):
     try:

--- a/backend/routes/disputes.py
+++ b/backend/routes/disputes.py
@@ -2,6 +2,7 @@
 disputes.py – Payment dispute/refund request endpoints for Spinr.
 """
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -15,11 +16,13 @@ try:
     from .. import db_supabase
     from ..dependencies import get_admin_user, get_current_user
     from ..features import send_push_notification
+    from ..services.zoho_desk_integration import create_ticket_for_dispute
     from ..settings_loader import get_app_settings
     from ..utils.audit_logger import log_admin_action
 except ImportError:
     import db_supabase
     from dependencies import get_admin_user, get_current_user
+    from services.zoho_desk_integration import create_ticket_for_dispute
     from settings_loader import get_app_settings
 
 db = db_supabase  # legacy alias
@@ -100,6 +103,10 @@ async def create_dispute(
             )
         except Exception as notif_err:
             logger.debug(f"Dispute created notification failed: {notif_err}")
+
+    # Raise a Zoho Desk ticket for support to track the dispute/refund —
+    # fire-and-forget; no-op when the integration is disabled.
+    asyncio.create_task(create_ticket_for_dispute(dispute, ride))
 
     return {"success": True, "dispute": dispute}
 

--- a/backend/routes/lost_and_found.py
+++ b/backend/routes/lost_and_found.py
@@ -12,6 +12,7 @@ Endpoints:
     POST /lost-and-found/{case_id}/messages — send a chat message
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
@@ -24,10 +25,12 @@ try:
     from .. import db_supabase
     from ..dependencies import get_current_user
     from ..features import send_push_notification
+    from ..services.zoho_desk_integration import create_ticket_for_lost_and_found
 except ImportError:
     import db_supabase  # type: ignore
     from dependencies import get_current_user  # type: ignore
     from features import send_push_notification  # type: ignore
+    from services.zoho_desk_integration import create_ticket_for_lost_and_found  # type: ignore
 
 api_router = APIRouter(prefix="/lost-and-found", tags=["Lost & Found"])
 
@@ -221,6 +224,11 @@ async def driver_report_found_item(
             {"type": "lost_and_found", "case_id": case["id"]},
             target_app="rider",
         )
+
+    # Raise a Zoho Desk ticket for support to track the return — fire-and-forget
+    # so a Zoho hiccup never blocks or fails the driver's report. No-op when the
+    # integration is disabled.
+    asyncio.create_task(create_ticket_for_lost_and_found(case, ride))
 
     return {"success": True, "case": case}
 

--- a/backend/routes/support.py
+++ b/backend/routes/support.py
@@ -18,12 +18,16 @@ from pydantic import BaseModel
 
 try:
     from dependencies import get_current_user
+    from services.zoho_desk_integration import create_support_ticket
+    from services.zoho_desk_service import ZohoDeskError
 except ImportError:
     from .dependencies import get_current_user  # type: ignore
 
 api_router = APIRouter(tags=["Support Chat"])
 
-FALLBACK_REPLY = "I'm unable to answer that right now. Please call our driver support line: 1-800-SPINR or email support@spinr.ca"
+FALLBACK_REPLY = (
+    "I'm unable to answer that right now. Please call our driver support line: 1-800-SPINR or email support@spinr.ca"
+)
 
 SYSTEM_PROMPT = """You are a helpful support assistant for Spinr, a Canadian rideshare platform.
 You help drivers with questions about the Spinr driver app.
@@ -144,3 +148,30 @@ async def support_chat(
 
         logging.warning("Gemini support chat failed: %s", exc)
         return {"reply": FALLBACK_REPLY}
+
+
+class EscalateRequest(BaseModel):
+    message: str
+    transcript: str = ""
+
+
+@api_router.post("/support/escalate")
+async def support_escalate(
+    req: EscalateRequest,
+    current_user: dict = Depends(get_current_user),
+):
+    """Escalate a support chat to a human by opening a Zoho Desk ticket.
+
+    Returns the ticket number on success; on a Zoho outage / disabled
+    integration it falls back to the support contact line so the user is never
+    left without a path to help.
+    """
+    try:
+        result = await create_support_ticket(user=current_user, message=req.message, transcript=req.transcript or None)
+    except ZohoDeskError:
+        return {"success": False, "reply": FALLBACK_REPLY}
+    return {
+        "success": True,
+        "ticket_number": result.get("ticketNumber"),
+        "reply": "Your request has been escalated to our support team. We'll follow up by email shortly.",
+    }

--- a/backend/services/zoho_desk_db.py
+++ b/backend/services/zoho_desk_db.py
@@ -1,0 +1,159 @@
+"""
+Read helpers for the local Zoho Desk mirror (``zoho_desk_tickets``, migration
+123). The Help Desk serves lists / search / dashboards / trends from here so it
+doesn't spend Zoho API credits on every page view. Each row stores the full
+Zoho payload in ``raw``, so callers get back the exact ticket shape the
+frontend already handles.
+
+All functions return ``None`` (not an exception) when the mirror is unavailable
+or empty, so routes can transparently fall back to the live API before the
+first sync / migration.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    from .. import db_supabase
+except ImportError:  # pragma: no cover
+    import db_supabase
+
+logger = logging.getLogger(__name__)
+
+_TABLE = "zoho_desk_tickets"
+_PAGE = 1000  # Supabase per-request row cap
+
+
+async def mirror_count() -> Optional[int]:
+    """Total rows in the mirror, or None if the table is unavailable."""
+    if not db_supabase.supabase:
+        return None
+
+    def _fn():
+        res = db_supabase.supabase.table(_TABLE).select("zoho_id", count="exact").limit(1).execute()
+        return getattr(res, "count", None)
+
+    try:
+        return await db_supabase.run_sync(_fn)
+    except Exception as e:
+        logger.warning("Zoho mirror unavailable (not migrated yet?): %s", e)
+        return None
+
+
+def _apply_filters(q, *, status, priority, channel, assignee_id, department_id):
+    if status:
+        q = q.eq("status", status)
+    if priority:
+        q = q.eq("priority", priority)
+    if channel:
+        q = q.eq("channel", channel)
+    if assignee_id:
+        q = q.eq("assignee_id", assignee_id)
+    if department_id:
+        q = q.eq("department_id", department_id)
+    return q
+
+
+async def list_mirror(
+    *,
+    limit: int = 25,
+    offset: int = 0,
+    status: Optional[str] = None,
+    priority: Optional[str] = None,
+    channel: Optional[str] = None,
+    assignee_id: Optional[str] = None,
+    department_id: Optional[str] = None,
+    search: Optional[str] = None,
+    sort_by: str = "-createdTime",
+) -> Optional[List[Dict[str, Any]]]:
+    """Return a page of tickets (raw Zoho payloads) from the mirror, or None
+    if the mirror is unavailable."""
+    if not db_supabase.supabase:
+        return None
+    col = "modified_time" if "modifiedTime" in sort_by else "created_time"
+    desc = sort_by.startswith("-")
+
+    def _fn():
+        q = db_supabase.supabase.table(_TABLE).select("raw")
+        q = _apply_filters(
+            q,
+            status=status,
+            priority=priority,
+            channel=channel,
+            assignee_id=assignee_id,
+            department_id=department_id,
+        )
+        s = (search or "").strip()
+        if s:
+            esc = s.replace(",", " ")
+            q = q.or_(
+                f"ticket_number.ilike.%{esc}%,subject.ilike.%{esc}%,"
+                f"contact_email.ilike.%{esc}%,contact_name.ilike.%{esc}%"
+            )
+        q = q.order(col, desc=desc).range(offset, offset + limit - 1)
+        return q.execute()
+
+    try:
+        res = await db_supabase.run_sync(_fn)
+        rows = db_supabase._rows_from_res(res)
+        return [r.get("raw") for r in rows if r.get("raw")]
+    except Exception as e:
+        logger.warning("Zoho mirror list failed, falling back to live: %s", e)
+        return None
+
+
+async def count_by_status(department_id: Optional[str], statuses: List[str]) -> Optional[Tuple[int, Dict[str, int]]]:
+    """Exact (total, {status: count}) from the mirror, or None if unavailable."""
+    if not db_supabase.supabase:
+        return None
+
+    def _count(status: Optional[str]):
+        q = db_supabase.supabase.table(_TABLE).select("zoho_id", count="exact").limit(1)
+        if department_id:
+            q = q.eq("department_id", department_id)
+        if status:
+            q = q.eq("status", status)
+        return getattr(q.execute(), "count", 0) or 0
+
+    try:
+        total = await db_supabase.run_sync(lambda: _count(None))
+        by_status: Dict[str, int] = {}
+        for s in statuses:
+            by_status[s] = await db_supabase.run_sync(lambda s=s: _count(s))
+        return total, by_status
+    except Exception as e:
+        logger.warning("Zoho mirror count failed, falling back to live: %s", e)
+        return None
+
+
+async def fetch_window(
+    *, since_iso: str, department_id: Optional[str], assignee_id: Optional[str], max_rows: int = 5000
+) -> Optional[List[Dict[str, Any]]]:
+    """All tickets created since ``since_iso`` (raw payloads), paged. None if
+    the mirror is unavailable."""
+    if not db_supabase.supabase:
+        return None
+
+    out: List[Dict[str, Any]] = []
+    offset = 0
+    try:
+        while offset < max_rows:
+
+            def _fn(off=offset):
+                q = db_supabase.supabase.table(_TABLE).select("raw").gte("created_time", since_iso)
+                if department_id:
+                    q = q.eq("department_id", department_id)
+                if assignee_id:
+                    q = q.eq("assignee_id", assignee_id)
+                return q.order("created_time", desc=True).range(off, off + _PAGE - 1).execute()
+
+            res = await db_supabase.run_sync(_fn)
+            rows = db_supabase._rows_from_res(res)
+            out.extend(r.get("raw") for r in rows if r.get("raw"))
+            if len(rows) < _PAGE:
+                break
+            offset += _PAGE
+        return out
+    except Exception as e:
+        logger.warning("Zoho mirror window failed, falling back to live: %s", e)
+        return None

--- a/backend/services/zoho_desk_integration.py
+++ b/backend/services/zoho_desk_integration.py
@@ -39,9 +39,7 @@ def _split_name(name: str) -> tuple[str, Optional[str]]:
     return parts[0], (" ".join(parts[1:]) or None)
 
 
-async def create_ticket_for_lost_and_found(
-    case: Dict[str, Any], ride: Optional[Dict[str, Any]] = None
-) -> None:
+async def create_ticket_for_lost_and_found(case: Dict[str, Any], ride: Optional[Dict[str, Any]] = None) -> None:
     """Open a Zoho Desk ticket for a Lost & Found case and link it back via
     ``lost_and_found.zoho_ticket_id``. Safe to call fire-and-forget."""
     try:
@@ -80,22 +78,16 @@ async def create_ticket_for_lost_and_found(
         )
         zoho_id = str(result.get("id") or "")
         if zoho_id:
-            await db_supabase.update_one(
-                "lost_and_found", {"id": case["id"]}, {"zoho_ticket_id": zoho_id}
-            )
+            await db_supabase.update_one("lost_and_found", {"id": case["id"]}, {"zoho_ticket_id": zoho_id})
             logger.info("Created Zoho ticket %s for L&F case %s", zoho_id, case.get("id"))
     except ZohoDeskError as e:
         # Misconfigured / missing department / scope — log, don't break the flow.
         logger.warning("Zoho L&F ticket skipped (%s): %s", e.status, e.message)
     except Exception:
-        logger.error(
-            "Failed to create Zoho ticket for L&F case %s", case.get("id"), exc_info=True
-        )
+        logger.error("Failed to create Zoho ticket for L&F case %s", case.get("id"), exc_info=True)
 
 
-async def create_ticket_for_dispute(
-    dispute: Dict[str, Any], ride: Optional[Dict[str, Any]] = None
-) -> None:
+async def create_ticket_for_dispute(dispute: Dict[str, Any], ride: Optional[Dict[str, Any]] = None) -> None:
     """Open a Zoho Desk ticket for a payment dispute / refund request and link
     it back via ``disputes.zoho_ticket_id``. Fire-and-forget; idempotent."""
     try:
@@ -107,9 +99,7 @@ async def create_ticket_for_dispute(
         if uid:
             user = await db_supabase.find_one("users", {"id": uid}) or {}
 
-        name = (user.get("name") or "").strip() or (
-            f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
-        )
+        name = (user.get("name") or "").strip() or (f"{user.get('first_name', '')} {user.get('last_name', '')}".strip())
         first, last = _split_name(name or "Rider")
         reason = dispute.get("reason") or "Dispute"
         ride_code = (ride or {}).get("ride_code") or dispute.get("ride_id") or ""
@@ -136,13 +126,45 @@ async def create_ticket_for_dispute(
         )
         zoho_id = str(result.get("id") or "")
         if zoho_id:
-            await db_supabase.update_one(
-                "disputes", {"id": dispute["id"]}, {"zoho_ticket_id": zoho_id}
-            )
+            await db_supabase.update_one("disputes", {"id": dispute["id"]}, {"zoho_ticket_id": zoho_id})
             logger.info("Created Zoho ticket %s for dispute %s", zoho_id, dispute.get("id"))
     except ZohoDeskError as e:
         logger.warning("Zoho dispute ticket skipped (%s): %s", e.status, e.message)
     except Exception:
-        logger.error(
-            "Failed to create Zoho ticket for dispute %s", dispute.get("id"), exc_info=True
-        )
+        logger.error("Failed to create Zoho ticket for dispute %s", dispute.get("id"), exc_info=True)
+
+
+async def create_support_ticket(
+    *, user: Dict[str, Any], message: str, transcript: Optional[str] = None
+) -> Dict[str, Any]:
+    """Open a Zoho Desk ticket from a support-chat escalation. Unlike the
+    fire-and-forget helpers above, this is user-triggered, so it RAISES
+    ZohoDeskError on failure (disabled / not configured / missing department)
+    for the route to surface a friendly fallback."""
+    if not await _enabled():
+        raise ZohoDeskError("Zoho Desk integration is disabled.", status=503)
+
+    user = user or {}
+    email = user.get("email")
+    if not email and user.get("id"):
+        fetched = await db_supabase.find_one("users", {"id": user["id"]}) or {}
+        user = {**fetched, **{k: v for k, v in user.items() if v is not None}}
+        email = user.get("email")
+
+    name = (user.get("name") or "").strip() or (f"{user.get('first_name', '')} {user.get('last_name', '')}".strip())
+    first, last = _split_name(name or "Customer")
+    msg = (message or "").strip()
+    subject = (msg.splitlines()[0][:70] if msg else "") or "Support request"
+    description = msg or "(no message)"
+    if transcript:
+        description += f"\n\n--- Chat transcript ---\n{transcript}"
+
+    return await zoho.create_ticket(
+        subject=f"Support — {subject}",
+        description=description,
+        email=email,
+        first_name=first,
+        last_name=last,
+        phone=user.get("phone"),
+        channel="Chat",
+    )

--- a/backend/services/zoho_desk_integration.py
+++ b/backend/services/zoho_desk_integration.py
@@ -1,0 +1,93 @@
+"""
+App-event -> Zoho Desk ticket bridge.
+
+Helpers that raise a Zoho Desk ticket when something happens in the Spinr app
+(Lost & Found today; support / disputes next). All helpers are:
+
+  * **best-effort** — never raise into the caller's request flow (a Zoho outage
+    must not break reporting a found item),
+  * **idempotent** — they no-op when the source record already links a ticket,
+  * **opt-in** — they no-op when the integration is disabled.
+
+Call them via ``asyncio.create_task`` so the inline request stays fast.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+try:
+    from .. import db_supabase
+    from . import zoho_desk_service as zoho
+    from .zoho_desk_service import ZohoDeskError
+except ImportError:  # pragma: no cover
+    import db_supabase
+    from services import zoho_desk_service as zoho
+    from services.zoho_desk_service import ZohoDeskError
+
+logger = logging.getLogger(__name__)
+
+
+async def _enabled() -> bool:
+    cfg = await db_supabase.find_one("zoho_desk_config", {"id": "default"})
+    return bool(cfg and cfg.get("enabled"))
+
+
+def _split_name(name: str) -> tuple[str, Optional[str]]:
+    parts = (name or "").strip().split()
+    if not parts:
+        return "", None
+    return parts[0], (" ".join(parts[1:]) or None)
+
+
+async def create_ticket_for_lost_and_found(
+    case: Dict[str, Any], ride: Optional[Dict[str, Any]] = None
+) -> None:
+    """Open a Zoho Desk ticket for a Lost & Found case and link it back via
+    ``lost_and_found.zoho_ticket_id``. Safe to call fire-and-forget."""
+    try:
+        if case.get("zoho_ticket_id") or not await _enabled():
+            return
+
+        rider: Dict[str, Any] = {}
+        rid = case.get("rider_user_id")
+        if rid:
+            rider = await db_supabase.find_one("users", {"id": rid}) or {}
+
+        name = (rider.get("name") or "").strip() or (
+            f"{rider.get('first_name', '')} {rider.get('last_name', '')}".strip()
+        )
+        first, last = _split_name(name or "Rider")
+        item = case.get("item_description") or "item"
+        ride_code = (ride or {}).get("ride_code") or case.get("ride_id") or ""
+        description = (
+            "Lost & Found case opened from the Spinr app.\n\n"
+            f"Item: {item}\n"
+            f"Category: {case.get('item_category')}\n"
+            f"Ride: {ride_code}\n"
+            f"Case ID: {case.get('id')}\n"
+            f"Reported by: {case.get('reporter_type')}"
+        )
+
+        result = await zoho.create_ticket(
+            subject=f"Lost & Found — {item[:60]}",
+            description=description,
+            email=rider.get("email"),
+            first_name=first,
+            last_name=last,
+            phone=rider.get("phone"),
+            channel="Web",
+            category="Lost & Found",
+        )
+        zoho_id = str(result.get("id") or "")
+        if zoho_id:
+            await db_supabase.update_one(
+                "lost_and_found", {"id": case["id"]}, {"zoho_ticket_id": zoho_id}
+            )
+            logger.info("Created Zoho ticket %s for L&F case %s", zoho_id, case.get("id"))
+    except ZohoDeskError as e:
+        # Misconfigured / missing department / scope — log, don't break the flow.
+        logger.warning("Zoho L&F ticket skipped (%s): %s", e.status, e.message)
+    except Exception:
+        logger.error(
+            "Failed to create Zoho ticket for L&F case %s", case.get("id"), exc_info=True
+        )

--- a/backend/services/zoho_desk_integration.py
+++ b/backend/services/zoho_desk_integration.py
@@ -91,3 +91,58 @@ async def create_ticket_for_lost_and_found(
         logger.error(
             "Failed to create Zoho ticket for L&F case %s", case.get("id"), exc_info=True
         )
+
+
+async def create_ticket_for_dispute(
+    dispute: Dict[str, Any], ride: Optional[Dict[str, Any]] = None
+) -> None:
+    """Open a Zoho Desk ticket for a payment dispute / refund request and link
+    it back via ``disputes.zoho_ticket_id``. Fire-and-forget; idempotent."""
+    try:
+        if dispute.get("zoho_ticket_id") or not await _enabled():
+            return
+
+        user: Dict[str, Any] = {}
+        uid = dispute.get("user_id")
+        if uid:
+            user = await db_supabase.find_one("users", {"id": uid}) or {}
+
+        name = (user.get("name") or "").strip() or (
+            f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+        )
+        first, last = _split_name(name or "Rider")
+        reason = dispute.get("reason") or "Dispute"
+        ride_code = (ride or {}).get("ride_code") or dispute.get("ride_id") or ""
+        description = (
+            "Dispute / refund request opened from the Spinr app.\n\n"
+            f"Reason: {reason}\n"
+            f"Details: {dispute.get('description') or '—'}\n"
+            f"Requested amount: {dispute.get('requested_amount')}\n"
+            f"Original fare: {dispute.get('original_fare')}\n"
+            f"Ride: {ride_code}\n"
+            f"Dispute ID: {dispute.get('id')}"
+        )
+
+        result = await zoho.create_ticket(
+            subject=f"Dispute & Refund — {str(reason)[:50]}",
+            description=description,
+            email=user.get("email"),
+            first_name=first,
+            last_name=last,
+            phone=user.get("phone"),
+            priority="High",
+            channel="Web",
+            category="Payment",
+        )
+        zoho_id = str(result.get("id") or "")
+        if zoho_id:
+            await db_supabase.update_one(
+                "disputes", {"id": dispute["id"]}, {"zoho_ticket_id": zoho_id}
+            )
+            logger.info("Created Zoho ticket %s for dispute %s", zoho_id, dispute.get("id"))
+    except ZohoDeskError as e:
+        logger.warning("Zoho dispute ticket skipped (%s): %s", e.status, e.message)
+    except Exception:
+        logger.error(
+            "Failed to create Zoho ticket for dispute %s", dispute.get("id"), exc_info=True
+        )

--- a/backend/services/zoho_desk_service.py
+++ b/backend/services/zoho_desk_service.py
@@ -267,6 +267,44 @@ async def list_tickets(
     return data or {"data": []}
 
 
+async def search_tickets(
+    *,
+    query: str,
+    from_index: int = 1,
+    limit: int = 50,
+    department_id: Optional[str] = None,
+    status: Optional[str] = None,
+    priority: Optional[str] = None,
+    assignee_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Server-side ticket search across the whole account (not just one page).
+
+    Uses Zoho's /tickets/search. A purely numeric query is treated as a ticket
+    number; otherwise it's a wildcard keyword (`_all`) match over subject,
+    contact, etc. Requires the Desk.search.READ scope. Note: search uses the
+    singular `departmentId`/`assigneeId` params (unlike the list endpoint)."""
+    params: Dict[str, Any] = {
+        "from": max(1, from_index),
+        "limit": min(max(1, limit), 100),
+        "include": "contacts,assignee",
+    }
+    q = (query or "").strip()
+    if q.isdigit():
+        params["ticketNumber"] = q
+    elif q:
+        params["_all"] = f"*{q}*"
+    if department_id:
+        params["departmentId"] = department_id
+    if status:
+        params["status"] = status
+    if priority:
+        params["priority"] = priority
+    if assignee_id:
+        params["assigneeId"] = assignee_id
+    data = await _request("GET", "/api/v1/tickets/search", params=params)
+    return data or {"data": []}
+
+
 async def get_ticket(ticket_id: str) -> Dict[str, Any]:
     return await _request("GET", f"/api/v1/tickets/{ticket_id}", params={"include": "contacts,assignee,team"})
 

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -259,6 +259,54 @@ async def test_send_reply_includes_from_email(monkeypatch):
     assert seen["body"]["to"] == "x@y.ca"
 
 
+@pytest.mark.anyio
+async def test_lost_and_found_autocreate_happy(monkeypatch):
+    import services.zoho_desk_integration as integ
+
+    db = MagicMock()
+    db.find_one = AsyncMock(side_effect=[
+        {"id": "default", "enabled": True},  # config
+        {"id": "u1", "name": "Jane Doe", "email": "j@x.ca", "phone": "+1"},  # rider
+    ])
+    db.update_one = AsyncMock()
+    monkeypatch.setattr(integ, "db_supabase", db)
+    created = AsyncMock(return_value={"id": "zt1"})
+    monkeypatch.setattr(integ.zoho, "create_ticket", created)
+
+    await integ.create_ticket_for_lost_and_found(
+        {"id": "c1", "rider_user_id": "u1", "item_description": "Wallet", "item_category": "bag",
+         "ride_id": "r1", "reporter_type": "driver"},
+        {"ride_code": "SPN-1"},
+    )
+    created.assert_awaited_once()
+    kwargs = created.call_args.kwargs
+    assert kwargs["category"] == "Lost & Found"
+    assert kwargs["email"] == "j@x.ca" and kwargs["first_name"] == "Jane"
+    # linked the ticket id back onto the case
+    db.update_one.assert_awaited_once()
+    assert db.update_one.call_args.args[2] == {"zoho_ticket_id": "zt1"}
+
+
+@pytest.mark.anyio
+async def test_lost_and_found_autocreate_skips(monkeypatch):
+    import services.zoho_desk_integration as integ
+
+    db = MagicMock()
+    db.find_one = AsyncMock(return_value={"id": "default", "enabled": False})
+    db.update_one = AsyncMock()
+    monkeypatch.setattr(integ, "db_supabase", db)
+    created = AsyncMock()
+    monkeypatch.setattr(integ.zoho, "create_ticket", created)
+
+    # disabled integration -> no ticket
+    await integ.create_ticket_for_lost_and_found({"id": "c1"}, None)
+    created.assert_not_awaited()
+
+    # already linked -> no ticket (and never even checks config)
+    await integ.create_ticket_for_lost_and_found({"id": "c1", "zoho_ticket_id": "zt9"}, None)
+    created.assert_not_awaited()
+
+
 def test_parse_zoho_time_window():
     # Codex P2: the trends `days` selector must actually filter by created
     # time. The route helper parses Zoho timestamps; unparseable -> None.

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -264,18 +264,26 @@ async def test_lost_and_found_autocreate_happy(monkeypatch):
     import services.zoho_desk_integration as integ
 
     db = MagicMock()
-    db.find_one = AsyncMock(side_effect=[
-        {"id": "default", "enabled": True},  # config
-        {"id": "u1", "name": "Jane Doe", "email": "j@x.ca", "phone": "+1"},  # rider
-    ])
+    db.find_one = AsyncMock(
+        side_effect=[
+            {"id": "default", "enabled": True},  # config
+            {"id": "u1", "name": "Jane Doe", "email": "j@x.ca", "phone": "+1"},  # rider
+        ]
+    )
     db.update_one = AsyncMock()
     monkeypatch.setattr(integ, "db_supabase", db)
     created = AsyncMock(return_value={"id": "zt1"})
     monkeypatch.setattr(integ.zoho, "create_ticket", created)
 
     await integ.create_ticket_for_lost_and_found(
-        {"id": "c1", "rider_user_id": "u1", "item_description": "Wallet", "item_category": "bag",
-         "ride_id": "r1", "reporter_type": "driver"},
+        {
+            "id": "c1",
+            "rider_user_id": "u1",
+            "item_description": "Wallet",
+            "item_category": "bag",
+            "ride_id": "r1",
+            "reporter_type": "driver",
+        },
         {"ride_code": "SPN-1"},
     )
     created.assert_awaited_once()
@@ -312,24 +320,59 @@ async def test_dispute_autocreate_happy(monkeypatch):
     import services.zoho_desk_integration as integ
 
     db = MagicMock()
-    db.find_one = AsyncMock(side_effect=[
-        {"id": "default", "enabled": True},  # config
-        {"id": "u1", "name": "Sam Rider", "email": "s@x.ca"},  # user
-    ])
+    db.find_one = AsyncMock(
+        side_effect=[
+            {"id": "default", "enabled": True},  # config
+            {"id": "u1", "name": "Sam Rider", "email": "s@x.ca"},  # user
+        ]
+    )
     db.update_one = AsyncMock()
     monkeypatch.setattr(integ, "db_supabase", db)
     created = AsyncMock(return_value={"id": "zt7"})
     monkeypatch.setattr(integ.zoho, "create_ticket", created)
 
     await integ.create_ticket_for_dispute(
-        {"id": "d1", "user_id": "u1", "reason": "Overcharged", "description": "x",
-         "requested_amount": 12, "original_fare": 20, "ride_id": "r1"},
+        {
+            "id": "d1",
+            "user_id": "u1",
+            "reason": "Overcharged",
+            "description": "x",
+            "requested_amount": 12,
+            "original_fare": 20,
+            "ride_id": "r1",
+        },
         {"ride_code": "SPN-9"},
     )
     created.assert_awaited_once()
     assert created.call_args.kwargs["category"] == "Payment"
     assert created.call_args.kwargs["priority"] == "High"
     assert db.update_one.call_args.args[2] == {"zoho_ticket_id": "zt7"}
+
+
+@pytest.mark.anyio
+async def test_support_escalation(monkeypatch):
+    import services.zoho_desk_integration as integ
+    from services.zoho_desk_service import ZohoDeskError as ZErr
+
+    db = MagicMock()
+    monkeypatch.setattr(integ, "db_supabase", db)
+    created = AsyncMock(return_value={"id": "zt8", "ticketNumber": "555"})
+    monkeypatch.setattr(integ.zoho, "create_ticket", created)
+
+    # disabled -> raises (route turns this into the fallback reply)
+    db.find_one = AsyncMock(return_value={"id": "default", "enabled": False})
+    with pytest.raises(ZErr):
+        await integ.create_support_ticket(user={"id": "u1", "email": "a@b.ca"}, message="help")
+    created.assert_not_awaited()
+
+    # enabled -> creates a Chat-channel ticket
+    db.find_one = AsyncMock(return_value={"id": "default", "enabled": True})
+    res = await integ.create_support_ticket(
+        user={"id": "u1", "email": "a@b.ca", "name": "Al B"}, message="Card declined\nplease help"
+    )
+    assert res["ticketNumber"] == "555"
+    assert created.call_args.kwargs["channel"] == "Chat"
+    assert created.call_args.kwargs["subject"].startswith("Support — Card declined")
 
 
 def test_parse_zoho_time_window():

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -307,6 +307,31 @@ async def test_lost_and_found_autocreate_skips(monkeypatch):
     created.assert_not_awaited()
 
 
+@pytest.mark.anyio
+async def test_dispute_autocreate_happy(monkeypatch):
+    import services.zoho_desk_integration as integ
+
+    db = MagicMock()
+    db.find_one = AsyncMock(side_effect=[
+        {"id": "default", "enabled": True},  # config
+        {"id": "u1", "name": "Sam Rider", "email": "s@x.ca"},  # user
+    ])
+    db.update_one = AsyncMock()
+    monkeypatch.setattr(integ, "db_supabase", db)
+    created = AsyncMock(return_value={"id": "zt7"})
+    monkeypatch.setattr(integ.zoho, "create_ticket", created)
+
+    await integ.create_ticket_for_dispute(
+        {"id": "d1", "user_id": "u1", "reason": "Overcharged", "description": "x",
+         "requested_amount": 12, "original_fare": 20, "ride_id": "r1"},
+        {"ride_code": "SPN-9"},
+    )
+    created.assert_awaited_once()
+    assert created.call_args.kwargs["category"] == "Payment"
+    assert created.call_args.kwargs["priority"] == "High"
+    assert db.update_one.call_args.args[2] == {"zoho_ticket_id": "zt7"}
+
+
 def test_parse_zoho_time_window():
     # Codex P2: the trends `days` selector must actually filter by created
     # time. The route helper parses Zoho timestamps; unparseable -> None.

--- a/backend/utils/zoho_desk_sync.py
+++ b/backend/utils/zoho_desk_sync.py
@@ -1,0 +1,130 @@
+"""
+Zoho Desk -> Postgres mirror sync.
+
+Pulls recent tickets from Zoho Desk and upserts them into the
+``zoho_desk_tickets`` table (migration 123) so the admin Help Desk can serve
+lists, dashboards, and trends from our own DB instead of spending Zoho API
+credits on every page view. Writes (reply/assign/status/create) still go live
+to Zoho; the next sync reflects them.
+
+Replay-safe: upserts keyed on ``zoho_id``, so every replica can run the loop
+concurrently without creating duplicates. No-op when the integration is
+disabled or not connected.
+
+v1 strategy: each cycle re-pulls the most-recent N pages by createdTime and
+upserts them. This captures new tickets and status changes on recent tickets
+cheaply. (Modifications to very old tickets would need modifiedTime paging or
+webhooks — a later enhancement.)
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+try:
+    from .. import db_supabase
+    from ..services import zoho_desk_service as zoho
+    from ..services.zoho_desk_service import ZohoDeskError
+except ImportError:  # pragma: no cover - allow direct module imports
+    import db_supabase
+    from services import zoho_desk_service as zoho
+    from services.zoho_desk_service import ZohoDeskError
+
+logger = logging.getLogger(__name__)
+
+_TABLE = "zoho_desk_tickets"
+_CONFIG_TABLE = "zoho_desk_config"
+_CONFIG_ID = "default"
+
+SYNC_INTERVAL_SECONDS = 600  # 10 minutes
+SYNC_PAGES = 3  # up to 300 most-recent tickets per cycle
+
+
+def _name(obj: Dict[str, Any]) -> str:
+    full = f"{obj.get('firstName', '')} {obj.get('lastName', '')}".strip()
+    return full or ""
+
+
+def _map_ticket(t: Dict[str, Any]) -> Dict[str, Any]:
+    contact = t.get("contact") or {}
+    assignee = t.get("assignee") or {}
+    tags = [tag.get("name") if isinstance(tag, dict) else tag for tag in (t.get("tags") or [])]
+    return {
+        "zoho_id": str(t.get("id") or ""),
+        "ticket_number": str(t.get("ticketNumber") or ""),
+        "subject": t.get("subject"),
+        "status": t.get("status"),
+        "status_type": t.get("statusType"),
+        "priority": t.get("priority"),
+        "channel": t.get("channel"),
+        "category": t.get("category"),
+        "classification": t.get("classification"),
+        "department_id": t.get("departmentId"),
+        "assignee_id": assignee.get("id") or t.get("assigneeId"),
+        "assignee_name": _name(assignee) or None,
+        "contact_email": (contact.get("email") or t.get("email") or None),
+        "contact_name": _name(contact) or None,
+        "tags": [n for n in tags if n],
+        "created_time": t.get("createdTime"),
+        "modified_time": t.get("modifiedTime"),
+        "closed_time": t.get("closedTime"),
+        "due_date": t.get("dueDate"),
+        "web_url": t.get("webUrl"),
+        "raw": t,
+        "synced_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def _upsert_batch(rows: List[Dict[str, Any]]) -> None:
+    if not rows or not db_supabase.supabase:
+        return
+    serialized = [db_supabase._serialize_for_api(r) for r in rows]
+
+    def _fn():
+        return db_supabase.supabase.table(_TABLE).upsert(serialized).execute()
+
+    await db_supabase.run_sync(_fn)
+
+
+async def run_sync(pages: int = SYNC_PAGES) -> Dict[str, Any]:
+    """Pull recent tickets and upsert into the mirror. Returns a small summary.
+    Skips silently when the integration is disabled."""
+    cfg = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID})
+    if not cfg or not cfg.get("enabled"):
+        return {"skipped": "disabled"}
+
+    total = 0
+    for p in range(max(1, pages)):
+        page = await zoho.list_tickets(from_index=p * 100 + 1, limit=100, sort_by="-createdTime")
+        rows = (page or {}).get("data", [])
+        if not rows:
+            break
+        await _upsert_batch([_map_ticket(t) for t in rows])
+        total += len(rows)
+        if len(rows) < 100:
+            break
+
+    await db_supabase.update_one(
+        _CONFIG_TABLE,
+        {"id": _CONFIG_ID},
+        {
+            "last_synced_at": datetime.now(timezone.utc).isoformat(),
+            "last_sync_count": total,
+        },
+    )
+    logger.info("Zoho Desk sync upserted %s tickets", total)
+    return {"upserted": total}
+
+
+async def zoho_desk_sync_loop() -> None:
+    """Background loop: sync every SYNC_INTERVAL_SECONDS. Replay-safe (upsert)."""
+    while True:
+        try:
+            await run_sync()
+        except ZohoDeskError as e:
+            # Integration not configured / scope issue — warn, keep looping.
+            logger.warning("Zoho Desk sync skipped: %s", e.message)
+        except Exception:
+            logger.error("zoho_desk_sync tick failed", exc_info=True)
+        await asyncio.sleep(SYNC_INTERVAL_SECONDS)

--- a/backend/utils/zoho_desk_sync.py
+++ b/backend/utils/zoho_desk_sync.py
@@ -20,7 +20,7 @@ webhooks — a later enhancement.)
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 try:
     from .. import db_supabase
@@ -38,7 +38,18 @@ _CONFIG_TABLE = "zoho_desk_config"
 _CONFIG_ID = "default"
 
 SYNC_INTERVAL_SECONDS = 600  # 10 minutes
-SYNC_PAGES = 3  # up to 300 most-recent tickets per cycle
+SEED_MAX_PAGES = 10  # first run: pull up to 1000 most-recently-modified tickets
+INCREMENTAL_MAX_PAGES = 50  # safety cap; incremental runs stop at the cursor
+
+
+def _parse(value) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
 
 
 def _name(obj: Dict[str, Any]) -> str:
@@ -87,33 +98,53 @@ async def _upsert_batch(rows: List[Dict[str, Any]]) -> None:
     await db_supabase.run_sync(_fn)
 
 
-async def run_sync(pages: int = SYNC_PAGES) -> Dict[str, Any]:
-    """Pull recent tickets and upsert into the mirror. Returns a small summary.
-    Skips silently when the integration is disabled."""
+async def run_sync() -> Dict[str, Any]:
+    """Incrementally pull tickets by -modifiedTime and upsert into the mirror.
+
+    Stops as soon as it reaches a ticket modified at/before the stored cursor,
+    so a steady-state run is typically a single page. The first run (no cursor)
+    seeds up to SEED_MAX_PAGES. Skips silently when the integration is disabled.
+    """
     cfg = await db_supabase.find_one(_CONFIG_TABLE, {"id": _CONFIG_ID})
     if not cfg or not cfg.get("enabled"):
         return {"skipped": "disabled"}
 
+    cursor = _parse(cfg.get("sync_cursor"))
+    newest = cursor
+    max_pages = INCREMENTAL_MAX_PAGES if cursor else SEED_MAX_PAGES
     total = 0
-    for p in range(max(1, pages)):
-        page = await zoho.list_tickets(from_index=p * 100 + 1, limit=100, sort_by="-createdTime")
+
+    for p in range(max_pages):
+        page = await zoho.list_tickets(from_index=p * 100 + 1, limit=100, sort_by="-modifiedTime")
         rows = (page or {}).get("data", [])
         if not rows:
             break
-        await _upsert_batch([_map_ticket(t) for t in rows])
-        total += len(rows)
-        if len(rows) < 100:
+
+        batch: List[Dict[str, Any]] = []
+        stop = False
+        for t in rows:
+            mod = _parse(t.get("modifiedTime"))
+            if cursor and mod and mod <= cursor:
+                stop = True
+                break
+            batch.append(_map_ticket(t))
+            if mod and (newest is None or mod > newest):
+                newest = mod
+
+        if batch:
+            await _upsert_batch(batch)
+            total += len(batch)
+        if stop or len(rows) < 100:
             break
 
-    await db_supabase.update_one(
-        _CONFIG_TABLE,
-        {"id": _CONFIG_ID},
-        {
-            "last_synced_at": datetime.now(timezone.utc).isoformat(),
-            "last_sync_count": total,
-        },
-    )
-    logger.info("Zoho Desk sync upserted %s tickets", total)
+    updates: Dict[str, Any] = {
+        "last_synced_at": datetime.now(timezone.utc).isoformat(),
+        "last_sync_count": total,
+    }
+    if newest:
+        updates["sync_cursor"] = newest.isoformat()
+    await db_supabase.update_one(_CONFIG_TABLE, {"id": _CONFIG_ID}, updates)
+    logger.info("Zoho Desk sync upserted %s tickets (cursor=%s)", total, newest)
     return {"upserted": total}
 
 


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
