### PR TITLE
fix(driver-app): stop LogRocket hanging cold start on Android 16

### DIFF
--- a/docs/android-build-strategy.md
+++ b/docs/android-build-strategy.md
@@ -196,3 +196,50 @@ The pattern that should have triggered earlier strategic review: each fix unbloc
 build phase but introduced the next blocker. By failure #3 (the Stripe metadata error), it
 was clear we were spiraling. The right move was to step back, audit the dependency chain,
 and pick a coherent end-state — which is what this doc captures.
+
+---
+
+## Runtime: Android 16 hidden-API enforcement (LogRocket splash hang)
+
+This doc is mostly about BUILD breaks. This entry is a RUNTIME break — the build
+succeeds but the app hangs on first launch on a specific Android version.
+
+**Symptom:** On Android 16 devices (e.g. Samsung S26) the app cold-starts, shows the
+native splash, and never advances to the React UI. No crash / tombstone — a hang, not a
+crash. The same APK works fine on older Android phones.
+
+**Smoking gun in logcat:**
+
+```
+E om.spinr.driver: hiddenapi: Accessing hidden field
+Landroid/graphics/PorterDuffColorFilter;->mColor:I (api=max-target-o)
+from Lcom/logrocket/core/util/ReflectionUtils; (TargetSdkVersion=36)
+using reflection: denied
+```
+
+…followed (~30s later) by `ActivityTaskManager: Activity transferring splash screen
+timeout`.
+
+**Why:** Android gates hidden-API access by `targetSdkVersion`, and enforcement tightens
+with each OS release. `@logrocket/react-native`'s session-replay view serializer reflects
+into framework-internal fields (here `PorterDuffColorFilter.mColor`) to record colors. On
+Android 16 / targetSdk 36 that field is on the `max-target-o` blocklist, so the reflection
+is denied on the UI thread during view serialization. That wedges startup: React never
+renders its first frame, so `SplashScreen.hideAsync()` (called from `BrandSplash`'s
+`onLayout`) never runs and the native splash stays up forever.
+
+**Fix (shipped):** LogRocket is gated OFF on Android by default in both apps'
+`app/_layout.tsx`. Override per build with `EXPO_PUBLIC_ENABLE_LOGROCKET` (`'true'` /
+`'false'`); unset = iOS on, Android off. A 10s splash watchdog in `_layout.tsx` is the
+backstop — it force-hides the native splash and reports the stall (Sentry warning) so a
+future non-critical init can't silently brick cold start.
+
+**Re-enable Android when:** LogRocket ships a release that no longer reflects into blocked
+hidden APIs at the targetSdk we ship. Verify on a physical Android 16+ device (the hang is
+device-OS-specific and won't reproduce on older emulators), then set
+`EXPO_PUBLIC_ENABLE_LOGROCKET=true`.
+
+**General lesson:** any dependency that reflects on framework internals (session replay,
+screenshotting, view-tree analytics) is a latent runtime bomb that detonates on a future
+Android release, not at build time. Re-test those SDKs on a current-gen device before each
+targetSdk bump.

--- a/driver-app/.env.example
+++ b/driver-app/.env.example
@@ -6,3 +6,9 @@ EXPO_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 
 # Stripe (for payouts)
 # EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
+
+# LogRocket session replay. Disabled on Android by default — its view serializer
+# hits Android 16 / targetSdk 36 hidden-API blocks and hangs startup on devices
+# like the Samsung S26. 'true' force-enables and 'false' force-disables on BOTH
+# platforms; leave unset for the safe default (iOS on, Android off).
+# EXPO_PUBLIC_ENABLE_LOGROCKET=false

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -106,10 +106,11 @@ if (canUseNotifications) {
 // Override per build with EXPO_PUBLIC_ENABLE_LOGROCKET ('true'/'false'); leave
 // unset for the safe default (iOS on, Android off). Re-enable Android once
 // LogRocket ships an Android-16-safe SDK.
+// Only the literal strings 'true'/'false' override; any other inlined value
+// (undefined / '' when unset) falls through to the platform default.
+const lrFlag = process.env.EXPO_PUBLIC_ENABLE_LOGROCKET;
 const LOGROCKET_ENABLED =
-  process.env.EXPO_PUBLIC_ENABLE_LOGROCKET != null
-    ? process.env.EXPO_PUBLIC_ENABLE_LOGROCKET === 'true'
-    : Platform.OS === 'ios';
+  lrFlag === 'true' ? true : lrFlag === 'false' ? false : Platform.OS === 'ios';
 let LogRocket: any = null;
 if (!isExpoGo && Platform.OS !== 'web' && LOGROCKET_ENABLED) {
   try {

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -21,6 +21,23 @@ import * as SplashScreen from 'expo-splash-screen';
 // otherwise the driver home (which contains the SOSButton) momentarily
 // flashes through during the boot transition.
 SplashScreen.preventAutoHideAsync().catch(() => {});
+
+// Failsafe watchdog: a non-critical startup hang must never leave the driver
+// staring at a frozen native splash forever. (A bad analytics SDK on a new
+// Android release once hung the UI thread here and bricked cold start.) If our
+// React splash hasn't taken over within this window, force-hide the native
+// splash so BrandSplash (the in-app loading UI) shows, and report the stall so
+// the root cause gets fixed rather than silently masked. Cleared in
+// onLoadingLayout on the normal boot path.
+const SPLASH_WATCHDOG_MS = 10_000;
+let splashWatchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+  splashWatchdog = null;
+  SplashScreen.hideAsync().catch(() => {});
+  captureMessage(
+    'driver splash watchdog fired — startup stalled, native splash force-hidden',
+    'warning',
+  );
+}, SPLASH_WATCHDOG_MS);
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useAuthStore } from '@shared/store/authStore';
 import { useLocationStore } from '@shared/store/locationStore';
@@ -80,8 +97,21 @@ if (canUseNotifications) {
 // @logrocket/react-native ships a native module that isn't linked in Expo Go
 // — importing it eagerly throws on module-load. Lazy-require so the app
 // mounts in Expo Go / web, and no-op the init/identify calls there.
+//
+// Android is DISABLED by default: LogRocket's session-replay view serializer
+// reflects into hidden framework fields (e.g. PorterDuffColorFilter.mColor)
+// that Android 16 / targetSdk 36 blocks ("hiddenapi ... denied"). On Android 16
+// devices (e.g. Samsung S26) that denial hung the UI thread during startup, so
+// the first React frame never rendered and the app stuck on the native splash.
+// Override per build with EXPO_PUBLIC_ENABLE_LOGROCKET ('true'/'false'); leave
+// unset for the safe default (iOS on, Android off). Re-enable Android once
+// LogRocket ships an Android-16-safe SDK.
+const LOGROCKET_ENABLED =
+  process.env.EXPO_PUBLIC_ENABLE_LOGROCKET != null
+    ? process.env.EXPO_PUBLIC_ENABLE_LOGROCKET === 'true'
+    : Platform.OS === 'ios';
 let LogRocket: any = null;
-if (!isExpoGo && Platform.OS !== 'web') {
+if (!isExpoGo && Platform.OS !== 'web' && LOGROCKET_ENABLED) {
   try {
     LogRocket = require('@logrocket/react-native').default ?? require('@logrocket/react-native');
   } catch (e) {
@@ -525,6 +555,10 @@ export default function RootLayout() {
   }, [isAuthInitialized, authToken]);
 
   const onLoadingLayout = useCallback(() => {
+    if (splashWatchdog) {
+      clearTimeout(splashWatchdog);
+      splashWatchdog = null;
+    }
     SplashScreen.hideAsync().catch(() => {});
   }, []);
 

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -38,6 +38,11 @@ let splashWatchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => {
     'warning',
   );
 }, SPLASH_WATCHDOG_MS);
+
+// Minimum time the branded splash (logo + tagline) stays on screen, even when
+// auth/location init finishes sooner — otherwise the tagline animation (which
+// only starts ~400ms in) is cut off and the driver barely sees the branding.
+const SPLASH_MIN_DISPLAY_MS = 3000;
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useAuthStore } from '@shared/store/authStore';
 import { useLocationStore } from '@shared/store/locationStore';
@@ -360,6 +365,14 @@ export default function RootLayout() {
   const { initialize: initializeAuth, isInitialized: isAuthInitialized, token: authToken } = useAuthStore();
   const { initialize: initializeLocation, isInitialized: isLocationInitialized } = useLocationStore();
   const [isOffline, setIsOffline] = useState(false);
+  // Hold the branded splash for a minimum duration so the logo + tagline are
+  // actually seen — auth/location init can finish in <400ms, cutting off the
+  // tagline before it animates in. The loading gate below waits on this too.
+  const [minSplashElapsed, setMinSplashElapsed] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setMinSplashElapsed(true), SPLASH_MIN_DISPLAY_MS);
+    return () => clearTimeout(t);
+  }, []);
   // Guard so we only register the FCM token once per auth session.
   const fcmRegisteredRef = useRef(false);
   const prevAuthTokenRef = useRef(authToken);
