### PR TITLE
Replace SendGrid with Resend for transactional email

### DIFF
--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -195,10 +195,10 @@ export default function SettingsPage() {
                         </CardContent>
                     </Card>
 
-                    {/* Email / SendGrid */}
+                    {/* Email / Resend */}
                     <Card className="border-border/50">
                         <CardHeader>
-                            <CardTitle className="text-base">Email (SendGrid)</CardTitle>
+                            <CardTitle className="text-base">Email (Resend)</CardTitle>
                         </CardHeader>
                         <Separator />
                         <CardContent className="pt-4 space-y-4">
@@ -210,20 +210,20 @@ export default function SettingsPage() {
                                 <Label>API Key</Label>
                                 <Input
                                     type="password"
-                                    value={settings.sendgrid_api_key || ""}
+                                    value={settings.resend_api_key || ""}
                                     onChange={(e) =>
-                                        update("sendgrid_api_key", e.target.value)
+                                        update("resend_api_key", e.target.value)
                                     }
-                                    placeholder="SG...."
+                                    placeholder="re_...."
                                 />
                             </div>
                             <div className="space-y-2">
                                 <Label>From Email</Label>
                                 <Input
                                     type="email"
-                                    value={settings.sendgrid_from_email || ""}
+                                    value={settings.resend_from_email || ""}
                                     onChange={(e) =>
-                                        update("sendgrid_from_email", e.target.value)
+                                        update("resend_from_email", e.target.value)
                                     }
                                     placeholder="receipts@spinr.ca"
                                 />

--- a/backend/features.py
+++ b/backend/features.py
@@ -1444,11 +1444,11 @@ async def send_push_notification(
 
 
 async def send_email(*, to: str, subject: str, body: str) -> bool:
-    """Send a plain-text email via SendGrid when configured, log otherwise.
+    """Send a plain-text email via Resend when configured, log otherwise.
 
     Mirrors the fallback behaviour of utils.email_receipt.send_receipt_email —
-    in dev/test we don't require SendGrid credentials and the message is just
-    logged. Returns True if delivery was attempted against SendGrid and
+    in dev/test we don't require Resend credentials and the message is just
+    logged. Returns True if delivery was attempted against Resend and
     accepted (2xx), False otherwise.
     """
     if not to:
@@ -1458,28 +1458,29 @@ async def send_email(*, to: str, subject: str, body: str) -> bool:
         from settings_loader import get_app_settings
 
         settings = await get_app_settings()
-        sendgrid_key = settings.get("sendgrid_api_key", "")
+        resend_key = settings.get("resend_api_key", "")
+        from_email = settings.get("resend_from_email") or "noreply@spinr.ca"
 
-        if sendgrid_key:
+        if resend_key:
             import httpx
 
             response = await httpx.AsyncClient().post(
-                "https://api.sendgrid.com/v3/mail/send",
+                "https://api.resend.com/emails",
                 headers={
-                    "Authorization": f"Bearer {sendgrid_key}",
+                    "Authorization": f"Bearer {resend_key}",
                     "Content-Type": "application/json",
                 },
                 json={
-                    "personalizations": [{"to": [{"email": to}]}],
-                    "from": {"email": "noreply@spinr.ca", "name": "Spinr"},
+                    "from": f"Spinr <{from_email}>",
+                    "to": [to],
                     "subject": subject,
-                    "content": [{"type": "text/plain", "value": body}],
+                    "text": body,
                 },
             )
-            logger.info(f"[EMAIL] SendGrid sent subject={subject!r} status={response.status_code}")
+            logger.info(f"[EMAIL] Resend sent subject={subject!r} status={response.status_code}")
             return response.status_code in (200, 201, 202)
     except Exception as e:
-        logger.warning(f"[EMAIL] SendGrid failed: {e}")
+        logger.warning(f"[EMAIL] Resend failed: {e}")
 
     logger.info(f"[EMAIL] (fallback log) subject={subject!r}")
     return False
@@ -1508,7 +1509,7 @@ async def notify_safety_team(incident: dict) -> dict:
     reported_by = incident.get("reported_by_user_id")
 
     # Log at CRITICAL — on-call paging via log-aggregator alert rules
-    # works even before SendGrid is configured. Never include the raw
+    # works even before Resend is configured. Never include the raw
     # description here (may contain rider PII / addresses).
     logger.critical(
         f"[SAFETY] Incident opened id={incident_id} category={category} role={role} ride_id={ride_id or '-'}"

--- a/backend/migrations/110_settings_resend_email.sql
+++ b/backend/migrations/110_settings_resend_email.sql
@@ -1,0 +1,49 @@
+-- 110_settings_resend_email.sql
+--
+-- Migrate transactional email from SendGrid to Resend.
+--
+-- Spinr is switching its transactional email provider (ride receipts, T4A
+-- links, DSAR exports, corporate low-balance + safety alerts) from SendGrid
+-- to Resend. Resend uses a different API key format and endpoint, so the
+-- credential is a new column rather than a reuse of the old SendGrid key.
+--
+-- Fields landed:
+--   • resend_api_key    — Resend credential (masked on GET via
+--     _mask_credentials in routes/admin/settings.py; never returned
+--     in plaintext on a settings GET).
+--   • resend_from_email — verified sender address, e.g. receipts@spinr.ca.
+--     Backfilled from the existing sendgrid_from_email so receipts keep
+--     sending from the same verified address with no operator action.
+--
+-- The old sendgrid_api_key / sendgrid_from_email columns are intentionally
+-- left in place (append-only migration policy — never edit/drop a merged
+-- migration's columns in flight). The backend no longer reads them; they
+-- can be dropped in a later cleanup migration once we've confirmed nothing
+-- references them. The Resend API key must be set via the admin Settings
+-- page after deploy — it is NOT carried over from SendGrid.
+--
+-- All columns are nullable so the migration is forward-compatible with
+-- running traffic. Blank resend_api_key = email step skipped (same
+-- behaviour the SendGrid path had).
+--
+-- Rollback:
+--   ALTER TABLE settings DROP COLUMN IF EXISTS resend_api_key;
+--   ALTER TABLE settings DROP COLUMN IF EXISTS resend_from_email;
+
+ALTER TABLE public.settings
+    ADD COLUMN IF NOT EXISTS resend_api_key    TEXT,
+    ADD COLUMN IF NOT EXISTS resend_from_email TEXT;
+
+-- Carry the verified sender address forward so receipts don't silently
+-- start sending from the default fallback after the provider switch.
+UPDATE public.settings
+   SET resend_from_email = sendgrid_from_email
+ WHERE id = 'app_settings'
+   AND (resend_from_email IS NULL OR resend_from_email = '')
+   AND sendgrid_from_email IS NOT NULL
+   AND sendgrid_from_email <> '';
+
+COMMENT ON COLUMN public.settings.resend_api_key IS
+    'Resend API credential for transactional email (receipts, T4A links, alerts). Masked on GET via _mask_credentials in routes/admin/settings.py; never appears in plaintext in the admin UI. Replaces sendgrid_api_key.';
+COMMENT ON COLUMN public.settings.resend_from_email IS
+    'Verified Resend sender address (e.g. receipts@spinr.ca). Must be a domain verified in the Resend dashboard. Replaces sendgrid_from_email.';

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -45,9 +45,9 @@ _CREDENTIAL_FIELDS = frozenset(
         "stripe_webhook_secret",
         "twilio_auth_token",
         "google_maps_api_key",
-        # SendGrid API key is a credential too — without masking it would
+        # Resend API key is a credential too — without masking it would
         # otherwise round-trip in plaintext on every settings GET.
-        "sendgrid_api_key",
+        "resend_api_key",
     }
 )
 
@@ -96,10 +96,10 @@ class SettingsUpdateRequest(BaseModel):
     # Twilio Proxy is what masks rider↔driver phone numbers during a ride;
     # SID lives in app_settings so it rotates without a redeploy.
     twilio_proxy_service_sid: Optional[str] = None
-    # SendGrid powers transactional email (receipts, T4A links, support).
+    # Resend powers transactional email (receipts, T4A links, support).
     # api_key is a credential (masked on GET); from_email is plain.
-    sendgrid_api_key: Optional[str] = None
-    sendgrid_from_email: Optional[str] = None
+    resend_api_key: Optional[str] = None
+    resend_from_email: Optional[str] = None
     # Company info shown on rider receipts + driver T4A slips + the
     # admin dashboard footer. Edited via the Settings page → Company tab.
     company_name: Optional[str] = None

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -48,6 +48,11 @@ _CREDENTIAL_FIELDS = frozenset(
         # Resend API key is a credential too — without masking it would
         # otherwise round-trip in plaintext on every settings GET.
         "resend_api_key",
+        # Legacy SendGrid key: no longer read for sending, but migration 110
+        # leaves the column in place, so a still-populated value would round-
+        # trip in plaintext on GET unless it stays masked here. Keeps the
+        # super-admin-only reveal flow as the only way to read it.
+        "sendgrid_api_key",
     }
 )
 

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -321,6 +321,33 @@ class TestAdminSettingsValidation:
             )
         assert resp.status_code in (200, 422, 500)  # 422/500 acceptable from deep deps
 
+    def test_email_api_keys_masked_on_get(self):
+        """Both the Resend key and the legacy SendGrid key must be masked.
+
+        Migration 110 leaves the sendgrid_api_key column in place, and
+        get_app_settings() merges every DB column into the GET response, so a
+        still-populated legacy key would round-trip in plaintext unless it
+        stays in the credential mask set. Regression guard for PR #1573.
+        """
+        try:
+            from routes.admin.settings import _mask_credentials
+        except ImportError:
+            from backend.routes.admin.settings import _mask_credentials
+
+        masked = _mask_credentials(
+            {
+                "resend_api_key": "re_live_supersecretvalue",
+                "sendgrid_api_key": "SG.legacysupersecretvalue",
+                "company_name": "Spinr",
+            }
+        )
+        assert masked["resend_api_key"].endswith("*****")
+        assert "supersecret" not in masked["resend_api_key"]
+        assert masked["sendgrid_api_key"].endswith("*****")
+        assert "supersecret" not in masked["sendgrid_api_key"]
+        # Non-credential fields pass through untouched.
+        assert masked["company_name"] == "Spinr"
+
 
 # ---------------------------------------------------------------------------
 # Service area surge cap (A-P2-4 regression)

--- a/backend/tests/test_receipt_email.py
+++ b/backend/tests/test_receipt_email.py
@@ -1,7 +1,7 @@
 """Unit tests for send_ride_receipt_email.
 
 Covers:
-- Early return when sendgrid_api_key is missing (no HTTP call)
+- Early return when resend_api_key is missing (no HTTP call)
 - Decimal arithmetic for GST and grand_total
 - Surge line item hidden at 1.0x, shown above 1.0x
 - HTTP errors are swallowed (fire-and-forget contract)
@@ -83,8 +83,8 @@ def _make_async_client_mock(post_side_effect=None) -> MagicMock:
 
 
 @pytest.mark.anyio
-async def test_receipt_email_no_sendgrid_key():
-    """When sendgrid_api_key is absent, return without making any HTTP call."""
+async def test_receipt_email_no_resend_key():
+    """When resend_api_key is absent, return without making any HTTP call."""
     mock_client = _make_async_client_mock()
 
     with (
@@ -112,8 +112,8 @@ async def test_receipt_email_decimal_math():
             "settings_loader.get_app_settings",
             AsyncMock(
                 return_value={
-                    "sendgrid_api_key": "SG.test-key",
-                    "sendgrid_from_email": "receipts@spinr.ca",
+                    "resend_api_key": "re_test-key",
+                    "resend_from_email": "receipts@spinr.ca",
                 }
             ),
         ),
@@ -122,7 +122,7 @@ async def test_receipt_email_decimal_math():
         await send_ride_receipt_email(_BASE_RIDE, _BASE_RIDER)
 
     assert captured, "Expected an HTTP POST to be made"
-    content_value = captured["content"][0]["value"]
+    content_value = captured["text"]
 
     # subtotal = 11.00; GST = 11.00 * 0.05 = 0.55; PST = 11.00 * 0.06 = 0.66
     subtotal = Decimal("11.00")
@@ -153,8 +153,8 @@ async def test_receipt_email_surge_hidden_when_1x():
             "settings_loader.get_app_settings",
             AsyncMock(
                 return_value={
-                    "sendgrid_api_key": "SG.test-key",
-                    "sendgrid_from_email": "receipts@spinr.ca",
+                    "resend_api_key": "re_test-key",
+                    "resend_from_email": "receipts@spinr.ca",
                 }
             ),
         ),
@@ -163,7 +163,7 @@ async def test_receipt_email_surge_hidden_when_1x():
         await send_ride_receipt_email(ride, _BASE_RIDER)
 
     assert captured, "Expected an HTTP POST to be made"
-    content_value = captured["content"][0]["value"]
+    content_value = captured["text"]
     assert "Surge" not in content_value, "Surge line item must not appear when surge_multiplier is 1.0"
 
 
@@ -184,8 +184,8 @@ async def test_receipt_email_surge_shown_when_above_1x():
             "settings_loader.get_app_settings",
             AsyncMock(
                 return_value={
-                    "sendgrid_api_key": "SG.test-key",
-                    "sendgrid_from_email": "receipts@spinr.ca",
+                    "resend_api_key": "re_test-key",
+                    "resend_from_email": "receipts@spinr.ca",
                 }
             ),
         ),
@@ -194,7 +194,7 @@ async def test_receipt_email_surge_shown_when_above_1x():
         await send_ride_receipt_email(ride, _BASE_RIDER)
 
     assert captured, "Expected an HTTP POST to be made"
-    content_value = captured["content"][0]["value"]
+    content_value = captured["text"]
     assert "Surge" in content_value, "Surge line item must appear when surge_multiplier is above 1.0"
 
 
@@ -210,8 +210,8 @@ async def test_receipt_email_http_error_does_not_raise():
             "settings_loader.get_app_settings",
             AsyncMock(
                 return_value={
-                    "sendgrid_api_key": "SG.test-key",
-                    "sendgrid_from_email": "receipts@spinr.ca",
+                    "resend_api_key": "re_test-key",
+                    "resend_from_email": "receipts@spinr.ca",
                 }
             ),
         ),

