### PR TITLE
feat(support): auto-create + reverse-close for complaints, flags, safety

### DIFF
--- a/backend/migrations/128_support_entities_zoho_ticket.sql
+++ b/backend/migrations/128_support_entities_zoho_ticket.sql
@@ -1,0 +1,26 @@
+-- 128_support_entities_zoho_ticket.sql
+--
+-- Rollback:
+--   ALTER TABLE complaints       DROP COLUMN IF EXISTS zoho_ticket_id;
+--   ALTER TABLE flags            DROP COLUMN IF EXISTS zoho_ticket_id;
+--   ALTER TABLE safety_incidents DROP COLUMN IF EXISTS zoho_ticket_id;
+--
+-- Purpose: link complaints, flags, and safety incidents to the Zoho Desk
+-- ticket auto-created for each (idempotency + reverse-close: when the Zoho
+-- ticket is closed, the sync closes the linked record). lost_and_found (125)
+-- and disputes (126) already have this column.
+--
+-- Additive columns; safe in flight.
+
+ALTER TABLE complaints       ADD COLUMN IF NOT EXISTS zoho_ticket_id TEXT;
+ALTER TABLE flags            ADD COLUMN IF NOT EXISTS zoho_ticket_id TEXT;
+ALTER TABLE safety_incidents ADD COLUMN IF NOT EXISTS zoho_ticket_id TEXT;
+
+-- Reverse-close looks records up by their linked Zoho ticket id.
+CREATE INDEX IF NOT EXISTS idx_complaints_zoho       ON complaints (zoho_ticket_id);
+CREATE INDEX IF NOT EXISTS idx_flags_zoho            ON flags (zoho_ticket_id);
+CREATE INDEX IF NOT EXISTS idx_safety_zoho           ON safety_incidents (zoho_ticket_id);
+CREATE INDEX IF NOT EXISTS idx_lost_and_found_zoho   ON lost_and_found (zoho_ticket_id);
+CREATE INDEX IF NOT EXISTS idx_disputes_zoho         ON disputes (zoho_ticket_id);
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/routes/admin/support.py
+++ b/backend/routes/admin/support.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -10,10 +11,20 @@ from pydantic import BaseModel
 try:
     from ... import db_supabase
     from ...dependencies import get_admin_user
+    from ...services.zoho_desk_integration import (
+        create_ticket_for_complaint,
+        create_ticket_for_dispute,
+        create_ticket_for_flag,
+    )
     from ...utils.audit_logger import log_admin_action
 except ImportError:
     import db_supabase
     from dependencies import get_admin_user  # noqa: F401
+    from services.zoho_desk_integration import (
+        create_ticket_for_complaint,
+        create_ticket_for_dispute,
+        create_ticket_for_flag,
+    )
     from utils.audit_logger import log_admin_action  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -160,6 +171,7 @@ async def admin_create_dispute(dispute: DisputeCreateRequest):
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }
     await db_supabase.insert_one("disputes", doc)
+    asyncio.create_task(create_ticket_for_dispute(doc))
     return {"success": True, "dispute": doc}
 
 
@@ -395,6 +407,7 @@ async def admin_flag_ride_participant(
         "is_active": True,
     }
     result = await db_supabase.create_flag(flag_data)
+    asyncio.create_task(create_ticket_for_flag(result or flag_data, ride))
     await log_admin_action(
         admin,
         "flag_created",
@@ -485,6 +498,8 @@ async def admin_create_complaint(ride_id: str, req: ComplaintRequest):
         "created_by": "admin",
     }
     complaint = await db_supabase.create_complaint(complaint_data)
+    # Raise a Zoho Desk ticket for support — fire-and-forget, no-op if disabled.
+    asyncio.create_task(create_ticket_for_complaint(complaint or complaint_data, ride))
     return complaint
 
 