@@ -563,7 +576,7 @@ export default function RootLayout() {
     SplashScreen.hideAsync().catch(() => {});
   }, []);
 
-  if (!fontsLoaded || fontError || !isAuthInitialized || !isLocationInitialized) {
+  if (!fontsLoaded || fontError || !isAuthInitialized || !isLocationInitialized || !minSplashElapsed) {
     return (
       <QueryClientProvider client={queryClient}>
         <ErrorBoundary>

--- a/driver-app/components/BrandSplash.tsx
+++ b/driver-app/components/BrandSplash.tsx
@@ -1,53 +1,100 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated, Easing, StyleSheet, View, LayoutChangeEvent } from 'react-native';
+import {
+  ActivityIndicator,
+  Animated,
+  Easing,
+  LayoutChangeEvent,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 const LOGO = require('../assets/images/spinr-logo.png');
 
+// The logo asset is 384×156 (≈2.46:1). Keep the render box on that exact ratio
+// so `resizeMode="contain"` fills it with no letterboxing and the full mark is
+// always shown — never cropped, never squished.
+const LOGO_WIDTH = 260;
+const LOGO_HEIGHT = Math.round((LOGO_WIDTH * 156) / 384); // 106
+
 type Props = { onLayout?: (e: LayoutChangeEvent) => void };
 
+/**
+ * BrandSplash — the in-app splash shown while the app initializes (fonts, auth,
+ * location). Rendered by the loading gate in app/_layout.tsx, which also holds
+ * it for a minimum duration so the logo + tagline are actually seen. Plain core
+ * RN Animated (no Reanimated) so it can mount before the rest of the app is up.
+ */
 export default function BrandSplash({ onLayout }: Props) {
   const logoOpacity = useRef(new Animated.Value(0)).current;
+  const logoScale = useRef(new Animated.Value(0.92)).current;
   const tagOpacity = useRef(new Animated.Value(0)).current;
-  const tagY = useRef(new Animated.Value(8)).current;
+  const tagY = useRef(new Animated.Value(10)).current;
+  const footerOpacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    Animated.sequence([
+    // Logo: fade in with a gentle settle.
+    Animated.parallel([
       Animated.timing(logoOpacity, {
         toValue: 1,
-        duration: 400,
+        duration: 500,
         easing: Easing.out(Easing.cubic),
         useNativeDriver: true,
       }),
-      Animated.parallel([
-        Animated.timing(tagOpacity, {
-          toValue: 1,
-          duration: 500,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: true,
-        }),
-        Animated.timing(tagY, {
-          toValue: 0,
-          duration: 500,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: true,
-        }),
-      ]),
+      Animated.spring(logoScale, {
+        toValue: 1,
+        friction: 7,
+        tension: 60,
+        useNativeDriver: true,
+      }),
     ]).start();
-  }, [logoOpacity, tagOpacity, tagY]);
+
+    // Tagline: fade up shortly after the logo lands.
+    Animated.parallel([
+      Animated.timing(tagOpacity, {
+        toValue: 1,
+        duration: 600,
+        delay: 350,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.timing(tagY, {
+        toValue: 0,
+        duration: 600,
+        delay: 350,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // Footer loader: fades in last so the screen reads brand-first.
+    Animated.timing(footerOpacity, {
+      toValue: 1,
+      duration: 400,
+      delay: 700,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [logoOpacity, logoScale, tagOpacity, tagY, footerOpacity]);
 
   return (
     <View style={styles.root} onLayout={onLayout}>
-      <Animated.Image
-        source={LOGO}
-        style={[styles.logo, { opacity: logoOpacity }]}
-        resizeMode="contain"
-      />
-      <Animated.Text
-        style={[styles.subtitle, { opacity: tagOpacity, transform: [{ translateY: tagY }] }]}
-        allowFontScaling={false}
-      >
-        Ride Local · Support Local
-      </Animated.Text>
+      <View style={styles.center}>
+        <Animated.Image
+          source={LOGO}
+          resizeMode="contain"
+          style={[styles.logo, { opacity: logoOpacity, transform: [{ scale: logoScale }] }]}
+        />
+        <Animated.Text
+          allowFontScaling={false}
+          style={[styles.tagline, { opacity: tagOpacity, transform: [{ translateY: tagY }] }]}
+        >
+          Ride Local · Support Local
+        </Animated.Text>
+      </View>
+
+      <Animated.View style={[styles.footer, { opacity: footerOpacity }]}>
+        <ActivityIndicator size="small" color="#C7CBD1" />
+      </Animated.View>
     </View>
   );
 }
@@ -56,18 +103,30 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: '#FFFFFF',
+  },
+  center: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: 32,
   },
   logo: {
-    width: 220,
-    height: 80,
+    width: LOGO_WIDTH,
+    height: LOGO_HEIGHT,
   },
-  subtitle: {
-    marginTop: 18,
+  tagline: {
+    marginTop: 20,
     fontSize: 13,
-    letterSpacing: 1.2,
+    letterSpacing: 1.4,
     color: '#8A8F98',
     fontFamily: 'PlusJakartaSans_600SemiBold',
+    textAlign: 'center',
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 56,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
   },
 });

--- a/rider-app/.env.example
+++ b/rider-app/.env.example
@@ -7,6 +7,12 @@ EXPO_PUBLIC_GOOGLE_MAPS_API_KEY=your_google_maps_api_key
 # Stripe (for payments)
 # EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
 
+# LogRocket session replay. Disabled on Android by default — its view serializer
+# hits Android 16 / targetSdk 36 hidden-API blocks and hangs startup on devices
+# like the Samsung S26. 'true' force-enables and 'false' force-disables on BOTH
+# platforms; leave unset for the safe default (iOS on, Android off).
+# EXPO_PUBLIC_ENABLE_LOGROCKET=false
+
 # NOTE: The "Share Trip" tracking URL is NOT configured here. It's served
 # at runtime from the backend (GET /settings → track_base_url), backed by
 # the app_settings table. Set it via the admin dashboard Settings panel —

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -121,10 +121,11 @@ if (canUseNotifications) {
 // Override per build with EXPO_PUBLIC_ENABLE_LOGROCKET ('true'/'false'); leave
 // unset for the safe default (iOS on, Android off). Re-enable Android once
 // LogRocket ships an Android-16-safe SDK.
+// Only the literal strings 'true'/'false' override; any other inlined value
+// (undefined / '' when unset) falls through to the platform default.
+const lrFlag = process.env.EXPO_PUBLIC_ENABLE_LOGROCKET;
 const LOGROCKET_ENABLED =
-  process.env.EXPO_PUBLIC_ENABLE_LOGROCKET != null
-    ? process.env.EXPO_PUBLIC_ENABLE_LOGROCKET === 'true'
-    : Platform.OS === 'ios';
+  lrFlag === 'true' ? true : lrFlag === 'false' ? false : Platform.OS === 'ios';
 let LogRocket: any = null;
 if (!isExpoGo && Platform.OS !== 'web' && LOGROCKET_ENABLED) {
   try {

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -34,6 +34,11 @@ let splashWatchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => {
     'warning',
   );
 }, SPLASH_WATCHDOG_MS);
+
+// Minimum time the branded splash (logo + tagline) stays on screen, even when
+// auth/location init finishes sooner — otherwise the tagline animation (which
+// only starts ~400ms in) is cut off and the rider barely sees the branding.
+const SPLASH_MIN_DISPLAY_MS = 3000;
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import NetInfo from '@react-native-community/netinfo';
 import api from '@shared/api/client';
@@ -164,6 +169,14 @@ export default function RootLayout() {
   const { initialize: initializeLocation, isInitialized: isLocationInitialized } = useLocationStore();
   const hydrateWorkProfile = useWorkProfileStore(s => s.hydrate);
   const [isOffline, setIsOffline] = useState(false);
+  // Hold the branded splash for a minimum duration so the logo + tagline are
+  // actually seen — auth/location init can finish in <400ms, cutting off the
+  // tagline before it animates in. The loading gate below waits on this too.
+  const [minSplashElapsed, setMinSplashElapsed] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setMinSplashElapsed(true), SPLASH_MIN_DISPLAY_MS);
+    return () => clearTimeout(t);
+  }, []);
   const [stripePublishableKey, setStripePublishableKey] = useState<string | null>(null);
   const [trackBaseUrl, setTrackBaseUrl] = useState<string | null>(null);
   const fcmRegisteredRef = useRef(false);
@@ -552,7 +565,7 @@ export default function RootLayout() {
     SplashScreen.hideAsync().catch(() => {});
   }, []);
 
-  if (!fontsLoaded || fontError || !isAuthInitialized || !isLocationInitialized) {
+  if (!fontsLoaded || fontError || !isAuthInitialized || !isLocationInitialized || !minSplashElapsed) {
     return (
       <ErrorBoundary>
         <BrandSplash onLayout={onLoadingLayout} />

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -17,6 +17,23 @@ import * as SplashScreen from 'expo-splash-screen';
 import * as Updates from 'expo-updates';
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
+
+// Failsafe watchdog: a non-critical startup hang must never leave the rider
+// staring at a frozen native splash forever. (A bad analytics SDK on a new
+// Android release once hung the UI thread here and bricked cold start.) If our
+// React splash hasn't taken over within this window, force-hide the native
+// splash so BrandSplash (the in-app loading UI) shows, and report the stall so
+// the root cause gets fixed rather than silently masked. Cleared in
+// onLoadingLayout on the normal boot path.
+const SPLASH_WATCHDOG_MS = 10_000;
+let splashWatchdog: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+  splashWatchdog = null;
+  SplashScreen.hideAsync().catch(() => {});
+  captureMessage(
+    'rider splash watchdog fired — startup stalled, native splash force-hidden',
+    'warning',
+  );
+}, SPLASH_WATCHDOG_MS);
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import NetInfo from '@react-native-community/netinfo';
 import api from '@shared/api/client';
@@ -96,8 +113,20 @@ if (canUseNotifications) {
   }
 }
 
+// Android is DISABLED by default: LogRocket's session-replay view serializer
+// reflects into hidden framework fields (e.g. PorterDuffColorFilter.mColor)
+// that Android 16 / targetSdk 36 blocks ("hiddenapi ... denied"). On Android 16
+// devices (e.g. Samsung S26) that denial hung the UI thread during startup, so
+// the first React frame never rendered and the app stuck on the native splash.
+// Override per build with EXPO_PUBLIC_ENABLE_LOGROCKET ('true'/'false'); leave
+// unset for the safe default (iOS on, Android off). Re-enable Android once
+// LogRocket ships an Android-16-safe SDK.
+const LOGROCKET_ENABLED =
+  process.env.EXPO_PUBLIC_ENABLE_LOGROCKET != null
+    ? process.env.EXPO_PUBLIC_ENABLE_LOGROCKET === 'true'
+    : Platform.OS === 'ios';
 let LogRocket: any = null;
-if (!isExpoGo && Platform.OS !== 'web') {
+if (!isExpoGo && Platform.OS !== 'web' && LOGROCKET_ENABLED) {
   try {
     LogRocket = require('@logrocket/react-native').default ?? require('@logrocket/react-native');
   } catch (e) {
@@ -515,6 +544,10 @@ export default function RootLayout() {
   }, [isAuthInitialized, isOffline]);
 
   const onLoadingLayout = useCallback(() => {
+    if (splashWatchdog) {
+      clearTimeout(splashWatchdog);
+      splashWatchdog = null;
+    }
     SplashScreen.hideAsync().catch(() => {});
   }, []);
 

--- a/rider-app/components/BrandSplash.tsx
+++ b/rider-app/components/BrandSplash.tsx
@@ -1,53 +1,100 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated, Easing, StyleSheet, View, LayoutChangeEvent } from 'react-native';
+import {
+  ActivityIndicator,
+  Animated,
+  Easing,
+  LayoutChangeEvent,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 const LOGO = require('../assets/images/spinr-logo.png');
 
+// The logo asset is 384×156 (≈2.46:1). Keep the render box on that exact ratio
+// so `resizeMode="contain"` fills it with no letterboxing and the full mark is
+// always shown — never cropped, never squished.
+const LOGO_WIDTH = 260;
+const LOGO_HEIGHT = Math.round((LOGO_WIDTH * 156) / 384); // 106
+
 type Props = { onLayout?: (e: LayoutChangeEvent) => void };
 
+/**
+ * BrandSplash — the in-app splash shown while the app initializes (fonts, auth,
+ * location). Rendered by the loading gate in app/_layout.tsx, which also holds
+ * it for a minimum duration so the logo + tagline are actually seen. Plain core
+ * RN Animated (no Reanimated) so it can mount before the rest of the app is up.
+ */
 export default function BrandSplash({ onLayout }: Props) {
   const logoOpacity = useRef(new Animated.Value(0)).current;
+  const logoScale = useRef(new Animated.Value(0.92)).current;
   const tagOpacity = useRef(new Animated.Value(0)).current;
-  const tagY = useRef(new Animated.Value(8)).current;
+  const tagY = useRef(new Animated.Value(10)).current;
+  const footerOpacity = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
-    Animated.sequence([
+    // Logo: fade in with a gentle settle.
+    Animated.parallel([
       Animated.timing(logoOpacity, {
         toValue: 1,
-        duration: 400,
+        duration: 500,
         easing: Easing.out(Easing.cubic),
         useNativeDriver: true,
       }),
-      Animated.parallel([
-        Animated.timing(tagOpacity, {
-          toValue: 1,
-          duration: 500,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: true,
-        }),
-        Animated.timing(tagY, {
-          toValue: 0,
-          duration: 500,
-          easing: Easing.out(Easing.cubic),
-          useNativeDriver: true,
-        }),
-      ]),
+      Animated.spring(logoScale, {
+        toValue: 1,
+        friction: 7,
+        tension: 60,
+        useNativeDriver: true,
+      }),
     ]).start();
-  }, [logoOpacity, tagOpacity, tagY]);
+
+    // Tagline: fade up shortly after the logo lands.
+    Animated.parallel([
+      Animated.timing(tagOpacity, {
+        toValue: 1,
+        duration: 600,
+        delay: 350,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.timing(tagY, {
+        toValue: 0,
+        duration: 600,
+        delay: 350,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // Footer loader: fades in last so the screen reads brand-first.
+    Animated.timing(footerOpacity, {
+      toValue: 1,
+      duration: 400,
+      delay: 700,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [logoOpacity, logoScale, tagOpacity, tagY, footerOpacity]);
 
   return (
     <View style={styles.root} onLayout={onLayout}>
-      <Animated.Image
-        source={LOGO}
-        style={[styles.logo, { opacity: logoOpacity }]}
-        resizeMode="contain"
-      />
-      <Animated.Text
-        style={[styles.subtitle, { opacity: tagOpacity, transform: [{ translateY: tagY }] }]}
-        allowFontScaling={false}
-      >
-        Ride Local · Support Local
-      </Animated.Text>
+      <View style={styles.center}>
+        <Animated.Image
+          source={LOGO}
+          resizeMode="contain"
+          style={[styles.logo, { opacity: logoOpacity, transform: [{ scale: logoScale }] }]}
+        />
+        <Animated.Text
+          allowFontScaling={false}
+          style={[styles.tagline, { opacity: tagOpacity, transform: [{ translateY: tagY }] }]}
+        >
+          Ride Local · Support Local
+        </Animated.Text>
+      </View>
+
+      <Animated.View style={[styles.footer, { opacity: footerOpacity }]}>
+        <ActivityIndicator size="small" color="#C7CBD1" />
+      </Animated.View>
     </View>
   );
 }
@@ -56,18 +103,30 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: '#FFFFFF',
+  },
+  center: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    paddingHorizontal: 32,
   },
   logo: {
-    width: 220,
-    height: 80,
+    width: LOGO_WIDTH,
+    height: LOGO_HEIGHT,
   },
-  subtitle: {
-    marginTop: 18,
+  tagline: {
+    marginTop: 20,
     fontSize: 13,
-    letterSpacing: 1.2,
+    letterSpacing: 1.4,
     color: '#8A8F98',
     fontFamily: 'PlusJakartaSans_600SemiBold',
+    textAlign: 'center',
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 56,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
   },
 });


### PR DESCRIPTION
LogRocket's session-replay view serializer reflects into hidden framework
fields (PorterDuffColorFilter.mColor) that Android 16 / targetSdk 36 blocks
('hiddenapi ... denied'). On Android 16 devices (e.g. Samsung S26) the denied
reflection hung the UI thread during startup, so React never rendered its
first frame and the app stuck on the native splash until the system
splash-transfer timeout.

- Gate LogRocket off on Android by default; iOS unchanged. Override per build
  with EXPO_PUBLIC_ENABLE_LOGROCKET ('true'/'false').
- Add a 10s splash watchdog so a non-critical startup hang can never again
  leave the driver on a frozen native splash; it force-hides the splash and
  reports the stall (warning) instead of masking it.

https://claude.ai/code/session_0167A49T1aqMg7PuxBehevJq

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
