### PR TITLE
fix(admin): make ride invoice actions legible on gradient header

### DIFF
--- a/admin-dashboard/src/app/dashboard/driver-offers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/driver-offers/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
+} from "@/components/ui/table";
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select";
+import { CheckCircle, XCircle, Clock, RefreshCw, Send } from "lucide-react";
+import { getDriverOfferStats } from "@/lib/api";
+
+const DATE_RANGES = [
+  { value: "today", label: "Today" },
+  { value: "7d", label: "7 Days" },
+  { value: "30d", label: "30 Days" },
+  { value: "90d", label: "90 Days" },
+  { value: "1y", label: "1 Year" },
+];
+
+type SortKey = "offered" | "accepted" | "declined" | "ignored" | "accept_rate" | "ignore_rate";
+
+export default function DriverOffersPage() {
+  const [dateRange, setDateRange] = useState("30d");
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<any>(null);
+  const [sortKey, setSortKey] = useState<SortKey>("offered");
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getDriverOfferStats(dateRange).catch(() => null);
+      setData(res);
+    } finally {
+      setLoading(false);
+    }
+  }, [dateRange]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  const totals = data?.totals || {};
+  const drivers: any[] = Array.isArray(data?.drivers) ? [...data.drivers] : [];
+  drivers.sort((a, b) => (b[sortKey] ?? 0) - (a[sortKey] ?? 0));
+
+  const kpis = [
+    { label: "Offers Sent", value: totals.offered ?? 0, Icon: Send, cls: "text-foreground" },
+    { label: "Accepted", value: totals.accepted ?? 0, Icon: CheckCircle, cls: "text-emerald-600" },
+    { label: "Declined", value: totals.declined ?? 0, Icon: XCircle, cls: "text-red-600" },
+    { label: "Ignored", value: totals.ignored ?? 0, Icon: Clock, cls: "text-amber-600" },
+  ];
+
+  const SortHead = ({ k, children }: { k: SortKey; children: React.ReactNode }) => (
+    <TableHead
+      onClick={() => setSortKey(k)}
+      className={`cursor-pointer select-none text-right ${sortKey === k ? "text-primary font-bold" : ""}`}
+    >
+      {children}{sortKey === k ? " ↓" : ""}
+    </TableHead>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Driver Offer Analytics</h1>
+          <p className="text-sm text-muted-foreground">
+            Dispatch funnel per driver — who accepts, declines, and ignores ride offers.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={dateRange} onValueChange={setDateRange}>
+            <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {DATE_RANGES.map((r) => (
+                <SelectItem key={r.value} value={r.value}>{r.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <button
+            onClick={fetchData}
+            className="flex items-center gap-1.5 text-sm border rounded-lg px-3 py-2 hover:bg-muted transition-colors"
+          >
+            <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} /> Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {kpis.map(({ label, value, Icon, cls }) => (
+          <Card key={label}>
+            <CardContent className="pt-4">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Icon className={`h-4 w-4 ${cls}`} /> {label}
+              </div>
+              <div className={`text-2xl font-bold mt-1 tabular-nums ${cls}`}>{Number(value).toLocaleString()}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Per-Driver Breakdown {data?.total_drivers ? `(${data.total_drivers})` : ""}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="py-16 text-center text-sm text-muted-foreground">Loading…</div>
+          ) : drivers.length === 0 ? (
+            <div className="py-16 text-center text-sm text-muted-foreground">No offers in this window.</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Driver</TableHead>
+                  <SortHead k="offered">Offered</SortHead>
+                  <SortHead k="accepted">Accepted</SortHead>
+                  <SortHead k="declined">Declined</SortHead>
+                  <SortHead k="ignored">Ignored</SortHead>
+                  <SortHead k="accept_rate">Accept %</SortHead>
+                  <SortHead k="ignore_rate">Ignore %</SortHead>
+                  <TableHead className="text-right">Avg Reply</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {drivers.map((d) => (
+                  <TableRow key={d.driver_id}>
+                    <TableCell className="font-medium">
+                      <span className="flex items-center gap-2">
+                        {d.is_online && <span className="h-2 w-2 rounded-full bg-emerald-500" title="Online" />}
+                        {d.name}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{d.offered}</TableCell>
+                    <TableCell className="text-right tabular-nums text-emerald-600">{d.accepted}</TableCell>
+                    <TableCell className="text-right tabular-nums text-red-600">{d.declined}</TableCell>
+                    <TableCell className="text-right tabular-nums text-amber-600">{d.ignored}</TableCell>
+                    <TableCell className="text-right tabular-nums font-semibold">{d.accept_rate}%</TableCell>
+                    <TableCell className="text-right tabular-nums">{d.ignore_rate}%</TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {d.avg_response_seconds != null ? `${d.avg_response_seconds}s` : "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -744,7 +744,7 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                 {/* Offer Funnel — who was offered this ride and what they did */}
                                 {Array.isArray(ride.offers) && ride.offers.length > 0 && (
                                     <Card>
-                                        <CardHead title="Dispatch Offers" icon={Radio} />
+                                        <CardHead title={`Dispatch Offers · ${ride.offers.length} driver${ride.offers.length > 1 ? "s" : ""}`} icon={Radio} />
                                         <div className="p-4 space-y-2">
                                             {(() => {
                                                 const OFFER_META: Record<string, { label: string; cls: string; Icon: React.ElementType }> = {
@@ -772,7 +772,7 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                                     </span>
                                                                 ) : null
                                                             )}
-                                                            <span className="text-[11px] text-muted-foreground px-2 py-0.5">{ride.offers.length} offer{ride.offers.length > 1 ? "s" : ""} total</span>
+                                                            <span className="text-[11px] font-semibold text-foreground px-2 py-0.5 ml-auto">Offered to {ride.offers.length} driver{ride.offers.length > 1 ? "s" : ""}</span>
                                                         </div>
                                                         {ride.offers.map((o: any, i: number) => {
                                                             const meta = OFFER_META[o.status] || OFFER_META.pending;

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -421,57 +421,114 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                                     <Card>
                                         <CardHead title="Fare Breakdown" icon={Receipt} />
-                                        <div className="p-4 space-y-1">
-                                            <FR l="Base fare" v={ride.base_fare} />
-                                            <FR l={`Distance (${(ride.distance_km || 0).toFixed(1)} km)`} v={ride.distance_fare} />
-                                            <FR l={`Time (${ride.duration_minutes || 0} min)`} v={ride.time_fare} />
-                                            <FR l="Booking fee" v={ride.booking_fee} />
-                                            {(ride.airport_fee || 0) > 0 && <FR l="Airport fee" v={ride.airport_fee} />}
-                                            <div className="border-t my-2" />
-                                            <FR l="Subtotal" v={ride.total_fare} b />
-                                            {(parseFloat(String(ride.tip_amount ?? 0)) > 0 || ride.promo_code) && (
-                                                <>
+                                        {(() => {
+                                            const n = (v: any) => parseFloat(String(v ?? 0)) || 0;
+                                            const areaFees = Array.isArray(ride.area_fees_breakdown) ? ride.area_fees_breakdown : [];
+                                            const hasAreaFees = areaFees.some((f: any) => n(f.calculated_value) > 0);
+                                            // tax_breakdown: { "GST": {rate, amount}, "PST": {rate, amount} }
+                                            const taxEntries: [string, number, number | null][] = ride.tax_breakdown && typeof ride.tax_breakdown === "object"
+                                                ? Object.entries(ride.tax_breakdown).map(([k, t]: any) => [
+                                                    k,
+                                                    n(t?.amount ?? t),
+                                                    (t && typeof t === "object" && t.rate != null) ? Number(t.rate) : null,
+                                                ])
+                                                : [];
+                                            const taxTotal = ride.tax_amount != null ? n(ride.tax_amount) : taxEntries.reduce((s, [, a]) => s + a, 0);
+                                            const discount = n(ride.discount_amount);
+                                            const tip = n(ride.tip_amount);
+                                            const grand = ride.grand_total != null
+                                                ? n(ride.grand_total)
+                                                : n(ride.total_fare) + n(ride.area_fees_total) + taxTotal - discount;
+                                            return (
+                                                <div className="p-4 space-y-1">
+                                                    <FR l="Base fare" v={ride.base_fare} />
+                                                    <FR l={`Distance (${(ride.distance_km || 0).toFixed(1)} km)`} v={ride.distance_fare} />
+                                                    <FR l={`Time (${ride.duration_minutes || 0} min)`} v={ride.time_fare} />
+                                                    {(ride.surge_multiplier || 1) > 1 && (
+                                                        <p className="text-[11px] text-amber-600 dark:text-amber-400">Includes {ride.surge_multiplier}× surge</p>
+                                                    )}
+                                                    <FR l="Booking fee" v={ride.booking_fee} />
+                                                    {!hasAreaFees && n(ride.airport_fee) > 0 && <FR l="Airport fee" v={ride.airport_fee} />}
+                                                    {hasAreaFees && areaFees.map((f: any, i: number) => (
+                                                        n(f.calculated_value) > 0 ? <FR key={i} l={f.name || "Area fee"} v={n(f.calculated_value)} /> : null
+                                                    ))}
                                                     <div className="border-t my-2" />
-                                                    {ride.promo_code && (
+                                                    <FR l="Subtotal" v={ride.subtotal_fare ?? ride.total_fare} b />
+                                                    {discount > 0 && (
                                                         <div className="flex justify-between items-center">
-                                                            <span className="flex items-center gap-2 text-sm"><Ticket className="h-4 w-4 text-violet-500" />Promo: <b className="font-mono text-xs bg-violet-50 dark:bg-violet-900/20 px-1.5 py-0.5 rounded">{ride.promo_code}</b></span>
-                                                            <span className="text-sm font-semibold text-emerald-600">-{formatCurrency(ride.promo_discount || 0)}</span>
+                                                            <span className="flex items-center gap-2 text-sm"><Ticket className="h-4 w-4 text-violet-500" />Promo{ride.promo_code ? <b className="font-mono text-xs bg-violet-50 dark:bg-violet-900/20 px-1.5 py-0.5 rounded">{ride.promo_code}</b> : null}</span>
+                                                            <span className="text-sm font-semibold text-emerald-600">-{formatCurrency(discount)}</span>
                                                         </div>
                                                     )}
-                                                    {parseFloat(String(ride.tip_amount ?? 0)) > 0 && (
+                                                    {taxEntries.length > 0
+                                                        ? taxEntries.map(([name, amt, rate]) => (
+                                                            <FR key={name} l={`${name}${rate != null ? ` (${rate}%)` : ""}`} v={amt} />
+                                                        ))
+                                                        : taxTotal > 0 && <FR l="Tax" v={taxTotal} />}
+                                                    {tip > 0 && (
                                                         <div className="flex justify-between items-center">
                                                             <span className="flex items-center gap-2 text-sm"><DollarSign className="h-4 w-4 text-amber-500" />Tip</span>
-                                                            <span className="text-sm font-semibold text-amber-600">{formatCurrency(ride.tip_amount)}</span>
+                                                            <span className="text-sm font-semibold text-amber-600">{formatCurrency(tip)}</span>
                                                         </div>
                                                     )}
-                                                </>
-                                            )}
-                                        </div>
+                                                    <div className="border-t my-2" />
+                                                    <FR l="Grand total" v={grand} b />
+                                                    {tip > 0 && <FR l="Total charged (incl. tip)" v={grand + tip} b />}
+                                                </div>
+                                            );
+                                        })()}
                                     </Card>
 
                                     <Card>
-                                        <CardHead title="Revenue Split" icon={TrendingUp} />
-                                        <div className="p-4">
-                                            <div className="grid grid-cols-3 gap-2.5 mb-4">
-                                                <div className="bg-emerald-50 dark:bg-emerald-900/20 rounded-xl p-3.5 text-center">
-                                                    <p className="text-lg font-extrabold text-emerald-600 dark:text-emerald-400">{formatCurrency(ride.driver_earnings || 0)}</p>
-                                                    <p className="text-[11px] text-muted-foreground mt-1 font-medium">Driver</p>
+                                        <CardHead title="Driver & Platform Earnings" icon={TrendingUp} />
+                                        {(() => {
+                                            const n = (v: any) => parseFloat(String(v ?? 0)) || 0;
+                                            // 0% commission: driver keeps 100% of the ride fare components.
+                                            const rideFare = n(ride.base_fare) + n(ride.distance_fare) + n(ride.time_fare);
+                                            const tip = n(ride.tip_amount);
+                                            const incentives = n(ride.incentive_total);
+                                            const claims = Array.isArray(ride.incentive_claims) ? ride.incentive_claims : [];
+                                            const driverTotal = rideFare + tip + incentives;
+                                            const platformFees = n(ride.admin_earnings); // booking + airport
+                                            const discount = n(ride.discount_amount);
+                                            // Platform funds incentives + absorbs promo discount (0% commission model).
+                                            const platformNet = platformFees - incentives - discount;
+                                            return (
+                                                <div className="p-4">
+                                                    <div className="grid grid-cols-3 gap-2.5 mb-4">
+                                                        <div className="bg-emerald-50 dark:bg-emerald-900/20 rounded-xl p-3.5 text-center">
+                                                            <p className="text-lg font-extrabold text-emerald-600 dark:text-emerald-400">{formatCurrency(driverTotal)}</p>
+                                                            <p className="text-[11px] text-muted-foreground mt-1 font-medium">Driver receives</p>
+                                                        </div>
+                                                        <div className="bg-violet-50 dark:bg-violet-900/20 rounded-xl p-3.5 text-center">
+                                                            <p className="text-lg font-extrabold text-violet-600 dark:text-violet-400">{formatCurrency(platformNet)}</p>
+                                                            <p className="text-[11px] text-muted-foreground mt-1 font-medium">Platform net</p>
+                                                        </div>
+                                                        <div className="bg-amber-50 dark:bg-amber-900/20 rounded-xl p-3.5 text-center">
+                                                            <p className="text-lg font-extrabold text-amber-600 dark:text-amber-400">{formatCurrency(incentives)}</p>
+                                                            <p className="text-[11px] text-muted-foreground mt-1 font-medium">Incentives</p>
+                                                        </div>
+                                                    </div>
+                                                    <div className="border-t pt-3 space-y-1.5">
+                                                        <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-600 dark:text-emerald-400">Driver</p>
+                                                        <FR l="Ride fare (100%)" v={rideFare} />
+                                                        {tip > 0 && <FR l="Tip" v={tip} />}
+                                                        {claims.length > 0
+                                                            ? claims.map((c: any, i: number) => (
+                                                                <FR key={i} l={`Incentive — ${c.name || "Bonus"}`} v={n(c.bonus_amount)} />
+                                                            ))
+                                                            : incentives > 0 && <FR l="Incentives" v={incentives} />}
+                                                        <FR l="Driver total" v={driverTotal} b />
+                                                        <div className="border-t my-2" />
+                                                        <p className="text-[10px] font-bold uppercase tracking-wider text-violet-600 dark:text-violet-400">Platform</p>
+                                                        <FR l="Booking + airport fees" v={platformFees} />
+                                                        {incentives > 0 && <FR l="Less incentives funded" v={-incentives} />}
+                                                        {discount > 0 && <FR l="Less promo absorbed" v={-discount} />}
+                                                        <FR l="Platform net" v={platformNet} b />
+                                                    </div>
                                                 </div>
-                                                <div className="bg-violet-50 dark:bg-violet-900/20 rounded-xl p-3.5 text-center">
-                                                    <p className="text-lg font-extrabold text-violet-600 dark:text-violet-400">{formatCurrency(ride.admin_earnings || 0)}</p>
-                                                    <p className="text-[11px] text-muted-foreground mt-1 font-medium">Platform</p>
-                                                </div>
-                                                <div className="bg-amber-50 dark:bg-amber-900/20 rounded-xl p-3.5 text-center">
-                                                    <p className="text-lg font-extrabold text-amber-600 dark:text-amber-400">{formatCurrency(ride.tip_amount || 0)}</p>
-                                                    <p className="text-[11px] text-muted-foreground mt-1 font-medium">Tip</p>
-                                                </div>
-                                            </div>
-                                            <div className="border-t pt-3 space-y-1.5">
-                                                <FR l="Rider paid" v={parseFloat(String(ride.total_fare ?? 0)) + parseFloat(String(ride.tip_amount ?? 0)) - parseFloat(String(ride.promo_discount ?? 0))} b />
-                                                <FR l="Driver gets" v={parseFloat(String(ride.driver_earnings ?? 0)) + parseFloat(String(ride.tip_amount ?? 0))} />
-                                                <FR l="Platform gets" v={ride.admin_earnings ?? 0} />
-                                            </div>
-                                        </div>
+                                            );
+                                        })()}
                                     </Card>
                                 </div>
 

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -778,22 +778,30 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                             const meta = OFFER_META[o.status] || OFFER_META.pending;
                                                             const rs = respSecs(o);
                                                             return (
-                                                                <div key={`${o.driver_id}-${i}`} className="flex items-center gap-2.5 bg-muted/40 rounded-lg p-2.5">
-                                                                    <meta.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                                                                    <span className="text-xs font-semibold truncate flex-1">{o.driver_name || o.driver_id?.slice(0, 12)}</span>
-                                                                    {o.driver_rating != null && (
-                                                                        <span className="flex items-center gap-0.5 text-[11px] text-muted-foreground">
-                                                                            <Star className="h-3 w-3 text-amber-400 fill-amber-400" />{Number(o.driver_rating).toFixed(1)}
-                                                                        </span>
-                                                                    )}
-                                                                    {typeof o.eta_seconds === "number" && (
-                                                                        <span className="text-[11px] text-muted-foreground tabular-nums">{Math.round(o.eta_seconds)}s ETA</span>
-                                                                    )}
-                                                                    {rs != null && (
-                                                                        <span className="text-[11px] text-muted-foreground tabular-nums">replied {rs < 60 ? `${Math.round(rs)}s` : `${Math.round(rs / 60)}m`}</span>
-                                                                    )}
-                                                                    <span className="text-[10px] text-muted-foreground tabular-nums">{fmtTime(o.offered_at)}</span>
-                                                                    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${meta.cls}`}>{meta.label}</span>
+                                                                <div key={`${o.driver_id}-${i}`} className="bg-muted/40 rounded-lg p-2.5">
+                                                                    <div className="flex items-center gap-2.5">
+                                                                        <meta.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                                                                        <span className="text-xs font-semibold truncate flex-1">{o.driver_name || o.driver_id?.slice(0, 12)}</span>
+                                                                        {o.driver_rating != null && (
+                                                                            <span className="flex items-center gap-0.5 text-[11px] text-muted-foreground">
+                                                                                <Star className="h-3 w-3 text-amber-400 fill-amber-400" />{Number(o.driver_rating).toFixed(1)}
+                                                                            </span>
+                                                                        )}
+                                                                        {typeof o.eta_seconds === "number" && (
+                                                                            <span className="text-[11px] text-muted-foreground tabular-nums">{Math.round(o.eta_seconds)}s ETA</span>
+                                                                        )}
+                                                                        <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${meta.cls}`}>{meta.label}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center flex-wrap gap-x-3 gap-y-0.5 mt-1 pl-6 text-[10px] text-muted-foreground tabular-nums">
+                                                                        <span>Offered {fmtTime(o.offered_at)}</span>
+                                                                        {o.responded_at && (
+                                                                            <span>
+                                                                                {o.status === "accepted" ? "Accepted" : o.status === "declined" ? "Declined" : "Closed"} {fmtTime(o.responded_at)}
+                                                                                {rs != null && ` (${rs < 60 ? `${Math.round(rs)}s` : `${Math.round(rs / 60)}m`})`}
+                                                                            </span>
+                                                                        )}
+                                                                        {!o.responded_at && o.status === "expired" && <span>Timed out (no response)</span>}
+                                                                    </div>
                                                                 </div>
                                                             );
                                                         })}

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -185,15 +185,14 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                         </div>
                                     </div>
 
-                                    <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end">
-                                        {isRideLive(ride.status) && (
+                                    {isRideLive(ride.status) && (
+                                        <div className="flex items-center gap-2 shrink-0 flex-wrap justify-end mr-8">
                                             <a href={`/dashboard/rides/live/${ride.id}`}
                                                 className="flex items-center gap-1.5 text-xs font-semibold bg-white/20 hover:bg-white/30 text-white px-3 py-1.5 rounded-lg transition-colors backdrop-blur-sm">
                                                 <Radio className="h-3 w-3 animate-pulse" /> Live Track
                                             </a>
-                                        )}
-                                        <RideInvoice rideId={ride.id} status={ride.status} />
-                                    </div>
+                                        </div>
+                                    )}
                                 </div>
 
                                 {/* UUID footer */}
@@ -495,6 +494,14 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                 {(ride.payment_status || "pending").replace(/_/g, " ").toUpperCase()}
                                             </span>
                                         </div>
+                                        {ride.status === "completed" && (
+                                            <div className="px-4 pb-4 -mt-1">
+                                                <div className="flex items-center justify-between gap-2 pt-3 border-t">
+                                                    <span className="text-[11px] font-medium text-muted-foreground">Receipt</span>
+                                                    <RideInvoice rideId={ride.id} status={ride.status} />
+                                                </div>
+                                            </div>
+                                        )}
                                     </Card>
 
                                     <Card>

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -562,7 +562,7 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                     const cards: { key: CardKey; label: string; km: string; sub: string | null; colorCls: string; }[] = [
                                                         { key: "pickup",  label: "Pickup",       km: fmtKm(ride.phase_distances?.navigating_to_pickup), sub: fmtDur(ride.phase_durations?.navigating_to_pickup), colorCls: PHASE_COLORS.navigating_to_pickup },
                                                         { key: "actual",  label: "Actual Trip",  km: fmtKm(ride.phase_distances?.trip_in_progress ?? ride.actual_distance_km), sub: fmtDur(ride.phase_durations?.trip_in_progress), colorCls: PHASE_COLORS.trip_in_progress },
-                                                        { key: "planned", label: "Planned Trip", km: fmtKm(ride.planned_distance_km), sub: "Straight-line reference", colorCls: "bg-muted/60 text-foreground" },
+                                                        { key: "planned", label: "Planned Trip", km: fmtKm(ride.planned_distance_km), sub: (Array.isArray(ride.planned_route_polyline) && ride.planned_route_polyline.length > 1) ? "Planned route" : "Straight-line reference", colorCls: "bg-muted/60 text-foreground" },
                                                     ];
                                                     return cards.map(c => (
                                                         <button key={c.key} type="button" onClick={() => setSelectedPhase(c.key)}
@@ -585,15 +585,39 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                 ? pp.trip_in_progress.map((p: any) => ({ lat: p[0], lng: p[1], timestamp: p[2] })) : [];
 
                                             let pickupProp: typeof pickupPts | undefined;
+                                            let pickupApprox = false;
                                             let tripProp: typeof tripPts | undefined;
                                             let trailForMap: typeof tripPts | undefined;
+                                            let plannedProp: { lat: number; lng: number }[] | undefined;
                                             let label = "";
                                             let emptyHint: string | null = null;
 
                                             if (selectedPhase === "pickup") {
-                                                label = "Driver → Pickup (actual GPS)";
-                                                if (pickupPts.length > 1) pickupProp = pickupPts;
-                                                else emptyHint = "No Phase 2 GPS trail for this ride";
+                                                // Prefer the OSRM road-matched pickup leg, then raw Phase 2
+                                                // GPS, then a driver-start → pickup reference line so the
+                                                // card always shows the approach.
+                                                const pickupRoad = Array.isArray(ride.road_polyline_pickup) && ride.road_polyline_pickup.length > 1
+                                                    ? ride.road_polyline_pickup.map((p: any) => ({ lat: p[0], lng: p[1] })) : [];
+                                                if (pickupRoad.length > 1) {
+                                                    label = "Driver → Pickup (road-matched)";
+                                                    pickupProp = pickupRoad;
+                                                } else if (pickupPts.length > 1) {
+                                                    label = "Driver → Pickup (actual GPS)";
+                                                    pickupProp = pickupPts;
+                                                } else {
+                                                    // No GPS captured for the approach — draw a dashed
+                                                    // reference from the driver's start to the pickup.
+                                                    const dLat = ride.driver_initial_lat ?? ride.driver_lat;
+                                                    const dLng = ride.driver_initial_lng ?? ride.driver_lng;
+                                                    if (dLat != null && dLng != null && ride.pickup_lat != null && ride.pickup_lng != null) {
+                                                        label = "Driver → Pickup (approx — no GPS captured)";
+                                                        pickupProp = [{ lat: dLat, lng: dLng }, { lat: ride.pickup_lat, lng: ride.pickup_lng }];
+                                                        pickupApprox = true;
+                                                    } else {
+                                                        label = "Driver → Pickup";
+                                                        emptyHint = "No Phase 2 GPS trail for this ride";
+                                                    }
+                                                }
                                             } else if (selectedPhase === "actual") {
                                                 // Prefer the OSRM road-matched line (ride_routes.road_polyline) —
                                                 // the clean on-road route SGI / dispute review should see — then
@@ -614,7 +638,17 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                     else emptyHint = "No trip GPS trail for this ride";
                                                 }
                                             } else {
-                                                label = "Planned Trip (straight-line reference)";
+                                                // Planned route: the road-following polyline captured from
+                                                // the Directions API at booking. Falls back to the dashed
+                                                // straight line (drawn by the map) when none was stored.
+                                                const plannedPts = Array.isArray(ride.planned_route_polyline) && ride.planned_route_polyline.length > 1
+                                                    ? ride.planned_route_polyline.map((p: any) => ({ lat: p[0], lng: p[1] })) : [];
+                                                if (plannedPts.length > 1) {
+                                                    label = "Planned Trip (road-following)";
+                                                    plannedProp = plannedPts;
+                                                } else {
+                                                    label = "Planned Trip (straight-line reference)";
+                                                }
                                             }
 
                                             return (
@@ -631,7 +665,9 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                                             dropoffLat={ride.dropoff_lat}
                                                             dropoffLng={ride.dropoff_lng}
                                                             pickupTrail={pickupProp}
+                                                            pickupApprox={pickupApprox}
                                                             tripTrail={tripProp}
+                                                            plannedTrail={plannedProp}
                                                             locationTrail={trailForMap}
                                                         />
                                                     </div>

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -677,6 +677,69 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                     </div>
                                 </Card>
 
+                                {/* Offer Funnel — who was offered this ride and what they did */}
+                                {Array.isArray(ride.offers) && ride.offers.length > 0 && (
+                                    <Card>
+                                        <CardHead title="Dispatch Offers" icon={Radio} />
+                                        <div className="p-4 space-y-2">
+                                            {(() => {
+                                                const OFFER_META: Record<string, { label: string; cls: string; Icon: React.ElementType }> = {
+                                                    accepted: { label: "Accepted", cls: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400", Icon: CheckCircle2 },
+                                                    declined: { label: "Declined", cls: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400", Icon: XCircle },
+                                                    expired:  { label: "Ignored",  cls: "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400", Icon: Clock },
+                                                    pending:  { label: "Pending",  cls: "bg-muted text-muted-foreground", Icon: Radio },
+                                                };
+                                                const respSecs = (o: any) => {
+                                                    if (!o.offered_at || !o.responded_at) return null;
+                                                    const d = (new Date(o.responded_at).getTime() - new Date(o.offered_at).getTime()) / 1000;
+                                                    return Number.isFinite(d) && d >= 0 ? d : null;
+                                                };
+                                                const counts = ride.offers.reduce((acc: Record<string, number>, o: any) => {
+                                                    const k = o.status === "expired" ? "ignored" : (o.status || "pending");
+                                                    acc[k] = (acc[k] || 0) + 1; return acc;
+                                                }, {});
+                                                return (
+                                                    <>
+                                                        <div className="flex flex-wrap gap-2 mb-1">
+                                                            {[["accepted", "Accepted"], ["declined", "Declined"], ["ignored", "Ignored"], ["pending", "Pending"]].map(([k, lbl]) =>
+                                                                counts[k] ? (
+                                                                    <span key={k} className="text-[11px] font-semibold px-2 py-0.5 rounded-md bg-muted/60">
+                                                                        {lbl}: {counts[k]}
+                                                                    </span>
+                                                                ) : null
+                                                            )}
+                                                            <span className="text-[11px] text-muted-foreground px-2 py-0.5">{ride.offers.length} offer{ride.offers.length > 1 ? "s" : ""} total</span>
+                                                        </div>
+                                                        {ride.offers.map((o: any, i: number) => {
+                                                            const meta = OFFER_META[o.status] || OFFER_META.pending;
+                                                            const rs = respSecs(o);
+                                                            return (
+                                                                <div key={`${o.driver_id}-${i}`} className="flex items-center gap-2.5 bg-muted/40 rounded-lg p-2.5">
+                                                                    <meta.Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                                                                    <span className="text-xs font-semibold truncate flex-1">{o.driver_name || o.driver_id?.slice(0, 12)}</span>
+                                                                    {o.driver_rating != null && (
+                                                                        <span className="flex items-center gap-0.5 text-[11px] text-muted-foreground">
+                                                                            <Star className="h-3 w-3 text-amber-400 fill-amber-400" />{Number(o.driver_rating).toFixed(1)}
+                                                                        </span>
+                                                                    )}
+                                                                    {typeof o.eta_seconds === "number" && (
+                                                                        <span className="text-[11px] text-muted-foreground tabular-nums">{Math.round(o.eta_seconds)}s ETA</span>
+                                                                    )}
+                                                                    {rs != null && (
+                                                                        <span className="text-[11px] text-muted-foreground tabular-nums">replied {rs < 60 ? `${Math.round(rs)}s` : `${Math.round(rs / 60)}m`}</span>
+                                                                    )}
+                                                                    <span className="text-[10px] text-muted-foreground tabular-nums">{fmtTime(o.offered_at)}</span>
+                                                                    <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded ${meta.cls}`}>{meta.label}</span>
+                                                                </div>
+                                                            );
+                                                        })}
+                                                    </>
+                                                );
+                                            })()}
+                                        </div>
+                                    </Card>
+                                )}
+
                                 {/* Lost & Found */}
                                 <Card>
                                     <div className="p-4">

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
@@ -373,14 +373,14 @@ export default function RideInvoice({ rideId, status }: Props) {
 
     return (
         <div className="flex items-center gap-2">
-            {/* Rendered on the colored gradient hero — use solid/translucent
-             *  white pills so the actions stay legible on any status color. */}
+            {/* Rendered inside the Payment card (light surface) — filled primary
+             *  for the main action, outline for the secondary download. */}
             <button onClick={handleSend} disabled={sending}
-                className="flex items-center gap-1.5 text-xs font-semibold bg-white/20 hover:bg-white/30 text-white px-3 py-1.5 rounded-lg transition-colors backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed">
+                className="flex items-center gap-1.5 text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 px-3 py-1.5 rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                 <Send className="h-3.5 w-3.5" /> {sending ? "Sending..." : "Send Invoice"}
             </button>
             <button onClick={handleDownload} disabled={downloading}
-                className="flex items-center gap-1.5 text-xs font-semibold bg-white text-emerald-700 hover:bg-white/90 px-3 py-1.5 rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                className="flex items-center gap-1.5 text-xs font-semibold border border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-400 dark:hover:bg-emerald-900/20 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                 <Download className="h-3.5 w-3.5" /> {downloading ? "Generating..." : "Download PDF"}
             </button>
         </div>

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
@@ -372,13 +372,15 @@ export default function RideInvoice({ rideId, status }: Props) {
     };
 
     return (
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
+            {/* Rendered on the colored gradient hero — use solid/translucent
+             *  white pills so the actions stay legible on any status color. */}
             <button onClick={handleSend} disabled={sending}
-                className="flex items-center gap-1 text-xs font-semibold text-primary hover:bg-primary/10 px-2.5 py-1.5 rounded-lg disabled:opacity-50">
+                className="flex items-center gap-1.5 text-xs font-semibold bg-white/20 hover:bg-white/30 text-white px-3 py-1.5 rounded-lg transition-colors backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed">
                 <Send className="h-3.5 w-3.5" /> {sending ? "Sending..." : "Send Invoice"}
             </button>
             <button onClick={handleDownload} disabled={downloading}
-                className="flex items-center gap-1 text-xs font-semibold text-emerald-600 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 px-2.5 py-1.5 rounded-lg disabled:opacity-50">
+                className="flex items-center gap-1.5 text-xs font-semibold bg-white text-emerald-700 hover:bg-white/90 px-3 py-1.5 rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
                 <Download className="h-3.5 w-3.5" /> {downloading ? "Generating..." : "Download PDF"}
             </button>
         </div>

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-route-map.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-route-map.tsx
@@ -21,9 +21,17 @@ interface Props {
     /** Phase 2 (driver → pickup) GPS breadcrumbs. Rendered as a
      *  distinct amber road-following line. */
     pickupTrail?: { lat: number; lng: number; timestamp?: string }[];
+    /** When true the pickupTrail is an *approximation* (no GPS was
+     *  captured, e.g. a driver-start → pickup reference) — drawn dashed
+     *  and lighter so it can't be mistaken for an actual GPS trace. */
+    pickupApprox?: boolean;
     /** Phase 3 (pickup → dropoff) GPS breadcrumbs. Rendered as a
      *  distinct blue road-following line. */
     tripTrail?: { lat: number; lng: number; timestamp?: string }[];
+    /** Road-following planned route (rides.planned_route_polyline, from the
+     *  Directions API at booking). When present it replaces the dashed
+     *  straight-line reference with the real road geometry. */
+    plannedTrail?: { lat: number; lng: number }[];
 }
 
 const PLANNED_SOURCE_ID = "ride-planned-src";
@@ -42,7 +50,9 @@ export default function RideRouteMap({
     dropoffLng,
     locationTrail,
     pickupTrail,
+    pickupApprox,
     tripTrail,
+    plannedTrail,
 }: Props) {
     const containerRef = useRef<HTMLDivElement>(null);
     const mapRef = useRef<maplibregl.Map | null>(null);
@@ -52,7 +62,8 @@ export default function RideRouteMap({
 
         const hasPickupTrail = !!pickupTrail && pickupTrail.length > 1;
         const hasTripTrail = !!tripTrail && tripTrail.length > 1;
-        const hasPhaseTrails = hasPickupTrail || hasTripTrail;
+        const hasPlannedTrail = !!plannedTrail && plannedTrail.length > 1;
+        const hasPhaseTrails = hasPickupTrail || hasTripTrail || hasPlannedTrail;
 
         const map = new maplibregl.Map({
             container: containerRef.current,
@@ -82,10 +93,39 @@ export default function RideRouteMap({
                 .setPopup(new maplibregl.Popup({ closeButton: false, offset: 6 }).setText("Dropoff"))
                 .addTo(map);
 
+            // Road-following planned route (planned_route_polyline). Drawn
+            // as a gray dashed line — the "planned" reference, but real road
+            // geometry from the Directions API rather than a straight line.
+            if (hasPlannedTrail) {
+                map.addSource(PLANNED_SOURCE_ID, {
+                    type: "geojson",
+                    data: {
+                        type: "Feature",
+                        properties: {},
+                        geometry: {
+                            type: "LineString",
+                            coordinates: plannedTrail!.map((p) => [p.lng, p.lat]),
+                        },
+                    },
+                });
+                map.addLayer({
+                    id: PLANNED_LAYER_ID,
+                    type: "line",
+                    source: PLANNED_SOURCE_ID,
+                    layout: { "line-cap": "round", "line-join": "round" },
+                    paint: {
+                        "line-color": "#6b7280",
+                        "line-width": 3,
+                        "line-opacity": 0.7,
+                        "line-dasharray": ["literal", [2, 1.5]],
+                    },
+                });
+            }
+
             // Only draw the straight-line reference when we have no
-            // phase-specific GPS trail to render instead. When phase
-            // polylines are available the real road-following paths
-            // carry the visual; the dashed line would just be noise.
+            // phase-specific GPS trail (or planned route) to render instead.
+            // When real geometry is available it carries the visual; the
+            // dashed straight line would just be noise.
             if (!hasPhaseTrails) {
                 map.addSource(PLANNED_SOURCE_ID, {
                     type: "geojson",
@@ -133,7 +173,10 @@ export default function RideRouteMap({
                     paint: {
                         "line-color": "#f59e0b",
                         "line-width": 3,
-                        "line-opacity": 0.85,
+                        "line-opacity": pickupApprox ? 0.5 : 0.85,
+                        // Approximate (no GPS) → dashed so it reads as a
+                        // reference, not a recorded trace.
+                        ...(pickupApprox ? { "line-dasharray": ["literal", [2, 2]] } : {}),
                     },
                 });
             }
@@ -198,6 +241,7 @@ export default function RideRouteMap({
                 { lat: dropoffLat, lng: dropoffLng },
                 ...(pickupTrail ?? []).map((p) => ({ lat: p.lat, lng: p.lng })),
                 ...(tripTrail ?? []).map((p) => ({ lat: p.lat, lng: p.lng })),
+                ...(plannedTrail ?? []).map((p) => ({ lat: p.lat, lng: p.lng })),
                 ...(!hasPhaseTrails ? (locationTrail ?? []).map((p) => ({ lat: p.lat, lng: p.lng })) : []),
             ];
             fitBoundsToPoints(map, allPoints, 40);
@@ -207,7 +251,7 @@ export default function RideRouteMap({
             map.remove();
             mapRef.current = null;
         };
-    }, [pickupLat, pickupLng, dropoffLat, dropoffLng, locationTrail, pickupTrail, tripTrail]);
+    }, [pickupLat, pickupLng, dropoffLat, dropoffLng, locationTrail, pickupTrail, pickupApprox, tripTrail, plannedTrail]);
 
     return <div ref={containerRef} className="w-full h-[280px] rounded-xl overflow-hidden" />;
 }

--- a/admin-dashboard/src/components/sidebar.tsx
+++ b/admin-dashboard/src/components/sidebar.tsx
@@ -8,7 +8,7 @@ import {
     Flame, Building2, LifeBuoy, HelpCircle,
     LogOut, Menu, X, ChevronLeft, ChevronRight,
     Sun, Moon, Shield, ShieldAlert, Cloud, Trophy, TrendingUp, Activity,
-    Inbox, Clock, Headphones, BarChart3,
+    Inbox, Clock, Headphones, BarChart3, Send,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState, useEffect } from "react";
@@ -58,6 +58,7 @@ const NAV_GROUPS: NavGroup[] = [
             { href: "/dashboard/users", label: "Users", icon: Users, module: "users" },
             { href: "/dashboard/heatmap", label: "Heat Map", icon: Flame, module: "heatmap" },
             { href: "/dashboard/analytics", label: "Analytics", icon: LayoutDashboard, module: "dashboard" },
+            { href: "/dashboard/driver-offers", label: "Driver Offers", icon: Send, module: "dashboard" },
             { href: "/dashboard/forecast", label: "Demand Forecast", icon: TrendingUp, module: "dashboard" },
         ],
     },

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -1903,6 +1903,9 @@ export const getCancellationBreakdown = (dateRange = "30d", serviceAreaId?: stri
 export const getDriverAcceptanceRates = (dateRange = "30d", serviceAreaId?: string) =>
     request<any>(`/api/admin/analytics/driver-acceptance?date_range=${dateRange}${serviceAreaId ? `&service_area_id=${serviceAreaId}` : ''}`);
 
+export const getDriverOfferStats = (dateRange = "30d", serviceAreaId?: string) =>
+    request<any>(`/api/admin/analytics/driver-offer-stats?date_range=${dateRange}${serviceAreaId ? `&service_area_id=${serviceAreaId}` : ''}`);
+
 export const getDemandForecast = (hoursAhead = 24, areaId?: string) =>
     request<any>(`/api/admin/analytics/demand-forecast?hours_ahead=${hoursAhead}${areaId ? `&area_id=${areaId}` : ''}`);
 

--- a/backend/migrations/129_ride_routes_pickup_road_polyline.sql
+++ b/backend/migrations/129_ride_routes_pickup_road_polyline.sql
@@ -1,0 +1,226 @@
+-- 129_ride_routes_pickup_road_polyline.sql
+-- Adds the OSRM road-matched polyline for the PICKUP leg (Phase 2,
+-- driver→pickup) to the ride_routes side-table. Until now only the trip leg
+-- (Phase 3, pickup→dropoff) was road-snapped into `road_polyline`; the admin
+-- ride-detail map had nothing but raw GPS breadcrumbs (or nothing at all) for
+-- the pickup leg. `road_polyline_pickup` mirrors `road_polyline` but for the
+-- navigating_to_pickup phase so the admin map can draw a clean road-following
+-- line for the driver's approach to the rider.
+--
+-- Same retention class as the other geometry: GPS-derived PII. It is scrubbed
+-- at the 3-year mark by purge_pii_retention (Step I), alongside phase_polylines
+-- and road_polyline. This migration re-forks purge_pii_retention VERBATIM from
+-- migration 117 (the current authoritative definition — 118/120 did not
+-- redefine it) and changes ONLY Step I to also clear the new column. Diff-verify
+-- per docs/runbooks/migration-conflict-detection.md.
+--
+-- Rollback:
+--   ALTER TABLE ride_routes DROP COLUMN IF EXISTS road_polyline_pickup;
+--   then re-apply migration 117's purge_pii_retention (drop the new column from
+--   Step I's UPDATE/WHERE).
+
+ALTER TABLE ride_routes
+    ADD COLUMN IF NOT EXISTS road_polyline_pickup jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN ride_routes.road_polyline_pickup IS
+    'OSRM road-matched [[lat,lng],...] line for the navigating_to_pickup leg (Phase 2). Mirrors road_polyline (trip leg). GPS-derived PII — cleared at 3y by purge_pii_retention Step I.';
+
+CREATE OR REPLACE FUNCTION purge_pii_retention(p_dry_run BOOLEAN DEFAULT false)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_started_at         TIMESTAMPTZ := now();
+    v_rides_anonymized   INTEGER := 0;
+    v_rides_deleted      INTEGER := 0;
+    v_loc_deleted        INTEGER := 0;
+    v_msgs_deleted       INTEGER := 0;
+    v_tokens_deleted     INTEGER := 0;
+    v_stripe_deleted     INTEGER := 0;
+    v_audit_deleted      INTEGER := 0;
+    v_dsar_purged        INTEGER := 0;
+    v_routes_anonymized  INTEGER := 0;
+    v_result             JSONB;
+
+    c_gps_anon_age       INTERVAL := INTERVAL '3 years';
+    c_ride_keep_age      INTERVAL := INTERVAL '7 years';
+    c_loc_history_age    INTERVAL := INTERVAL '90 days';
+    c_chat_age           INTERVAL := INTERVAL '90 days';
+    c_token_grace_age    INTERVAL := INTERVAL '30 days';
+    c_stripe_event_age   INTERVAL := INTERVAL '90 days';
+    c_audit_log_age      INTERVAL := INTERVAL '7 years';
+BEGIN
+    -- Step A: anonymize ride GPS at 3y.
+    IF NOT p_dry_run THEN
+        UPDATE rides
+        SET pickup_lat         = NULL,
+            pickup_lng         = NULL,
+            dropoff_lat        = NULL,
+            dropoff_lng        = NULL,
+            route_polyline     = '[]'::jsonb,
+            phase_polylines    = '{}'::jsonb,
+            route_snapshot_url = NULL,
+            gps_anonymized_at  = v_started_at
+        WHERE created_at < v_started_at - c_gps_anon_age
+          AND gps_anonymized_at IS NULL;
+        GET DIAGNOSTICS v_rides_anonymized = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_rides_anonymized
+        FROM rides
+        WHERE created_at < v_started_at - c_gps_anon_age
+          AND gps_anonymized_at IS NULL;
+    END IF;
+
+    -- Step B: hard-delete rides at 7y.
+    IF NOT p_dry_run THEN
+        DELETE FROM rides
+        WHERE created_at < v_started_at - c_ride_keep_age;
+        GET DIAGNOSTICS v_rides_deleted = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_rides_deleted
+        FROM rides WHERE created_at < v_started_at - c_ride_keep_age;
+    END IF;
+
+    -- Step C: delete driver_location_history at 90d.
+    IF NOT p_dry_run THEN
+        DELETE FROM driver_location_history
+        WHERE recorded_at < v_started_at - c_loc_history_age;
+        GET DIAGNOSTICS v_loc_deleted = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_loc_deleted
+        FROM driver_location_history
+        WHERE recorded_at < v_started_at - c_loc_history_age;
+    END IF;
+
+    -- Step D: delete ride_messages at 90d.
+    IF NOT p_dry_run THEN
+        DELETE FROM ride_messages
+        WHERE created_at < v_started_at - c_chat_age;
+        GET DIAGNOSTICS v_msgs_deleted = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_msgs_deleted
+        FROM ride_messages
+        WHERE created_at < v_started_at - c_chat_age;
+    END IF;
+
+    -- Step E: delete revoked/expired refresh_tokens after 30d grace period.
+    IF NOT p_dry_run THEN
+        DELETE FROM refresh_tokens
+        WHERE revoked_at IS NOT NULL
+          AND revoked_at < v_started_at - c_token_grace_age;
+        GET DIAGNOSTICS v_tokens_deleted = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_tokens_deleted
+        FROM refresh_tokens
+        WHERE revoked_at IS NOT NULL
+          AND revoked_at < v_started_at - c_token_grace_age;
+    END IF;
+
+    -- Step F: delete stripe_events at 90d.
+    IF NOT p_dry_run THEN
+        DELETE FROM stripe_events
+        WHERE created_at < v_started_at - c_stripe_event_age;
+        GET DIAGNOSTICS v_stripe_deleted = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_stripe_deleted
+        FROM stripe_events
+        WHERE created_at < v_started_at - c_stripe_event_age;
+    END IF;
+
+    -- Step G: delete audit_logs at 7y (gated by session-flag).
+    IF NOT p_dry_run AND current_setting('spinr.audit_logs.allow_delete', true) = 'true' THEN
+        DELETE FROM audit_logs
+        WHERE created_at < v_started_at - c_audit_log_age;
+        GET DIAGNOSTICS v_audit_deleted = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_audit_deleted
+        FROM audit_logs
+        WHERE created_at < v_started_at - c_audit_log_age;
+    END IF;
+
+    -- Step H: anonymize DSAR pending-deletion users after 30d grace period.
+    IF NOT p_dry_run THEN
+        UPDATE users
+        SET phone        = NULL,
+            email        = NULL,
+            first_name   = 'Deleted',
+            last_name    = 'User',
+            deleted_at   = v_started_at,
+            deletion_scheduled_at = NULL
+        WHERE deletion_scheduled_at IS NOT NULL
+          AND deletion_scheduled_at <= v_started_at;
+        GET DIAGNOSTICS v_dsar_purged = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_dsar_purged
+        FROM users
+        WHERE deletion_scheduled_at IS NOT NULL
+          AND deletion_scheduled_at <= v_started_at;
+    END IF;
+
+    -- Step I (migration 117, extended by migration 129): clear ride_routes GPS
+    -- geometry at 3y, mirroring the rides GPS anonymization (Step A). Keeps
+    -- per-phase distance/duration scalars for the 7y SGI window; the row itself
+    -- cascades on the 7y rides delete. Migration 129 adds road_polyline_pickup
+    -- to the cleared set and the non-empty gate so re-runs stay no-ops.
+    IF NOT p_dry_run THEN
+        UPDATE ride_routes
+        SET phase_polylines       = '{}'::jsonb,
+            road_polyline         = '[]'::jsonb,
+            road_polyline_pickup  = '[]'::jsonb
+        WHERE computed_at < v_started_at - c_gps_anon_age
+          AND (phase_polylines <> '{}'::jsonb
+               OR road_polyline <> '[]'::jsonb
+               OR road_polyline_pickup <> '[]'::jsonb);
+        GET DIAGNOSTICS v_routes_anonymized = ROW_COUNT;
+    ELSE
+        SELECT COUNT(*) INTO v_routes_anonymized
+        FROM ride_routes
+        WHERE computed_at < v_started_at - c_gps_anon_age
+          AND (phase_polylines <> '{}'::jsonb
+               OR road_polyline <> '[]'::jsonb
+               OR road_polyline_pickup <> '[]'::jsonb);
+    END IF;
+
+    v_result := jsonb_build_object(
+        'started_at',                 v_started_at,
+        'completed_at',               now(),
+        'dry_run',                    p_dry_run,
+        'rides_anonymized',           v_rides_anonymized,
+        'rides_deleted',              v_rides_deleted,
+        'driver_location_deleted',    v_loc_deleted,
+        'ride_messages_deleted',      v_msgs_deleted,
+        'refresh_tokens_deleted',     v_tokens_deleted,
+        'stripe_events_deleted',      v_stripe_deleted,
+        'audit_logs_deleted',         v_audit_deleted,
+        'dsar_users_purged',          v_dsar_purged,
+        'ride_routes_anonymized',     v_routes_anonymized
+    );
+
+    -- Audit trail — uses actor_id (migration 57 schema); user_email was
+    -- dropped by migration 51.
+    IF NOT p_dry_run THEN
+        INSERT INTO audit_logs (id, action, entity_type, entity_id, actor_id, details, created_at)
+        VALUES (
+            gen_random_uuid()::text,
+            'pii_retention_purge',
+            'system',
+            v_started_at::text,
+            'system:retention_purge',
+            v_result::text,
+            now()
+        );
+    END IF;
+
+    RETURN v_result;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION purge_pii_retention(BOOLEAN) FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION purge_pii_retention(BOOLEAN) TO service_role;
+
+COMMENT ON FUNCTION purge_pii_retention(BOOLEAN) IS
+    'B-P1-6 + B-P1-7 + B-P2-4 + DV-8 retention enforcement. Uses actor_id (migration 57 schema). Step I (migration 117, extended 129) clears ride_routes geometry — phase_polylines, road_polyline, road_polyline_pickup — at 3y. p_dry_run=true returns counts without mutating.';
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/repositories/ride_repo.py
+++ b/backend/repositories/ride_repo.py
@@ -299,6 +299,19 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
             )
         )
 
+    async def _fetch_offers():
+        # The per-ride dispatch funnel: which drivers were offered this ride
+        # and what each did (accepted / declined / expired==ignored / pending).
+        return await run_sync(
+            lambda rid=ride_id: _rows_from_res(
+                supabase.table("ride_offers")
+                .select("driver_id,status,eta_seconds,offered_at,responded_at")
+                .eq("ride_id", rid)
+                .order("offered_at")
+                .execute()
+            )
+        )
+
     (
         rider,
         rider_area,
@@ -311,6 +324,7 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
         ride_complaints,
         ride_lost_items,
         ride_location_trail,
+        ride_offers,
     ) = await asyncio.gather(
         _fetch_rider(),
         _fetch_rider_area(),
@@ -323,6 +337,7 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
         _fetch_complaints(),
         _fetch_lost_items(),
         _fetch_location_trail(),
+        _fetch_offers(),
     )
 
     # --- Batch 2: lookups that depend on batch 1 results ---
@@ -421,6 +436,25 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
     ride["complaints"] = ride_complaints
     ride["lost_and_found"] = ride_lost_items
     ride["location_trail"] = ride_location_trail
+
+    # --- Offer funnel (which drivers were offered this ride and their reply) ---
+    if ride_offers:
+        offer_driver_ids = list({o.get("driver_id") for o in ride_offers if o.get("driver_id")})
+        offer_drivers = (
+            await run_sync(
+                lambda ids=offer_driver_ids: _rows_from_res(
+                    supabase.table("drivers").select("id,name,rating,user_id").in_("id", ids).execute()
+                )
+            )
+            if offer_driver_ids
+            else []
+        )
+        offer_driver_map = {d["id"]: d for d in offer_drivers if d.get("id")}
+        for o in ride_offers:
+            d = offer_driver_map.get(o.get("driver_id"))
+            o["driver_name"] = (d.get("name") if d else None) or (o.get("driver_id") or "")[:12]
+            o["driver_rating"] = d.get("rating") if d else None
+    ride["offers"] = ride_offers
 
     # --- Route geometry (ride_routes side-table; off the hot rides row) ---
     # New rides store phase_polylines + the OSRM road_polyline (and a copy of the

--- a/backend/repositories/ride_repo.py
+++ b/backend/repositories/ride_repo.py
@@ -433,6 +433,7 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
     route = await run_sync(_get_route)
     if route:
         ride["road_polyline"] = route.get("road_polyline") or []
+        ride["road_polyline_pickup"] = route.get("road_polyline_pickup") or []
         for _k in ("phase_polylines", "phase_distances", "phase_durations", "route_quality"):
             if route.get(_k):
                 ride[_k] = route[_k]

--- a/backend/repositories/ride_repo.py
+++ b/backend/repositories/ride_repo.py
@@ -456,6 +456,36 @@ async def get_ride_details_enriched(ride_id: str) -> Optional[Dict[str, Any]]:
             o["driver_rating"] = d.get("rating") if d else None
     ride["offers"] = ride_offers
 
+    # --- Driver incentives/bonuses paid on this ride (0% commission model:
+    #     these are platform-funded bonuses on top of the 100% fare) ---
+    def _get_incentive_claims():
+        claims = _rows_from_res(
+            supabase.table("ride_incentive_claims")
+            .select("incentive_id,bonus_amount,claimed_at")
+            .eq("ride_id", ride_id)
+            .order("claimed_at")
+            .execute()
+        )
+        if claims:
+            inc_ids = list({c.get("incentive_id") for c in claims if c.get("incentive_id")})
+            if inc_ids:
+                names = _rows_from_res(
+                    supabase.table("ride_incentives").select("id,name,incentive_type").in_("id", inc_ids).execute()
+                )
+                name_map = {n["id"]: n for n in names if n.get("id")}
+                for c in claims:
+                    meta = name_map.get(c.get("incentive_id"))
+                    c["name"] = (meta.get("name") if meta else None) or "Incentive"
+                    c["incentive_type"] = meta.get("incentive_type") if meta else None
+        return claims
+
+    try:
+        incentive_claims = await run_sync(_get_incentive_claims)
+    except Exception:
+        incentive_claims = []
+    ride["incentive_claims"] = incentive_claims
+    ride["incentive_total"] = round(sum(float(c.get("bonus_amount") or 0) for c in incentive_claims), 2)
+
     # --- Route geometry (ride_routes side-table; off the hot rides row) ---
     # New rides store phase_polylines + the OSRM road_polyline (and a copy of the
     # per-phase scalars) in ride_routes; merge them under the keys the admin

--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -40,6 +40,17 @@ def _parse_date_range(date_range: str) -> datetime:
     return now - delta
 
 
+def _parse_iso(value) -> Optional[datetime]:
+    """Best-effort parse of an ISO-8601 timestamp string to an aware datetime."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
 # ── Cancellation Reason Breakdown ────────────────────────────────────
 
 
@@ -64,9 +75,7 @@ async def get_cancellation_breakdown(
         logger.error(f"Failed to fetch cancelled rides: {e}", exc_info=True)
         from fastapi import HTTPException as _HTTPException
 
-        raise _HTTPException(
-            status_code=503, detail="Analytics data unavailable — database error"
-        ) from e
+        raise _HTTPException(status_code=503, detail="Analytics data unavailable — database error") from e
 
     # Categorize cancellation reasons
     reason_counter = Counter()
@@ -79,14 +88,9 @@ async def get_cancellation_breakdown(
 
         if not raw_reason:
             reason = "unspecified"
-        elif (
-            "no nearby drivers" in raw_reason.lower()
-            or "no driver" in raw_reason.lower()
-        ):
+        elif "no nearby drivers" in raw_reason.lower() or "no driver" in raw_reason.lower():
             reason = "no_drivers_available"
-        elif (
-            "rider" in raw_reason.lower() or "cancelled by rider" in raw_reason.lower()
-        ):
+        elif "rider" in raw_reason.lower() or "cancelled by rider" in raw_reason.lower():
             reason = "rider_cancelled"
             cancelled_by = "rider"
         elif "driver" in raw_reason.lower():
@@ -104,9 +108,7 @@ async def get_cancellation_breakdown(
         cancelled_by_counter[cancelled_by] += 1
 
         # Hourly distribution
-        created = (
-            r.get("cancelled_at") or r.get("updated_at") or r.get("created_at", "")
-        )
+        created = r.get("cancelled_at") or r.get("updated_at") or r.get("created_at", "")
         if isinstance(created, str) and len(created) >= 13:
             try:
                 hour = int(created[11:13])
@@ -160,9 +162,7 @@ async def get_driver_acceptance_rates(
     try:
         drivers = await db.get_rows("drivers", {}, limit=500)
     except Exception as e:
-        logger.error(
-            f"Failed to fetch drivers: {e}", exc_info=True, extra={"domain": "admin"}
-        )
+        logger.error(f"Failed to fetch drivers: {e}", exc_info=True, extra={"domain": "admin"})
         raise HTTPException(status_code=503, detail="analytics_unavailable") from e
 
     if service_area_id:
@@ -194,9 +194,7 @@ async def get_driver_acceptance_rates(
     users_list: list = []
     if user_ids:
         try:
-            users_list = await db.get_rows(
-                "users", {"id": {"$in": user_ids}}, limit=len(user_ids)
-            )
+            users_list = await db.get_rows("users", {"id": {"$in": user_ids}}, limit=len(user_ids))
         except Exception as e:
             logger.error(
                 f"Failed to fetch users for acceptance stats: {e}",
@@ -222,25 +220,14 @@ async def get_driver_acceptance_rates(
         cancelled_by_driver = sum(
             1
             for r in period_rides
-            if r.get("status") == "cancelled"
-            and "driver" in (r.get("cancellation_reason") or "").lower()
+            if r.get("status") == "cancelled" and "driver" in (r.get("cancellation_reason") or "").lower()
         )
 
-        acceptance_rate = (
-            round((completed / total_assigned * 100), 1) if total_assigned > 0 else 0
-        )
-        cancellation_rate = (
-            round((cancelled_by_driver / total_assigned * 100), 1)
-            if total_assigned > 0
-            else 0
-        )
+        acceptance_rate = round((completed / total_assigned * 100), 1) if total_assigned > 0 else 0
+        cancellation_rate = round((cancelled_by_driver / total_assigned * 100), 1) if total_assigned > 0 else 0
 
         user = users_map.get(driver.get("user_id"))
-        name = (
-            f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
-            if user
-            else "Unknown"
-        )
+        name = f"{user.get('first_name', '')} {user.get('last_name', '')}".strip() if user else "Unknown"
 
         result.append(
             {
@@ -262,14 +249,8 @@ async def get_driver_acceptance_rates(
     result.sort(key=lambda x: x["acceptance_rate"], reverse=True)
 
     # Summary stats
-    avg_acceptance = (
-        round(sum(r["acceptance_rate"] for r in result) / len(result), 1)
-        if result
-        else 0
-    )
-    low_performers = [
-        r for r in result if r["acceptance_rate"] < 70 and r["total_rides"] >= 5
-    ]
+    avg_acceptance = round(sum(r["acceptance_rate"] for r in result) / len(result), 1) if result else 0
+    low_performers = [r for r in result if r["acceptance_rate"] < 70 and r["total_rides"] >= 5]
 
     return {
         "date_range": date_range,
@@ -312,17 +293,13 @@ async def get_analytics_overview(
         logger.error(f"Failed to fetch rides: {e}", exc_info=True)
         from fastapi import HTTPException as _HTTPException
 
-        raise _HTTPException(
-            status_code=503, detail="Analytics data unavailable — database error"
-        ) from e
+        raise _HTTPException(status_code=503, detail="Analytics data unavailable — database error") from e
 
     total = len(period_rides)
     completed = sum(1 for r in period_rides if r.get("status") == "completed")
     cancelled = sum(1 for r in period_rides if r.get("status") == "cancelled")
     in_progress = sum(
-        1
-        for r in period_rides
-        if r.get("status") in ("in_progress", "driver_arrived", "driver_accepted")
+        1 for r in period_rides if r.get("status") in ("in_progress", "driver_arrived", "driver_accepted")
     )
     searching = sum(1 for r in period_rides if r.get("status") == "searching")
     scheduled = sum(1 for r in period_rides if r.get("is_scheduled"))
@@ -331,18 +308,10 @@ async def get_analytics_overview(
     cancellation_rate = round(cancelled / total * 100, 1) if total > 0 else 0
 
     total_revenue = float(
-        sum(
-            Decimal(str(r.get("total_fare") or 0))
-            for r in period_rides
-            if r.get("status") == "completed"
-        )
+        sum(Decimal(str(r.get("total_fare") or 0)) for r in period_rides if r.get("status") == "completed")
     )
     total_tips = float(
-        sum(
-            Decimal(str(r.get("tip_amount") or 0))
-            for r in period_rides
-            if r.get("status") == "completed"
-        )
+        sum(Decimal(str(r.get("tip_amount") or 0)) for r in period_rides if r.get("status") == "completed")
     )
     avg_fare = round(total_revenue / completed, 2) if completed > 0 else 0
 
@@ -457,8 +426,7 @@ async def get_surge_history(
                 "created_at": r.get("created_at"),
             }
             for r in records
-            if isinstance(r.get("created_at", ""), str)
-            and r.get("created_at", "") >= cutoff
+            if isinstance(r.get("created_at", ""), str) and r.get("created_at", "") >= cutoff
         ]
         # Reverse to chronological order
         filtered.reverse()
@@ -471,6 +439,154 @@ async def get_surge_history(
         )
         from fastapi import HTTPException as _HTTPException
 
-        raise _HTTPException(
-            status_code=503, detail="Surge history unavailable — database error"
-        ) from e
+        raise _HTTPException(status_code=503, detail="Surge history unavailable — database error") from e
+
+
+# ── Driver Offer Stats (dispatch funnel) ─────────────────────────────
+
+
+@api_router.get("/driver-offer-stats")
+async def get_driver_offer_stats(
+    date_range: str = Query("30d", pattern="^(today|7d|30d|90d|1y)$"),
+    service_area_id: Optional[str] = None,
+    limit: int = Query(100, ge=1, le=500),
+    admin: dict = Depends(get_admin_user),
+):
+    """Per-driver aggregation of ride offers — who accepted / declined / ignored.
+
+    Reads the append-only ``ride_offers`` ledger (offered_at, responded_at,
+    status) over the window and rolls it up per driver so ops can see who
+    accepts most, who declines most, and who ignores (lets offers time out)
+    most. ``ignored`` == offers that expired without a response; ``pending``
+    (still in-flight) is excluded from the decided-rate denominators.
+    """
+    start_date = _parse_date_range(date_range)
+
+    try:
+        offers = await db.get_rows(
+            "ride_offers",
+            {"offered_at": {"$gte": start_date.isoformat()}},
+            limit=100000,
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to fetch ride_offers for offer stats: {e}",
+            exc_info=True,
+            extra={"domain": "admin"},
+        )
+        raise HTTPException(status_code=503, detail="analytics_unavailable") from e
+
+    # Roll up per driver.
+    by_driver: dict = defaultdict(
+        lambda: {
+            "offered": 0,
+            "accepted": 0,
+            "declined": 0,
+            "ignored": 0,
+            "pending": 0,
+            "_response_secs": [],
+        }
+    )
+    for o in offers:
+        did = o.get("driver_id")
+        if not did:
+            continue
+        agg = by_driver[did]
+        agg["offered"] += 1
+        status = o.get("status")
+        if status == "accepted":
+            agg["accepted"] += 1
+        elif status == "declined":
+            agg["declined"] += 1
+        elif status == "expired":
+            agg["ignored"] += 1
+        elif status == "pending":
+            agg["pending"] += 1
+        # Response latency for the offers the driver actually answered.
+        if status in ("accepted", "declined"):
+            offered_at = _parse_iso(o.get("offered_at"))
+            responded_at = _parse_iso(o.get("responded_at"))
+            if offered_at and responded_at and responded_at >= offered_at:
+                agg["_response_secs"].append((responded_at - offered_at).total_seconds())
+
+    driver_ids = list(by_driver.keys())
+    drivers_list: list = []
+    if driver_ids:
+        try:
+            drivers_list = await db.get_rows("drivers", {"id": {"$in": driver_ids}}, limit=len(driver_ids))
+        except Exception as e:
+            logger.error(
+                f"Failed to fetch drivers for offer stats: {e}",
+                exc_info=True,
+                extra={"domain": "admin"},
+            )
+            raise HTTPException(status_code=503, detail="analytics_unavailable") from e
+
+    if service_area_id:
+        drivers_list = [d for d in drivers_list if d.get("service_area_id") == service_area_id]
+
+    drivers_map = {d["id"]: d for d in drivers_list if d.get("id")}
+
+    user_ids = list({d.get("user_id") for d in drivers_list if d.get("user_id")})
+    users_list: list = []
+    if user_ids:
+        try:
+            users_list = await db.get_rows("users", {"id": {"$in": user_ids}}, limit=len(user_ids))
+        except Exception as e:
+            logger.error(
+                f"Failed to fetch users for offer stats: {e}",
+                exc_info=True,
+                extra={"domain": "admin"},
+            )
+            raise HTTPException(status_code=503, detail="analytics_unavailable") from e
+    users_map = {u["id"]: u for u in users_list if u.get("id")}
+
+    result = []
+    for did, agg in by_driver.items():
+        driver = drivers_map.get(did)
+        # When a service-area filter is set, drop drivers outside it.
+        if service_area_id and driver is None:
+            continue
+        decided = agg["accepted"] + agg["declined"] + agg["ignored"]
+        user = users_map.get(driver.get("user_id")) if driver else None
+        name = (
+            f"{user.get('first_name', '')} {user.get('last_name', '')}".strip()
+            if user
+            else (driver.get("name") if driver else None)
+        ) or did[:12]
+        response_secs = agg.pop("_response_secs")
+        result.append(
+            {
+                "driver_id": did,
+                "name": name,
+                "offered": agg["offered"],
+                "accepted": agg["accepted"],
+                "declined": agg["declined"],
+                "ignored": agg["ignored"],
+                "pending": agg["pending"],
+                "accept_rate": round(agg["accepted"] / decided * 100, 1) if decided else 0.0,
+                "decline_rate": round(agg["declined"] / decided * 100, 1) if decided else 0.0,
+                "ignore_rate": round(agg["ignored"] / decided * 100, 1) if decided else 0.0,
+                "avg_response_seconds": (round(sum(response_secs) / len(response_secs), 1) if response_secs else None),
+                "rating": driver.get("rating") if driver else None,
+                "is_online": driver.get("is_online", False) if driver else False,
+            }
+        )
+
+    # Default ordering: most offers handled first (most active drivers on top).
+    result.sort(key=lambda x: x["offered"], reverse=True)
+
+    totals = {
+        "offered": sum(r["offered"] for r in result),
+        "accepted": sum(r["accepted"] for r in result),
+        "declined": sum(r["declined"] for r in result),
+        "ignored": sum(r["ignored"] for r in result),
+        "pending": sum(r["pending"] for r in result),
+    }
+
+    return {
+        "date_range": date_range,
+        "total_drivers": len(result),
+        "totals": totals,
+        "drivers": result[:limit],
+    }

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -3381,6 +3381,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
     pickup_to_driver_km = 0.0
     route_polyline = []
     road_polyline: list = []
+    road_polyline_pickup: list = []
     gps_points_count = 0
     trip_points_count = 0
     rejected_segments = 0
@@ -3558,6 +3559,24 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                         f"{actual_distance_km_haversine}km — keeping haversine value"
                     )
 
+            # Road-snap the PICKUP leg (Phase 2, driver→pickup) too, so the admin
+            # map can draw a clean road-following line for the approach — not just
+            # the trip. Display-only (it does not feed billing), so unlike the trip
+            # leg above there is no sanity gate against a billing baseline; a failed
+            # snap simply leaves road_polyline_pickup empty and the admin falls back
+            # to the raw Phase 2 GPS breadcrumbs.
+            try:
+                pickup_road_result = await compute_road_route(
+                    all_breadcrumbs, phase="navigating_to_pickup"
+                )
+                if pickup_road_result is not None:
+                    road_polyline_pickup = pickup_road_result.get("polyline") or []
+            except Exception:
+                logger.warning(
+                    "[complete_ride] pickup-leg road-snap raised; leaving empty",
+                    exc_info=True,
+                )
+
             # Per-phase polylines for SGI / dispute tooling. Each phase is
             # downsampled to MAX_PER_PHASE points so a long trip's payload
             # stays bounded. Stored as [lat, lng, iso_ts] tuples so the
@@ -3635,6 +3654,7 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
         "phase_durations": phase_durations,
         "phase_polylines": phase_polylines,
         "road_polyline": road_polyline,
+        "road_polyline_pickup": road_polyline_pickup,
         "gps_points_count": gps_points_count,
         "route_quality": route_quality,
         "save_status": "saved",

--- a/backend/utils/route_distance.py
+++ b/backend/utils/route_distance.py
@@ -227,8 +227,8 @@ async def _compute_via_google_roads(trip_points: list[dict], api_key: str) -> Op
     return round(total_km, 3), _cap_polyline(polyline, _MAX_ROAD_POLYLINE_POINTS)
 
 
-async def compute_road_route(breadcrumbs: list[dict]) -> Optional[dict]:
-    """Road-snap the trip and return {"distance_km": float, "polyline": [[lat,lng],...]}.
+async def compute_road_route(breadcrumbs: list[dict], phase: str = "trip_in_progress") -> Optional[dict]:
+    """Road-snap a single ride phase and return {"distance_km": float, "polyline": [[lat,lng],...]}.
 
     Prefers self-hosted OSRM /match when OSRM_URL (or the app_settings
     ``osrm_url`` override) is set; otherwise Google Roads snapToRoads. Returns
@@ -238,6 +238,9 @@ async def compute_road_route(breadcrumbs: list[dict]) -> Optional[dict]:
     Args:
       breadcrumbs: ordered list of {lat, lng, tracking_phase, ...} dicts from
                    driver_location_history for a single ride.
+      phase: which insurance/tracking phase to road-snap. Defaults to
+             ``trip_in_progress`` (Phase 3) for back-compat; pass
+             ``navigating_to_pickup`` to snap the driver→pickup leg (Phase 2).
     """
     if not breadcrumbs:
         return None
@@ -245,7 +248,7 @@ async def compute_road_route(breadcrumbs: list[dict]) -> Optional[dict]:
     trip_points = [
         b
         for b in breadcrumbs
-        if b.get("tracking_phase") == "trip_in_progress" and b.get("lat") is not None and b.get("lng") is not None
+        if b.get("tracking_phase") == phase and b.get("lat") is not None and b.get("lng") is not None
     ]
     if len(trip_points) < _MIN_POINTS:
         return None


### PR DESCRIPTION
Send Invoice and Download PDF used text-primary/text-emerald-600, which
washed out against the colored status gradient in the ride-detail hero.
Restyle them as proper buttons — a translucent white pill for Send Invoice
(matching Live Track) and a solid white button with emerald label for
Download PDF — so both stay readable on any status color.

https://claude.ai/code/session_018sroptJ7Zc41mDeubYYp7p

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