--- a/backend/utils/email_receipt.py
+++ b/backend/utils/email_receipt.py
@@ -1,6 +1,6 @@
 """
 Receipt generator for Spinr rides.
-Generates HTML receipt and sends via email (SendGrid when configured, logs otherwise).
+Generates HTML receipt and sends via email (Resend when configured, logs otherwise).
 
 Line items
 ----------
@@ -298,7 +298,7 @@ def _receipt_total(ride: dict, tip: float = 0) -> Decimal:
 
 
 async def send_receipt_email(ride: dict, rider: dict, driver: dict = None, tip: float = 0):
-    """Send receipt email. Uses SendGrid when configured, logs otherwise."""
+    """Send receipt email. Uses Resend when configured, logs otherwise."""
     email = rider.get("email", "")
     if not email:
         logger.warning(f"No email for rider {rider.get('id')} — skipping receipt")
@@ -307,33 +307,34 @@ async def send_receipt_email(ride: dict, rider: dict, driver: dict = None, tip: 
     html = generate_receipt_html(ride, rider, driver, tip)
     total = _receipt_total(ride, tip)
 
-    # Try SendGrid
+    # Try Resend
     try:
         from ..settings_loader import get_app_settings
 
         settings = await get_app_settings()
-        sendgrid_key = settings.get("sendgrid_api_key", "")
+        resend_key = settings.get("resend_api_key", "")
+        from_email = settings.get("resend_from_email") or "receipts@spinr.ca"
 
-        if sendgrid_key:
+        if resend_key:
             import httpx
 
             response = await httpx.AsyncClient().post(
-                "https://api.sendgrid.com/v3/mail/send",
-                headers={"Authorization": f"Bearer {sendgrid_key}", "Content-Type": "application/json"},
+                "https://api.resend.com/emails",
+                headers={"Authorization": f"Bearer {resend_key}", "Content-Type": "application/json"},
                 json={
-                    "personalizations": [{"to": [{"email": email}]}],
-                    "from": {"email": "receipts@spinr.ca", "name": "Spinr"},
+                    "from": f"Spinr <{from_email}>",
+                    "to": [email],
                     "subject": f"Your Spinr ride receipt — ${total:.2f}",
-                    "content": [{"type": "text/html", "value": html}],
+                    "html": html,
                 },
             )
-            logger.info(f"[EMAIL] SendGrid receipt sent to {redact_email(email)} (status: {response.status_code})")
+            logger.info(f"[EMAIL] Resend receipt sent to {redact_email(email)} (status: {response.status_code})")
             return response.status_code in (200, 201, 202)
     except ImportError:
         pass
     except Exception as e:
-        logger.warning(f"[EMAIL] SendGrid failed: {e}")
+        logger.warning(f"[EMAIL] Resend failed: {e}")
 
     # Fallback: log only (PII-safe: email + total amount redacted)
-    logger.info(f"[EMAIL] Receipt for ride {ride.get('id')} → {redact_email(email)} (SendGrid not configured)")
+    logger.info(f"[EMAIL] Receipt for ride {ride.get('id')} → {redact_email(email)} (Resend not configured)")
     return False

--- a/backend/utils/receipt_email.py
+++ b/backend/utils/receipt_email.py
@@ -1,7 +1,7 @@
 """
 Send ride receipt emails with Canadian GST/PST tax line items.
 
