### PR TITLE
fix(admin): address Codex review on driver update routing

### DIFF
--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -880,6 +880,9 @@ async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: di
     """
     # Fields that live on the `users` account row.
     user_fields = {"first_name", "last_name", "email", "phone", "gender"}
+    # Subset that exists ONLY on `users` (no mirror on `drivers`): these
+    # require a linked account row to persist at all.
+    user_only_fields = {"email", "gender"}
     # Fields that live on the `drivers` row (`city` is drivers-only; the
     # name/phone columns are mirrored from users for forward-compat — see
     # migration 63_phase3b_field_alignment.sql).
@@ -917,25 +920,33 @@ async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: di
 
     # Keep the legacy `drivers.name` atom in sync when either name part changes,
     # since enrichment falls back to it when there is no linked user row.
+    # Coalesce explicit JSON nulls to "" so a cleared part never renders as the
+    # literal "None" in the rebuilt name.
     if "first_name" in driver_updates or "last_name" in driver_updates:
-        new_first = driver_updates.get("first_name", existing.get("first_name") or "")
-        new_last = driver_updates.get("last_name", existing.get("last_name") or "")
+        new_first = driver_updates.get("first_name", existing.get("first_name")) or ""
+        new_last = driver_updates.get("last_name", existing.get("last_name")) or ""
         driver_updates["name"] = f"{new_first} {new_last}".strip()
 
     user_id = existing.get("user_id")
-    # Account-level fields (email/gender) can only be persisted to a linked
-    # user row. Surface loudly rather than silently dropping the edit.
-    if user_updates and not user_id:
+    # email/gender exist ONLY on `users`, so they cannot be persisted without a
+    # linked account row — surface loudly rather than silently dropping them.
+    # Mirrored fields (first/last name, phone) also live on `drivers`, so an
+    # orphaned driver row can still be edited for those via the drivers write.
+    user_only_updates = {k: v for k, v in user_updates.items() if k in user_only_fields}
+    if user_only_updates and not user_id:
         raise HTTPException(
             status_code=409,
-            detail="Driver has no linked user account; cannot update email/name/phone/gender.",
+            detail="Driver has no linked user account; cannot update email/gender.",
         )
 
     try:
-        if driver_updates:
-            await db_supabase.update_one("drivers", {"id": driver_id}, driver_updates)
+        # Write the account row first: list/stats views prefer the user row
+        # over the driver mirror, so if the second write fails the surviving
+        # state is the canonical one, not a stale mirror.
         if user_updates and user_id:
             await db_supabase.update_one("users", {"id": user_id}, user_updates)
+        if driver_updates:
+            await db_supabase.update_one("drivers", {"id": driver_id}, driver_updates)
     except HTTPException:
         raise
     except Exception as e:

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -483,7 +483,7 @@ class TestAdminUpdateDriver:
         assert writes["users"]["first_name"] == "New"
         assert writes["users"]["last_name"] == "Driver"
 
-    def test_409_when_user_field_but_no_linked_user(self):
+    def test_409_when_user_only_field_but_no_linked_user(self):
         from fastapi import HTTPException
 
         from backend.routes.admin import drivers as admin_drivers
@@ -504,6 +504,83 @@ class TestAdminUpdateDriver:
                     )
                 )
         assert exc.value.status_code == 409
+
+    def test_orphaned_driver_can_edit_mirrored_fields(self):
+        """An orphaned driver (no user_id) must still be editable for fields
+        mirrored on `drivers` (name/phone); only email/gender 409."""
+        from backend.routes.admin import drivers as admin_drivers
+
+        driver = _driver(user_id=None)
+        update_mock = AsyncMock(return_value=driver)
+
+        with (
+            patch("backend.routes.admin.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.drivers._log_driver_activity", AsyncMock()),
+        ):
+            asyncio.run(
+                admin_drivers.admin_update_driver(
+                    driver_id=DRIVER_ID,
+                    updates={"first_name": "Jane", "city": "Regina"},
+                    admin=ADMIN_USER,
+                )
+            )
+
+        writes = {call.args[0]: call.args[2] for call in update_mock.call_args_list}
+        # No users row to touch; drivers gets the mirrored + driver-only fields.
+        assert "users" not in writes
+        assert writes["drivers"]["first_name"] == "Jane"
+        assert writes["drivers"]["city"] == "Regina"
+
+    def test_null_name_part_not_rendered_as_literal_none(self):
+        from backend.routes.admin import drivers as admin_drivers
+
+        driver = _driver(first_name="Alice", last_name="Smith")
+        update_mock = AsyncMock(return_value=driver)
+
+        with (
+            patch("backend.routes.admin.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers.db_supabase.update_one", update_mock),
+            patch("backend.routes.admin.drivers._log_driver_activity", AsyncMock()),
+        ):
+            asyncio.run(
+                admin_drivers.admin_update_driver(
+                    driver_id=DRIVER_ID,
+                    updates={"last_name": None},
+                    admin=ADMIN_USER,
+                )
+            )
+
+        writes = {call.args[0]: call.args[2] for call in update_mock.call_args_list}
+        assert writes["drivers"]["name"] == "Alice"
+        assert "None" not in writes["drivers"]["name"]
+
+    def test_account_row_written_before_driver_row(self):
+        """Ordering guard: the canonical users row is written before the
+        drivers mirror, so a failed second write leaves the preferred state."""
+        from backend.routes.admin import drivers as admin_drivers
+
+        driver = _driver()
+        order = []
+
+        async def _record(table, _filters, _payload):
+            order.append(table)
+            return driver
+
+        with (
+            patch("backend.routes.admin.drivers.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
+            patch("backend.routes.admin.drivers.db_supabase.update_one", _record),
+            patch("backend.routes.admin.drivers._log_driver_activity", AsyncMock()),
+        ):
+            asyncio.run(
+                admin_drivers.admin_update_driver(
+                    driver_id=DRIVER_ID,
+                    updates={"email": "new@example.com", "city": "Regina"},
+                    admin=ADMIN_USER,
+                )
+            )
+
+        assert order == ["users", "drivers"]
 
 
 class TestAdminVerifyDriver:


### PR DESCRIPTION
- Write the users row before the drivers mirror so a failed second write leaves the canonical (user-preferred) state, not a stale mirror.
- Coalesce explicit JSON null name parts to empty so a cleared name never renders as the literal 'None' in drivers.name.
- Only 409 for user-only fields (email/gender) when a driver has no linked user; orphaned drivers can still edit mirrored name/phone via the drivers write.

https://claude.ai/code/session_01BmUELBnVTdLm2N6M61mmSS

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