--- a/backend/routes/safety.py
+++ b/backend/routes/safety.py
@@ -7,6 +7,7 @@ issue (weapon, assault, medical) also broadcasts to on-call admins
 over the admin WebSocket channel.
 """
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -19,9 +20,11 @@ try:
     from .. import db_supabase
     from ..dependencies import get_current_user
     from ..features import notify_safety_team
+    from ..services.zoho_desk_integration import create_ticket_for_safety
 except ImportError:
     import db_supabase
     from dependencies import get_current_user
+    from services.zoho_desk_integration import create_ticket_for_safety
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +93,10 @@ async def submit_safety_report(
         f"[SAFETY] Incident {incident_id} reported by {user_role} {user_id} "
         f"category={body.category} ride_id={incident['ride_id']}"
     )
+
+    # Raise a Zoho Desk ticket (urgent) for the safety team — fire-and-forget,
+    # no-op when the integration is disabled; never blocks the report.
+    asyncio.create_task(create_ticket_for_safety(incident))
 
     # Notify the safety team — WS broadcast to admin dashboard + email
     # to the configured distribution list + CRITICAL log line for

--- a/backend/services/zoho_desk_integration.py
+++ b/backend/services/zoho_desk_integration.py
@@ -39,6 +39,158 @@ def _split_name(name: str) -> tuple[str, Optional[str]]:
     return parts[0], (" ".join(parts[1:]) or None)
 
 
+async def _link_ticket(
+    *,
+    table: str,
+    record: Dict[str, Any],
+    subject: str,
+    description: str,
+    category: Optional[str] = None,
+    priority: Optional[str] = None,
+    contact_user_id: Optional[str] = None,
+) -> None:
+    """Create a Zoho ticket for a source record and link it back via
+    ``<table>.zoho_ticket_id``. Best-effort + idempotent + opt-in. Used by the
+    per-entity helpers below."""
+    try:
+        if record.get("zoho_ticket_id") or not await _enabled():
+            return
+        user: Dict[str, Any] = {}
+        if contact_user_id:
+            user = await db_supabase.find_one("users", {"id": contact_user_id}) or {}
+        name = (user.get("name") or "").strip() or (
+            f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+        )
+        first, last = _split_name(name or "Customer")
+        result = await zoho.create_ticket(
+            subject=subject,
+            description=description,
+            email=user.get("email"),
+            first_name=first,
+            last_name=last,
+            phone=user.get("phone"),
+            priority=priority,
+            channel="Web",
+            category=category,
+        )
+        zoho_id = str(result.get("id") or "")
+        if zoho_id:
+            await db_supabase.update_one(table, {"id": record["id"]}, {"zoho_ticket_id": zoho_id})
+            logger.info("Created Zoho ticket %s for %s %s", zoho_id, table, record.get("id"))
+    except ZohoDeskError as e:
+        logger.warning("Zoho ticket skipped for %s (%s): %s", table, e.status, e.message)
+    except Exception:
+        logger.error("Failed to create Zoho ticket for %s %s", table, record.get("id"), exc_info=True)
+
+
+async def create_ticket_for_complaint(complaint: Dict[str, Any], ride: Optional[Dict[str, Any]] = None) -> None:
+    """Zoho ticket for an admin complaint against a participant."""
+    against = complaint.get("against_type")
+    contact = complaint.get("against_id") if against == "rider" else None
+    ride_code = (ride or {}).get("ride_code") or complaint.get("ride_id") or ""
+    await _link_ticket(
+        table="complaints",
+        record=complaint,
+        subject=f"Complaint — {complaint.get('category') or 'ride'}",
+        description=(
+            "Complaint logged from the Spinr admin panel.\n\n"
+            f"Against: {against}\n"
+            f"Category: {complaint.get('category')}\n"
+            f"Details: {complaint.get('description') or '—'}\n"
+            f"Ride: {ride_code}\n"
+            f"Complaint ID: {complaint.get('id')}"
+        ),
+        category="Complaint",
+        contact_user_id=contact,
+    )
+
+
+async def create_ticket_for_flag(flag: Dict[str, Any], ride: Optional[Dict[str, Any]] = None) -> None:
+    """Zoho ticket for a participant flag."""
+    target = flag.get("target_type")
+    contact = flag.get("target_id") if target == "rider" else None
+    ride_code = (ride or {}).get("ride_code") or flag.get("ride_id") or ""
+    await _link_ticket(
+        table="flags",
+        record=flag,
+        subject=f"Flag — {flag.get('reason') or target or 'participant'}",
+        description=(
+            "Participant flagged from the Spinr admin panel.\n\n"
+            f"Target: {target}\n"
+            f"Reason: {flag.get('reason')}\n"
+            f"Details: {flag.get('description') or '—'}\n"
+            f"Ride: {ride_code}\n"
+            f"Flag ID: {flag.get('id')}"
+        ),
+        category="Flag",
+        contact_user_id=contact,
+    )
+
+
+async def create_ticket_for_safety(incident: Dict[str, Any]) -> None:
+    """Zoho ticket for a safety incident (high priority)."""
+    await _link_ticket(
+        table="safety_incidents",
+        record=incident,
+        subject=f"Safety — {incident.get('category') or 'incident'}",
+        description=(
+            "Safety incident reported from the Spinr app.\n\n"
+            f"Category: {incident.get('category')}\n"
+            f"Reported by: {incident.get('role')}\n"
+            f"Details: {incident.get('description') or '—'}\n"
+            f"Ride: {incident.get('ride_id') or '—'}\n"
+            f"Incident ID: {incident.get('id')}"
+        ),
+        category="Safety",
+        priority="Urgent",
+        contact_user_id=incident.get("reported_by_user_id"),
+    )
+
+
+# Tables whose records auto-close when their linked Zoho ticket is closed.
+# `is_active` entries use the boolean flag; otherwise the status column is set.
+_LINKED_TABLES = [
+    {"table": "lost_and_found", "status_col": "status", "closed": "resolved"},
+    {"table": "disputes", "status_col": "status", "closed": "resolved"},
+    {"table": "complaints", "status_col": "status", "closed": "resolved"},
+    {"table": "safety_incidents", "status_col": "status", "closed": "resolved"},
+    {"table": "flags", "is_active": True},
+]
+
+
+async def close_linked_records(closed_zoho_ids) -> None:
+    """When Zoho tickets close, close the linked Spinr records (reverse sync).
+
+    Called from the mirror sync for incrementally-changed tickets only, so the
+    id set stays small. Idempotent: skips records already closed.
+    """
+    ids = [str(i) for i in (closed_zoho_ids or []) if i]
+    if not ids:
+        return
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    for spec in _LINKED_TABLES:
+        table = spec["table"]
+        try:
+            rows = await db_supabase.get_rows(table, {"zoho_ticket_id": {"$in": ids}})
+            for r in rows or []:
+                if spec.get("is_active"):
+                    if r.get("is_active") is False:
+                        continue
+                    await db_supabase.update_one(table, {"id": r["id"]}, {"is_active": False})
+                else:
+                    col = spec["status_col"]
+                    if r.get(col) == spec["closed"]:
+                        continue
+                    await db_supabase.update_one(
+                        table, {"id": r["id"]}, {col: spec["closed"], "updated_at": now}
+                    )
+                logger.info("Closed %s %s from Zoho ticket %s", table, r.get("id"), r.get("zoho_ticket_id"))
+        except Exception:
+            logger.error("Reverse-close failed for table %s", table, exc_info=True)
+
+
 async def create_ticket_for_lost_and_found(case: Dict[str, Any], ride: Optional[Dict[str, Any]] = None) -> None:
     """Open a Zoho Desk ticket for a Lost & Found case and link it back via
     ``lost_and_found.zoho_ticket_id``. Safe to call fire-and-forget."""

--- a/backend/tests/test_zoho_desk.py
+++ b/backend/tests/test_zoho_desk.py
@@ -375,6 +375,48 @@ async def test_support_escalation(monkeypatch):
     assert created.call_args.kwargs["subject"].startswith("Support — Card declined")
 
 
+@pytest.mark.anyio
+async def test_complaint_and_safety_autocreate(monkeypatch):
+    import services.zoho_desk_integration as integ
+
+    db = MagicMock()
+    db.find_one = AsyncMock(return_value={"id": "default", "enabled": True})
+    db.update_one = AsyncMock()
+    monkeypatch.setattr(integ, "db_supabase", db)
+    created = AsyncMock(return_value={"id": "zt1"})
+    monkeypatch.setattr(integ.zoho, "create_ticket", created)
+
+    await integ.create_ticket_for_safety(
+        {"id": "s1", "category": "assault", "role": "rider", "reported_by_user_id": None}
+    )
+    assert created.call_args.kwargs["category"] == "Safety"
+    assert created.call_args.kwargs["priority"] == "Urgent"
+    db.update_one.assert_awaited()  # linked back to safety_incidents
+
+
+@pytest.mark.anyio
+async def test_reverse_close_links(monkeypatch):
+    import services.zoho_desk_integration as integ
+
+    db = MagicMock()
+    # complaints has one open row linked to a closed ticket; flags one active row
+    async def _get_rows(table, *a, **k):
+        if table == "complaints":
+            return [{"id": "c1", "status": "open", "zoho_ticket_id": "zt1"}]
+        if table == "flags":
+            return [{"id": "f1", "is_active": True, "zoho_ticket_id": "zt1"}]
+        return []
+
+    db.get_rows = AsyncMock(side_effect=_get_rows)
+    db.update_one = AsyncMock()
+    monkeypatch.setattr(integ, "db_supabase", db)
+
+    await integ.close_linked_records(["zt1"])
+    calls = {c.args[0]: c.args[2] for c in db.update_one.call_args_list}
+    assert calls["complaints"]["status"] == "resolved"
+    assert calls["flags"] == {"is_active": False}
+
+
 def test_parse_zoho_time_window():
     # Codex P2: the trends `days` selector must actually filter by created
     # time. The route helper parses Zoho timestamps; unparseable -> None.

--- a/backend/utils/zoho_desk_sync.py
+++ b/backend/utils/zoho_desk_sync.py
@@ -25,10 +25,12 @@ from typing import Any, Dict, List, Optional
 try:
     from .. import db_supabase
     from ..services import zoho_desk_service as zoho
+    from ..services.zoho_desk_integration import close_linked_records
     from ..services.zoho_desk_service import ZohoDeskError
 except ImportError:  # pragma: no cover - allow direct module imports
     import db_supabase
     from services import zoho_desk_service as zoho
+    from services.zoho_desk_integration import close_linked_records
     from services.zoho_desk_service import ZohoDeskError
 
 logger = logging.getLogger(__name__)
@@ -120,6 +122,7 @@ async def run_sync() -> Dict[str, Any]:
     max_pages = SEED_MAX_PAGES if seeding else INCREMENTAL_MAX_PAGES
     total = 0
     reached_end = False
+    closed_ids: List[str] = []
 
     for p in range(max_pages):
         page = await zoho.list_tickets(from_index=p * 100 + 1, limit=100, sort_by="-modifiedTime")
@@ -138,6 +141,8 @@ async def run_sync() -> Dict[str, Any]:
             batch.append(_map_ticket(t))
             if mod and (newest is None or mod > newest):
                 newest = mod
+            if (t.get("statusType") or "").lower() == "closed" or "closed" in (t.get("status") or "").lower():
+                closed_ids.append(str(t.get("id")))
 
         if batch:
             await _upsert_batch(batch)
@@ -145,6 +150,12 @@ async def run_sync() -> Dict[str, Any]:
         if stop or len(rows) < 100:
             reached_end = True
             break
+
+    # Reverse sync: close linked Spinr records (L&F / disputes / complaints /
+    # safety / flags) for tickets that just closed. Skipped during the seed —
+    # we only act on incremental transitions, not the initial backfill.
+    if not seeding and closed_ids:
+        await close_linked_records(closed_ids)
 
     updates: Dict[str, Any] = {
         "last_synced_at": datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
- migration 128: zoho_ticket_id on complaints/flags/safety_incidents (+ indexes)
- create Zoho tickets for: complaints, flags, safety incidents (Urgent) and admin-created disputes — fire-and-forget, idempotent, opt-in (joins existing Lost & Found + rider disputes)
- reverse-close: when a linked Zoho ticket closes, the sync closes the Spinr record (status->resolved, or flags->is_active=false). Runs on incremental ticket transitions only (not the seed); idempotent. +2 tests (18 total)

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:safety -->
## Tier 5 · Safety details

- **Insurance period derivation correct** (derive from ride state, not UI): `[ ]`
- **`driver_insurance_periods` rows append-only** — no update/delete: `[ ]`
- **SOS never auto-dials 911** — only offers one-tap: `[ ]` or N/A
- **Emergency-contact fan-out tested end-to-end**: `[ ]` or N/A