-Uses the SendGrid REST API via httpx (same pattern as features.send_email and
+Uses the Resend REST API via httpx (same pattern as features.send_email and
 utils.email_receipt.send_receipt_email). Settings are loaded from the
 app_settings Supabase table via settings_loader.get_app_settings().
 
@@ -126,12 +126,12 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
             from settings_loader import get_app_settings
 
         settings = await get_app_settings()
-        sendgrid_key = settings.get("sendgrid_api_key", "")
-        from_email = settings.get("sendgrid_from_email") or settings.get("email_from") or "receipts@spinr.ca"
+        resend_key = settings.get("resend_api_key", "")
+        from_email = settings.get("resend_from_email") or settings.get("email_from") or "receipts@spinr.ca"
 
-        if not sendgrid_key:
+        if not resend_key:
             logger.warning(
-                "[receipt_email] sendgrid_api_key not configured — receipt not sent for rider %s",
+                "[receipt_email] resend_api_key not configured — receipt not sent for rider %s",
                 rider_id,
             )
             return
@@ -147,16 +147,16 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
 
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(
-                "https://api.sendgrid.com/v3/mail/send",
+                "https://api.resend.com/emails",
                 headers={
-                    "Authorization": f"Bearer {sendgrid_key}",
+                    "Authorization": f"Bearer {resend_key}",
                     "Content-Type": "application/json",
                 },
                 json={
-                    "personalizations": [{"to": [{"email": email}]}],
-                    "from": {"email": from_email, "name": "Spinr"},
+                    "from": f"Spinr <{from_email}>",
+                    "to": [email],
                     "subject": subject,
-                    "content": [{"type": "text/plain", "value": plain_body}],
+                    "text": plain_body,
                 },
             )
 
@@ -168,7 +168,7 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
             )
         else:
             logger.error(
-                "[receipt_email] SendGrid returned %s for rider %s — body: %s",
+                "[receipt_email] Resend returned %s for rider %s — body: %s",
                 response.status_code,
                 rider_id,
                 response.text[:200],

--- a/docs/audit/15_TECH_STACK_AND_FILE_MAPPING.md
+++ b/docs/audit/15_TECH_STACK_AND_FILE_MAPPING.md
@@ -303,7 +303,7 @@ spinr/
 | `backend/utils/audit_logger.py` | Structured security event logging | `log_security_event(event, **kwargs)`, `SecurityEvent` constants |
 | `backend/utils/analytics.py` | Ride + revenue analytics | Aggregation queries, time-series fare data |
 | `backend/utils/cloudinary.py` | Image upload + transform | `upload_document(file)`, `get_secure_url(public_id)` |
-| `backend/utils/email_receipt.py` | Post-trip email receipt | Jinja2 template render + SMTP/SendGrid send |
+| `backend/utils/email_receipt.py` | Post-trip email receipt | Jinja2 template render + Resend send |
 | `backend/utils/error_handling.py` | Global error handler | Sanitised error responses, Sentry breadcrumb logging |
 | `backend/utils/rate_limiter.py` | Custom Redis rate limiter | Sliding window, composite key (user_id + IP), `Retry-After` header |
 | `backend/utils/crypto.py` | Cryptographic helpers | `hash_otp(code)` SHA-256, `hash_token(raw)` |

--- a/docs/scoping/P0-5_PHASE_E_RUNBOOK.md
+++ b/docs/scoping/P0-5_PHASE_E_RUNBOOK.md
@@ -80,7 +80,7 @@ Any valid future expiry + any 3-digit CVC + any postal code works.
        - [ ] Ride row in DB has `payment_status="paid"`, `payment_intent_id=pi_...`
        - [ ] Stripe dashboard shows a **Succeeded** payment with matching metadata
              `ride_id`, `rider_id`, `source=ride_completion_charge`
-       - [ ] Receipt email delivered (if SendGrid is configured in staging)
+       - [ ] Receipt email delivered (if Resend is configured in staging)
 
 ### 3.2 Scenario B — Card declined (`4000 0000 0000 0002`)
 

--- a/docs/vendor-inventory.md
+++ b/docs/vendor-inventory.md
@@ -81,7 +81,7 @@ Each vendor row carries:
 
 | Vendor | Service | Data class | Region | DPA | Disclosed | DPIA | Criticality | Contract owner |
 |---|---|:-:|---|:-:|:-:|:-:|:-:|---|
-| **Email provider** (SendGrid / Postmark — TBD) | Transactional email | C3 (email addr) | US | ✅ on contract | Required | — | HIGH | backend |
+| **Email provider** (Resend) | Transactional email | C3 (email addr) | US | ✅ on contract | Required | — | HIGH | backend |
 | **Status page provider** (Statuspage / Atlassian — TBD) | Public status page | C1 | US | ✅ on contract | Partial | — | MEDIUM | devops |
 | **PagerDuty / OpsGenie — TBD** | On-call paging | C2 (internal IDs only) | US | ✅ on contract | — | — | HIGH | devops |
 


### PR DESCRIPTION
Switch all transactional email (ride receipts, T4A links, DSAR exports,
corporate low-balance + safety alerts) from the SendGrid REST API to
Resend.

- features.send_email, utils.email_receipt.send_receipt_email, and
  utils.receipt_email.send_ride_receipt_email now POST to
  https://api.resend.com/emails with Resend's {from, to[], subject,
  text|html} body shape.
- Settings keys renamed sendgrid_api_key/sendgrid_from_email →
  resend_api_key/resend_from_email; resend_api_key is masked on GET.
- Migration 110 adds resend_api_key/resend_from_email columns and
  backfills resend_from_email from sendgrid_from_email. Old SendGrid
  columns left in place (append-only policy); no longer read.
- Admin Settings page Email card updated to Resend.
- Tests and docs updated.

https://claude.ai/code/session_01Ew9pZD27RirjzN6D6R4qJW

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
