### PR TITLE
ci(deploy): set Fly secrets manually, verify presence in bootstrap

### DIFF
--- a/.github/workflows/bootstrap-fly.yml
+++ b/.github/workflows/bootstrap-fly.yml
@@ -2,25 +2,31 @@ name: Bootstrap Fly.io app (one-time / manual)
 
 # Manually-triggered, idempotent bootstrap so you never need flyctl locally:
 #   1. creates the Fly app (no-op if it already exists)
-#   2. sets all production secrets from GitHub Actions secrets
+#   2. verifies the required secrets already exist ON THE FLY APP
 #   3. (optional) deploys and scales to 2 machines in yyz, then probes /health
 #
-# Ongoing deploys are handled separately by deploy-fly.yml on every push to main.
-# Run this once to launch, or again whenever you rotate secrets.
+# Secrets are NOT managed here — set them directly in Fly (dashboard or
+# `fly secrets set ...`) so production values never live in GitHub. This job
+# only checks they are present before deploying. Ongoing deploys are handled by
+# deploy-fly.yml on every push to main.
 #
-# ── Required GitHub Actions secrets ──────────────────────────────────────────
-#   FLY_API_TOKEN  — must be ORG-scoped to create the app
-#                    (`fly tokens create org`), not a per-app deploy token.
-#   The production values, copied from Railway (same values, byte-identical):
-#     SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, JWT_SECRET, ADMIN_PASSWORD,
-#     ADMIN_EMAIL, FIREBASE_SERVICE_ACCOUNT_JSON, FIREBASE_DRIVER_APP_ID,
-#     FIREBASE_RIDER_APP_ID, REDIS_URL, RATE_LIMIT_REDIS_URL, WS_REDIS_URL,
-#     ALLOWED_ORIGINS
+# ── Required GitHub Actions secret ───────────────────────────────────────────
+#   FLY_API_TOKEN  — must have access to the org (to create the app). A personal
+#                    token (Fly dashboard → Account → Access Tokens) works; a
+#                    per-app deploy token does not have create permission.
 #
-# Notes:
-#   - FIREBASE_SERVICE_ACCOUNT_JSON must be raw JSON minified to a SINGLE line
-#     (core/security.init_firebase() runs json.loads on it, so do NOT base64 it;
-#     `fly secrets import` parses line by line, so it must contain no newlines).
+# ── Required Fly secrets (set in Fly, not GitHub) ────────────────────────────
+#   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, JWT_SECRET, ADMIN_PASSWORD,
+#   ADMIN_EMAIL, FIREBASE_SERVICE_ACCOUNT_JSON, FIREBASE_DRIVER_APP_ID,
+#   FIREBASE_RIDER_APP_ID, REDIS_URL, RATE_LIMIT_REDIS_URL, WS_REDIS_URL,
+#   ALLOWED_ORIGINS
+#
+# Notes (set these correctly in Fly):
+#   - FIREBASE_SERVICE_ACCOUNT_JSON must be raw JSON (core/security.init_firebase()
+#     runs json.loads on it — do NOT base64 it). It has embedded double quotes, so
+#     set it from a file: fly secrets set "FIREBASE_SERVICE_ACCOUNT_JSON=$(cat sa.json)"
+#   - ADMIN_EMAIL must be a real address; the default admin@spinr.ca is rejected
+#     by the production config guard and the app will not boot.
 #   - Redis URLs must keep credentials and use the alias host, e.g.
 #     rediss://:<password>@redis.spinr.ca:6379. If using rediss:// with the alias,
 #     the Redis origin must present a TLS cert valid for redis.spinr.ca (provider
@@ -76,50 +82,25 @@ jobs:
             flyctl apps create "${FLY_APP}" --org "${{ inputs.org }}"
           fi
 
-      # Pipe secrets over stdin so values never appear in the command line or
-      # process list. GitHub masks them in logs. This stages one release.
-      - name: Set Fly secrets
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
-          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
-          FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
-          FIREBASE_DRIVER_APP_ID: ${{ secrets.FIREBASE_DRIVER_APP_ID }}
-          FIREBASE_RIDER_APP_ID: ${{ secrets.FIREBASE_RIDER_APP_ID }}
-          REDIS_URL: ${{ secrets.REDIS_URL }}
-          RATE_LIMIT_REDIS_URL: ${{ secrets.RATE_LIMIT_REDIS_URL }}
-          WS_REDIS_URL: ${{ secrets.WS_REDIS_URL }}
-          ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
+      # Secrets are set manually in Fly (not stored in GitHub). Verify the
+      # required ones are present on the app before deploying so a missing one
+      # fails fast here instead of crash-looping the Machines past /health.
+      - name: Verify required Fly secrets exist
+        if: ${{ inputs.deploy }}
         run: |
