### PR TITLE
Claude/zoho desk admin integration zlwu f

### DIFF
--- a/backend/migrations/127_zoho_desk_mirror_backfilled.sql
+++ b/backend/migrations/127_zoho_desk_mirror_backfilled.sql
@@ -1,0 +1,15 @@
+-- 127_zoho_desk_mirror_backfilled.sql
+--
+-- Rollback:
+--   ALTER TABLE zoho_desk_config DROP COLUMN IF EXISTS mirror_backfilled;
+--
+-- Purpose: completeness marker for the Zoho Desk mirror. The Help Desk reads
+-- from the local mirror only AFTER a full backfill has completed; until then it
+-- serves live from Zoho so partially-seeded accounts never hide historical
+-- tickets or report wrong totals. Set true by the sync once it pages to the end.
+--
+-- Additive column on the backend-only config table; safe in flight.
+
+ALTER TABLE zoho_desk_config ADD COLUMN IF NOT EXISTS mirror_backfilled BOOLEAN NOT NULL DEFAULT FALSE;
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -270,21 +270,25 @@ async def dashboard(
 ):
     dept = await _resolve_department(department_id)
 
-    # Prefer the local mirror — exact counts, no Zoho credits, no sample cap.
-    db = await zoho_desk_db.count_by_status(dept, _DASHBOARD_STATUSES)
-    if db is not None and db[0] > 0:
-        total, by_status = db
-        recent = await zoho_desk_db.list_mirror(limit=10, department_id=dept, sort_by="-createdTime") or []
-        return {
-            "total": total,
-            "total_available": True,
-            "open": total - by_status.get("Closed", 0),
-            "by_status": by_status,
-            "recent": recent,
-            "sample_size": total,
-            "approximate": False,
-            "source": "db",
-        }
+    # Serve from the mirror only after a full backfill (exact counts, no Zoho
+    # credits, no sample cap). Open count uses status_type so custom closed
+    # statuses (e.g. 'Resolved') aren't reported as open.
+    if await zoho_desk_db.mirror_ready():
+        oc = await zoho_desk_db.open_closed_counts(dept)
+        by = await zoho_desk_db.count_by_status(dept, _DASHBOARD_STATUSES)
+        if oc is not None and by is not None:
+            total, closed = oc
+            recent = await zoho_desk_db.list_mirror(limit=10, department_id=dept, sort_by="-createdTime") or []
+            return {
+                "total": total,
+                "total_available": True,
+                "open": max(0, total - closed),
+                "by_status": by[1],
+                "recent": recent,
+                "sample_size": total,
+                "approximate": False,
+                "source": "db",
+            }
 
     # Live fallback (before the first sync / migration).
     try:
@@ -326,13 +330,16 @@ async def trends(
     dept = await _resolve_department(department_id)
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
-    rows = await zoho_desk_db.fetch_window(since_iso=cutoff.isoformat(), department_id=dept, assignee_id=assignee_id)
-    if rows is not None and len(rows) > 0:
-        result = _aggregate_trends(rows)
-        result["sample_size"] = len(rows)
-        result["approximate"] = False
-        result["source"] = "db"
-        return result
+    if await zoho_desk_db.mirror_ready():
+        rows = await zoho_desk_db.fetch_window(
+            since_iso=cutoff.isoformat(), department_id=dept, assignee_id=assignee_id
+        )
+        if rows is not None:
+            result = _aggregate_trends(rows)
+            result["sample_size"] = len(rows)
+            result["approximate"] = False
+            result["source"] = "db"
+            return result
 
     # Live fallback.
     try:
@@ -419,19 +426,21 @@ async def tickets(
     admin: dict = Depends(require_module("support_tickets")),
 ):
     dept = await _resolve_department(department_id)
-    # DB-first: serve from the mirror when it has data; else live.
-    rows = await zoho_desk_db.list_mirror(
-        limit=limit,
-        offset=from_index - 1,
-        status=status,
-        priority=priority,
-        channel=channel,
-        assignee_id=assignee_id,
-        department_id=dept,
-        sort_by=sort_by,
-    )
-    if rows is not None and (rows or (await zoho_desk_db.mirror_count() or 0) > 0):
-        return {"data": rows, "source": "db"}
+    # Serve from the mirror only after a full backfill; else live (so an empty
+    # page from a partially-seeded mirror never hides historical tickets).
+    if await zoho_desk_db.mirror_ready():
+        rows = await zoho_desk_db.list_mirror(
+            limit=limit,
+            offset=from_index - 1,
+            status=status,
+            priority=priority,
+            channel=channel,
+            assignee_id=assignee_id,
+            department_id=dept,
+            sort_by=sort_by,
+        )
+        if rows is not None:
+            return {"data": rows, "source": "db"}
     try:
         return await zoho.list_tickets(
             from_index=from_index,
@@ -461,18 +470,19 @@ async def search(
     """Account-wide ticket search. Served from the local mirror when synced
     (fast, no Zoho credits); otherwise Zoho /tickets/search."""
     dept = await _resolve_department(department_id)
-    rows = await zoho_desk_db.list_mirror(
-        limit=limit,
-        offset=from_index - 1,
-        search=q,
-        status=status,
-        priority=priority,
-        assignee_id=assignee_id,
-        department_id=dept,
-        sort_by="-createdTime",
-    )
-    if rows is not None and (rows or (await zoho_desk_db.mirror_count() or 0) > 0):
-        return {"data": rows, "source": "db"}
+    if await zoho_desk_db.mirror_ready():
+        rows = await zoho_desk_db.list_mirror(
+            limit=limit,
+            offset=from_index - 1,
+            search=q,
+            status=status,
+            priority=priority,
+            assignee_id=assignee_id,
+            department_id=dept,
+            sort_by="-createdTime",
+        )
+        if rows is not None:
+            return {"data": rows, "source": "db"}
     try:
         return await zoho.search_tickets(
             query=q,

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -31,6 +31,7 @@ try:
 except ImportError:  # pragma: no cover - direct module import in tests
     import db_supabase
     from dependencies import get_admin_user, require_module
+    from services import zoho_desk_db
     from services import zoho_desk_service as zoho
     from services.zoho_desk_service import ZohoDeskError
     from utils.audit_logger import log_admin_action

--- a/backend/routes/support.py
+++ b/backend/routes/support.py
@@ -22,6 +22,8 @@ try:
     from services.zoho_desk_service import ZohoDeskError
 except ImportError:
     from .dependencies import get_current_user  # type: ignore
+    from .services.zoho_desk_integration import create_support_ticket  # type: ignore
+    from .services.zoho_desk_service import ZohoDeskError  # type: ignore
 
 api_router = APIRouter(tags=["Support Chat"])
 

--- a/backend/services/zoho_desk_db.py
+++ b/backend/services/zoho_desk_db.py
@@ -24,6 +24,42 @@ _TABLE = "zoho_desk_tickets"
 _PAGE = 1000  # Supabase per-request row cap
 
 
+async def mirror_ready() -> bool:
+    """True only after a full backfill has completed — until then reads are
+    served live so a partially-seeded mirror never hides historical tickets or
+    reports wrong totals."""
+    if not db_supabase.supabase:
+        return False
+    try:
+        cfg = await db_supabase.find_one("zoho_desk_config", {"id": "default"})
+        return bool(cfg and cfg.get("mirror_backfilled"))
+    except Exception:
+        return False
+
+
+async def open_closed_counts(department_id: Optional[str]) -> Optional[Tuple[int, int]]:
+    """Exact (total, closed) using `status_type` so custom closed statuses
+    (e.g. 'Resolved') count as closed — not just the literal 'Closed' label."""
+    if not db_supabase.supabase:
+        return None
+
+    def _count(closed: bool):
+        q = db_supabase.supabase.table(_TABLE).select("zoho_id", count="exact").limit(1)
+        if department_id:
+            q = q.eq("department_id", department_id)
+        if closed:
+            q = q.eq("status_type", "Closed")
+        return getattr(q.execute(), "count", 0) or 0
+
+    try:
+        total = await db_supabase.run_sync(lambda: _count(False))
+        closed = await db_supabase.run_sync(lambda: _count(True))
+        return total, closed
+    except Exception as e:
+        logger.warning("Zoho mirror open/closed count failed: %s", e)
+        return None
+
+
 async def mirror_count() -> Optional[int]:
     """Total rows in the mirror, or None if the table is unavailable."""
     if not db_supabase.supabase:

--- a/backend/utils/zoho_desk_sync.py
+++ b/backend/utils/zoho_desk_sync.py
@@ -38,7 +38,7 @@ _CONFIG_TABLE = "zoho_desk_config"
 _CONFIG_ID = "default"
 
 SYNC_INTERVAL_SECONDS = 600  # 10 minutes
-SEED_MAX_PAGES = 10  # first run: pull up to 1000 most-recently-modified tickets
+SEED_MAX_PAGES = 500  # first run: full backfill (safety cap ~50k tickets)
 INCREMENTAL_MAX_PAGES = 50  # safety cap; incremental runs stop at the cursor
 
 
@@ -110,14 +110,17 @@ async def run_sync() -> Dict[str, Any]:
         return {"skipped": "disabled"}
 
     cursor = _parse(cfg.get("sync_cursor"))
+    seeding = cursor is None and not cfg.get("mirror_backfilled")
     newest = cursor
-    max_pages = INCREMENTAL_MAX_PAGES if cursor else SEED_MAX_PAGES
+    max_pages = SEED_MAX_PAGES if seeding else INCREMENTAL_MAX_PAGES
     total = 0
+    reached_end = False
 
     for p in range(max_pages):
         page = await zoho.list_tickets(from_index=p * 100 + 1, limit=100, sort_by="-modifiedTime")
         rows = (page or {}).get("data", [])
         if not rows:
+            reached_end = True
             break
 
         batch: List[Dict[str, Any]] = []
@@ -135,6 +138,7 @@ async def run_sync() -> Dict[str, Any]:
             await _upsert_batch(batch)
             total += len(batch)
         if stop or len(rows) < 100:
+            reached_end = True
             break
 
     updates: Dict[str, Any] = {
@@ -143,9 +147,18 @@ async def run_sync() -> Dict[str, Any]:
     }
     if newest:
         updates["sync_cursor"] = newest.isoformat()
+    # The mirror is only authoritative for reads once a full backfill has paged
+    # to the end. Incremental runs (cursor already set) keep it true.
+    if reached_end and (seeding or cfg.get("mirror_backfilled")):
+        updates["mirror_backfilled"] = True
     await db_supabase.update_one(_CONFIG_TABLE, {"id": _CONFIG_ID}, updates)
-    logger.info("Zoho Desk sync upserted %s tickets (cursor=%s)", total, newest)
-    return {"upserted": total}
+    logger.info(
+        "Zoho Desk sync upserted %s tickets (cursor=%s, backfilled=%s)",
+        total,
+        newest,
+        updates.get("mirror_backfilled", cfg.get("mirror_backfilled")),
+    )
+    return {"upserted": total, "backfilled": bool(updates.get("mirror_backfilled") or cfg.get("mirror_backfilled"))}
 
 
 async def zoho_desk_sync_loop() -> None:


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
