### PR TITLE
fix(pickup): address Codex PR 1568 review (snap matching, arrival, re…

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -3217,17 +3217,24 @@ async def arrive_at_pickup(ride_id: str, current_user: dict = Depends(get_curren
     if not ride:
         raise HTTPException(status_code=404, detail="Ride not found")
 
-    # Geofence check - verify driver is within 200m of pickup location
+    # Geofence check - verify driver is within 200m of pickup location.
+    # Accept arrival within radius of EITHER the rider's exact pin OR the
+    # road-snapped nav point we actually navigated the driver to — for a pin
+    # dropped inside a mall/airport these can differ by more than the radius, and
+    # a driver who followed our navigation must not be rejected as too far.
     ARRIVAL_RADIUS_KM = 0.2  # 200 meters
     driver_lat = driver.get("lat", 0)
     driver_lng = driver.get("lng", 0)
-    pickup_lat = ride.get("pickup_lat", 0)
-    pickup_lng = ride.get("pickup_lng", 0)
+    targets = []
+    if ride.get("pickup_lat") and ride.get("pickup_lng"):
+        targets.append((ride["pickup_lat"], ride["pickup_lng"]))
+    if ride.get("pickup_nav_lat") is not None and ride.get("pickup_nav_lng") is not None:
+        targets.append((ride["pickup_nav_lat"], ride["pickup_nav_lng"]))
 
-    if driver_lat and driver_lng and pickup_lat and pickup_lng:
-        distance_to_pickup = calculate_distance(driver_lat, driver_lng, pickup_lat, pickup_lng)
-        if distance_to_pickup > ARRIVAL_RADIUS_KM:
-            distance_m = int(distance_to_pickup * 1000)
+    if driver_lat and driver_lng and targets:
+        nearest_km = min(calculate_distance(driver_lat, driver_lng, t[0], t[1]) for t in targets)
+        if nearest_km > ARRIVAL_RADIUS_KM:
+            distance_m = int(nearest_km * 1000)
             raise HTTPException(
                 status_code=400,
                 detail=f"You are {distance_m}m away from the pickup. "
@@ -4071,8 +4078,21 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
 async def cancel_ride(
     ride_id: str,
     reason: str = Query(""),
+    request: Request = None,
     current_user: dict = Depends(get_current_user),
 ):
+    # Prefer the reason from the JSON body so a free-text note never rides in the
+    # URL (proxy/access logs leak query strings). Fall back to legacy ?reason=.
+    _body_reason = None
+    if request is not None:
+        try:
+            _b = await request.json()
+            if isinstance(_b, dict):
+                _body_reason = _b.get("reason")
+        except Exception:
+            _body_reason = None
+    reason = (str(_body_reason).strip() if _body_reason else "") or reason
+
     driver = (lambda _r: _r[0] if _r else None)(
         await db_supabase.get_rows("drivers", {"user_id": current_user["id"]}, limit=1)
     )

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -709,8 +709,9 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
             maps_key = app_settings.get("google_maps_api_key", "")
             eta_map = await batch_get_etas(
                 [d for d, _ in pre_filtered],
-                ride["pickup_lat"],
-                ride["pickup_lng"],
+                # ETA to the road-snapped pickup the driver actually drives to.
+                ride["pickup_nav_lat"] if ride.get("pickup_nav_lat") is not None else ride["pickup_lat"],
+                ride["pickup_nav_lng"] if ride.get("pickup_nav_lng") is not None else ride["pickup_lng"],
                 maps_key,
             )
             ranked = rank_by_eta_with_acceptance([(d, eta_map.get(d["id"], 9999)) for d, _ in pre_filtered])
@@ -3664,6 +3665,19 @@ async def cancel_ride_rider(
         from logging_utils import diag_logger  # type: ignore
 
     diag_logger.info(f"[CANCEL] called ride_id={ride_id} user_id={current_user.get('id')}")
+
+    # Prefer the reason from the JSON body — free-text notes must not ride in the
+    # URL query string (proxy/access logs, crash breadcrumbs leak it). Fall back
+    # to the legacy ?reason= for older app builds.
+    _body_reason = None
+    if request is not None:
+        try:
+            _b = await request.json()
+            if isinstance(_b, dict):
+                _body_reason = _b.get("reason")
+        except Exception:
+            _body_reason = None
+    reason = (str(_body_reason).strip() if _body_reason else "") or reason
 
     _cancellable_states = (
         "requested",

--- a/backend/services/dispatch_service.py
+++ b/backend/services/dispatch_service.py
@@ -123,8 +123,12 @@ def filter_and_rank_drivers(
 
     No side effects. Safe to call from tests with hand-built dicts.
     """
-    pickup_lat = ride["pickup_lat"]
-    pickup_lng = ride["pickup_lng"]
+    # Match against the road-snapped pickup the driver will actually navigate to
+    # (pickup_nav_*) when present — for a pin dropped inside a mall/airport the
+    # reachable road point can be materially different, so ranking on the raw pin
+    # would filter out nearby drivers and produce wrong ETAs. Falls back to the pin.
+    pickup_lat = ride["pickup_nav_lat"] if ride.get("pickup_nav_lat") is not None else ride["pickup_lat"]
+    pickup_lng = ride["pickup_nav_lng"] if ride.get("pickup_nav_lng") is not None else ride["pickup_lng"]
     needs_rating = algorithm in ("rating_based", "combined")
 
     wav_required = bool(ride.get("requires_wav"))

--- a/driver-app/__tests__/store/driverStore.test.ts
+++ b/driver-app/__tests__/store/driverStore.test.ts
@@ -175,7 +175,7 @@ describe('driverStore', () => {
 
       await useDriverStore.getState().cancelRide('ride-1', 'Rider not found');
 
-      expect(api.post).toHaveBeenCalledWith('/drivers/rides/ride-1/cancel?reason=Rider%20not%20found');
+      expect(api.post).toHaveBeenCalledWith('/drivers/rides/ride-1/cancel', { reason: 'Rider not found' });
       expect(useDriverStore.getState().rideState).toBe('idle');
       expect(useDriverStore.getState().activeRide).toBeNull();
     });

--- a/driver-app/store/__tests__/driverStore.test.ts
+++ b/driver-app/store/__tests__/driverStore.test.ts
@@ -426,7 +426,8 @@ describe('driverStore — ride state machine', () => {
     expect(state.activeRide).toBeNull();
     expect(state.incomingRide).toBeNull();
     expect(mockApi.post).toHaveBeenCalledWith(
-      expect.stringContaining('ride-123/cancel')
+      expect.stringContaining('ride-123/cancel'),
+      { reason: 'Driver unavailable' }
     );
   });
 });

--- a/driver-app/store/driverStore.ts
+++ b/driver-app/store/driverStore.ts
@@ -627,7 +627,8 @@ export const useDriverStore = create<DriverState>((set, get) => ({
     cancelRide: async (rideId: string, reason?: string) => {
         set({ isLoading: true, isCancellingRide: true, error: null });
         try {
-            await api.post(`/drivers/rides/${rideId}/cancel?reason=${encodeURIComponent(reason || '')}`);
+            // Reason goes in the body (not the URL) so it can't leak into logs.
+            await api.post(`/drivers/rides/${rideId}/cancel`, reason && reason.trim() ? { reason: reason.trim() } : {});
             set({
                 rideState: 'idle',
                 activeRide: null,

--- a/driver-app/store/driverStore.ts
+++ b/driver-app/store/driverStore.ts
@@ -627,8 +627,14 @@ export const useDriverStore = create<DriverState>((set, get) => ({
     cancelRide: async (rideId: string, reason?: string) => {
         set({ isLoading: true, isCancellingRide: true, error: null });
         try {
-            // Reason goes in the body (not the URL) so it can't leak into logs.
-            await api.post(`/drivers/rides/${rideId}/cancel`, reason && reason.trim() ? { reason: reason.trim() } : {});
+            // Reason goes in the body (not the URL) so it can't leak into logs;
+            // omit the body when there's no reason (plain single-arg POST).
+            const trimmed = reason?.trim();
+            if (trimmed) {
+                await api.post(`/drivers/rides/${rideId}/cancel`, { reason: trimmed });
+            } else {
+                await api.post(`/drivers/rides/${rideId}/cancel`);
+            }
             set({
                 rideState: 'idle',
                 activeRide: null,

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -662,8 +662,14 @@ export const useRideStore = create<RideState>((set, get) => ({
     try {
       set({ isLoading: true });
       // Send the reason in the body (not the URL) so a free-text note doesn't
-      // leak into proxy/access logs.
-      await api.post(`/rides/${currentRide.id}/cancel`, reason && reason.trim() ? { reason: reason.trim() } : {});
+      // leak into proxy/access logs. Omit the body entirely when there's no
+      // reason so the call stays a plain single-arg POST.
+      const trimmed = reason?.trim();
+      if (trimmed) {
+        await api.post(`/rides/${currentRide.id}/cancel`, { reason: trimmed });
+      } else {
+        await api.post(`/rides/${currentRide.id}/cancel`);
+      }
       set({ currentRide: null, currentDriver: null, isLoading: false });
       AsyncStorage.removeItem(ACTIVE_RIDE_KEY).catch(() => {});
     } catch (error: unknown) {

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -661,8 +661,9 @@ export const useRideStore = create<RideState>((set, get) => ({
 
     try {
       set({ isLoading: true });
-      const qs = reason && reason.trim() ? `?reason=${encodeURIComponent(reason.trim())}` : '';
-      await api.post(`/rides/${currentRide.id}/cancel${qs}`);
+      // Send the reason in the body (not the URL) so a free-text note doesn't
+      // leak into proxy/access logs.
+      await api.post(`/rides/${currentRide.id}/cancel`, reason && reason.trim() ? { reason: reason.trim() } : {});
       set({ currentRide: null, currentDriver: null, isLoading: false });
       AsyncStorage.removeItem(ACTIVE_RIDE_KEY).catch(() => {});
     } catch (error: unknown) {


### PR DESCRIPTION
…ason leak)

- Dispatch now ranks/ETAs candidates against the snapped pickup_nav_* (the point the driver actually drives to), not the raw pin — so drivers near a mall/airport's reachable curb aren't filtered out or mis-ranked.
- arrive_at_pickup accepts arrival within 200m of EITHER the rider pin OR the nav point, so a driver who follows our navigation isn't rejected as too far.
- Cancellation reason now travels in the POST body (rider + driver), not the URL query string, so free-text notes can't leak into proxy/access logs. Backend still falls back to ?reason= for older app builds.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