+          present="$(flyctl secrets list -a "${FLY_APP}" 2>/dev/null || true)"
           missing=0
-          for v in SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY JWT_SECRET \
+          for k in SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY JWT_SECRET \
                    ADMIN_PASSWORD ADMIN_EMAIL FIREBASE_SERVICE_ACCOUNT_JSON \
                    FIREBASE_DRIVER_APP_ID FIREBASE_RIDER_APP_ID REDIS_URL \
                    RATE_LIMIT_REDIS_URL WS_REDIS_URL ALLOWED_ORIGINS; do
-            if [ -z "${!v}" ]; then
-              echo "::error title=Missing secret::GitHub secret ${v} is not set."
+            if ! printf '%s\n' "$present" | grep -qw "$k"; then
+              echo "::error title=Missing Fly secret::${k} is not set on ${FLY_APP}. Set it with: fly secrets set ${k}=... -a ${FLY_APP}"
               missing=1
             fi
           done
-          [ "$missing" -eq 0 ] || exit 1
-
-          flyctl secrets import -a "${FLY_APP}" <<EOF
-          SUPABASE_URL=${SUPABASE_URL}
-          SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
-          JWT_SECRET=${JWT_SECRET}
-          ADMIN_PASSWORD=${ADMIN_PASSWORD}
-          ADMIN_EMAIL=${ADMIN_EMAIL}
-          FIREBASE_SERVICE_ACCOUNT_JSON=${FIREBASE_SERVICE_ACCOUNT_JSON}
-          FIREBASE_DRIVER_APP_ID=${FIREBASE_DRIVER_APP_ID}
-          FIREBASE_RIDER_APP_ID=${FIREBASE_RIDER_APP_ID}
-          REDIS_URL=${REDIS_URL}
-          RATE_LIMIT_REDIS_URL=${RATE_LIMIT_REDIS_URL}
-          WS_REDIS_URL=${WS_REDIS_URL}
-          ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
-          EOF
-          echo "Secrets staged."
+          [ "$missing" -eq 0 ] || { echo "Set the missing secrets in Fly, then re-run."; exit 1; }
+          echo "All required secrets present on ${FLY_APP}."
 
       # Build context must be backend/ (root Dockerfile COPYs a root
       # requirements.txt that does not exist — only backend/ has one).

--- a/docs/runbooks/railway-fly-failover.md
+++ b/docs/runbooks/railway-fly-failover.md
@@ -32,11 +32,11 @@ api-spinr.spinr.ca                 redis.spinr.ca
 Two workflows mean you never need flyctl locally:
 
 - **`.github/workflows/bootstrap-fly.yml`** (manual `workflow_dispatch`) — creates
-  the app, sets all secrets from GitHub Actions secrets, then deploys and scales.
-  Run this once to launch (or again to rotate secrets). Needs an **org-scoped**
-  `FLY_API_TOKEN` (`fly tokens create org`) plus the production values stored as
-  GitHub secrets (`SUPABASE_URL`, `JWT_SECRET`, `ADMIN_EMAIL`, `REDIS_URL`, … —
-  see that workflow's header for the full list).
+  the app (idempotent), verifies the required secrets are present on the Fly app,
+  then deploys and scales. Needs a `FLY_API_TOKEN` with access to the org (a Fly
+  personal token works; a per-app deploy token can't create the app).
+  **Secrets are set directly in Fly, not GitHub** — set them with `fly secrets set`
+  (next section) before running with `deploy=true`.
 - **`.github/workflows/deploy-fly.yml`** — deploys Fly on every push to `main`, in
   parallel with `.github/workflows/deploy-backend.yml` for Railway.
 


### PR DESCRIPTION
Per ops preference, production secrets are managed directly in Fly (fly secrets set / dashboard), not stored as GitHub secrets. Replace the secret-setting step with a pre-deploy check that the required secrets already exist on the Fly app (via fly secrets list), failing fast with the missing key names instead of crash-looping the Machines. Update the runbook accordingly.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
