### PR TITLE
fix(admin): route driver email/gender edits to users table

### DIFF
--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -868,13 +868,25 @@ async def admin_nudge_driver_expiry(
 
 @router.put("/drivers/{driver_id}")
 async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: dict = Depends(get_admin_user)):
-    """Update driver details from admin dashboard."""
-    allowed = {
+    """Update driver details from admin dashboard.
+
+    Editable identity fields are spread across two tables: account-level
+    fields (``email``, ``gender``) live ONLY on ``users``, vehicle/compliance
+    fields live ONLY on ``drivers``, and a few (``first_name``, ``last_name``,
+    ``phone``) are mirrored on both. The admin dashboard surfaces all of them
+    on a single driver row, so this handler must route each field to the table
+    it actually exists on — writing ``email`` to ``drivers`` raises
+    PGRST204 ("Could not find the 'email' column of 'drivers'") -> 500.
+    """
+    # Fields that live on the `users` account row.
+    user_fields = {"first_name", "last_name", "email", "phone", "gender"}
+    # Fields that live on the `drivers` row (`city` is drivers-only; the
+    # name/phone columns are mirrored from users for forward-compat — see
+    # migration 63_phase3b_field_alignment.sql).
+    driver_fields = {
         "first_name",
         "last_name",
-        "email",
         "phone",
-        "gender",
         "city",
         "service_area_id",
         "vehicle_type_id",
@@ -891,6 +903,7 @@ async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: di
         "background_check_expiry_date",
         "work_eligibility_expiry_date",
     }
+    allowed = user_fields | driver_fields
     filtered = {k: v for k, v in updates.items() if k in allowed}
     if not filtered:
         raise HTTPException(status_code=400, detail="No valid fields to update")
@@ -899,8 +912,32 @@ async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: di
     if not existing:
         raise HTTPException(status_code=404, detail=f"Driver {driver_id} not found")
 
+    user_updates = {k: v for k, v in filtered.items() if k in user_fields}
+    driver_updates = {k: v for k, v in filtered.items() if k in driver_fields}
+
+    # Keep the legacy `drivers.name` atom in sync when either name part changes,
+    # since enrichment falls back to it when there is no linked user row.
+    if "first_name" in driver_updates or "last_name" in driver_updates:
+        new_first = driver_updates.get("first_name", existing.get("first_name") or "")
+        new_last = driver_updates.get("last_name", existing.get("last_name") or "")
+        driver_updates["name"] = f"{new_first} {new_last}".strip()
+
+    user_id = existing.get("user_id")
+    # Account-level fields (email/gender) can only be persisted to a linked
+    # user row. Surface loudly rather than silently dropping the edit.
+    if user_updates and not user_id:
+        raise HTTPException(
+            status_code=409,
+            detail="Driver has no linked user account; cannot update email/name/phone/gender.",
+        )
+
     try:
-        await db_supabase.update_one("drivers", {"id": driver_id}, filtered)
+        if driver_updates:
+            await db_supabase.update_one("drivers", {"id": driver_id}, driver_updates)
+        if user_updates and user_id:
+            await db_supabase.update_one("users", {"id": user_id}, user_updates)
+    except HTTPException:
+        raise
     except Exception as e:
         # B-P3-leak-cleanup: full traceback to logs, generic detail
         # to client. Supabase / postgrest errors carry table internals.

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -425,6 +425,86 @@ class TestAdminUpdateDriver:
                 )
         assert exc.value.status_code == 404
 
+    def test_email_routes_to_users_table_not_drivers(self):
+        """Regression: `email` lives on `users`, not `drivers`. Writing it to
+        `drivers` triggers PGRST204. It must be routed to the users row."""
+        from backend.routes.admin import drivers as admin_drivers
+
+        driver = _driver()
+        update_mock = AsyncMock(return_value=driver)
+
+        with (
+            patch("backend.routes.admin.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.drivers._log_driver_activity", AsyncMock()),
+        ):
+            asyncio.run(
+                admin_drivers.admin_update_driver(
+                    driver_id=DRIVER_ID,
+                    updates={"email": "new@example.com", "gender": "Female"},
+                    admin=ADMIN_USER,
+                )
+            )
+
+        tables_written = {call.args[0]: call.args[2] for call in update_mock.call_args_list}
+        # email/gender must hit `users`, keyed by user_id — never `drivers`.
+        assert "users" in tables_written
+        assert tables_written["users"] == {"email": "new@example.com", "gender": "Female"}
+        users_call = next(c for c in update_mock.call_args_list if c.args[0] == "users")
+        assert users_call.args[1] == {"id": DRIVER_USER_ID}
+        if "drivers" in tables_written:
+            assert "email" not in tables_written["drivers"]
+            assert "gender" not in tables_written["drivers"]
+
+    def test_name_change_syncs_users_and_drivers(self):
+        """first_name/last_name are mirrored on both tables; the legacy
+        `drivers.name` atom must be recomputed."""
+        from backend.routes.admin import drivers as admin_drivers
+
+        driver = _driver(first_name="Old", last_name="Name")
+        update_mock = AsyncMock(return_value=driver)
+
+        with (
+            patch("backend.routes.admin.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.drivers._log_driver_activity", AsyncMock()),
+        ):
+            asyncio.run(
+                admin_drivers.admin_update_driver(
+                    driver_id=DRIVER_ID,
+                    updates={"first_name": "New", "last_name": "Driver"},
+                    admin=ADMIN_USER,
+                )
+            )
+
+        writes = {call.args[0]: call.args[2] for call in update_mock.call_args_list}
+        assert writes["drivers"]["first_name"] == "New"
+        assert writes["drivers"]["name"] == "New Driver"
+        assert writes["users"]["first_name"] == "New"
+        assert writes["users"]["last_name"] == "Driver"
+
+    def test_409_when_user_field_but_no_linked_user(self):
+        from fastapi import HTTPException
+
+        from backend.routes.admin import drivers as admin_drivers
+
+        driver = _driver(user_id=None)
+
+        with (
+            patch("backend.routes.admin.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers.db_supabase.update_one", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers._log_driver_activity", AsyncMock()),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    admin_drivers.admin_update_driver(
+                        driver_id=DRIVER_ID,
+                        updates={"email": "x@example.com"},
+                        admin=ADMIN_USER,
+                    )
+                )
+        assert exc.value.status_code == 409
+
 
 class TestAdminVerifyDriver:
     def test_approves_driver(self):


### PR DESCRIPTION
Editing a driver from the admin panel wrote every field to the drivers
table, but email and gender only exist on users. This raised
PGRST204 ("Could not find the 'email' column of 'drivers'") -> 500.

Route account-level fields (email, gender, plus mirrored first/last
name and phone) to the linked users row, and driver/vehicle fields to
drivers. Keep the legacy drivers.name atom in sync on name changes, and
return 409 if an account field is edited on a driver with no linked
user. Adds regression tests.

https://claude.ai/code/session_01BmUELBnVTdLm2N6M61mmSS