### PR TITLE
fix(ws): don't let Redis location-cache outage block driver DB write

### DIFF
--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -387,6 +387,26 @@ async def lifespan(app: FastAPI):
         ws_redis_url = resolve_ws_redis_url(settings.WS_REDIS_URL, settings.RATE_LIMIT_REDIS_URL)
         ws_started = await ws_pubsub.start(ws_manager, ws_redis_url)
         app.state.ws_pubsub = ws_pubsub
+
+        # Connectivity diagnosis — probe every Redis URL (PING + pub/sub
+        # round-trip) and print a password-free banner so operators can tell
+        # "down" from "up but pub/sub broken" from "wrong URL kind" straight
+        # from the Fly logs. Best-effort; never blocks boot.
+        try:
+            from utils.redis_diag import diagnose_redis, log_diagnosis
+
+            _diag = await diagnose_redis(
+                {
+                    "REDIS_URL": settings.REDIS_URL,
+                    "RATE_LIMIT_REDIS_URL": settings.RATE_LIMIT_REDIS_URL,
+                    "WS_REDIS_URL (effective)": ws_redis_url,
+                }
+            )
+            log_diagnosis(_diag)
+            app.state.redis_diagnosis = _diag
+        except Exception as _diag_err:
+            logger.warning(f"Redis diagnosis failed: {_diag_err}")
+
         if not ws_started and settings.ENV.lower() == "production":
             # Production without distributed WS is a correctness
             # hazard, but not a boot-blocker — a single-machine prod

--- a/backend/dependencies/__init__.py
+++ b/backend/dependencies/__init__.py
@@ -157,8 +157,28 @@ async def _verify_admin_payload(payload: dict) -> "dict | None":
         return None
     user_id = payload["user_id"]
     jti = payload.get("jti")
-    if jti and await redis_get(f"admin:revoked:{jti}"):
-        raise HTTPException(status_code=401, detail="ERR_TOKEN_REVOKED")
+    if jti:
+        # Per-JTI revocation denylist is a Redis FAST-PATH for single-session
+        # logout. When Redis (Upstash) is unreachable we fail OPEN on this one
+        # check rather than locking every admin out of the live dashboard on a
+        # cache blip — the industry-standard "degrade auth on cache-dependency
+        # failure, keep the authoritative control" pattern (Uber/Lyft/Netflix).
+        # It's safe because the AUTHORITATIVE revocation for staff —
+        # /auth/logout-all — bumps admin_staff.token_version, verified below
+        # against the DB (no Redis). Every cryptographic / audience / expiry /
+        # account-active check also still runs. Worst case during an outage: a
+        # single explicitly-revoked token stays usable until it expires. Logged
+        # loudly so the degraded decision is auditable.
+        try:
+            _jti_revoked = await redis_get(f"admin:revoked:{jti}")
+        except Exception as _revoke_err:
+            logger.error(
+                "[auth] admin revocation denylist unreachable (Redis down) — "
+                f"failing OPEN for jti={jti}; DB token_version still enforced: {_revoke_err}"
+            )
+            _jti_revoked = None
+        if _jti_revoked:
+            raise HTTPException(status_code=401, detail="ERR_TOKEN_REVOKED")
     if user_id != "admin-001":
         staff_rows = await db_supabase.get_rows("admin_staff", {"id": user_id}, limit=1)
         staff = staff_rows[0] if staff_rows else None

--- a/backend/routes/admin/monitoring.py
+++ b/backend/routes/admin/monitoring.py
@@ -315,10 +315,36 @@ async def get_redis_health(
     ]
     prefixes_with_meta.sort(key=lambda x: x["count"], reverse=True)
 
+    # Live connectivity probe — PING + pub/sub round-trip on every configured
+    # Redis URL. This is what tells you "Redis up but pub/sub broken" (the
+    # failure mode that breaks cross-replica admin live-monitoring on Upstash),
+    # which get_redis_stats's INFO snapshot can't see. Best-effort.
+    connectivity: List[Dict[str, Any]] = []
+    try:
+        try:
+            from ...core.config import settings
+            from ...utils.redis_diag import diagnose_redis
+            from ...utils.ws_pubsub import resolve_ws_redis_url
+        except ImportError:
+            from core.config import settings  # type: ignore
+            from utils.redis_diag import diagnose_redis  # type: ignore
+            from utils.ws_pubsub import resolve_ws_redis_url  # type: ignore
+
+        connectivity = await diagnose_redis(
+            {
+                "REDIS_URL": settings.REDIS_URL,
+                "RATE_LIMIT_REDIS_URL": settings.RATE_LIMIT_REDIS_URL,
+                "WS_REDIS_URL (effective)": resolve_ws_redis_url(settings.WS_REDIS_URL, settings.RATE_LIMIT_REDIS_URL),
+            }
+        )
+    except Exception as exc:
+        connectivity = [{"label": "probe", "status": "error", "error": str(exc)}]
+
     return {
         "stats": stats,
         "prefix_counts": prefixes_with_meta,
         "flushable_prefixes": sorted(_FLUSHABLE_PREFIXES),
+        "connectivity": connectivity,
     }
 
 

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -786,10 +786,14 @@ async def websocket_endpoint(
                             mocked=last_pt.get("mocked"),
                         )
                         if trusted:
-                            await manager.update_driver_location(driver_id, _lat, _lng)
+                            # Authoritative DB write first; the ephemeral Redis
+                            # cache is best-effort and must not gate it (mirrors
+                            # the single-ping handler — a Redis blip on the cache
+                            # previously skipped persistence and hid the marker).
                             await db_supabase.update_driver_location(
                                 driver_id, _lat, _lng, heading=last_pt.get("heading")
                             )
+                            await manager.update_driver_location(driver_id, _lat, _lng)
                             await mark_present(driver_id)
 
                             # Fan-out latest batch position to riders — the single-ping

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -592,8 +592,16 @@ async def websocket_endpoint(
                     if not trusted:
                         continue
 
-                    await manager.update_driver_location(driver_id, lat, lng)
+                    # Persist to the authoritative drivers table FIRST. The
+                    # admin live-monitoring marker and /drivers/nearby read
+                    # lat/lng from this row, so the durable write must not be
+                    # gated behind the ephemeral Redis cache below — a Redis
+                    # blip there previously raised and skipped this DB write,
+                    # leaving an online driver with no position (no car marker).
                     await db_supabase.update_driver_location(driver_id, lat, lng, heading=data.get("heading"))
+                    # Best-effort 60 s cache for the rider-map fast path;
+                    # swallows its own Redis errors (see ConnectionManager).
+                    await manager.update_driver_location(driver_id, lat, lng)
                     # Location pings are an even stronger liveness signal
                     # than pongs — fresh GPS proves the app is running and
                     # foregrounded, not just that TCP is open.

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -390,7 +390,17 @@ class ConnectionManager:
                 "updated_at": datetime.now(timezone.utc).isoformat(),
             }
         )
-        await redis_set(f"spinr:driver:location:{driver_id}", payload, ttl=60)
+        # This is an ephemeral 60 s cache (rider-map fast path); the
+        # authoritative location lives in the drivers table. A Redis outage
+        # here is degraded-but-recovered — log a warning and move on rather
+        # than letting redis_set's re-raise propagate. Letting it raise once
+        # blocked the caller's downstream DB write of the same coordinates,
+        # so a Redis blip left drivers with no persisted position and the
+        # admin live-monitoring map drew no car marker for an online driver.
+        try:
+            await redis_set(f"spinr:driver:location:{driver_id}", payload, ttl=60)
+        except Exception as e:
+            logger.warning(f"driver location cache write failed (driver={driver_id}): {e}")
 
     async def get_driver_location(self, driver_id: str) -> Optional[Dict]:
         try:

--- a/backend/tests/test_admin_revocation_failopen.py
+++ b/backend/tests/test_admin_revocation_failopen.py
@@ -1,0 +1,62 @@
+"""Regression: admin JTI-revocation denylist fails OPEN on a Redis outage.
+
+A Redis (Upstash) blip must not lock every admin out of the live dashboard —
+the per-JTI denylist is a fast-path, and the authoritative revocation
+(/auth/logout-all) is enforced via the DB token_version check, not Redis. But
+a genuine revocation (Redis reachable, key present) must still be blocked.
+
+Uses the admin-001 bootstrap identity so the staff-table DB lookup is skipped
+and the test exercises only the revocation branch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+import dependencies
+from dependencies import JWT_AUD_ADMIN, _verify_admin_payload
+
+
+def _admin_payload() -> dict:
+    return {
+        "user_id": "admin-001",
+        "role": "admin",
+        "email": "ops@spinr.ca",
+        "aud": JWT_AUD_ADMIN,
+        "jti": "tok-1",
+        "token_version": 0,
+    }
+
+
+@pytest.mark.anyio
+async def test_fails_open_when_redis_unavailable(monkeypatch):
+    """redis_get raising (Upstash down) must NOT reject a valid admin token."""
+    monkeypatch.setattr(
+        dependencies, "redis_get", AsyncMock(side_effect=RuntimeError("Upstash unreachable"))
+    )
+    user = await _verify_admin_payload(_admin_payload())
+    assert user is not None
+    assert user["id"] == "admin-001"
+    assert user["role"] == "admin"
+
+
+@pytest.mark.anyio
+async def test_blocks_when_redis_reports_revoked(monkeypatch):
+    """When Redis IS reachable and the JTI is on the denylist, still 401."""
+    monkeypatch.setattr(dependencies, "redis_get", AsyncMock(return_value="1"))
+    with pytest.raises(HTTPException) as exc:
+        await _verify_admin_payload(_admin_payload())
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "ERR_TOKEN_REVOKED"
+
+
+@pytest.mark.anyio
+async def test_allows_when_redis_reports_not_revoked(monkeypatch):
+    """Healthy Redis, JTI absent from denylist → token passes."""
+    monkeypatch.setattr(dependencies, "redis_get", AsyncMock(return_value=None))
+    user = await _verify_admin_payload(_admin_payload())
+    assert user is not None
+    assert user["id"] == "admin-001"

--- a/backend/tests/test_driver_location_redis_resilience.py
+++ b/backend/tests/test_driver_location_redis_resilience.py
@@ -1,0 +1,57 @@
+"""Regression: a Redis outage on the ephemeral driver-location cache must
+not block the authoritative DB write of the driver's coordinates.
+
+Bug (redis driver display): ``ConnectionManager.update_driver_location``
+called ``redis_set`` with no error handling, and ``redis_set`` re-raises
+when ``REDIS_URL`` is configured but Redis is unreachable. In the driver
+WebSocket location handler that cache write ran BEFORE the durable
+``drivers`` table write, so a Redis blip raised and skipped persistence —
+leaving an online driver with no lat/lng and no car marker on the admin
+live-monitoring map.
+
+Contract:
+  - ``update_driver_location`` swallows a Redis failure (logs, no raise),
+    so the caller's downstream DB write still executes.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_update_driver_location_swallows_redis_error(monkeypatch):
+    """A raising redis_set must not propagate out of the cache write."""
+    from socket_manager import ConnectionManager
+
+    failing = AsyncMock(side_effect=RuntimeError("Redis configured but unavailable"))
+    # redis_set is imported lazily inside the method from utils.redis_client.
+    import utils.redis_client as rc
+
+    monkeypatch.setattr(rc, "redis_set", failing)
+
+    mgr = ConnectionManager()
+
+    # Must NOT raise — the ephemeral cache is best-effort.
+    await mgr.update_driver_location("driver-123", 50.4452, -104.6189)
+
+    assert failing.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_update_driver_location_writes_cache_when_redis_ok(monkeypatch):
+    """Happy path still writes the 60 s location cache key."""
+    import utils.redis_client as rc
+    from socket_manager import ConnectionManager
+
+    ok = AsyncMock(return_value=None)
+    monkeypatch.setattr(rc, "redis_set", ok)
+
+    mgr = ConnectionManager()
+    await mgr.update_driver_location("driver-123", 50.4452, -104.6189)
+
+    ok.assert_awaited_once()
+    key = ok.await_args.args[0]
+    assert key == "spinr:driver:location:driver-123"

--- a/backend/tests/test_redis_diag.py
+++ b/backend/tests/test_redis_diag.py
@@ -1,0 +1,53 @@
+"""Tests for the Redis connectivity diagnostic (Upstash debugging helper)."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.redis_diag import diagnose_redis, probe_redis_url
+
+
+@pytest.mark.anyio
+async def test_unset_url_reported_as_unset():
+    res = await probe_redis_url("REDIS_URL", "")
+    assert res["status"] == "unset"
+    assert res["configured"] is False
+
+
+@pytest.mark.anyio
+async def test_rest_url_rejected_before_dialing():
+    """An Upstash REST URL (https) can't do pub/sub — flag it without a socket."""
+    res = await probe_redis_url("WS_REDIS_URL", "https://my-db.upstash.io")
+    assert res["status"] == "error"
+    assert "REST" in res["error"]
+    assert res["scheme"] == "https"
+    # Never leak anything resembling the password — only scheme/host/port.
+    assert res["endpoint"] == "https://my-db.upstash.io:?"
+
+
+@pytest.mark.anyio
+async def test_plaintext_redis_warns_about_tls():
+    res = await probe_redis_url("REDIS_URL", "redis://h:6379", timeout=0.01)
+    # Connection will fail/timeout in the test env, but the TLS warning must be
+    # attached from the scheme check regardless of reachability.
+    assert res.get("warning")
+    assert "rediss://" in res["warning"]
+
+
+@pytest.mark.anyio
+async def test_diagnose_dedupes_shared_url():
+    """Two labels pointing at the same URL should be marked as shared, not
+    dialed twice (matters under Upstash connection caps)."""
+    url = "https://same.upstash.io"
+    results = await diagnose_redis({"RATE_LIMIT_REDIS_URL": url, "WS_REDIS_URL (effective)": url})
+    assert len(results) == 2
+    # Second occurrence references the first.
+    assert results[1].get("same_as") == "RATE_LIMIT_REDIS_URL"
+
+
+@pytest.mark.anyio
+async def test_masked_endpoint_excludes_credentials():
+    res = await probe_redis_url("REDIS_URL", "rediss://default:supersecret@host.upstash.io:6379", timeout=0.01)
+    # endpoint is scheme://host:port only — credentials must never appear.
+    assert "supersecret" not in str(res)
+    assert res["endpoint"] == "rediss://host.upstash.io:6379"

--- a/backend/utils/redis_diag.py
+++ b/backend/utils/redis_diag.py
@@ -1,0 +1,175 @@
+"""Redis connectivity diagnostics (Upstash / Fly debugging).
+
+``get_redis_stats`` in ``redis_client`` answers "is the default REDIS_URL
+reachable and how full is it" — but the WebSocket fan-out that powers admin
+live-monitoring rides on ``WS_REDIS_URL``/``RATE_LIMIT_REDIS_URL`` *and* on
+pub/sub specifically, which INFO/DBSIZE never exercise. This module probes a
+given Redis URL end to end:
+
+  * parse + mask (never log the password)
+  * classify obvious misconfigurations before dialing (Upstash REST URL,
+    plaintext ``redis://`` to a TLS-only endpoint)
+  * ``PING`` with latency
+  * a real subscribe → publish → receive round-trip on a throwaway channel,
+    because Upstash's serverless REST tier and some proxies accept PING but
+    silently drop pub/sub — which is exactly the failure that leaves a
+    driver online on one replica but invisible on another.
+
+Used by the startup banner (``core/lifespan``) and the admin ``/redis``
+endpoint so operators can tell "Redis is down" from "Redis is up but pub/sub
+is broken" from "URL is the wrong kind" at a glance.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from loguru import logger
+
+
+def _classify_error(exc: Exception) -> str:
+    """Map a raw connection exception to an operator-actionable hint."""
+    name = type(exc).__name__
+    msg = str(exc).lower()
+    if "wrong version number" in msg or "ssl" in msg or "eof occurred" in msg:
+        return f"{name}: TLS handshake failed — Upstash requires rediss:// (TLS). Check the URL scheme."
+    if "max" in msg and ("client" in msg or "connection" in msg or "request" in msg):
+        return f"{name}: connection/request limit hit — Upstash plan cap exceeded across replicas."
+    if "noauth" in msg or "wrongpass" in msg or "auth" in msg:
+        return f"{name}: auth rejected — token/password in the URL is wrong."
+    if "name or service not known" in msg or "nodename" in msg or "getaddrinfo" in msg:
+        return f"{name}: DNS resolution failed — host unreachable from this replica."
+    if "timed out" in msg or isinstance(exc, asyncio.TimeoutError):
+        return f"{name}: timed out — host/port blocked or wrong (TLS port vs plaintext?)."
+    return f"{name}: {exc}"
+
+
+async def _pubsub_roundtrip(client: Any, timeout: float) -> Dict[str, Any]:
+    """Subscribe to a throwaway channel, publish, and confirm receipt."""
+    channel = f"spinr:diag:{uuid4().hex}"
+    ps = client.pubsub()
+    try:
+        await asyncio.wait_for(ps.subscribe(channel), timeout=timeout)
+        await asyncio.wait_for(client.publish(channel, "1"), timeout=timeout)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            msg = await ps.get_message(ignore_subscribe_messages=True, timeout=1.0)
+            if msg and msg.get("type") == "message":
+                return {"ok": True}
+        return {
+            "ok": False,
+            "error": "no message echoed back — pub/sub unsupported or blocked (Upstash REST tier? proxy?)",
+        }
+    except Exception as exc:
+        return {"ok": False, "error": _classify_error(exc)}
+    finally:
+        try:
+            await ps.unsubscribe(channel)
+        except Exception:  # noqa: S110 - best effort cleanup
+            pass
+        try:
+            await ps.aclose()
+        except Exception:  # noqa: S110
+            pass
+
+
+async def probe_redis_url(label: str, url: str, *, timeout: float = 5.0) -> Dict[str, Any]:
+    """End-to-end probe of one Redis URL. Never includes the password."""
+    info: Dict[str, Any] = {"label": label, "configured": bool(url)}
+    if not url:
+        info["status"] = "unset"
+        return info
+
+    parsed = urlparse(url)
+    info["scheme"] = parsed.scheme
+    info["host"] = parsed.hostname or "?"
+    info["port"] = parsed.port
+    info["tls"] = parsed.scheme == "rediss"
+    info["endpoint"] = f"{parsed.scheme}://{parsed.hostname or '?'}:{parsed.port or '?'}"
+
+    # Catch the two most common Upstash-on-Fly mistakes before dialing.
+    if parsed.scheme in ("http", "https"):
+        info["status"] = "error"
+        info["error"] = (
+            "this is an Upstash REST URL (http/https) — redis.asyncio needs the "
+            "TCP rediss://…:6379 endpoint; pub/sub does NOT work over REST."
+        )
+        return info
+    if parsed.scheme == "redis":
+        # Not fatal (some self-hosted Redis is plaintext), but Upstash is TLS-only.
+        info["warning"] = "plaintext redis:// — Upstash requires rediss:// (TLS); will fail if this is Upstash."
+
+    try:
+        import redis.asyncio as redis_asyncio  # type: ignore
+    except ImportError:
+        info["status"] = "error"
+        info["error"] = "redis package not installed"
+        return info
+
+    client = None
+    try:
+        client = redis_asyncio.from_url(url, decode_responses=True)
+        t0 = time.perf_counter()
+        await asyncio.wait_for(client.ping(), timeout=timeout)
+        info["ping_ms"] = round((time.perf_counter() - t0) * 1000, 1)
+        info["pubsub"] = await _pubsub_roundtrip(client, timeout=timeout)
+        info["status"] = "ok" if info["pubsub"].get("ok") else "degraded"
+    except Exception as exc:
+        info["status"] = "error"
+        info["error"] = _classify_error(exc)
+    finally:
+        if client is not None:
+            try:
+                await client.aclose()
+            except Exception:  # noqa: S110
+                pass
+    return info
+
+
+async def diagnose_redis(urls: Dict[str, str], *, timeout: float = 5.0) -> List[Dict[str, Any]]:
+    """Probe a {label: url} map. Deduplicates identical URLs so a shared
+    Redis isn't dialed three times (matters under Upstash connection caps)."""
+    seen: Dict[str, Dict[str, Any]] = {}
+    results: List[Dict[str, Any]] = []
+    for label, url in urls.items():
+        key = url or f"__unset__:{label}"
+        if url and key in seen:
+            shared = dict(seen[key])
+            shared["label"] = label
+            shared["same_as"] = seen[key]["label"]
+            results.append(shared)
+            continue
+        res = await probe_redis_url(label, url, timeout=timeout)
+        if url:
+            seen[key] = res
+        results.append(res)
+    return results
+
+
+def log_diagnosis(results: List[Dict[str, Any]]) -> None:
+    """Emit a compact, password-free banner for the boot logs / Fly logs."""
+    logger.info("── Redis connectivity diagnosis ───────────────────────────")
+    for r in results:
+        label = r["label"]
+        status = r.get("status", "?")
+        if status == "unset":
+            logger.info(f"  {label:22s} UNSET")
+            continue
+        endpoint = r.get("endpoint", "?")
+        same = f" (== {r['same_as']})" if r.get("same_as") else ""
+        if status == "ok":
+            logger.info(f"  {label:22s} OK     {endpoint}  ping={r.get('ping_ms')}ms  pubsub=ok{same}")
+        elif status == "degraded":
+            logger.warning(
+                f"  {label:22s} DEGRADED {endpoint}  ping={r.get('ping_ms')}ms  "
+                f"pubsub FAILED: {r.get('pubsub', {}).get('error')}{same}"
+            )
+        else:
+            logger.error(f"  {label:22s} ERROR  {endpoint}  {r.get('error')}{same}")
+        if r.get("warning"):
+            logger.warning(f"  {label:22s} note: {r['warning']}")
+    logger.info("───────────────────────────────────────────────────────────")

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - spinrvm  (2026-05-29)
+# Graph Report - spinrvm  (2026-06-05)
 
 ## Corpus Check
-- 1711 files · ~2,564,463 words
+- 1794 files · ~2,581,330 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 28871 nodes · 43507 edges · 3367 communities (1406 shown, 1961 thin omitted)
-- Extraction: 85% EXTRACTED · 15% INFERRED · 0% AMBIGUOUS · INFERRED: 6497 edges (avg confidence: 0.61)
+- 31938 nodes · 56825 edges · 3490 communities (1511 shown, 1979 thin omitted)
+- Extraction: 88% EXTRACTED · 12% INFERRED · 0% AMBIGUOUS · INFERRED: 6619 edges (avg confidence: 0.61)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `31045f7a`
+- Built from commit: `f88ced3d`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -171,6 +171,7 @@
 - [[_COMMUNITY_Community 153|Community 153]]
 - [[_COMMUNITY_Community 154|Community 154]]
 - [[_COMMUNITY_Community 155|Community 155]]
+- [[_COMMUNITY_Community 156|Community 156]]
 - [[_COMMUNITY_Community 157|Community 157]]
 - [[_COMMUNITY_Community 158|Community 158]]
 - [[_COMMUNITY_Community 159|Community 159]]
@@ -186,6 +187,7 @@
 - [[_COMMUNITY_Community 169|Community 169]]
 - [[_COMMUNITY_Community 170|Community 170]]
 - [[_COMMUNITY_Community 171|Community 171]]
+- [[_COMMUNITY_Community 172|Community 172]]
 - [[_COMMUNITY_Community 173|Community 173]]
 - [[_COMMUNITY_Community 174|Community 174]]
 - [[_COMMUNITY_Community 175|Community 175]]
@@ -197,7 +199,9 @@
 - [[_COMMUNITY_Community 181|Community 181]]
 - [[_COMMUNITY_Community 182|Community 182]]
 - [[_COMMUNITY_Community 183|Community 183]]
+- [[_COMMUNITY_Community 184|Community 184]]
 - [[_COMMUNITY_Community 185|Community 185]]
+- [[_COMMUNITY_Community 186|Community 186]]
 - [[_COMMUNITY_Community 187|Community 187]]
 - [[_COMMUNITY_Community 188|Community 188]]
 - [[_COMMUNITY_Community 189|Community 189]]
@@ -211,20 +215,27 @@
 - [[_COMMUNITY_Community 197|Community 197]]
 - [[_COMMUNITY_Community 198|Community 198]]
 - [[_COMMUNITY_Community 199|Community 199]]
+- [[_COMMUNITY_Community 200|Community 200]]
 - [[_COMMUNITY_Community 201|Community 201]]
 - [[_COMMUNITY_Community 202|Community 202]]
+- [[_COMMUNITY_Community 203|Community 203]]
 - [[_COMMUNITY_Community 204|Community 204]]
+- [[_COMMUNITY_Community 205|Community 205]]
 - [[_COMMUNITY_Community 206|Community 206]]
 - [[_COMMUNITY_Community 207|Community 207]]
+- [[_COMMUNITY_Community 208|Community 208]]
 - [[_COMMUNITY_Community 209|Community 209]]
 - [[_COMMUNITY_Community 210|Community 210]]
 - [[_COMMUNITY_Community 211|Community 211]]
+- [[_COMMUNITY_Community 212|Community 212]]
 - [[_COMMUNITY_Community 213|Community 213]]
 - [[_COMMUNITY_Community 214|Community 214]]
 - [[_COMMUNITY_Community 215|Community 215]]
+- [[_COMMUNITY_Community 216|Community 216]]
 - [[_COMMUNITY_Community 217|Community 217]]
 - [[_COMMUNITY_Community 218|Community 218]]
 - [[_COMMUNITY_Community 219|Community 219]]
+- [[_COMMUNITY_Community 220|Community 220]]
 - [[_COMMUNITY_Community 221|Community 221]]
 - [[_COMMUNITY_Community 222|Community 222]]
 - [[_COMMUNITY_Community 223|Community 223]]
@@ -266,6 +277,7 @@
 - [[_COMMUNITY_Community 259|Community 259]]
 - [[_COMMUNITY_Community 260|Community 260]]
 - [[_COMMUNITY_Community 261|Community 261]]
+- [[_COMMUNITY_Community 262|Community 262]]
 - [[_COMMUNITY_Community 263|Community 263]]
 - [[_COMMUNITY_Community 264|Community 264]]
 - [[_COMMUNITY_Community 265|Community 265]]
@@ -290,7 +302,10 @@
 - [[_COMMUNITY_Community 285|Community 285]]
 - [[_COMMUNITY_Community 286|Community 286]]
 - [[_COMMUNITY_Community 287|Community 287]]
+- [[_COMMUNITY_Community 288|Community 288]]
 - [[_COMMUNITY_Community 289|Community 289]]
+- [[_COMMUNITY_Community 290|Community 290]]
+- [[_COMMUNITY_Community 291|Community 291]]
 - [[_COMMUNITY_Community 292|Community 292]]
 - [[_COMMUNITY_Community 293|Community 293]]
 - [[_COMMUNITY_Community 294|Community 294]]
@@ -298,8 +313,14 @@
 - [[_COMMUNITY_Community 296|Community 296]]
 - [[_COMMUNITY_Community 297|Community 297]]
 - [[_COMMUNITY_Community 298|Community 298]]
+- [[_COMMUNITY_Community 299|Community 299]]
+- [[_COMMUNITY_Community 300|Community 300]]
+- [[_COMMUNITY_Community 301|Community 301]]
 - [[_COMMUNITY_Community 302|Community 302]]
+- [[_COMMUNITY_Community 303|Community 303]]
 - [[_COMMUNITY_Community 304|Community 304]]
+- [[_COMMUNITY_Community 305|Community 305]]
+- [[_COMMUNITY_Community 306|Community 306]]
 - [[_COMMUNITY_Community 307|Community 307]]
 - [[_COMMUNITY_Community 308|Community 308]]
 - [[_COMMUNITY_Community 309|Community 309]]
@@ -2459,6 +2480,7 @@
 - [[_COMMUNITY_Community 2496|Community 2496]]
 - [[_COMMUNITY_Community 2497|Community 2497]]
 - [[_COMMUNITY_Community 2498|Community 2498]]
+- [[_COMMUNITY_Community 2499|Community 2499]]
 - [[_COMMUNITY_Community 2500|Community 2500]]
 - [[_COMMUNITY_Community 2501|Community 2501]]
 - [[_COMMUNITY_Community 2502|Community 2502]]
@@ -2473,6 +2495,7 @@
 - [[_COMMUNITY_Community 2511|Community 2511]]
 - [[_COMMUNITY_Community 2512|Community 2512]]
 - [[_COMMUNITY_Community 2513|Community 2513]]
+- [[_COMMUNITY_Community 2514|Community 2514]]
 - [[_COMMUNITY_Community 2515|Community 2515]]
 - [[_COMMUNITY_Community 2516|Community 2516]]
 - [[_COMMUNITY_Community 2517|Community 2517]]
@@ -2526,6 +2549,7 @@
 - [[_COMMUNITY_Community 2565|Community 2565]]
 - [[_COMMUNITY_Community 2566|Community 2566]]
 - [[_COMMUNITY_Community 2567|Community 2567]]
+- [[_COMMUNITY_Community 2568|Community 2568]]
 - [[_COMMUNITY_Community 2569|Community 2569]]
 - [[_COMMUNITY_Community 2570|Community 2570]]
 - [[_COMMUNITY_Community 2571|Community 2571]]
@@ -2571,6 +2595,7 @@
 - [[_COMMUNITY_Community 2611|Community 2611]]
 - [[_COMMUNITY_Community 2612|Community 2612]]
 - [[_COMMUNITY_Community 2613|Community 2613]]
+- [[_COMMUNITY_Community 2614|Community 2614]]
 - [[_COMMUNITY_Community 2615|Community 2615]]
 - [[_COMMUNITY_Community 2616|Community 2616]]
 - [[_COMMUNITY_Community 2617|Community 2617]]
@@ -2607,9 +2632,11 @@
 - [[_COMMUNITY_Community 2648|Community 2648]]
 - [[_COMMUNITY_Community 2649|Community 2649]]
 - [[_COMMUNITY_Community 2650|Community 2650]]
+- [[_COMMUNITY_Community 2651|Community 2651]]
 - [[_COMMUNITY_Community 2652|Community 2652]]
 - [[_COMMUNITY_Community 2653|Community 2653]]
 - [[_COMMUNITY_Community 2654|Community 2654]]
+- [[_COMMUNITY_Community 2655|Community 2655]]
 - [[_COMMUNITY_Community 2656|Community 2656]]
 - [[_COMMUNITY_Community 2657|Community 2657]]
 - [[_COMMUNITY_Community 2658|Community 2658]]
@@ -2651,6 +2678,7 @@
 - [[_COMMUNITY_Community 2694|Community 2694]]
 - [[_COMMUNITY_Community 2695|Community 2695]]
 - [[_COMMUNITY_Community 2696|Community 2696]]
+- [[_COMMUNITY_Community 2697|Community 2697]]
 - [[_COMMUNITY_Community 2698|Community 2698]]
 - [[_COMMUNITY_Community 2699|Community 2699]]
 - [[_COMMUNITY_Community 2700|Community 2700]]
@@ -2665,6 +2693,7 @@
 - [[_COMMUNITY_Community 2709|Community 2709]]
 - [[_COMMUNITY_Community 2710|Community 2710]]
 - [[_COMMUNITY_Community 2711|Community 2711]]
+- [[_COMMUNITY_Community 2712|Community 2712]]
 - [[_COMMUNITY_Community 2713|Community 2713]]
 - [[_COMMUNITY_Community 2714|Community 2714]]
 - [[_COMMUNITY_Community 2715|Community 2715]]
@@ -2759,6 +2788,8 @@
 - [[_COMMUNITY_Community 2804|Community 2804]]
 - [[_COMMUNITY_Community 2805|Community 2805]]
 - [[_COMMUNITY_Community 2806|Community 2806]]
+- [[_COMMUNITY_Community 2807|Community 2807]]
+- [[_COMMUNITY_Community 2808|Community 2808]]
 - [[_COMMUNITY_Community 2809|Community 2809]]
 - [[_COMMUNITY_Community 2810|Community 2810]]
 - [[_COMMUNITY_Community 2811|Community 2811]]
@@ -2785,6 +2816,7 @@
 - [[_COMMUNITY_Community 2832|Community 2832]]
 - [[_COMMUNITY_Community 2833|Community 2833]]
 - [[_COMMUNITY_Community 2834|Community 2834]]
+- [[_COMMUNITY_Community 2835|Community 2835]]
 - [[_COMMUNITY_Community 2836|Community 2836]]
 - [[_COMMUNITY_Community 2837|Community 2837]]
 - [[_COMMUNITY_Community 2838|Community 2838]]
@@ -2803,6 +2835,7 @@
 - [[_COMMUNITY_Community 2851|Community 2851]]
 - [[_COMMUNITY_Community 2852|Community 2852]]
 - [[_COMMUNITY_Community 2853|Community 2853]]
+- [[_COMMUNITY_Community 2854|Community 2854]]
 - [[_COMMUNITY_Community 2855|Community 2855]]
 - [[_COMMUNITY_Community 2856|Community 2856]]
 - [[_COMMUNITY_Community 2857|Community 2857]]
@@ -2822,6 +2855,7 @@
 - [[_COMMUNITY_Community 2871|Community 2871]]
 - [[_COMMUNITY_Community 2872|Community 2872]]
 - [[_COMMUNITY_Community 2873|Community 2873]]
+- [[_COMMUNITY_Community 2874|Community 2874]]
 - [[_COMMUNITY_Community 2875|Community 2875]]
 - [[_COMMUNITY_Community 2876|Community 2876]]
 - [[_COMMUNITY_Community 2877|Community 2877]]
@@ -2833,6 +2867,7 @@
 - [[_COMMUNITY_Community 2883|Community 2883]]
 - [[_COMMUNITY_Community 2884|Community 2884]]
 - [[_COMMUNITY_Community 2885|Community 2885]]
+- [[_COMMUNITY_Community 2886|Community 2886]]
 - [[_COMMUNITY_Community 2887|Community 2887]]
 - [[_COMMUNITY_Community 2888|Community 2888]]
 - [[_COMMUNITY_Community 2889|Community 2889]]
@@ -2878,6 +2913,7 @@
 - [[_COMMUNITY_Community 2929|Community 2929]]
 - [[_COMMUNITY_Community 2930|Community 2930]]
 - [[_COMMUNITY_Community 2931|Community 2931]]
+- [[_COMMUNITY_Community 2932|Community 2932]]
 - [[_COMMUNITY_Community 2933|Community 2933]]
 - [[_COMMUNITY_Community 2934|Community 2934]]
 - [[_COMMUNITY_Community 2935|Community 2935]]
@@ -3160,6 +3196,7 @@
 - [[_COMMUNITY_Community 3212|Community 3212]]
 - [[_COMMUNITY_Community 3213|Community 3213]]
 - [[_COMMUNITY_Community 3214|Community 3214]]
+- [[_COMMUNITY_Community 3215|Community 3215]]
 - [[_COMMUNITY_Community 3216|Community 3216]]
 - [[_COMMUNITY_Community 3217|Community 3217]]
 - [[_COMMUNITY_Community 3218|Community 3218]]
@@ -3189,11 +3226,13 @@
 - [[_COMMUNITY_Community 3242|Community 3242]]
 - [[_COMMUNITY_Community 3243|Community 3243]]
 - [[_COMMUNITY_Community 3244|Community 3244]]
+- [[_COMMUNITY_Community 3245|Community 3245]]
 - [[_COMMUNITY_Community 3246|Community 3246]]
 - [[_COMMUNITY_Community 3247|Community 3247]]
 - [[_COMMUNITY_Community 3248|Community 3248]]
 - [[_COMMUNITY_Community 3249|Community 3249]]
 - [[_COMMUNITY_Community 3250|Community 3250]]
+- [[_COMMUNITY_Community 3251|Community 3251]]
 - [[_COMMUNITY_Community 3252|Community 3252]]
 - [[_COMMUNITY_Community 3253|Community 3253]]
 - [[_COMMUNITY_Community 3254|Community 3254]]
@@ -3214,8 +3253,16 @@
 - [[_COMMUNITY_Community 3269|Community 3269]]
 - [[_COMMUNITY_Community 3270|Community 3270]]
 - [[_COMMUNITY_Community 3271|Community 3271]]
+- [[_COMMUNITY_Community 3272|Community 3272]]
+- [[_COMMUNITY_Community 3273|Community 3273]]
 - [[_COMMUNITY_Community 3274|Community 3274]]
+- [[_COMMUNITY_Community 3275|Community 3275]]
+- [[_COMMUNITY_Community 3276|Community 3276]]
+- [[_COMMUNITY_Community 3277|Community 3277]]
 - [[_COMMUNITY_Community 3278|Community 3278]]
+- [[_COMMUNITY_Community 3279|Community 3279]]
+- [[_COMMUNITY_Community 3280|Community 3280]]
+- [[_COMMUNITY_Community 3281|Community 3281]]
 - [[_COMMUNITY_Community 3282|Community 3282]]
 - [[_COMMUNITY_Community 3283|Community 3283]]
 - [[_COMMUNITY_Community 3284|Community 3284]]
@@ -3305,245 +3352,314 @@
 - [[_COMMUNITY_Community 3377|Community 3377]]
 - [[_COMMUNITY_Community 3378|Community 3378]]
 - [[_COMMUNITY_Community 3379|Community 3379]]
+- [[_COMMUNITY_Community 3380|Community 3380]]
 - [[_COMMUNITY_Community 3381|Community 3381]]
 - [[_COMMUNITY_Community 3382|Community 3382]]
 - [[_COMMUNITY_Community 3383|Community 3383]]
 - [[_COMMUNITY_Community 3384|Community 3384]]
+- [[_COMMUNITY_Community 3385|Community 3385]]
+- [[_COMMUNITY_Community 3386|Community 3386]]
 - [[_COMMUNITY_Community 3387|Community 3387]]
 - [[_COMMUNITY_Community 3388|Community 3388]]
 - [[_COMMUNITY_Community 3389|Community 3389]]
+- [[_COMMUNITY_Community 3390|Community 3390]]
+- [[_COMMUNITY_Community 3391|Community 3391]]
 - [[_COMMUNITY_Community 3392|Community 3392]]
+- [[_COMMUNITY_Community 3393|Community 3393]]
+- [[_COMMUNITY_Community 3394|Community 3394]]
+- [[_COMMUNITY_Community 3395|Community 3395]]
+- [[_COMMUNITY_Community 3396|Community 3396]]
+- [[_COMMUNITY_Community 3397|Community 3397]]
 - [[_COMMUNITY_Community 3398|Community 3398]]
+- [[_COMMUNITY_Community 3399|Community 3399]]
+- [[_COMMUNITY_Community 3400|Community 3400]]
+- [[_COMMUNITY_Community 3401|Community 3401]]
+- [[_COMMUNITY_Community 3402|Community 3402]]
+- [[_COMMUNITY_Community 3403|Community 3403]]
+- [[_COMMUNITY_Community 3404|Community 3404]]
+- [[_COMMUNITY_Community 3405|Community 3405]]
+- [[_COMMUNITY_Community 3406|Community 3406]]
+- [[_COMMUNITY_Community 3407|Community 3407]]
+- [[_COMMUNITY_Community 3408|Community 3408]]
+- [[_COMMUNITY_Community 3409|Community 3409]]
 - [[_COMMUNITY_Community 3410|Community 3410]]
+- [[_COMMUNITY_Community 3411|Community 3411]]
+- [[_COMMUNITY_Community 3412|Community 3412]]
+- [[_COMMUNITY_Community 3413|Community 3413]]
+- [[_COMMUNITY_Community 3414|Community 3414]]
+- [[_COMMUNITY_Community 3415|Community 3415]]
+- [[_COMMUNITY_Community 3416|Community 3416]]
+- [[_COMMUNITY_Community 3417|Community 3417]]
+- [[_COMMUNITY_Community 3418|Community 3418]]
+- [[_COMMUNITY_Community 3419|Community 3419]]
+- [[_COMMUNITY_Community 3420|Community 3420]]
+- [[_COMMUNITY_Community 3421|Community 3421]]
+- [[_COMMUNITY_Community 3422|Community 3422]]
+- [[_COMMUNITY_Community 3423|Community 3423]]
+- [[_COMMUNITY_Community 3424|Community 3424]]
+- [[_COMMUNITY_Community 3425|Community 3425]]
+- [[_COMMUNITY_Community 3426|Community 3426]]
+- [[_COMMUNITY_Community 3427|Community 3427]]
+- [[_COMMUNITY_Community 3428|Community 3428]]
+- [[_COMMUNITY_Community 3429|Community 3429]]
+- [[_COMMUNITY_Community 3430|Community 3430]]
+- [[_COMMUNITY_Community 3431|Community 3431]]
+- [[_COMMUNITY_Community 3432|Community 3432]]
+- [[_COMMUNITY_Community 3433|Community 3433]]
+- [[_COMMUNITY_Community 3434|Community 3434]]
+- [[_COMMUNITY_Community 3435|Community 3435]]
+- [[_COMMUNITY_Community 3436|Community 3436]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `Communities` - 722 edges
 2. `HTTPException` - 279 edges
-3. `SpinrException` - 245 edges
-4. `request()` - 213 edges
-5. `BaseModel` - 184 edges
-6. `RideStatus` - 181 edges
-7. `useTheme()` - 172 edges
-8. `AgentTask` - 170 edges
-9. `DuplicateRecordError` - 168 edges
-10. `BaseAgent` - 157 edges
+3. `SpinrException` - 267 edges
+4. `useTheme()` - 261 edges
+5. `request()` - 240 edges
+6. `BaseModel` - 197 edges
+7. `RideStatus` - 189 edges
+8. `AgentTask` - 184 edges
+9. `DuplicateRecordError` - 173 edges
+10. `BaseAgent` - 168 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `recordNonFatal()` --calls--> `crashlytics()`  [INFERRED]
-  driver-app/utils/crashlytics.ts → shared/services/errorReporting.ts
-- `recordNonFatal()` --calls--> `crashlytics()`  [INFERRED]
-  rider-app/utils/crashlytics.ts → shared/services/errorReporting.ts
-- `recordNonFatal()` --calls--> `crashlytics()`  [INFERRED]
-  rider-app/utils/crashlytics.ts → shared/services/errorReporting.ts
-- `_storeSessionAndRedirect()` --calls--> `setUser()`  [INFERRED]
-  admin-dashboard/src/app/login/page.tsx → shared/services/errorReporting.ts
-- `DocumentsScreen()` --calls--> `useTheme()`  [EXTRACTED]
-  driver-app/app/documents.tsx → shared/theme/ThemeContext.tsx
+- `FR()` --calls--> `formatCurrency()`  [INFERRED]
+  admin-dashboard/src/app/dashboard/rides/_components/ride-ui-helpers.tsx → driver-app/app/driver/payout.tsx
+- `Sidebar()` --calls--> `useTheme()`  [INFERRED]
+  admin-dashboard/src/components/sidebar.tsx → shared/theme/ThemeContext.tsx
+- `TaskPriority` --uses--> `Run Comprehensive Code Review using Agent System Demonstrates how the orchestrat`  [INFERRED]
+  agents/base_agent.py → scripts/run_code_review.py
+- `TaskPriority` --uses--> `Run a comprehensive code review of the entire Spinr project.     The orchestrato`  [INFERRED]
+  agents/base_agent.py → scripts/run_code_review.py
+- `KnowledgeEntry` --uses--> `Run Comprehensive Code Review using Agent System Demonstrates how the orchestrat`  [INFERRED]
+  agents/base_agent.py → scripts/run_code_review.py
 
-## Communities (3367 total, 1961 thin omitted)
+## Import Cycles
+- 1-file cycle: `backend/routes/admin/auth.py -> backend/routes/admin/auth.py`
+- 1-file cycle: `backend/routes/admin/rides.py -> backend/routes/admin/rides.py`
+- 1-file cycle: `backend/routes/admin/wallet.py -> backend/routes/admin/wallet.py`
+- 1-file cycle: `backend/features.py -> backend/features.py`
+- 1-file cycle: `backend/onboarding_status.py -> backend/onboarding_status.py`
+- 1-file cycle: `backend/routes/auth.py -> backend/routes/auth.py`
+- 1-file cycle: `backend/routes/drivers.py -> backend/routes/drivers.py`
+- 1-file cycle: `backend/routes/payments.py -> backend/routes/payments.py`
+- 1-file cycle: `backend/routes/promotions.py -> backend/routes/promotions.py`
+- 1-file cycle: `backend/routes/rides.py -> backend/routes/rides.py`
+- 1-file cycle: `backend/routes/wallet.py -> backend/routes/wallet.py`
+- 1-file cycle: `backend/services/cancellation_service.py -> backend/services/cancellation_service.py`
+- 1-file cycle: `backend/services/payment_service.py -> backend/services/payment_service.py`
+- 1-file cycle: `backend/utils/breadcrumbs.py -> backend/utils/breadcrumbs.py`
+- 1-file cycle: `backend/utils/t4a_annual_job.py -> backend/utils/t4a_annual_job.py`
+- 1-file cycle: `backend/utils/zoho_desk_sync.py -> backend/utils/zoho_desk_sync.py`
+- 1-file cycle: `backend/core/lifespan.py -> backend/core/lifespan.py`
+- 1-file cycle: `backend/dependencies/__init__.py -> backend/dependencies/__init__.py`
+- 1-file cycle: `backend/routes/admin/analytics.py -> backend/routes/admin/analytics.py`
+- 1-file cycle: `backend/routes/fare_split.py -> backend/routes/fare_split.py`
+
+## Communities (3490 total, 1979 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.02
-Nodes (188): admin_add_driver_note(), admin_assign_driver_area(), admin_delete_driver_note(), admin_driver_action(), admin_get_approval_queue(), admin_get_driver_activity(), admin_get_driver_daily_stats(), admin_get_driver_live_stats() (+180 more)
+Nodes (231): admin_create_document_requirement(), admin_delete_document_requirement(), admin_get_document_requirements(), admin_get_driver_documents(), admin_get_pending_documents(), admin_review_driver_document(), admin_update_document_requirement(), DocumentRequirementCreateRequest (+223 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.03
-Nodes (96): _CircuitBreaker, claim_driver_atomic(), create_complaint(), create_flag(), create_kyb_upload_url(), create_lost_and_found(), create_user(), delete_allowed_domain() (+88 more)
+Cohesion: 0.05
+Nodes (97): add_allowed_domain(), _apply_filters(), _build_or_clause(), _build_or_clause_term(), _CircuitBreaker, claim_driver_atomic(), claim_stripe_event(), count_documents() (+89 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (157): Any, BackgroundTasks, bool, Decimal, float, Request, RideRatingRequest, str (+149 more)
+Cohesion: 0.12
+Nodes (22): Regression tests for B-P0-2: process_payment 409 after complete_ride — state str, process_payment guard: 409 when ride status is not completed., process_payment guard passes when ride status is exactly 'completed'., cancel_ride must reject when ride status is 'in_progress'., complete_ride must not set payment_status to any value — it leaves it untouched., trip_in_progress' is a GPS phase name — it must never appear as a ride status., Cancellation must be blocked when ride status is 'in_progress' (the real string), Regression: the old guard used 'trip_in_progress' and silently let cancels throu (+14 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.01
-Nodes (282): fetchLogs(), fetchData(), handleDelete(), handleSend(), resetForm(), handleAdd(), handleDelete(), loadNotes() (+274 more)
+Cohesion: 0.02
+Nodes (274): usePlacesAutocomplete(), fetchLogs(), fetchData(), handleDelete(), handleSend(), resetForm(), CreateRideModal(), distanceKm() (+266 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.04
-Nodes (42): ABC, BaseAgent, from_dict(), Any, bool, int, Path, str (+34 more)
+Cohesion: 0.05
+Nodes (41): BaseAgent, from_dict(), Any, bool, int, Path, str, Create task from dictionary. (+33 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.05
-Nodes (110): AuthResponse, bool, int, Response, str, bool, datetime, int (+102 more)
+Cohesion: 0.06
+Nodes (85): AuthResponse, bool, int, Response, str, bool, datetime, int (+77 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.04
-Nodes (92): admin_credit_wallet(), admin_debit_wallet(), admin_get_wallet(), _q(), Admin wallet operations — credit a user's wallet, view balance + history.  Every, Credit a user's wallet. Writes an audited ledger entry., Credit a user's wallet. Writes an audited ledger entry., Debit (deduct from) a user's wallet — refunds, correction, fraud clawback. (+84 more)
+Cohesion: 0.10
+Nodes (41): bool, float, int, str, earn_points_for_ride(), Award loyalty points for a completed ride. Called after ride completion., Award loyalty points for a completed ride. Called after ride completion., Redeem loyalty points for wallet credit. (+33 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.05
-Nodes (66): break_glass_access(), Emergency access endpoint — issues a 1-hour super_admin JWT when a     valid pre, Emergency access endpoint — issues a 1-hour super_admin JWT when a     valid pre, _consume_retry_token(), Any, int, Request, str (+58 more)
+Cohesion: 0.08
+Nodes (43): Any, int, Request, str, bool, float, str, float (+35 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.02
-Nodes (103): count_documents(), delete_one(), find_nearby_drivers(), find_one(), get_rows(), insert_one(), update_one(), get_driver_documents() (+95 more)
+Cohesion: 0.09
+Nodes (34): delete_one(), find_one(), get_rows(), insert_one(), test_check_expiring_documents(), test_create_document_requirement(), test_delete_document_file(), test_delete_document_requirement() (+26 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.02
-Nodes (151): Decimal, int, Request, str, _actual_duration_minutes(), add_stop_mid_trip(), AddStopMidTripRequest, _build_fare_breakdown() (+143 more)
+Cohesion: 0.04
+Nodes (55): DATA_CENTERS, ZohoConfigCard(), DriverRegistrationPage(), handleChange(), handleFileChange(), nextStep(), renderStepContent(), submitRegistration() (+47 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.06
-Nodes (44): int, str, float, int, str, Regression tests for B-P3-2: ±10% jitter and per-loop metrics.  Verifies:   - Th, interval * (0.9 + random.random() * 0.2) is always in [0.9×, 1.1×)., Loop-body sleep is in [0.9×, 1.1×) of INTERVAL_SECONDS. (+36 more)
+Cohesion: 0.09
+Nodes (32): int, Regression tests for B-P3-2: ±10% jitter and per-loop metrics.  Verifies:   - Th, interval * (0.9 + random.random() * 0.2) is always in [0.9×, 1.1×)., Loop-body sleep is in [0.9×, 1.1×) of INTERVAL_SECONDS., spinr_bgloop_duration_ms gauge is emitted after every tick., spinr_bgloop_errors_total is incremented when the tick raises., spinr_bgloop_errors_total is NOT emitted when the tick succeeds., presence_sweeper_loop has an initial random jitter sleep BEFORE the     while lo (+24 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.06
 Nodes (36): bool, object, Attach a unique X-Request-ID to every request/response pair., Attach a unique X-Request-ID to every request/response pair., RequestIDMiddleware, _app_with_handler(), _isolate_module_imports(), B-P2-1 — pin the error-response sanitisation contract.  Three concerns covered: (+28 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.12
-Nodes (29): Admin Dashboard (Next.js), Spinr Comprehensive Code Analysis Report, AODA (Accessibility for Ontarians with Disabilities Act), Spinr Architecture Document, Code Gap Analysis Report (spinrApp 2026-03-12), CustomAlert Component, Accessibility Compliance (WCAG 2.1 AA / AODA), E2E Testing Guide (+21 more)
+Cohesion: 0.09
+Nodes (35): Admin Dashboard (Next.js), Spinr Comprehensive Code Analysis Report, AODA (Accessibility for Ontarians with Disabilities Act), Spinr Architecture Document, brace-expansion Security Vulnerability (moderate), CustomAlert Component, Driver App (Expo), Driver App npm Audit Report (+27 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.10
-Nodes (19): Validate a CRA Business Number format (9 digits, optional CRA program identifier, Validate a CRA Business Number format (9 digits, optional CRA program identifier, Validate a two-letter Canadian province/territory code., Validate a two-letter Canadian province/territory code., Normalize and validate an email domain for allowlist use.      Strips whitespace, Normalize and validate an email domain for allowlist use.      Strips whitespace, validate_canadian_tax_region(), validate_cra_business_number() (+11 more)
+Cohesion: 0.07
+Nodes (49): getBackendUrl(), API_URL, getBackendUrl(), { height }, LOCATION_CONFIGS, RECONNECT_DELAYS, _toFiniteCoord(), useDriverDashboard() (+41 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.11
-Nodes (21): ConnectionManager, Broadcast to every socket connected to THIS machine.          Intentionally loca, P1-6: WebSocket reconnect with state preservation (C8)  The server does not buff, test_connect_registers_client(), test_disconnect_removes_client(), test_message_to_disconnected_client_does_not_raise(), test_reconnect_replaces_previous_socket(), test_send_personal_message_falls_back_to_local_when_pubsub_disabled() (+13 more)
+Cohesion: 0.08
+Nodes (28): ConnectionManager, Broadcast to every socket connected to THIS machine.          Intentionally loca, str, P1-6: WebSocket reconnect with state preservation (C8)  The server does not buff, Pins `GET /rides/active` as the reconnect state-recovery mechanism.      When a, The rider reconnects right after the driver accepted — must see         driver_a, After ride completes mid-disconnect, reconnect must not restore a         stale, A ride still in 'searching' is active from the rider's perspective —         the (+20 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.07
-Nodes (6): Unit tests for database layer (db.py and db_supabase.py). Tests cover CRUD opera, test_claim_driver_atomic(), test_get_ride(), test_get_rides_for_user(), test_run_sync(), test_run_sync_with_exception()
+Nodes (4): mock_cursor(), test_get_ride(), test_run_sync(), test_run_sync_with_exception()
 
 ### Community 16 - "Community 16"
-Cohesion: 0.10
-Nodes (21): MagicMock, str, app_with_ws(), _make_settings_mock(), _patch_firebase_auth_and_db(), _patch_jwt_auth_and_db(), Tests for the WebSocket auth-ack behavior in backend/routes/websocket.py.  Conte, Patches for admin WebSocket auth via legacy JWT.      Admin tokens are minted by (+13 more)
+Cohesion: 0.12
+Nodes (25): MagicMock, str, admin_user(), app_with_ws(), driver_user(), _make_settings_mock(), _patch_firebase_auth_and_db(), _patch_jwt_auth_and_db() (+17 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.17
+Cohesion: 0.21
 Nodes (23): bool, int, str, check_auth_rejects_unauthenticated(), check_cors_rejects_unknown_origin(), check_docs(), check_health(), check_openapi_schema() (+15 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.07
-Nodes (29): RideOTPRequest, Walk the complete ride state machine: accept → arrive → verify-otp → complete., Walk the complete ride state machine: accept → arrive → verify-otp → complete., Sample ride creation request data., Test successful ride creation., Test ride creation with promo code., Test updating ride status., Test updating ride with driver assignment. (+21 more)
+Cohesion: 0.10
+Nodes (22): RideOTPRequest, Walk the complete ride state machine: accept → arrive → verify-otp → complete., Walk the complete ride state machine: accept → arrive → verify-otp → complete., Sample ride creation request data., Test successful ride creation., Test ride creation with promo code., Test updating ride status., Test updating ride with driver assignment. (+14 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.08
 Nodes (23): Any, bool, str, WebSocket fan-out over Redis pub/sub (audit P0-B3).  The in-process ``Connection, Publish a unicast message to the shared channel.          Returns True if the me, Publish a prefix-broadcast to every VM.          Each replica delivers ``message, Return all buffered outbox messages for a client (up to 50)., Publish a prefix-broadcast to every VM.          Each replica delivers ``message (+15 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.03
-Nodes (55): handleDeleteAccount(), handleDownloadData(), PrivacySettingsScreen(), SettingsScreen(), SettingToggle(), CustomToggleProps, styles, DriverData (+47 more)
+Cohesion: 0.06
+Nodes (48): StripeKeyContext, createStyles(), handleDeleteAccount(), handleDownloadData(), PrivacySettingsScreen(), SettingRow(), createStyles(), handleTopUp() (+40 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.16
-Nodes (8): point_in_polygon(), bool, 3 points on a line form a degenerate polygon — point shouldn't be 'inside'., Polygon covering a large area should still work., Edge cases for the n < 3 guard and invalid inputs., Exactly 3 points (triangle) should work., TestPointInPolygon, TestPointInPolygonEdgeCases
+Cohesion: 0.12
+Nodes (12): point_in_polygon(), bool, str, patch_external_dependencies(), Tests for geo_utils — pure math, no external deps., Override the conftest autouse fixture — these tests need no mocking., 3 points on a line form a degenerate polygon — point shouldn't be 'inside'., Polygon covering a large area should still work. (+4 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.14
-Nodes (7): client(), _mock_db(), P3 coverage: addresses, favorites, safety, and disputes routes., Build a mock db_supabase module with sensible defaults., TestAddresses, TestDisputes, TestSafety
+Cohesion: 0.11
+Nodes (9): client(), _mock_db(), _mock_fav_db(), P3 coverage: addresses, favorites, safety, and disputes routes., Build a mock db_supabase module with sensible defaults., TestAddresses, TestDisputes, TestFavorites (+1 more)
 
 ### Community 23 - "Community 23"
-Cohesion: 0.04
-Nodes (58): setAppCheckTokenProvider(), DriverRootLayoutInner(), incentives, parsed, questHint, RootLayout(), RootLayoutInner(), suppressTypes (+50 more)
+Cohesion: 0.06
+Nodes (61): setAppCheckTokenProvider(), asyncStoragePersister, DriverRootLayoutInner(), GestureRootWrapper(), incentives, MaybeStripeProvider(), parsed, questHint (+53 more)
 
 ### Community 24 - "Community 24"
-Cohesion: 0.06
-Nodes (53): Any, bool, int, str, bool, str, admin_send_test_push(), create_notification() (+45 more)
+Cohesion: 0.05
+Nodes (61): Any, bool, int, str, bool, str, admin_send_test_push(), create_notification() (+53 more)
 
 ### Community 25 - "Community 25"
-Cohesion: 0.05
-Nodes (52): bool, Decimal, int, str, float, int, str, admin_get_quest_participants() (+44 more)
+Cohesion: 0.15
+Nodes (18): float, get_available_quests(), join_quest(), Get quests available to the current driver., Get quests available to the current driver., _driver_row(), _progress(), _quest() (+10 more)
 
 ### Community 26 - "Community 26"
 Cohesion: 0.08
 Nodes (35): Any, bool, float, str, AmplitudeService, AnalyticsService, get_analytics(), init_analytics() (+27 more)
 
 ### Community 27 - "Community 27"
-Cohesion: 0.10
-Nodes (21): corporate_account_row(), Build a CorporateAccountDetailResponse-shaped dict for route tests.      The res, Build a CorporateAccountDetailResponse-shaped dict for route tests.      The res, test_list_filters_by_status(), test_cannot_reopen_closed_company_in_flow(), test_create_approve_suspend_reactivate_flow(), test_approve_kyb_flips_status_to_active(), test_reject_kyb_flips_status_to_suspended() (+13 more)
+Cohesion: 0.05
+Nodes (65): Any, str, corporate_account_row(), driver_row(), _now(), payout_row(), promotion_row(), Factory helpers for corporate-account tests.  Kept out of conftest.py because py (+57 more)
 
 ### Community 28 - "Community 28"
-Cohesion: 0.05
-Nodes (33): str, Load a driver's ride only if it is in one of ``allowed_states``.      Raises 409, _require_ride_in_state(), _driver_row(), End-to-end ride-lifecycle smoke suite.  Exercises the full happy-path a ride tra, Arrive is only legal from driver_accepted or driver_arrived (idempotent)., Start transitions driver_arrived → in_progress. Must verify rider OTP., Complete is only legal from in_progress. Completing a completed ride → 409. (+25 more)
+Cohesion: 0.20
+Nodes (10): Load a driver's ride only if it is in one of ``allowed_states``.      Raises 409, Load a driver's ride only if it is in one of ``allowed_states``.      Raises 409, _require_ride_in_state(), Retrying arrive after the first call should succeed, not 409., Cannot start a ride that was already completed., Pin the state-machine guard behavior., Return a context manager that patches backend.routes.drivers.db         so find_, A cancelled ride cannot be completed — must raise 409, not 404. (+2 more)
 
 ### Community 29 - "Community 29"
-Cohesion: 0.07
-Nodes (18): make_mock_db(), Integration tests for the quest/bonus-challenge endpoints.  Routes under test (b, POST /api/v1/quests/{quest_id}/join, GET /api/v1/quests/my-quests, POST /api/v1/quests/progress/{progress_id}/claim, POST /api/v1/quests/admin/create, GET /api/v1/quests/admin/list, PATCH /api/v1/quests/admin/{quest_id} (+10 more)
+Cohesion: 0.08
+Nodes (19): client(), make_mock_db(), Integration tests for the quest/bonus-challenge endpoints.  Routes under test (b, POST /api/v1/quests/{quest_id}/join, GET /api/v1/quests/my-quests, POST /api/v1/quests/progress/{progress_id}/claim, POST /api/v1/quests/admin/create, GET /api/v1/quests/admin/list (+11 more)
 
 ### Community 30 - "Community 30"
 Cohesion: 0.14
-Nodes (17): Any, str, mock_jwt_token(), Sample user data for testing., Sample user data for testing., Sample driver data for testing., Sample driver data for testing., Sample ride data for testing. (+9 more)
+Nodes (17): Any, str, auth_headers(), Sample user data for testing., Sample user data for testing., Sample driver data for testing., Sample driver data for testing., Sample ride data for testing. (+9 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.08
-Nodes (17): make_mock_db(), Integration tests for the fare-split endpoints.  Routes under test (backend/rout, POST /api/v1/fare-split, $30 split 3 ways = $10 each., GET /api/v1/fare-split/{split_id}, A user who is neither requester nor participant cannot view., GET /api/v1/fare-split/ride/{ride_id}, POST /api/v1/fare-split/participant/{id}/respond (+9 more)
+Nodes (18): client(), make_mock_db(), Integration tests for the fare-split endpoints.  Routes under test (backend/rout, POST /api/v1/fare-split, $30 split 3 ways = $10 each., GET /api/v1/fare-split/{split_id}, A user who is neither requester nor participant cannot view., GET /api/v1/fare-split/ride/{ride_id} (+10 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.12
 Nodes (11): Non-super_admin tokens cannot mutate staff rows., Non-super_admin tokens cannot mutate staff rows., Override get_admin_user with a support-role token., Override get_admin_user with a super_admin token., A support-role actor gets 403 on PUT /staff/{id} (A-P3-5)., A support-role actor gets 403 on PUT /staff/{id} (A-P3-5)., A support-role actor gets 403 on DELETE /staff/{id}., A support-role actor gets 403 on DELETE /staff/{id}. (+3 more)
 
 ### Community 33 - "Community 33"
-Cohesion: 0.10
-Nodes (38): bool, datetime, Decimal, str, evaluate_policy(), evaluate_policy_for_ride(), _from_dict(), PolicyResult (+30 more)
+Cohesion: 0.09
+Nodes (61): bool, datetime, Decimal, str, bool, Decimal, float, int (+53 more)
 
 ### Community 34 - "Community 34"
 Cohesion: 0.06
 Nodes (37): str, str, _active_ride(), _body(), _mock_request(), E8: Duplicate ride request — double-tap confirm guard  Backend already implement, E8 — second create_ride while first is active → 409 Conflict.      This is the ", Once the previous ride is completed/cancelled, a new one can be created. (+29 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.09
+Cohesion: 0.10
 Nodes (12): Sanitize string input to prevent XSS and other injection attacks.      Args:, Sanitize string input to prevent XSS and other injection attacks.      Args:, sanitize_string(), patch_external_dependencies(), Tests for validators.sanitize_string() — pure unit tests, no DB/external deps., Override the conftest autouse fixture — these tests need no mocking., TestBasicSanitization, TestHTMLStripping (+4 more)
 
 ### Community 36 - "Community 36"
 Cohesion: 0.06
-Nodes (19): Tests that admin_router routes require authentication.  The router-level `Depend, A-P3-2: 5 failed logins → 423 account locked for 24 hours., A-P3-5: Only super_admin may create / update staff., A-P2-2: requests from staff idle > 30 min are rejected with 401., A-P3-1: ADMIN_PASSWORD must be compared via bcrypt, not plaintext., Verify admin routes reject unauthenticated requests., Use the TestClient from conftest., GET /api/admin/settings without token → 401 or 403. (+11 more)
+Nodes (20): _app(), Tests that admin_router routes require authentication.  The router-level `Depend, A-P3-2: 5 failed logins → 423 account locked for 24 hours., A-P3-5: Only super_admin may create / update staff., A-P2-2: requests from staff idle > 30 min are rejected with 401., A-P3-1: ADMIN_PASSWORD must be compared via bcrypt, not plaintext., Verify admin routes reject unauthenticated requests., Use the TestClient from conftest. (+12 more)
 
 ### Community 37 - "Community 37"
-Cohesion: 0.05
-Nodes (36): _money(), Route tests for /company/{id}/** (admin-only endpoints).  Uses `app.dependency_o, Compare API money values regardless of whether they are returned as     str (pos, Any active member can read the policy (rider Work Profile needs it)., Inject a fake current_user for `/company/**` endpoints., Any active member can read the policy (rider Work Profile needs it)., No policy configured → empty dict, not 404., No policy configured → empty dict, not 404. (+28 more)
+Cohesion: 0.07
+Nodes (46): _money(), Route tests for /company/{id}/** (admin-only endpoints).  Uses `app.dependency_o, Compare API money values regardless of whether they are returned as     str (pos, Any active member can read the policy (rider Work Profile needs it)., Inject a fake current_user for `/company/**` endpoints., Any active member can read the policy (rider Work Profile needs it)., No policy configured → empty dict, not 404., No policy configured → empty dict, not 404. (+38 more)
 
 ### Community 38 - "Community 38"
 Cohesion: 0.05
-Nodes (11): A-P2-7: Admin business logic tests.  Covers driver approve/reject/suspend/ban, w, Turning surge_enabled off must zero any parked surge on the area., Switching off a parked >2.5x surge must not require a justification.          Th, Make every test in this module run as super_admin by default., _set_super_admin(), TestAdminDriverActions, TestAdminRideCancel, TestAdminSettingsValidation (+3 more)
+Nodes (16): app_fixture(), client(), A-P2-7: Admin business logic tests.  Covers driver approve/reject/suspend/ban, w, Both the Resend key and the legacy SendGrid key must be masked.          Migrati, Turning surge_enabled off must zero any parked surge on the area., Switching off a parked >2.5x surge must not require a justification.          Th, Turning surge_enabled off must zero any parked surge on the area., Switching off a parked >2.5x surge must not require a justification.          Th (+8 more)
 
 ### Community 39 - "Community 39"
-Cohesion: 0.13
-Nodes (20): CodeReviewHelper, main(), int, Path, str, Categorize changed files by component., Scan files for potential secrets and sensitive information., Check if protected endpoints have proper auth dependencies. (+12 more)
+Cohesion: 0.12
+Nodes (21): CodeReviewHelper, main(), int, Path, str, Categorize changed files by component., Scan files for potential secrets and sensitive information., Check if protected endpoints have proper auth dependencies. (+13 more)
 
 ### Community 40 - "Community 40"
-Cohesion: 0.11
-Nodes (30): _apply_all_patches(), _fake_corporate_ride(), _fake_fare_info(), _mock_create_ride_deps(), _mock_process_payment_deps(), Tests for corporate ride payment wiring — Plans 4 & 5.  Tests for:   A. create_r, No work_profile → list_active_memberships_for_user never called., work_profile=true but no matching membership → 400 no_corporate_membership. (+22 more)
+Cohesion: 0.14
+Nodes (31): _apply_all_patches(), _fake_corporate_ride(), _fake_fare_info(), _get_rows_side_effect(), _mock_create_ride_deps(), _mock_process_payment_deps(), Tests for corporate ride payment wiring — Plans 4 & 5.  Tests for:   A. create_r, No work_profile → list_active_memberships_for_user never called. (+23 more)
 
 ### Community 41 - "Community 41"
-Cohesion: 0.10
-Nodes (12): make_mock_db(), Integration tests for the in-app wallet endpoints.  Routes under test (backend/r, POST /api/v1/wallet/top-up, POST /api/v1/wallet/pay, GET /api/v1/wallet/transactions, POST /api/v1/wallet/transfer, Build a mock db using the flat Supabase-style interface wallet routes use., TestGetTransactions (+4 more)
+Cohesion: 0.11
+Nodes (13): client(), make_mock_db(), Integration tests for the in-app wallet endpoints.  Routes under test (backend/r, POST /api/v1/wallet/top-up, POST /api/v1/wallet/pay, GET /api/v1/wallet/transactions, POST /api/v1/wallet/transfer, Build a mock db using the flat Supabase-style interface wallet routes use. (+5 more)
 
 ### Community 42 - "Community 42"
-Cohesion: 0.08
-Nodes (25): AsyncMock, bool, float, str, PayoutRequest, _driver_row(), _payout_row(), P2-16: Payout / T4A driver flows (D8, D13)  Implemented endpoints:   POST /drive (+17 more)
+Cohesion: 0.07
+Nodes (48): formatDate(), CopyableField(), Field(), formatCurrency(), formatDate(), handleRetry(), Payout, PayoutDetailPage() (+40 more)
 
 ### Community 43 - "Community 43"
 Cohesion: 0.09
 Nodes (29): Dimension 05: Android & iOS UI/UX Quality, Dimension 08: Payments & Earnings, Dimension 10: Error Handling & Resilience, Dimension 12: Compliance PII/PCI/PIPEDA, Dimension 13: Notifications, AI Support & FAQ, Dimension 15: Accessibility (WCAG 2.1/AODA), Dimension 16: i18n & Localisation, Backend Admin & Ops Domain Docs (+21 more)
 
 ### Community 44 - "Community 44"
-Cohesion: 0.13
-Nodes (13): str, _make_admin(), A-P2-8: RBAC matrix tests — verify require_module() enforces module boundaries., Support has 'users' module — should be reachable., Support has 'dashboard' module — analytics should be reachable., Install a dependency override for get_admin_user., Finance has 'earnings' module — endpoint is reachable (422 on bad body, not 403), _set_admin() (+5 more)
+Cohesion: 0.15
+Nodes (15): str, app(), client(), _make_admin(), A-P2-8: RBAC matrix tests — verify require_module() enforces module boundaries., Support has 'users' module — should be reachable., Support has 'dashboard' module — analytics should be reachable., Install a dependency override for get_admin_user. (+7 more)
 
 ### Community 45 - "Community 45"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (12): _extract_coords(), _extract_points(), patch_external_dependencies(), Tests for the location-batch endpoint's input parsing logic., The endpoint uses points[-1] — verify the pattern., # NOTE: Full endpoint integration tests require firebase_admin + full backend de, Mirrors the point extraction logic from update_location_batch., Mirrors the coordinate extraction from the latest point. (+4 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.10
-Nodes (17): float, int, Update driver location in batch (from background tracking)., update_location_batch(), _point(), P3-20: Background location for drivers (iOS policy changes)  Backend location-ba, Batch from background tracking — most-recent position applied., DB update uses user_id from current_user, not any field in the payload. (+9 more)
+Cohesion: 0.06
+Nodes (52): float, int, Any, bool, datetime, float, int, object (+44 more)
 
 ### Community 47 - "Community 47"
 Cohesion: 0.09
 Nodes (28): float, int, MagicMock, str, _completed_ride(), _driver(), _rating_req(), E2E — Driver-rating regression suite (B-P0-1).  The first-rating crash was cause (+20 more)
 
 ### Community 48 - "Community 48"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (11): Regression tests for B-P2-1: float() replaced with Decimal in corporate paths., Allowance check: 0.01 remaining should count as > 0 (rider not blocked)., B-P2-2: Stripe webhook must reject unknown event types with 400., _compute_remaining must use Decimal arithmetic, not float., 1234.56 - 0.01 must equal 1234.55 exactly, not 1234.5499...., Negative used (grants posted) should not inflate remaining above amount., evaluate_policy max_fare and allowance checks must use Decimal comparisons., Fare exactly at the cap must PASS (not fail due to float rounding). (+3 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.13
-Nodes (18): add_card(), Add a saved card. Requires client-side tokenization.      Contract:       - Body, Add a saved card. Requires client-side tokenization.      Contract:       - Body, Invalid JSON body returns 400., test_add_card_invalid_json(), _mock_request(), Tests for the PCI-DSS perimeter on POST /payments/cards.  Pins the C-PAY-01 fix:, Demo mode (no stripe_secret_key) still requires payment_method_id. (+10 more)
+Cohesion: 0.11
+Nodes (24): add_card(), Add a saved card. Requires client-side tokenization.      Contract:       - Body, Add a saved card. Requires client-side tokenization.      Contract:       - Body, _mock_request(), First card on file becomes the default automatically., CardError is surfaced as PaymentMethodInvalidException (400)., Invalid JSON body returns 400., test_add_card_generic_stripe_error_returns_500() (+16 more)
 
 ### Community 50 - "Community 50"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (18): float, MagicMock, str, _active_ride(), E2E — SOS / emergency-alert flow (R-P0-1 regression suite).  The original silent, Emergency record must include the rider's GPS coordinates., Driver triggers SOS on their own active ride., Non-participants must be rejected; missing rides must 404. (+10 more)
 
 ### Community 51 - "Community 51"
@@ -3551,35 +3667,35 @@ Cohesion: 0.00
 Nodes (722): Communities, Community 0 - "Community 0", Community 100 - "Community 100", Community 101 - "Community 101", Community 102 - "Community 102", Community 103 - "Community 103", Community 104 - "Community 104", Community 105 - "Community 105" (+714 more)
 
 ### Community 52 - "Community 52"
-Cohesion: 0.15
-Nodes (20): CloudMessageRequest, Regression tests for A-P1-9: bulk push notifications must fan out concurrently., The DB record inserted immediately must have successful=0, failed_count=0., Immediate broadcast must return 202 (not 200) and enqueue a background task., Scheduled send must return 200 and must NOT register a background task., _fan_out_push handles both dict rows and bare string IDs., Rows missing an id key must be silently dropped., asyncio.Semaphore(50) must cap concurrent in-flight push calls. (+12 more)
+Cohesion: 0.08
+Nodes (40): admin_delete_cloud_message(), admin_get_cloud_message_stats(), admin_get_cloud_messages(), admin_send_cloud_message(), CloudMessageRequest, _fan_out_push(), Send or schedule a cloud message to users/drivers.      Immediate sends return 2, Get cloud messages with optional filters. (+32 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.15
+Cohesion: 0.16
 Nodes (19): AdminCancelRideRequest, str, _driver_row(), Regression tests for the driver-accept → rider-sees-update handoff.  User report, Accepting a ride must open insurance Period 2 (en route to pickup —         TNC, The rider app's polling fallback calls GET /rides/{id} every 15 s.     Once acce, When the atomic guard returns None (ride already taken by concurrent request),, The rider app's polling fallback calls GET /rides/{id} every 15 s.     Once acce (+11 more)
 
 ### Community 54 - "Community 54"
-Cohesion: 0.13
-Nodes (17): _apply_history_filter(), Regression tests for B-P1-7: ride history DB-side status filter.  Background ---, Confirm the per-request DB cap is 500, not the old 2000., get_ride_history must call db_supabase.get_rows with     status=$in[completed,ca, Cancelled rides with no driver_id must be filtered out in Python., Mirror of the Python post-filter in get_ride_history., Ride cancelled before any driver matched — not shown in history., Verify the filter dict passed to get_rows includes status $in. (+9 more)
+Cohesion: 0.07
+Nodes (23): _apply_history_filter(), _FakeQuery, _FakeResult, _FakeSupabase, Regression tests for B-P1-7: ride history DB-side status filter.  Background ---, Confirm the per-request DB cap is 500, not the old 2000., get_ride_history must call db_supabase.get_rows with     status=$in[completed,ca, Cancelled rides with no driver_id must be filtered out in Python. (+15 more)
 
 ### Community 55 - "Community 55"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (21): bool, float, int, MagicMock, _make_atomic_counter(), _promo(), P3-5: Promo concurrency tests.  increment_promo_uses is an atomic Postgres RPC:, RPC data=False (uses == max_uses) → helper returns False. (+13 more)
 
 ### Community 56 - "Community 56"
-Cohesion: 0.11
-Nodes (17): str, _driver(), E2E — Ride cancellation scenarios.  Covers every valid and invalid cancellation, Rider cancels after driver arrives — $5 flat fee to driver, $0.50 to admin., Cancel from in_progress or completed must raise 409., Driver cancels from driver_accepted — rider receives WS ride_cancelled event., Driver cancels from driver_accepted — rider receives WS ride_cancelled event., Regression: a fee-write failure after the cancel is claimed must NOT     strand (+9 more)
+Cohesion: 0.06
+Nodes (44): Any, str, JSONResponse, RequestValidationError, AddCardRequest, Add-card request body.      Accepts only a Stripe `payment_method_id` created cl, Add-card request body.      Accepts only a Stripe `payment_method_id` created cl, _driver() (+36 more)
 
 ### Community 57 - "Community 57"
-Cohesion: 0.03
-Nodes (73): admin_airport_zones_diagnostic(), admin_create_area_fee(), admin_create_service_area(), admin_delete_area_fee(), admin_delete_service_area(), admin_get_area_fees(), admin_get_area_tax(), admin_get_vehicle_pricing() (+65 more)
+Cohesion: 0.06
+Nodes (42): str, _app_with_mocked_auth(), _driver_row(), _make_ride(), _patch_settings(), _patch_stripe_confirm(), P0 ship-blocker tests — pins the five highest-priority end-to-end paths called o, A driver must not be able to nuke a trip that's already rolling —         that's (+34 more)
 
 ### Community 58 - "Community 58"
 Cohesion: 0.13
 Nodes (17): Any, bool, int, str, CloudinaryService, get_cloudinary_service(), init_cloudinary(), Cloudinary Integration for Spinr Provides image upload, transformation, and mana (+9 more)
 
 ### Community 59 - "Community 59"
-Cohesion: 0.16
+Cohesion: 0.20
 Nodes (18): LogoutRequest, Regression tests for A-P1-7: admin access-token JTI blacklisting.  Background --, admin_logout with a valid Bearer token must write admin:revoked:{jti}     to Red, get_current_user must raise 401 ERR_TOKEN_REVOKED when the token's JTI     is pr, Pre-fix tokens without jti must not be blocked (backwards compat)., Token with jti that is in the blacklist must be rejected., Valid token with jti that is NOT in the blacklist must pass., TTL passed to redis_set equals seconds remaining until exp. (+10 more)
 
 ### Community 60 - "Community 60"
@@ -3587,27 +3703,27 @@ Cohesion: 0.10
 Nodes (24): str, _admin_jwt(), B-P1-13 — pin the contract for /auth/logout-all and /admin/auth/logout-all.  The, B-P1-11: kick is best-effort. The token_version bump + refresh         revoke ar, First-ever logout-all on a user row that predates the         token_version colu, If we cannot bump token_version, refuse to claim success.         Per CLAUDE.md, Mint a JWT the admin handler will accept. Uses the conftest     JWT_SECRET fixtu, Pin /admin/auth/logout-all behaviour. Handler lives at     backend/routes/admin/ (+16 more)
 
 ### Community 61 - "Community 61"
-Cohesion: 0.15
+Cohesion: 0.16
 Nodes (16): float, str, _completed_ride(), _payment_request(), E2E — Fare-collection guard (B-P0-2 regression suite).  Exercises the atomic pay, The pending→processing atomic swap prevents double-charging under concurrency., Simulates two concurrent process_payment calls on the same ride.         The fir, Tip boundary checks are validated before any Stripe call. (+8 more)
 
 ### Community 62 - "Community 62"
-Cohesion: 0.20
+Cohesion: 0.21
 Nodes (7): str, _driver_row(), P2-14: SOS E2E — in-ride emergency button (R13)  Backend emergency endpoint is f, Pins trigger_emergency: persist + WS notify admin.      Code under test: backend, _Req, _ride(), TestTriggerEmergency
 
 ### Community 63 - "Community 63"
-Cohesion: 0.12
-Nodes (30): list_wallet_transactions(), update_corporate_wallet_config(), int, str, Any, Decimal, str, _Numeric (+22 more)
+Cohesion: 0.14
+Nodes (33): get_corporate_wallet_by_company(), int, str, Any, Decimal, str, _Numeric, AdjustRequest (+25 more)
 
 ### Community 64 - "Community 64"
 Cohesion: 0.04
-Nodes (46): async(), DriverArrivedScreenContent(), handleCancelPress(), handleCopyOtp(), DriverArrivingScreenContent(), handleBack(), handleCall(), handleCopyDetails() (+38 more)
+Nodes (64): async(), createStyles(), DriverArrivedScreenContent(), createStyles(), DriverArrivingScreenContent(), handleBack(), handleCall(), handleCopyDetails() (+56 more)
 
 ### Community 65 - "Community 65"
 Cohesion: 0.20
 Nodes (18): Driver App Adaptive Icon (Expo 'e' logo, blue rounded square, Android adaptive icon), App Onboarding/Promo Image (Expo 'e' logo splash, dark background), Car Map Marker PNG (top-down flat-style car, dark navy with blue windows, yellow/red lights), Car 3D Front-View SVG (perspective view, white/silver body, blue glass, yellow front lights, red rear lights), Car Top-Down 3D SVG (white/silver car with gradient body, blue glass, yellow/red lights, detailed 3D style), Car Top-Down SVG (top view, dark body, yellow headlights, red tail lights, map marker graphic), Car Top-Down SVG (dark flat-style car, top view), Driver App (React Native / Expo SDK 54) (+10 more)
 
 ### Community 66 - "Community 66"
-Cohesion: 0.17
+Cohesion: 0.20
 Nodes (19): int, Path, str, _apply_one(), _checksum(), _classify(), _connect(), _discover_migrations() (+11 more)
 
 ### Community 67 - "Community 67"
@@ -3615,19 +3731,19 @@ Cohesion: 0.18
 Nodes (10): str, _driver_row(), P1-10: Driver offline mid-trip (E5)  When a driver toggles offline via PUT /driv, A driver with no active ride can go offline freely., A completed ride must not block the driver from going offline., Going online must never be blocked by the active-ride check —         the guard, A driver can only toggle their own status — not another driver's., Pins that going offline is blocked when the driver has an active ride.      Code (+2 more)
 
 ### Community 68 - "Community 68"
-Cohesion: 0.06
-Nodes (27): apply(), Driver, DriverMapProps, ServiceArea, GeofenceMapProps, pointsToGeoJSON(), PolygonPoint, toolbarButtonStyle (+19 more)
+Cohesion: 0.07
+Nodes (41): apply(), Driver, DriverMap(), DriverMapProps, ServiceArea, GeofenceMap(), GeofenceMapProps, lineStringGeoJSON() (+33 more)
 
 ### Community 69 - "Community 69"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (17): _driver(), Regression tests for two backend P0 fixes.  B-P0-1: rate_driver aggregation now, Driver has one 4-star ride; new 5-star → average 4.5., Driver has one 4-star ride; new 5-star → average 4.5., complete_ride writes status='completed'.  process_payment must accept     that v, complete_ride writes status='completed'.  process_payment must accept     that v, Ride in 'in_progress' must raise 409., Ride in 'in_progress' must raise 409. (+9 more)
 
 ### Community 70 - "Community 70"
-Cohesion: 0.05
-Nodes (38): buildReceiptText(), fmt(), handleShareInvoice(), handleSubmit(), RideCompletedScreenContent(), showPaymentAlert(), toNum(), PaymentSheetResult (+30 more)
+Cohesion: 0.12
+Nodes (23): api, apiImpl, buttonKinds, err, makeApi(), makeStripe(), promise, stripe (+15 more)
 
 ### Community 71 - "Community 71"
-Cohesion: 0.14
+Cohesion: 0.18
 Nodes (14): generate_validation_report(), main(), Validate that documentation files exist and are referenced correctly., Run a test code review to validate the workflow., Generate a validation report., Validate that the code review workflow document is properly formatted., Main validation function., Validate that the code review helper script is properly implemented. (+6 more)
 
 ### Community 72 - "Community 72"
@@ -3651,51 +3767,51 @@ Cohesion: 0.19
 Nodes (15): 16-Dimension Audit Framework, Remediation Priority Tiers P0-P4, Severity Scale (CRITICAL/HIGH/MEDIUM/LOW/PASS/RECOMMENDATION), Feature Gap Analysis, Spinr Discovery Report, Security Findings & Remediation, Driver Verification & KYC Workflow, Real-time Scalable Driver Matching (+7 more)
 
 ### Community 77 - "Community 77"
-Cohesion: 0.04
-Nodes (40): onRefresh(), AreaStat, PHASE_COLORS, Props, RideDetailModal(), RideRouteMap, STATUS_META, Props (+32 more)
+Cohesion: 0.05
+Nodes (64): onRefresh(), AreaStat, AreaStatsTable(), ChartCard(), ChartData, DriverCharts(), tooltipStyle, DriverStatsCards() (+56 more)
 
 ### Community 78 - "Community 78"
-Cohesion: 0.13
-Nodes (20): int, str, _maybe_run_tick(), Daily Stripe ↔ DB ↔ wallet reconciliation loop.  Runs once per day (aligned to 0, Return total succeeded PaymentIntent amount in cents for the given UTC date., Return sum of delta_cents in financial_events for the given date and type., Return sum of delta_cents in financial_events for the given date and type., Write a reconciliation_discrepancies row for ops follow-up. (+12 more)
+Cohesion: 0.06
+Nodes (69): flush_redis_prefix(), FlushPrefixRequest, get_redis_health(), Redis memory/usage snapshot + per-prefix key counts.      Returns a two-part pay, Redis memory/usage snapshot + per-prefix key counts.      Returns a two-part pay, Redis memory/usage snapshot + per-prefix key counts.      Returns a two-part pay, Delete every key matching a prefix glob (prefix + '*').      Restricted to the a, Delete every key matching a prefix glob (prefix + '*').      Restricted to the a (+61 more)
 
 ### Community 79 - "Community 79"
-Cohesion: 0.22
+Cohesion: 0.25
 Nodes (17): bool, int, object, str, _assert_case(), _assert_idempotency(), CaseResult, _delete_customer() (+9 more)
 
 ### Community 80 - "Community 80"
-Cohesion: 0.21
-Nodes (14): Spinr Development Agents System (hierarchical autonomous agents), Driver App Production Readiness Audit 2026-04-18 (227 findings: 7 CRITICAL, 26 HIGH), frontend/ — Deprecated legacy combined Expo app, Knowledge Base Agent (shared knowledge repo manager), Orchestrator Agent (top-level coordinator), P0-1: Login crash — revoked vs revoked_at field mismatch in auth.py, P0 Critical Fixes — 7 issues to fix before device testing, P0-6: Driver licence photos publicly accessible without auth (+6 more)
+Cohesion: 0.08
+Nodes (26): Spinr Development Agents System (hierarchical autonomous agents), Driver App Production Readiness Audit 2026-04-18 (227 findings: 7 CRITICAL, 26 HIGH), Canonical Replacement, ⚠️ DEPRECATED — Do Not Use, References, Removal Timeline, Web Builds, Why (+18 more)
 
 ### Community 81 - "Community 81"
-Cohesion: 0.23
+Cohesion: 0.30
 Nodes (13): str, Migration 51 (B-P1-7) shape tests — audit_logs lockdown + 7y retention.  The ful, Migration 50's INSERT used migration 08's never-applied columns     (actor_id, a, SECURITY DEFINER + pinned search_path + service_role-only EXECUTE     — same pos, sql(), test_adds_audit_logs_7y_purge_step(), test_blocks_update_via_trigger(), test_drops_for_all_admin_policy() (+5 more)
 
 ### Community 82 - "Community 82"
-Cohesion: 0.03
-Nodes (72): DocumentsScreen(), DriverDocument, EXT_TO_MIME, getMimeFromUri(), handleUpload(), loadData(), pickFile(), pickImage() (+64 more)
+Cohesion: 0.02
+Nodes (102): queryClient, queryKeys, createStyles(), FormField(), FormFieldProps, handleSubmit(), showAlert(), VehicleInfoScreen() (+94 more)
 
 ### Community 83 - "Community 83"
-Cohesion: 0.03
-Nodes (172): add_tip(), create_ride(), get_call_info(), get_chat_status(), get_share_trip_link(), match_driver_to_ride(), process_payment(), ProcessPaymentRequest (+164 more)
+Cohesion: 0.01
+Nodes (409): Decimal, Request, str, add_stop_mid_trip(), add_tip(), AddStopMidTripRequest, _batch_offer_timeout_handler(), _build_fare_breakdown() (+401 more)
 
 ### Community 84 - "Community 84"
-Cohesion: 0.02
-Nodes (66): ConfirmPickupScreen(), CorporateAccount, PaymentConfirmScreenContent(), SavedCard, confirmTimeSelection(), handleCancelSchedule(), handleConfirm(), handleDateChange() (+58 more)
+Cohesion: 0.04
+Nodes (65): Analytics, noop(), ConfirmPickupScreen(), createStyles(), haversineM(), CorporateAccount, createStyles(), PaymentConfirmScreenContent() (+57 more)
 
 ### Community 85 - "Community 85"
-Cohesion: 0.04
-Nodes (31): uploadFile(), BecomeDriverScreen(), fetchRequirements(), fetchVehicleTypes(), handleSubmit(), handleUpload(), nextStep(), pickFile() (+23 more)
+Cohesion: 0.05
+Nodes (44): getAuthHeader(), getStoredToken(), uploadFile(), fetchRequirements(), fetchVehicleTypes(), handleSubmit(), handleUpload(), nextStep() (+36 more)
 
 ### Community 86 - "Community 86"
 Cohesion: 0.32
 Nodes (12): Emergent Platform (app framework referenced in splash screen branding), Frontend Adaptive Icon PNG (Android adaptive icon, Expo emergent style), Frontend App Image PNG (dark splash with emergent icon, identical to splash-image), Frontend Assets Images Directory, Frontend Favicon PNG (Expo emergent icon, small size for browser tab), Frontend App Icon PNG (Expo emergent blue rounded square with white e letterform), Frontend Splash Screen PNG (dark background, emergent icon, 'Start building apps on emergent'), Partial/Cropped React Logo PNG (teal, top-left quadrant of atom icon) (+4 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.20
+Cohesion: 0.24
 Nodes (11): bool, _guarded_fetch(), Regression tests for A-P1-10: analytics driver-list DB error must surface as 503, Mirror of the fixed guard: raise on DB error instead of returning []., Core invariant: DB failure must raise, never silently return []., Regression proof: the old code swallowed the error and returned []., Driver-list DB failure must propagate as 503, not return partial data., test_db_error_raises_instead_of_returning_empty_list() (+3 more)
 
 ### Community 88 - "Community 88"
-Cohesion: 0.36
+Cohesion: 0.41
 Nodes (13): _change_requests_section(), _error_details(), _error_table(), _executive_summary(), _fix_plan(), _footer(), generate(), _header() (+5 more)
 
 ### Community 89 - "Community 89"
@@ -3704,74 +3820,78 @@ Nodes (11): KYB Review Workflow (approve/reject corporate signups), Migration 27
 
 ### Community 90 - "Community 90"
 Cohesion: 0.02
-Nodes (210): admin_review_driver_document(), Review and approve/reject a driver document.      On approval, if an ``expiry_da, Review and approve/reject a driver document.      On approval, if an ``expiry_da, admin_verify_driver(), Verify or unverify a driver.      NOTE: the Supabase `drivers` table in producti, Verify or unverify a driver.      NOTE: the Supabase `drivers` table in producti, admin_send_notification(), Send a notification to a specific user or audience. (+202 more)
+Nodes (289): Any, BackgroundTasks, bool, Decimal, float, int, Request, RideRatingRequest (+281 more)
 
 ### Community 91 - "Community 91"
-Cohesion: 0.04
-Nodes (146): ActivityPage(), currentMonth(), POLICY_RESULT_COLORS, STATUS_COLORS, STATUS_COLORS, Filter, STATUS_COLORS, AllowanceDraft (+138 more)
+Cohesion: 0.05
+Nodes (164): ActivityPage(), currentMonth(), formatCAD(), POLICY_RESULT_COLORS, STATUS_COLORS, STATUS_COLORS, AllowanceRequestsPage(), Filter (+156 more)
 
 ### Community 92 - "Community 92"
 Cohesion: 0.14
 Nodes (12): bool, float, Token, deadline_exhausted(), get_request_deadline(), Per-request deadline propagation via a contextvar.  Clients send an `X-Deadline-, Set (or clear) the monotonic-clock deadline for this request.      `deadline_mon, Return the monotonic-clock deadline for this request, or None. (+4 more)
 
 ### Community 93 - "Community 93"
-Cohesion: 0.19
-Nodes (10): clearQueue(), enqueueRequest(), initOfflineQueue(), isErrorLike(), isResponseError(), _persist(), processQueue(), _queue (+2 more)
+Cohesion: 0.28
+Nodes (14): clearQueue(), enqueueRequest(), getQueue(), getQueueLength(), initOfflineQueue(), isErrorLike(), isOnline(), isResponseError() (+6 more)
 
 ### Community 94 - "Community 94"
-Cohesion: 0.18
-Nodes (3): Tests for the public GET /service-areas endpoint.  Pins that:   - Active service, A stale multiplier/active flag must not surface unless surge_enabled., TestPublicServiceAreas
+Cohesion: 0.13
+Nodes (6): client(), Tests for the public GET /service-areas endpoint.  Pins that:   - Active service, A stale multiplier/active flag must not surface unless surge_enabled., Admin dashboard saves GeoJSON dicts — endpoint must normalize them., A stale multiplier/active flag must not surface unless surge_enabled., TestPublicServiceAreas
 
 ### Community 95 - "Community 95"
-Cohesion: 0.05
-Nodes (94): bytes, str, get_public_settings(), Extended unit tests for utility modules.  Covers:   - utils/surge_engine.py  (30, Test error paths in verify_estimate_token that are not covered by existing tests, # NOTE: test_debug_env_returns_masked_values removed — the /debug-env endpoint, Ensure the RateLimiter creates sensible keys., TestAuditLogger (+86 more)
+Cohesion: 0.08
+Nodes (104): bytes, str, Request, get_public_settings(), Extended unit tests for utility modules.  Covers:   - utils/surge_engine.py  (30, Test error paths in verify_estimate_token that are not covered by existing tests, # NOTE: test_debug_env_returns_masked_values removed — the /debug-env endpoint, TestAuditLogger (+96 more)
 
 ### Community 96 - "Community 96"
-Cohesion: 0.02
-Nodes (60): hasAuthToken(), SpinrApiError, handleBack(), handleCall(), handleQuickReply(), sendMessage(), styles, Message (+52 more)
+Cohesion: 0.03
+Nodes (63): hasAuthToken(), SpinrApiError, createStyles(), handleBack(), handleCall(), handleQuickReply(), sendMessage(), styles (+55 more)
 
 ### Community 97 - "Community 97"
-Cohesion: 0.02
-Nodes (213): BreakGlassRequest, RefreshRequest, SessionResponse, admin_create_document_requirement(), admin_get_document_requirements(), DocumentRequirementCreateRequest, DocumentRequirementUpdateRequest, DocumentReviewRequest (+205 more)
+Cohesion: 0.01
+Nodes (401): admin_airport_zones_diagnostic(), admin_create_area_fee(), admin_create_service_area(), admin_delete_area_fee(), admin_delete_service_area(), admin_get_area_fees(), admin_get_area_tax(), admin_get_service_areas() (+393 more)
 
 ### Community 98 - "Community 98"
-Cohesion: 0.05
-Nodes (26): DriverActionRequest, DriverVerifyRequest, str, _driver(), Extended unit tests for routes/admin/rides.py and routes/admin/drivers.py.  rout, _ride(), TestAdminAddDriverNote, TestAdminCompleteRide (+18 more)
+Cohesion: 0.08
+Nodes (32): DriverActionRequest, DriverNoteCreate, DriverSearchRequest, DriverVerifyRequest, str, _driver(), Extended unit tests for routes/admin/rides.py and routes/admin/drivers.py.  rout, Regression: `email` lives on `users`, not `drivers`. Writing it to         `driv (+24 more)
 
 ### Community 99 - "Community 99"
-Cohesion: 0.03
-Nodes (77): DATE_RANGES, REASON_COLORS, REASON_LABELS, DATE_RANGE_PRESETS, HeatMap, useIsMobile(), HeatMapData, HeatMapSettings (+69 more)
+Cohesion: 0.04
+Nodes (102): ForbiddenPage(), AnalyticsPage(), DATE_RANGES, REASON_COLORS, REASON_LABELS, GlobalError(), NotFound(), handleLogoutEverywhere() (+94 more)
+
+### Community 100 - "Community 100"
+Cohesion: 0.39
+Nodes (7): PUT /admin/corporate-accounts/{id}/wallet/config — auto-topup configuration., test_disabling_autotopup_is_allowed_without_other_fields(), test_empty_body_returns_wallet_unchanged(), test_enabling_without_threshold_or_amount_rejected(), test_invalid_amount_rejected_by_pydantic(), test_update_autotopup_config(), test_update_config_404_when_wallet_missing()
 
 ### Community 101 - "Community 101"
-Cohesion: 0.54
+Cohesion: 0.61
 Nodes (7): _event(), _post(), Stripe webhook — corporate top-up branch., test_corporate_topup_duplicate_event_is_noop(), test_corporate_topup_webhook_credits_wallet(), test_non_corporate_topup_passes_through(), test_unknown_event_type_not_marked_processed()
 
 ### Community 102 - "Community 102"
-Cohesion: 0.18
+Cohesion: 0.20
 Nodes (11): bool, int, str, Create a mock urlopen context manager., _fetch_page(), main(), Quarterly sub-processor monitoring for PIPEDA compliance.  Fetches each vendor's, Fetch URL text content and ETag. Returns (content, etag_or_None). (+3 more)
 
 ### Community 103 - "Community 103"
-Cohesion: 0.06
-Nodes (21): nativeModule, QUEST_TYPE_ICONS, QUEST_TYPE_LABELS, QuestsScreen(), fetchDocuments(), handleDownload(), onRefresh(), showAlert() (+13 more)
+Cohesion: 0.11
+Nodes (18): nativeModule, SafeRefreshControl(), createStyles(), QUEST_TYPE_ICONS, QUEST_TYPE_LABELS, QuestsScreen(), isAxiosError(), MyQuestProgress (+10 more)
 
 ### Community 104 - "Community 104"
-Cohesion: 0.02
-Nodes (79): defaultProps, { getAllByText }, { getByText }, initialMetrics, mockRide, mockRider, { queryByText }, { toJSON } (+71 more)
+Cohesion: 0.03
+Nodes (90): ActivityView(), parseMoney(), Period, StatusFilter, styles, toMoney(), defaultProps, { getAllByText } (+82 more)
 
 ### Community 105 - "Community 105"
-Cohesion: 0.04
-Nodes (138): _apply_filters(), _build_or_clause(), _build_or_clause_term(), _postgrest_pattern(), Supabase database access layer.  Shared infrastructure (run_sync, circuit breake, Any, str, Any (+130 more)
+Cohesion: 0.06
+Nodes (125): Any, bool, Decimal, float, int, str, Any, bool (+117 more)
 
 ### Community 106 - "Community 106"
-Cohesion: 0.03
-Nodes (136): PostgREST treats `*` as a wildcard in (i)like filters. Escape `*` and     `,` so, Convert one {col: predicate} pair into a PostgREST or_() leaf term., Flatten a list of {col: predicate} dicts into a PostgREST or_() string., Return the first row matching filters, or None., Bulk insert using Supabase's native batch insert (single round-trip)., Atomically increment a wallet balance. Returns the new balance., Atomically debit wallet and mark ride paid. Returns the new balance.      Raises, Atomically transfer between two wallets. Returns (sender_balance, recipient_bala (+128 more)
+Cohesion: 0.05
+Nodes (100): fare_split_pay_share(), increment_promo_uses(), PostgREST treats `*` as a wildcard in (i)like filters. Escape `*` and     `,` so, Convert one {col: predicate} pair into a PostgREST or_() leaf term., Flatten a list of {col: predicate} dicts into a PostgREST or_() string., Return the first row matching filters, or None., Bulk insert using Supabase's native batch insert (single round-trip)., Atomically increment a wallet balance. Returns the new balance. (+92 more)
 
 ### Community 107 - "Community 107"
 Cohesion: 0.05
-Nodes (52): Any, Decimal, float, Request, str, bool, Decimal, float (+44 more)
+Nodes (57): Any, Decimal, float, Request, str, bool, Decimal, float (+49 more)
 
 ### Community 108 - "Community 108"
-Cohesion: 0.36
+Cohesion: 0.46
 Nodes (9): result, digitsOnly(), normalizePhone(), validateCoordinates(), validateEmail(), validateLatitude(), validateLongitude(), validatePhone() (+1 more)
 
 ### Community 109 - "Community 109"
@@ -3779,192 +3899,212 @@ Cohesion: 0.39
 Nodes (8): Admin Dashboard Public Assets Directory, File SVG Icon (document with folded corner and text lines), Globe SVG Icon (world/internet globe with grid lines), Next.js Framework, Next.js Wordmark Logo SVG, Vercel Deployment Platform, Vercel Logo SVG (white triangle/chevron wordmark), Window SVG Icon (browser/app window with three dots)
 
 ### Community 110 - "Community 110"
-Cohesion: 0.03
-Nodes (77): Any, int, str, Any, float, str, _apply_filters(), _build_or_clause() (+69 more)
+Cohesion: 0.04
+Nodes (83): Any, bool, int, str, Any, bool, float, int (+75 more)
 
 ### Community 111 - "Community 111"
-Cohesion: 0.25
-Nodes (5): admin_get_stats(), Get admin dashboard statistics., Get admin dashboard statistics., Test admin_get_stats correctly iterates over lists from db., TestAdminStats
+Cohesion: 0.02
+Nodes (171): _active_subs_at(), admin_bulk_retry_payouts(), admin_cancel_ride(), admin_close_payout_period(), admin_complete_ride(), admin_create_ride(), admin_export_drivers(), admin_export_rides() (+163 more)
 
 ### Community 112 - "Community 112"
-Cohesion: 0.29
-Nodes (5): B-P2-7: tests for the explicit DB ThreadPoolExecutor.  Contract:   - run_sync us, When work is submitted, the thread name should start with     'spinr-db' — confi, run_sync must hand the function to _DB_EXECUTOR specifically,     not the defaul, test_db_executor_threads_have_spinr_prefix(), test_run_sync_dispatches_to_db_executor()
+Cohesion: 0.36
+Nodes (6): B-P2-7: tests for the explicit DB ThreadPoolExecutor.  Contract:   - run_sync us, When work is submitted, the thread name should start with     'spinr-db' — confi, run_sync must hand the function to _DB_EXECUTOR specifically,     not the defaul, test_db_executor_has_explicit_size_default_32(), test_db_executor_threads_have_spinr_prefix(), test_run_sync_dispatches_to_db_executor()
 
 ### Community 113 - "Community 113"
 Cohesion: 0.29
 Nodes (3): PIPEDA DSAR completeness test (B-P1-9).  Asserts that the driver data-export bac, _build_and_email_data_export must include all DSAR_FIELDS., TestDsarExportCompleteness
 
 ### Community 114 - "Community 114"
-Cohesion: 0.05
-Nodes (47): admin_close_ticket(), admin_deactivate_flag(), admin_delete_complaint(), admin_delete_dispute(), admin_delete_flag(), admin_delete_ticket(), admin_get_dispute_details(), admin_get_disputes() (+39 more)
+Cohesion: 0.07
+Nodes (51): admin_credit_wallet(), admin_debit_wallet(), admin_get_wallet(), AdminCreditRequest, AdminDebitRequest, _q(), Admin wallet operations — credit a user's wallet, view balance + history.  Every, Credit a user's wallet. Writes an audited ledger entry. (+43 more)
 
 ### Community 115 - "Community 115"
 Cohesion: 0.02
-Nodes (109): AccessibilityScreen(), EmergencyContact, EmergencyContactsScreen(), RELATIONSHIPS, log, StripeKeyContext, formatPhoneDisplay(), handlePhoneChange() (+101 more)
+Nodes (141): AccessibilityScreen(), createStyles(), handleCancelPress(), handleCopyOtp(), createStyles(), EmergencyContact, EmergencyContactsScreen(), RELATIONSHIPS (+133 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.38
+Cohesion: 0.42
 Nodes (9): _api(), _build_issue_body(), create_or_update_issue(), main(), Create a GitHub Issue from a CI audit report.  Only creates issues for findings, _search_existing(), Any, int (+1 more)
 
 ### Community 117 - "Community 117"
-Cohesion: 0.05
-Nodes (53): str, str, str, float, int, str, int, str (+45 more)
+Cohesion: 0.07
+Nodes (38): str, str, float, int, str, str, str, TestMetrics (+30 more)
 
 ### Community 118 - "Community 118"
-Cohesion: 0.24
-Nodes (6): str, support.py — AI-powered support chat endpoint using Gemini 1.5 Flash.  POST /sup, Send a message to the Gemini AI support bot and receive a reply.      The user m, Send a message to the Gemini AI support bot and receive a reply.      The user m, _scrub_pii(), support_chat()
+Cohesion: 0.18
+Nodes (11): str, ChatRequest, EscalateRequest, support.py — AI-powered support chat endpoint using Gemini 1.5 Flash.  POST /sup, Send a message to the Gemini AI support bot and receive a reply.      The user m, Send a message to the Gemini AI support bot and receive a reply.      The user m, Send a message to the Gemini AI support bot and receive a reply.      The user m, Escalate a support chat to a human by opening a Zoho Desk ticket.      Returns t (+3 more)
+
+### Community 119 - "Community 119"
+Cohesion: 0.48
+Nodes (5): Admin approve/deny for allowance requests (Task 8)., rider_override(), test_already_decided_request_returns_409(), test_approve_request_grants_amount(), test_deny_request_skips_grant()
+
+### Community 120 - "Community 120"
+Cohesion: 0.07
+Nodes (34): CarMapCameraState, clampDelta(), useCarMapCamera, zoomInDelta(), zoomOutDelta(), buildHandoffUrl(), BUTTON, CarRoute (+26 more)
 
 ### Community 121 - "Community 121"
-Cohesion: 0.33
+Cohesion: 0.38
 Nodes (5): B-P2-6: tests for the DSAR (data export) handler in routes/drivers.py.  Contract, All 6 reads must complete in 2 await-points (not 6)., A user with no driver row must not query rides/payouts/documents     (those quer, test_data_export_skips_wave2_for_rider_only_account(), test_data_export_uses_two_waves_of_parallel_reads()
 
 ### Community 122 - "Community 122"
-Cohesion: 0.16
+Cohesion: 0.18
 Nodes (13): bytes, float, str, _coerce_polyline(), _extract_trail(), Render a PNG snapshot of a ride's route via Google Static Maps API.  Used for: -, Convert phase_polylines entry [lat, lng, ts] to 'lat,lng' strings., OSM/staticmap fallback — used only when Google API key is unavailable. (+5 more)
 
 ### Community 123 - "Community 123"
-Cohesion: 0.11
-Nodes (26): calculate_airport_fee(), calculate_all_fees(), check_airport_fee(), fare_estimate(), get_area_config(), _money(), point_in_polygon(), Any (+18 more)
+Cohesion: 0.10
+Nodes (46): agents(), _aggregate_trends(), comment_ticket(), CommentRequest, _config_status(), create_ticket(), CreateTicketRequest, dashboard() (+38 more)
 
 ### Community 124 - "Community 124"
-Cohesion: 0.03
-Nodes (84): CreateRideRequest, datetime, float, float, int, str, str, _body() (+76 more)
+Cohesion: 0.10
+Nodes (17): str, P2-17: Scheduled rides + DST (R3, E14)  Implemented endpoints:   GET  /rides/sch, Pins cancel_scheduled_ride: owner guard, status update, guards.      Code under, Ride lookup includes rider_id + is_scheduled filter;         wrong owner or non-, E14 — scheduled ride times and DST boundary handling., A ride stored with an explicit UTC ISO timestamp is retrieved as-is.         No, E14 — scheduled ride times and DST boundary handling., A ride stored with an explicit UTC ISO timestamp is retrieved as-is.         No (+9 more)
 
 ### Community 125 - "Community 125"
 Cohesion: 0.09
-Nodes (80): AllowanceCreate, AllowanceRequestDecision, AllowanceUpdate, AllowedDomainCreate, get_corporate_member_by_id(), get_corporate_policy(), get_corporate_wallet_by_company(), get_member_allowance() (+72 more)
+Nodes (81): AllowanceCreate, AllowanceRequestDecision, AllowanceUpdate, AllowedDomainCreate, get_corporate_member_by_id(), get_corporate_policy(), get_member_allowance(), update_corporate_member() (+73 more)
 
 ### Community 126 - "Community 126"
-Cohesion: 0.05
-Nodes (69): int, MagicMock, str, bool, float, int, str, _make_stripe_mock() (+61 more)
+Cohesion: 0.06
+Nodes (70): int, MagicMock, str, bool, float, int, str, _make_stripe_mock() (+62 more)
 
 ### Community 127 - "Community 127"
 Cohesion: 0.03
-Nodes (69): dependencies, ajv, axios, expo, expo-application, expo-asset, expo-audio, expo-blur (+61 more)
+Nodes (70): dependencies, ajv, axios, expo, expo-application, expo-asset, expo-audio, expo-blur (+62 more)
 
 ### Community 128 - "Community 128"
-Cohesion: 0.12
-Nodes (11): asyncStoragePersister, queryClient, queryKeys, handleNotificationPress(), markAsRead(), Notification, NotificationsScreen(), useMarkAllNotificationsRead() (+3 more)
+Cohesion: 0.07
+Nodes (28): styles, { width }, styles, DriverArrivedScreen(), RideStatusScreen(), HomeScreen(), AppMap, Driver (+20 more)
 
 ### Community 129 - "Community 129"
 Cohesion: 0.03
-Nodes (63): dependencies, ajv, axios, expo, expo-blur, expo-build-properties, expo-clipboard, expo-constants (+55 more)
+Nodes (62): dependencies, ajv, axios, expo, expo-blur, expo-build-properties, expo-clipboard, expo-constants (+54 more)
 
 ### Community 130 - "Community 130"
-Cohesion: 0.04
-Nodes (67): admin_create_requirement(), admin_delete_requirement(), admin_get_driver_documents(), admin_get_requirements(), admin_review_document(), delete_driver_document(), _extract_signed_url(), get_document_file() (+59 more)
+Cohesion: 0.05
+Nodes (68): admin_create_requirement(), admin_delete_requirement(), admin_get_driver_documents(), admin_get_requirements(), admin_review_document(), admin_update_requirement(), CreateRequirementRequest, delete_driver_document() (+60 more)
 
 ### Community 131 - "Community 131"
-Cohesion: 0.06
-Nodes (59): admin_login(), _admin_login_rate_limit(), admin_logout(), admin_logout_all(), admin_mfa_challenge(), admin_mfa_confirm(), admin_mfa_disable(), admin_mfa_enroll() (+51 more)
+Cohesion: 0.05
+Nodes (79): admin_login(), _admin_login_rate_limit(), admin_logout(), admin_logout_all(), admin_mfa_challenge(), admin_mfa_confirm(), admin_mfa_disable(), admin_mfa_enroll() (+71 more)
 
 ### Community 132 - "Community 132"
-Cohesion: 0.23
-Nodes (23): bool, Decimal, float, int, str, _d(), _f(), _money_str() (+15 more)
+Cohesion: 0.05
+Nodes (41): 10. Safety incident submission (see #4), 11. Subscription verify-session + cancel hooks vs Stripe, 12. Driver-side listing of safety/emergency history, 13. Two push-token endpoints, only one used, 14. Two driver-status endpoints, 15. Two account-deletion endpoints — driver is using the wrong one (PIPEDA risk), 16. Driver destination zone (commute home), 17. Driver leaderboard (+33 more)
 
 ### Community 133 - "Community 133"
-Cohesion: 0.08
-Nodes (36): Backend Agent Specialized for Python/FastAPI backend development., Agent specialized in backend development for the Spinr platform., AgentTask, KnowledgeEntry, Entry structure for knowledge base., Task structure for agent execution., Code Reviewer Agent Automated code quality assurance and review., Agent specialized in code review and quality assurance. (+28 more)
+Cohesion: 0.09
+Nodes (28): ABC, Backend Agent Specialized for Python/FastAPI backend development., Agent specialized in backend development for the Spinr platform., KnowledgeEntry, Base Agent Module Provides the foundation for all agents in the Spinr developmen, Entry structure for knowledge base., Task execution status., TaskStatus (+20 more)
 
 ### Community 134 - "Community 134"
 Cohesion: 0.53
 Nodes (6): Driver User Account (UUID a358ee20-f82e-40f4-b6c3-3752889f8908), Driver Profile Upload - Child Portrait (front-facing, indoor hallway), Driver Profile Upload - Child Portrait (seated near desk, gaming room), Driver Profile Upload - Adult and Child Selfie (two persons, indoor), Car Map Marker PNG (top-down car icon for map display), Car Top-Down SVG Graphic (dark body, blue glass panels, yellow/red lights)
 
 ### Community 135 - "Community 135"
-Cohesion: 0.05
-Nodes (33): BillingPage(), downloadCSV(), formatCAD(), monthOptions(), toCSV(), COMPARE_COLORS, fmtMoney(), fmtPeriodKey() (+25 more)
+Cohesion: 0.06
+Nodes (52): BillingPage(), downloadCSV(), formatCAD(), Metric(), monthOptions(), toCSV(), CancellationMixBar(), CeoMetricsHeader() (+44 more)
 
 ### Community 136 - "Community 136"
-Cohesion: 0.06
-Nodes (19): ChartData, tooltipStyle, DriverStatsData, DEFAULT_CONFIG, DriverTimeline(), EVENT_CONFIG, groupByDate(), DocSummary (+11 more)
+Cohesion: 0.07
+Nodes (54): DEFAULT_CONFIG, DriverTimeline(), EVENT_CONFIG, fmtDate(), fmtDateTime(), groupByDate(), CopyableField(), DetailField() (+46 more)
 
 ### Community 137 - "Community 137"
-Cohesion: 0.08
-Nodes (34): ConnectionStatus, KNOWN_EVENT_TYPES, useMonitoringSocket(), UseMonitoringSocketOptions, AlertFeed(), AlertFeedProps, ICON_MAP, DriverPanelProps (+26 more)
+Cohesion: 0.09
+Nodes (27): find_nearby_drivers(), Any, str, main(), random_digits(), create_user(), delete_otp_record(), get_otp_record() (+19 more)
 
 ### Community 138 - "Community 138"
-Cohesion: 0.08
-Nodes (49): Request, bool, create_setup_intent(), delete_card(), get_cards(), get_or_create_stripe_customer(), get_payment_methods(), Create a SetupIntent to save a new payment method (+41 more)
+Cohesion: 0.10
+Nodes (54): Request, str, bool, confirm_payment(), create_setup_intent(), delete_card(), get_cards(), get_or_create_stripe_customer() (+46 more)
 
 ### Community 139 - "Community 139"
-Cohesion: 0.06
-Nodes (51): float, str, str, Auto-top-up scheduled tick for corporate wallets., Two replica instances processing the same wallet simultaneously must     produce, test_concurrent_replicas_use_same_stripe_idempotency_key(), test_no_op_when_stripe_secret_missing(), test_skips_when_company_not_active() (+43 more)
+Cohesion: 0.13
+Nodes (29): float, str, _autotopup_wallet(), _expected_autotopup_key(), Replay-safety guarantees for payment-touching background loops.  CLAUDE.md, Back, When the conditional update returns None (another replica won     the race), the, The replica that wins the conditional update is the one that     notifies the dr, The claim filter must include payment_retry_count=<prior> so two     replicas ra (+21 more)
 
 ### Community 140 - "Community 140"
-Cohesion: 0.07
-Nodes (54): AllowanceRequestCreate, accept_member_invite(), get_corporate_account_by_id(), insert_corporate_member_invite(), list_active_memberships_for_user(), str, Decimal, str (+46 more)
+Cohesion: 0.12
+Nodes (45): AllowanceRequestCreate, accept_member_invite(), get_corporate_account_by_id(), insert_corporate_member_invite(), list_active_memberships_for_user(), Decimal, str, Any (+37 more)
 
 ### Community 141 - "Community 141"
-Cohesion: 0.47
+Cohesion: 0.52
 Nodes (5): haversine_km(), main(), str, Read-only diagnostic for "XL driver online but not showing in rider app".  Usage, section()
 
 ### Community 142 - "Community 142"
-Cohesion: 0.40
-Nodes (3): End-to-end happy path for the Plan-3 member lifecycle.  Walks the full flow thro, Same current_user for admin + rider endpoints — guard/auth distinction     is ma, user_override()
+Cohesion: 0.47
+Nodes (4): End-to-end happy path for the Plan-3 member lifecycle.  Walks the full flow thro, Same current_user for admin + rider endpoints — guard/auth distinction     is ma, test_full_member_lifecycle(), user_override()
+
+### Community 143 - "Community 143"
+Cohesion: 0.53
+Nodes (4): GET /admin/corporate-accounts/{id}/wallet — balance + transaction history., test_get_wallet_404_when_missing(), test_get_wallet_caps_limit_at_200(), test_get_wallet_returns_balance_and_txns()
 
 ### Community 144 - "Community 144"
-Cohesion: 0.11
-Nodes (12): calculate_distance(), get_service_area_polygon(), Any, float, str, Return polygon as list of {lat, lng} from a service area row.     Supports both, DispatchService — driver-matching logic separated from the HTTP layer.  Extracts, patch_external_dependencies() (+4 more)
+Cohesion: 0.14
+Nodes (38): Any, bool, int, str, add_comment(), add_tags(), create_ticket(), _dc_domains() (+30 more)
 
 ### Community 145 - "Community 145"
-Cohesion: 0.07
-Nodes (64): bool, int, Request, Response, str, Validate generic ID format (alphanumeric with underscores/hyphens).      Args:, Validate generic ID format (alphanumeric with underscores/hyphens).      Args:, validate_id() (+56 more)
+Cohesion: 0.05
+Nodes (88): bool, int, Request, Response, str, Validate generic ID format (alphanumeric with underscores/hyphens).      Args:, Validate generic ID format (alphanumeric with underscores/hyphens).      Args:, Validate a CRA Business Number format (9 digits, optional CRA program identifier (+80 more)
 
 ### Community 146 - "Community 146"
-Cohesion: 0.14
-Nodes (23): Decimal, str, cancel_fare_split(), create_fare_split(), _d(), get_fare_split(), get_fare_split_for_ride(), _money_str() (+15 more)
+Cohesion: 0.16
+Nodes (26): Decimal, str, cancel_fare_split(), create_fare_split(), CreateFareSplitRequest, _d(), get_fare_split(), get_fare_split_for_ride() (+18 more)
 
 ### Community 147 - "Community 147"
-Cohesion: 0.06
-Nodes (56): str, str, str, _app_with_mocked_auth(), _make_ride(), charge_ride returns succeeded → process_payment returns 200., charge_ride returns declined → process_payment returns 402., charge_ride returns declined → process_payment returns 402. (+48 more)
+Cohesion: 0.16
+Nodes (21): str, _completed_ride(), _install_common_patches(), _last_payment_status_write(), _noop_async(), Integration tests for the card branch of backend/routes/rides.py::process_paymen, Off-session 3DS path: mark ride failed and raise 402 so the rider         is pro, Ops-level failure (api_connection_error, invalid_request,         rate_limit) — (+13 more)
 
 ### Community 148 - "Community 148"
 Cohesion: 0.07
-Nodes (20): Any, float, int, str, AuthenticationException, error_response(), InvalidOTPException, OTPExpiredException (+12 more)
+Nodes (16): Any, float, int, str, error_response(), OTPExpiredException, Convert exception to dictionary for JSON response., Convert exception to dictionary for JSON response. (+8 more)
 
 ### Community 149 - "Community 149"
-Cohesion: 0.48
+Cohesion: 0.50
 Nodes (6): _build_cr(), generate(), main(), Generate structured Change Request drafts from fix recommendations.  These CRs r, Any, str
+
+### Community 150 - "Community 150"
+Cohesion: 0.47
+Nodes (4): mock_db(), Replace the `db` used in backend.server with simple async mocks for collections., test_send_otp_rate_limit(), test_verify_otp_rate_limit()
 
 ### Community 151 - "Community 151"
 Cohesion: 0.04
 Nodes (49): dependencies, axios, expo, expo-blur, expo-clipboard, expo-constants, expo-document-picker, expo-font (+41 more)
 
 ### Community 152 - "Community 152"
-Cohesion: 0.09
-Nodes (23): add_allowed_domain(), get_member_by_invite_token(), list_allowances_due_for_reset(), list_company_members(), list_pending_allowance_requests_for_member(), reset_allowance_period(), date, Monthly allowance reset tick tests (Task 9). (+15 more)
+Cohesion: 0.30
+Nodes (10): Thin happy-path tests for the Plan-3 db_supabase helpers.  The helpers are pass-, test_accept_member_invite_flips_status(), test_add_allowed_domain_inserts_lowercase(), test_get_member_by_invite_token_returns_row(), test_insert_member_invite_writes_row(), test_list_allowances_due_for_reset_filters(), test_list_company_members_filters_status(), test_list_pending_requests_orders_desc() (+2 more)
 
 ### Community 153 - "Community 153"
 Cohesion: 0.08
-Nodes (25): BaseSettings, Hash ADMIN_PASSWORD with bcrypt at startup (A-P3-1).          The plaintext env, Refuse to start in production with weak placeholder values, short         secret, Settings, Regression tests for backend P1 auth-hardening items.  B-P1-1: FIREBASE_DRIVER_A, JWT_SECRET shorter than 32 chars must raise in production., 32-char JWT_SECRET + both Firebase IDs → no exception., Exactly 32 chars is the minimum — must not raise. (+17 more)
+Nodes (26): BaseSettings, Hash ADMIN_PASSWORD with bcrypt at startup (A-P3-1).          The plaintext env, Refuse to start in production with weak placeholder values, short         secret, Hash ADMIN_PASSWORD with bcrypt at startup (A-P3-1).          The plaintext env, Refuse to start in production with weak placeholder values, short         secret, Settings, JWT_SECRET shorter than 32 chars must raise in production., 32-char JWT_SECRET + both Firebase IDs → no exception. (+18 more)
 
 ### Community 154 - "Community 154"
-Cohesion: 0.04
+Cohesion: 0.06
 Nodes (47): active_branch, blockers, branch_sync_status, claude/ci-error-audit-system-HPjKP, feat/phase4-type-safety-docs, feature/payment-idempotency, fix/cookie-expires-utc, fix/otp-cookie-auth-navigation (+39 more)
 
 ### Community 155 - "Community 155"
 Cohesion: 0.04
 Nodes (46): 10. Realtime layer, 11. Fare split (`routes/fare_split.py`), 12. Admin surface, 13. Fares endpoints (`routes/fares.py`), 14. Geo utilities (`geo_utils.py`), 15. Common tasks, 1. Domain concepts, 2. Ride state machine (+38 more)
 
+### Community 156 - "Community 156"
+Cohesion: 0.60
+Nodes (3): test_generates_signed_upload_url(), test_rejects_extra_fields(), test_rejects_non_pdf_or_image()
+
 ### Community 157 - "Community 157"
 Cohesion: 0.09
 Nodes (14): str, TipRequest, _driver(), Extended unit tests for routes/rides.py.  Covers branches not exercised by exist, _ride(), TestAddTip, TestCancelScheduledRide, TestGetChatStatus (+6 more)
 
 ### Community 158 - "Community 158"
-Cohesion: 0.04
-Nodes (28): DataPoint, EarningsBarChartProps, styles, { width: SCREEN_WIDTH }, DataPoint, EarningsLineChartProps, styles, { width: SCREEN_WIDTH } (+20 more)
+Cohesion: 0.29
+Nodes (5): DataPoint, EarningsBarChart(), EarningsBarChartProps, styles, { width: SCREEN_WIDTH }
 
 ### Community 159 - "Community 159"
 Cohesion: 0.04
 Nodes (46): content_hash, etag, last_changed, last_reviewed, name, subprocessor_url, _last_audit, _note (+38 more)
 
 ### Community 160 - "Community 160"
-Cohesion: 0.07
-Nodes (22): exampleDirPath, fs, oldDirs, path, readline, rl, root, exampleDirPath (+14 more)
+Cohesion: 0.11
+Nodes (25): exampleDirPath, fs, moveDirectories(), oldDirs, path, readline, rl, root (+17 more)
 
 ### Community 161 - "Community 161"
-Cohesion: 0.03
-Nodes (55): ActivityView(), parseMoney(), Period, StatusFilter, styles, toMoney(), ActiveRide, DailyEarning (+47 more)
+Cohesion: 0.05
+Nodes (48): ActiveRide, DailyEarning, DriverState, EarningsSummary, IncomingRide, RideState, TripEarning, useDriverStore (+40 more)
 
 ### Community 162 - "Community 162"
 Cohesion: 0.04
@@ -3975,40 +4115,40 @@ Cohesion: 0.04
 Nodes (45): 1. 🟠 [P1] TEST — `driver-app-test`, 2. 🟠 [P1] BUILD — `driver-app-test`, 3. 🟠 [P1] TEST — `backend-test`, 4. 🟠 [P1] BUILD — `backend-test`, 5. 🟠 [P1] TEST — `admin-test`, 6. 🟠 [P1] TEST — `rider-app-test`, 7. 🟠 [P1] BUILD — `rider-app-test`, Audit Metadata (+37 more)
 
 ### Community 164 - "Community 164"
-Cohesion: 0.12
-Nodes (20): admin_delete_cloud_message(), admin_get_cloud_message_stats(), admin_get_cloud_messages(), admin_send_cloud_message(), _fan_out_push(), Send or schedule a cloud message to users/drivers.      Immediate sends return 2, Get cloud messages with optional filters., Get cloud messaging statistics. (+12 more)
+Cohesion: 0.06
+Nodes (34): 1. Cloudinary Integration, 1. Unit Tests with Pytest (Backend), 2. E2E Tests with Detox (Frontend), 2. Mixpanel/Amplitude Analytics, 3. Enhanced Error Handling, Adding New Error Types, Adding New Tests, CI/CD Pipeline (+26 more)
 
 ### Community 165 - "Community 165"
 Cohesion: 0.04
 Nodes (45): 1. 🟠 [P1] TEST — `rider-app-test`, 2. 🟠 [P1] BUILD — `rider-app-test`, 3. 🟠 [P1] TEST — `admin-test`, 4. 🟠 [P1] TEST — `driver-app-test`, 5. 🟠 [P1] BUILD — `driver-app-test`, 6. 🟠 [P1] TEST — `backend-test`, 7. 🟠 [P1] BUILD — `backend-test`, Audit Metadata (+37 more)
 
 ### Community 166 - "Community 166"
-Cohesion: 0.07
-Nodes (24): activeRide, AsyncStorageMock, completedRide, conflictErr, createdRide, dropoff, err, loc (+16 more)
+Cohesion: 0.08
+Nodes (27): activeRide, AsyncStorageMock, completedRide, conflictErr, createdRide, dropoff, err, loc (+19 more)
 
 ### Community 167 - "Community 167"
 Cohesion: 0.04
 Nodes (45): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, 3. 🟠 [P1] TEST — `admin-test`, 4. 🟠 [P1] TEST — `driver-app-test`, 5. 🟠 [P1] BUILD — `driver-app-test`, 6. 🟠 [P1] TEST — `rider-app-test`, 7. 🟠 [P1] BUILD — `rider-app-test`, Audit Metadata (+37 more)
 
 ### Community 168 - "Community 168"
-Cohesion: 0.83
-Nodes (3): check_user(), main(), promote_user()
+Cohesion: 0.06
+Nodes (31): Admin Dashboard, Agent Framework (`agents/`), Architecture, Backend (Python/FastAPI), Background Loop Recipe, Batch size rule, Claude-Adjacent Directories, Commands (+23 more)
 
 ### Community 169 - "Community 169"
-Cohesion: 0.07
-Nodes (28): float, _is_corporate_paid(), True when the ride will be settled against a corporate account.      Surge does, True when the ride will be settled against a corporate account.      Surge does, _patch_create_ride_deps(), _patch_estimate_deps(), Surge-bypass guarantees for corporate-paid rides.  CLAUDE.md, Surge pricing rule, Fare row with a non-trivial surge so personal vs corporate diverge. (+20 more)
+Cohesion: 0.06
+Nodes (40): float, _is_corporate_paid(), True when the ride will be settled against a corporate account.      Surge does, True when the ride will be settled against a corporate account.      Surge does, True when the ride will be settled against a corporate account.      Surge does, _patch_create_ride_deps(), _patch_estimate_deps(), Surge-bypass guarantees for corporate-paid rides.  CLAUDE.md, Surge pricing rule (+32 more)
 
 ### Community 170 - "Community 170"
 Cohesion: 0.67
 Nodes (4): admin-dashboard: /dashboard/monitoring page with Google Maps, Live Monitoring Page Implementation Plan, backend/routes/admin/monitoring.py (GET /drivers, GET /rides), Live Monitoring Page Design Spec
 
 ### Community 173 - "Community 173"
-Cohesion: 0.12
-Nodes (11): actual, badgeStub, cardStubs, dialogStubs, list, noop, overrides, selectStubs (+3 more)
+Cohesion: 0.18
+Nodes (14): actual, badgeStub, cardStubs, dialogStubs, list, noop, overrides, pageSubComponentStub() (+6 more)
 
 ### Community 174 - "Community 174"
-Cohesion: 0.24
-Nodes (6): attrs, badReq, cookieSetSpy, req, DELETE(), POST()
+Cohesion: 0.29
+Nodes (8): attrs, badReq, cookieSetSpy, makeRequest(), _makeResponseObj(), req, DELETE(), POST()
 
 ### Community 175 - "Community 175"
 Cohesion: 0.04
@@ -4020,7 +4160,7 @@ Nodes (44): 1. 🟠 [P1] TEST — `driver-app-test`, 2. 🟠 [P1] BUILD — `dri
 
 ### Community 177 - "Community 177"
 Cohesion: 0.03
-Nodes (77): SettingsPage(), AuditLogsPage(), CloudMessagingPage(), docRequiresExpiry(), DocRow, DocumentReviewer(), DocumentReviewerProps, isPdf() (+69 more)
+Nodes (97): AuditLogsPage(), CloudMessagingPage(), docRequiresExpiry(), DocRow, DocumentReviewer(), DocumentReviewerProps, isPdf(), REQUIRES_EXPIRY_KEYWORDS (+89 more)
 
 ### Community 178 - "Community 178"
 Cohesion: 0.04
@@ -4031,8 +4171,8 @@ Cohesion: 0.04
 Nodes (44): 1. 🟠 [P1] TEST — `admin-test`, 2. 🟠 [P1] TEST — `driver-app-test`, 3. 🟠 [P1] BUILD — `driver-app-test`, 4. 🟠 [P1] BUILD — `security-scan`, 5. 🟡 [P2] LINT — `backend-test`, 6. 🟠 [P1] BUILD — `backend-test`, 7. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata (+36 more)
 
 ### Community 180 - "Community 180"
-Cohesion: 0.12
-Nodes (12): CreateRideModal(), PriceBreakdown, SelectedPlace, useDebounce(), AdminLocation, pendingResolve, useAdminLocation(), Prediction (+4 more)
+Cohesion: 0.10
+Nodes (15): client(), make_mock_db(), Integration tests for the loyalty rewards endpoints.  Routes under test (backend, GET /api/v1/loyalty/history, POST /api/v1/loyalty/earn, Silver tier (1.25×) earns bonus points., Second call raises DuplicateRecordError on insert → idempotent no-op., POST /api/v1/loyalty/redeem (+7 more)
 
 ### Community 181 - "Community 181"
 Cohesion: 0.04
@@ -4059,12 +4199,16 @@ Cohesion: 0.04
 Nodes (44): 1. 🟠 [P1] TEST — `driver-app-test`, 2. 🟠 [P1] BUILD — `driver-app-test`, 3. 🟡 [P2] LINT — `backend-test`, 4. 🟠 [P1] BUILD — `backend-test`, 5. 🟠 [P1] BUILD — `security-scan`, 6. 🟠 [P1] TEST — `admin-test`, 7. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata (+36 more)
 
 ### Community 189 - "Community 189"
-Cohesion: 0.07
+Cohesion: 0.08
 Nodes (34): errors, fatal, errors, fatal, url, ASSIGNED_RIDE, COMPLETED_RESPONSE, earningsCalled (+26 more)
+
+### Community 190 - "Community 190"
+Cohesion: 0.50
+Nodes (3): calls, goOfflineNoPermission(), goOnlineWithPermission()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.03
-Nodes (62): ApiErrorBody, ApiErrorLogEntry, ensureFreshToken(), _errorLog, ExtractedError, extractError(), extractErrorMessage(), handleApiError() (+54 more)
+Nodes (102): ApiErrorBody, ApiErrorLogEntry, appCheckHeader(), clearApiErrorLog(), deadlineHeader(), ensureFreshToken(), _errorLog, ExtractedError (+94 more)
 
 ### Community 192 - "Community 192"
 Cohesion: 0.04
@@ -4087,7 +4231,7 @@ Cohesion: 0.04
 Nodes (44): 1. 🟠 [P1] TEST — `driver-app-test`, 2. 🟠 [P1] BUILD — `driver-app-test`, 3. 🟡 [P2] LINT — `backend-test`, 4. 🟠 [P1] BUILD — `backend-test`, 5. 🟠 [P1] TEST — `admin-test`, 6. 🟠 [P1] BUILD — `security-scan`, 7. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata (+36 more)
 
 ### Community 197 - "Community 197"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (30): BASE_DRIVER_ARRIVED_RIDE, BASE_SEARCHING_RIDE, MOCK_ESTIMATES, MOCK_RIDE, MOCK_USER, mockBackend(), PAYMENT_RESPONSES, PaymentResponseKey (+22 more)
 
 ### Community 198 - "Community 198"
@@ -4103,32 +4247,36 @@ Cohesion: 0.21
 Nodes (10): setAdminAuthCookie(), critical, mockDashboardAPIs(), pagesToCheck, critical, errors, MOCK_DRIVER, MOCK_RIDES (+2 more)
 
 ### Community 202 - "Community 202"
-Cohesion: 0.05
+Cohesion: 0.04
 Nodes (43): 1. Executive Summary, 2.1 Workflows, 2.2 CI Jobs Inventory (ci.yml), 2.3 Test Infrastructure, 2.4 Security Tooling, 2. CI Infrastructure Assessment, 3. Findings and Gaps, 4. Change Requests (Pending Approval) (+35 more)
 
-### Community 204 - "Community 204"
+### Community 203 - "Community 203"
 Cohesion: 0.06
-Nodes (41): _check_vehicle_year(), int, Any, bool, datetime, Decimal, float, int (+33 more)
+Nodes (31): 1. Backend URL Configuration, 1. Driver App Ride Flow, 1. Missing Environment Variables, 2. Duplicate Config Files, 2. Firebase Not Configured, 2. Rider App Ride Flow, 3. Admin Dashboard Missing Features, 3. Twilio Not Configured (+23 more)
+
+### Community 204 - "Community 204"
+Cohesion: 0.05
+Nodes (47): _check_license_plate(), _check_vehicle_year(), _check_vin(), int, Any, bool, datetime, Decimal (+39 more)
 
 ### Community 206 - "Community 206"
-Cohesion: 0.04
-Nodes (30): AuthState, useAuthStore, User, mockUser, state, setCsrfToken(), handleLogoutEverywhere(), NAV_GROUPS (+22 more)
+Cohesion: 0.17
+Nodes (16): AuthState, useAuthStore, User, mockUser, state, _ACTIVITY_EVENTS, cancelRefreshTimer(), clearAuthCookie() (+8 more)
 
 ### Community 207 - "Community 207"
-Cohesion: 0.11
-Nodes (18): formatDate(), buildNav(), CompanyPortalLayout(), NavItem, CompanyDetailPage(), confirmTransition(), handleAdjust(), handleToggleAutotopup() (+10 more)
+Cohesion: 0.12
+Nodes (23): SettingsPage(), formatDate(), CompanyPortalLandingPage(), buildNav(), CompanyPortalLayout(), NavItem, CompanyDetailPage(), confirmTransition() (+15 more)
 
 ### Community 209 - "Community 209"
 Cohesion: 0.05
 Nodes (43): binaryPath, build, type, app, device, app, device, binaryPath (+35 more)
 
 ### Community 210 - "Community 210"
-Cohesion: 0.05
-Nodes (48): str, Any, Decimal, float, str, _patch_settings(), _patch_stripe_confirm(), When payment_intent_id is supplied, confirm() is called, not create(). (+40 more)
+Cohesion: 0.10
+Nodes (27): str, Any, float, str, _patch_settings(), _patch_stripe(), Unit tests for backend/utils/stripe_charge.py::charge_ride().  charge_ride() is, Float 19.999 must round to 2000 cents, not 1999 or 2001. (+19 more)
 
 ### Community 211 - "Community 211"
-Cohesion: 0.03
-Nodes (82): Any, float, int, str, Unit tests for backend/utils/surge_engine.py  Coverage: - ratio_to_multiplier: a, get_service_area_polygon returns None → supply is 0., DB exception in _count_supply_in_area → returns 0 (does not propagate)., Drivers not in present_driver_ids set are excluded from supply count. (+74 more)
+Cohesion: 0.05
+Nodes (54): Unit tests for backend/utils/surge_engine.py  Coverage: - ratio_to_multiplier: a, get_service_area_polygon returns None → supply is 0., DB exception in _count_supply_in_area → returns 0 (does not propagate)., Drivers not in present_driver_ids set are excluded from supply count., presence_driver_ids failure → warning logged, DB drivers used as-is (safe fallba, demand=0, supply=5 → ratio=0 → multiplier=1.0., demand=5, supply=0 → ratio=5/1=5.0 → SURGE_CAP (2.5)., demand=15, supply=4 → ratio=3.75 → SURGE_CAP. (+46 more)
 
 ### Community 213 - "Community 213"
 Cohesion: 0.05
@@ -4143,11 +4291,11 @@ Cohesion: 0.05
 Nodes (39): 4a — In-App Navigation, 4b — Earnings CSV Export, `backend/routes/auth.py`, `backend/routes/drivers.py` (accept_ride endpoint), `backend/utils/audit_logger.py` (new in this branch), `backend/utils/audit_logger.py` (new in this branch), Branch 1: `sprint3/driver-background-push`, Branch 2: `sprint3/otp-lockout` (+31 more)
 
 ### Community 217 - "Community 217"
-Cohesion: 0.06
+Cohesion: 0.07
 Nodes (26): bool, object, str, _all_response_models(), _import_aggregate_rows(), _is_money_field(), _money_fields(), Money-on-wire serialization snapshot test.  Audit 17 P0-1 mandates that every mo (+18 more)
 
 ### Community 218 - "Community 218"
-Cohesion: 0.05
+Cohesion: 0.06
 Nodes (40): branch_at_audit, branch_at_delta, delta_timestamp, findings, model_in_attribution, model_pinned, model_running_at_delta, repo (+32 more)
 
 ### Community 219 - "Community 219"
@@ -4155,8 +4303,8 @@ Cohesion: 0.05
 Nodes (40): 1. Clone and Install Dependencies, 2. Create `.env` Files, 2a. `backend/.env`, 2b. `rider-app/.env`, 2c. `driver-app/.env`, 3. Start the Backend, 4. Start the Admin Dashboard, 5. Start the Mobile Apps (+32 more)
 
 ### Community 221 - "Community 221"
-Cohesion: 0.05
-Nodes (47): metadata, AnalyticsWrapper(), AuthInitializer(), handleConfirm(), handleDone(), MfaEnrollDialog(), Props, startEnroll() (+39 more)
+Cohesion: 0.07
+Nodes (48): SettingsPage(), CATEGORIES, DriverNotes(), fmtDateTime(), handleAdd(), handleDelete(), loadNotes(), handleConfirm() (+40 more)
 
 ### Community 222 - "Community 222"
 Cohesion: 0.05
@@ -4171,8 +4319,8 @@ Cohesion: 0.05
 Nodes (40): buildType, releaseStatus, serviceAccountKeyPath, track, build, development, preview, production (+32 more)
 
 ### Community 225 - "Community 225"
-Cohesion: 0.06
-Nodes (32): ErrorCode, SpinrError, SpinrErrorResponse, FareEstimate, MoneyString, Receipt, TransactionType, WalletBalance (+24 more)
+Cohesion: 0.08
+Nodes (33): ErrorCode, SpinrError, SpinrErrorResponse, FareEstimate, MoneyString, moneyToDisplay(), Receipt, TransactionType (+25 more)
 
 ### Community 226 - "Community 226"
 Cohesion: 0.05
@@ -4195,31 +4343,31 @@ Cohesion: 0.05
 Nodes (38): 1. Backend URL Configuration, 1. Driver App Ride Flow, 1. Missing Environment Variables, 2. Duplicate Config Files, 2. Firebase Not Configured, 2. Rider App Ride Flow, 3. Admin Dashboard Missing Features, 3. Twilio Not Configured (+30 more)
 
 ### Community 231 - "Community 231"
-Cohesion: 0.05
-Nodes (44): formatDate(), submitDecision(), save(), fetchDisputes(), fetchStats(), handleResolve(), refresh(), handleDelete() (+36 more)
+Cohesion: 0.09
+Nodes (27): submitDecision(), save(), FLAG_REASONS, handleSubmit(), Props, RideFlagForm(), handleDelete(), handleSave() (+19 more)
 
 ### Community 232 - "Community 232"
-Cohesion: 0.08
-Nodes (32): str, Decimal, int, str, _make_driver(), _make_ride(), Tests for utils/t4a_annual_job.py — P4-7 CRA T4A annual issuance loop.  Covers:, No drivers above threshold — no pushes, audit still written. (+24 more)
+Cohesion: 0.11
+Nodes (31): str, int, str, _make_driver(), _make_ride(), Tests for utils/t4a_annual_job.py — P4-7 CRA T4A annual issuance loop.  Covers:, No drivers above threshold — no pushes, audit still written., Drivers missing user_id are skipped silently. (+23 more)
 
 ### Community 233 - "Community 233"
-Cohesion: 0.08
-Nodes (36): get_analytics_overview(), get_cancellation_breakdown(), get_demand_forecast(), get_demand_forecast_summary(), get_driver_acceptance_rates(), get_surge_history(), _parse_date_range(), Admin analytics — acceptance rate, cancellation breakdown, driver performance. (+28 more)
+Cohesion: 0.07
+Nodes (50): _fetch_rows_in_chunks(), get_analytics_overview(), get_cancellation_breakdown(), get_demand_forecast(), get_demand_forecast_summary(), get_driver_acceptance_rates(), get_driver_offer_stats(), get_driver_offer_trends() (+42 more)
 
 ### Community 234 - "Community 234"
 Cohesion: 0.15
 Nodes (16): list_users(), make_admin(), str, str, Tests for ``backend.utils.pii`` PIPEDA redaction helpers.  These helpers are man, test_redact_email_masks_local_part(), test_redact_email_never_leaks_local_beyond_first_char(), test_redact_email_rejects_malformed() (+8 more)
 
 ### Community 235 - "Community 235"
-Cohesion: 0.06
-Nodes (50): build_monitoring_ride(), fetch_monitoring_drivers(), fetch_monitoring_rides(), flush_redis_prefix(), get_infrastructure_stats(), get_monitoring_drivers(), get_monitoring_rides(), get_redis_health() (+42 more)
+Cohesion: 0.09
+Nodes (42): fetch_monitoring_drivers(), fetch_monitoring_rides(), get_dashboard_health(), get_infrastructure_stats(), get_monitoring_drivers(), get_monitoring_rides(), _humanize_bytes_local(), Core fetcher for driver monitoring data. Called by REST and WS handlers. (+34 more)
 
 ### Community 236 - "Community 236"
 Cohesion: 0.05
 Nodes (37): 10. Start Ride, 11. Complete Ride, 12. Ride History & Earnings, 1. Authentication Flow, 2. Ride State Machine, 3. Location Tracking, 4. WebSocket Connection, 5. Ride Offer Flow (+29 more)
 
 ### Community 237 - "Community 237"
-Cohesion: 0.05
+Cohesion: 0.06
 Nodes (37): app_store_connect, age_rating, apple_id, bundle_identifier, content_rights, localizations, marketing_url, name (+29 more)
 
 ### Community 238 - "Community 238"
@@ -4227,20 +4375,20 @@ Cohesion: 0.05
 Nodes (36): Acceptance criteria (overall), code:block1 (HEAD: 4780a4d1 (vms) — Metro alias for @tanstack/react-query), code:diff (@@ line ~12 (RN imports)), code:diff (export type ThemeColors = {), code:diff (- const VARIANT_CONFIG: Record<AlertVariant, {), code:tsx (import FormScreen from '@shared/components/FormScreen';), code:diff (@@ line ~17), code:diff (@@ line ~19) (+28 more)
 
 ### Community 239 - "Community 239"
-Cohesion: 0.05
+Cohesion: 0.06
 Nodes (37): app_store_connect, age_rating, apple_id, bundle_identifier, content_rights, localizations, marketing_url, name (+29 more)
 
 ### Community 240 - "Community 240"
-Cohesion: 0.11
-Nodes (10): ChatMessage, CompanyInfo, Faq, IoniconName, Props, Role, SupportScreen(), SYSTEM_PROMPTS (+2 more)
+Cohesion: 0.15
+Nodes (14): RiderSupportScreen(), askClaude(), ChatMessage, CompanyInfo, createStyles(), Faq, IoniconName, Props (+6 more)
 
 ### Community 241 - "Community 241"
-Cohesion: 0.05
+Cohesion: 0.06
 Nodes (37): description, devDependencies, @types/node, @types/react, typescript, exports, ./api, ./api/cachedClient (+29 more)
 
 ### Community 242 - "Community 242"
 Cohesion: 0.10
-Nodes (33): bool, int, str, _batch_offer_timeout_handler(), Expire all still-pending batch offers after timeout (no grace period)., Expire all still-pending batch offers after timeout (no grace period)., clear_presence(), get_miss_streak() (+25 more)
+Nodes (38): bool, int, str, clear_presence(), get_miss_streak(), increment_miss_streak(), is_present(), _key() (+30 more)
 
 ### Community 243 - "Community 243"
 Cohesion: 0.05
@@ -4251,16 +4399,16 @@ Cohesion: 0.05
 Nodes (35): 1.1 Create corporate_accounts Table, 1.2 Add corporate_account_id to users Table, 1.3 Add corporate_account_id to rides Table, 2.1 Corporate Accounts CRUD, 2.2 Heat Map Data Endpoint, 2.3 Settings for Heat Map Configuration, 3.1 New Heat Map Page Structure, 3.2 Heat Map Component (+27 more)
 
 ### Community 245 - "Community 245"
-Cohesion: 0.07
-Nodes (21): PlaceBias, PlaceDetails, PlacePrediction, PlacesAutocompleteQuery, StructuredFormatting, handleSave(), PLACE_TYPES, resetForm() (+13 more)
+Cohesion: 0.08
+Nodes (23): buildPlacesQuery(), PlaceBias, PlaceDetails, PlacePrediction, PlacesAutocompleteQuery, StructuredFormatting, createStyles(), handleSave() (+15 more)
 
 ### Community 246 - "Community 246"
-Cohesion: 0.09
-Nodes (34): float, str, _build_default_fares(), build_fares_for_area(), _fare_cache_key(), _fares_for_location_impl(), _fd(), get_fares_for_location() (+26 more)
+Cohesion: 0.05
+Nodes (56): calculate_distance(), get_service_area_polygon(), Any, float, Return polygon as list of {lat, lng} from a service area row.     Supports both, float, str, _build_default_fares() (+48 more)
 
 ### Community 247 - "Community 247"
-Cohesion: 0.11
-Nodes (20): FastAPI, str, TestClient, CSRFMiddleware, Double-submit cookie CSRF protection for state-changing requests.      Only enfo, Double-submit cookie CSRF protection for state-changing requests.      Only enfo, client(), _make_app() (+12 more)
+Cohesion: 0.12
+Nodes (22): FastAPI, str, TestClient, CSRFMiddleware, Double-submit cookie CSRF protection for state-changing requests.      Only enfo, Double-submit cookie CSRF protection for state-changing requests.      Only enfo, client(), _make_app() (+14 more)
 
 ### Community 248 - "Community 248"
 Cohesion: 0.06
@@ -4270,13 +4418,17 @@ Nodes (35): compilerOptions, paths, strict, exclude, extends, include, @/*, axio
 Cohesion: 0.32
 Nodes (25): BackendAgent, CodeReviewerAgent, DeploymentAgent, DocumentationAgent, FrontendAgent, Spinr Development Agents System A hierarchical, autonomous agent system for deve, KnowledgeBaseAgent, AgentRegistry (+17 more)
 
+### Community 250 - "Community 250"
+Cohesion: 0.50
+Nodes (3): existing, GLOBALS_TO_LOCK, noop()
+
 ### Community 251 - "Community 251"
 Cohesion: 0.06
 Nodes (34): 1. 🟠 [P1] BUILD — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] TEST — `rider-app-test`, 4. 🟠 [P1] BUILD — `rider-app-test`, 5. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T05:55:06.5404957Z Could not pull latest version i) (+26 more)
 
 ### Community 252 - "Community 252"
-Cohesion: 0.13
-Nodes (11): Analytics, handleCodeChange(), handleResend(), handleVerify(), styles, triggerShake(), OtpScreen(), storage (+3 more)
+Cohesion: 0.60
+Nodes (3): styles, OtpScreen(), storage
 
 ### Community 253 - "Community 253"
 Cohesion: 0.06
@@ -4314,9 +4466,13 @@ Nodes (34): 1. 🟠 [P1] TEST — `driver-app-test`, 2. 🟠 [P1] BUILD — `dri
 Cohesion: 0.06
 Nodes (34): 1. 🟡 [P2] LINT — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, 3. 🟠 [P1] TEST — `driver-app-test`, 4. 🟠 [P1] BUILD — `driver-app-test`, 5. 🟠 [P1] TEST — `admin-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T14:25:23.6115924Z Found 11 errors.) (+26 more)
 
+### Community 263 - "Community 263"
+Cohesion: 0.43
+Nodes (6): constructor(), MapPlaceholder, Noop(), setValue(), styles, timing()
+
 ### Community 264 - "Community 264"
-Cohesion: 0.13
-Nodes (15): admin_delete_document_requirement(), admin_get_driver_documents(), admin_get_pending_documents(), admin_update_document_requirement(), _legacy_expiry_field_for_requirement(), Paginated list of driver documents awaiting review.      Cursor is the ``id`` of, Delete a document requirement., Paginated list of driver documents awaiting review.      Cursor is the ``id`` of (+7 more)
+Cohesion: 0.12
+Nodes (18): _connected_config(), _FakeClient, _FakeResponse, _patch_db(), _patch_http(), Unit tests for the Zoho Desk integration (services/zoho_desk_service.py).  Cover, Async-context-manager stand-in for httpx.AsyncClient. ``handler`` is a     calla, test_401_triggers_single_refresh_retry() (+10 more)
 
 ### Community 265 - "Community 265"
 Cohesion: 0.06
@@ -4347,16 +4503,20 @@ Cohesion: 0.06
 Nodes (34): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, 3. 🟠 [P1] TEST — `driver-app-test`, 4. 🟠 [P1] BUILD — `driver-app-test`, 5. 🟠 [P1] TEST — `admin-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T03:30:22.3061787Z FAILED tests/test_p3_admin_jwt_) (+26 more)
 
 ### Community 273 - "Community 273"
-Cohesion: 0.12
-Nodes (8): eslintConfig, Config, { defineConfig }, expoConfig, { defineConfig }, expoConfig, { defineConfig }, expoConfig
+Cohesion: 0.10
+Nodes (10): eslintConfig, Config, { defineConfig }, expoConfig, Item, { defineConfig }, expoConfig, pytest_collection_modifyitems() (+2 more)
+
+### Community 274 - "Community 274"
+Cohesion: 0.29
+Nodes (6): nextConfig, securityHeaders, PUBLIC_PREFIXES, isTrackingHost(), TRACK_CSP, trackingHosts()
 
 ### Community 277 - "Community 277"
-Cohesion: 0.09
+Cohesion: 0.10
 Nodes (16): bool, str, Direct unit tests for ``backend/utils/crypto.py``.  Covers the OTP-hashing helpe, Boundary inputs the auth code might plausibly pass through., ``hash_otp`` must be a pure SHA-256 of the OTP bytes — no salt, no nonce.      S, ``verify_otp_hash`` returns True only for the matching OTP., Verification MUST go through ``hmac.compare_digest``.      Plain ``==`` short-ci, TestEdgeCases (+8 more)
 
 ### Community 279 - "Community 279"
-Cohesion: 0.07
-Nodes (27): get_ride_messages(), Fetch persistent chat messages for a ride, Fetch persistent chat messages for a ride, Fetch persistent chat messages for a ride, Send a chat message for an active or recently completed ride.      Persists the, Send a chat message for an active or recently completed ride.      Persists the, Send a chat message for an active or recently completed ride.      Persists the, send_ride_message() (+19 more)
+Cohesion: 0.11
+Nodes (16): Send a chat message for an active or recently completed ride.      Persists the, Send a chat message for an active or recently completed ride.      Persists the, Send a chat message for an active or recently completed ride.      Persists the, Send a chat message for an active or recently completed ride.      Persists the, send_ride_message(), SendMessageRequest, test_send_ride_message_not_found(), SendMessageRequest Pydantic model enforces 1–500 character bounds. (+8 more)
 
 ### Community 281 - "Community 281"
 Cohesion: 0.40
@@ -4364,15 +4524,15 @@ Nodes (4): btn, criticalViolations, method, url
 
 ### Community 282 - "Community 282"
 Cohesion: 0.06
-Nodes (35): dashboard, accountNotVerified, accountNotVerifiedMsg, accountSuspended, actionRequired, addVehicle, addVehicleDetails, addVehicleInfo (+27 more)
+Nodes (36): dashboard, accountNotVerified, accountNotVerifiedMsg, accountSuspended, actionRequired, addVehicle, addVehicleDetails, addVehicleInfo (+28 more)
 
 ### Community 284 - "Community 284"
 Cohesion: 0.06
-Nodes (35): dashboard, accountNotVerified, accountNotVerifiedMsg, accountSuspended, actionRequired, addVehicle, addVehicleDetails, addVehicleInfo (+27 more)
+Nodes (36): dashboard, accountNotVerified, accountNotVerifiedMsg, accountSuspended, actionRequired, addVehicle, addVehicleDetails, addVehicleInfo (+28 more)
 
 ### Community 285 - "Community 285"
 Cohesion: 0.06
-Nodes (35): dashboard, accountNotVerified, accountNotVerifiedMsg, accountSuspended, actionRequired, addVehicle, addVehicleDetails, addVehicleInfo (+27 more)
+Nodes (36): dashboard, accountNotVerified, accountNotVerifiedMsg, accountSuspended, actionRequired, addVehicle, addVehicleDetails, addVehicleInfo (+28 more)
 
 ### Community 286 - "Community 286"
 Cohesion: 0.06
@@ -4408,15 +4568,15 @@ Nodes (33): code:block1 (rider-app/app/_layout.tsx              ← FCM setup, b
 
 ### Community 297 - "Community 297"
 Cohesion: 0.11
-Nodes (23): Decimal, int, str, Decimal, int, Money, Pin Decimal correctness for dollar↔cent conversions.  These tests document the f, Sanity-check the conversion for amounts Spinr actually sees in prod.      The na (+15 more)
+Nodes (25): Decimal, int, str, Decimal, int, Decimal, Money, Pin Decimal correctness for dollar↔cent conversions.  These tests document the f (+17 more)
 
 ### Community 298 - "Community 298"
-Cohesion: 0.06
+Cohesion: 0.11
 Nodes (33): Accuracy, AntDesign, AnyFn, Auth, Constants, ExpoConfig, FirebaseUser, FontAwesome (+25 more)
 
 ### Community 302 - "Community 302"
-Cohesion: 0.06
-Nodes (34): account_suspended, invalid_credentials, otp_expired, otp_invalid, otp_locked, token_expired, documents_expired, documents_pending (+26 more)
+Cohesion: 0.05
+Nodes (41): account_suspended, invalid_credentials, otp_expired, otp_invalid, otp_locked, token_expired, documents_expired, documents_pending (+33 more)
 
 ### Community 304 - "Community 304"
 Cohesion: 0.06
@@ -4427,8 +4587,8 @@ Cohesion: 0.06
 Nodes (32): Auth (D02), Backend API — Production-Readiness Audit Plan v1, Backend-Specific Risk Checklist, Branch Strategy, code:block1 (You are running a production-readiness audit of the Spinr ba), code:bash (# Audit findings branch (current)), code:bash (# 1. Python dependency vulnerabilities), code:yaml (===FINDINGS-YAML===) (+24 more)
 
 ### Community 308 - "Community 308"
-Cohesion: 0.10
-Nodes (18): bool, int, str, Test RedisRateLimiter using its in-memory fallback path.      We do NOT need a r, is_rate_limited returns memory result when _get_redis returns 'memory'., _get_redis should set self._redis = 'memory' when connection fails., TestRedisRateLimiterMemoryFallback, _is_otp_key() (+10 more)
+Cohesion: 0.07
+Nodes (19): bool, int, str, Test RedisRateLimiter using its in-memory fallback path.      We do NOT need a r, is_rate_limited returns memory result when _get_redis returns 'memory'., _get_redis should set self._redis = 'memory' when connection fails., TestRedisRateLimiterMemoryFallback, TestValidatePhone (+11 more)
 
 ### Community 309 - "Community 309"
 Cohesion: 0.06
@@ -4443,8 +4603,8 @@ Cohesion: 0.06
 Nodes (32): Admin Dashboard (Next.js 16), Auth (`/routes/auth.py`), Backend (FastAPI), CI / CD Requirements, Compliance, Coverage Minimums, Deployment Requirements, Dev / Staging (+24 more)
 
 ### Community 312 - "Community 312"
-Cohesion: 0.24
-Nodes (6): logger, BACKEND_URL, BACKEND_URL, clearSessionCookies(), POST(), verifyCsrf()
+Cohesion: 0.26
+Nodes (7): logger, BACKEND_URL, POST(), BACKEND_URL, clearSessionCookies(), POST(), verifyCsrf()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.06
@@ -4456,7 +4616,7 @@ Nodes (31): 1. 🟠 [P1] BUILD — `security-scan`, 2. 🟠 [P1] BUILD — `depl
 
 ### Community 315 - "Community 315"
 Cohesion: 0.10
-Nodes (42): AgentMessage, AgentMessage, AgentStatus, Create task from dictionary., Agent operational status., Task priority levels., Task execution status., Message structure for inter-agent communication. (+34 more)
+Nodes (39): AgentMessage, AgentMessage, AgentStatus, Agent operational status., Task priority levels., Message structure for inter-agent communication., TaskPriority, OrchestratorAgent (+31 more)
 
 ### Community 316 - "Community 316"
 Cohesion: 0.06
@@ -4475,8 +4635,8 @@ Cohesion: 0.06
 Nodes (31): code:block1 (rider-app/app/(tabs)/index.tsx), code:block2 (You are auditing the Spinr rider app for Android & iOS UI/UX), code:block3 (rider-app/hooks/useRiderSocket.ts), code:block4 (You are auditing the Spinr rider app for real-time reliabili), code:block5 (rider-app/store/rideStore.ts            ← state machine, hyd), code:block6 (You are auditing the Spinr rider app for state machine corre), code:block7 (rider-app/app/payment-confirm.tsx), code:block8 (You are auditing the Spinr rider app for payment safety and ) (+23 more)
 
 ### Community 329 - "Community 329"
-Cohesion: 0.20
-Nodes (6): Tests for get_current_user dependency., Mock HTTP authorization credentials., Test get_current_user with valid token., Test get_current_user with invalid token., Test get_current_user with missing credentials., TestGetCurrentUser
+Cohesion: 0.06
+Nodes (29): 10. Scheduled Rides Missing Reminder Logic, 11. Inconsistent Error Responses, 12. Missing Rate Limiting on Promo Validation, 13. Hardcoded Query Limits, 14. No Logging for Dispute Resolution, 15. Missing Index on Notification Queries, 18. Missing Type Hints in Some Functions, 19. Inconsistent ISO Date Format (+21 more)
 
 ### Community 334 - "Community 334"
 Cohesion: 0.20
@@ -4486,13 +4646,9 @@ Nodes (6): Tests for document requirement management., Test getting all document
 Cohesion: 0.06
 Nodes (31): code:block1 (rider-app/jest.config.js), code:block2 (You are auditing the Spinr rider app for test coverage quali), code:block3 (rider-app/app/ride-options.tsx          ← fetchEstimates err), code:block4 (You are auditing the Spinr rider app for error handling and ), code:block5 (backend/main.py                        ← CORS middleware con), code:block6 (You are auditing the Spinr rider app and its backend for sec), code:block7 (backend/routes/rides.py               ← rider fields in driv), code:block8 (You are auditing the Spinr rider app for PII protection and ) (+23 more)
 
-### Community 336 - "Community 336"
-Cohesion: 0.12
-Nodes (27): JSONResponse, Request, RequestValidationError, _make_request(), test_spinr_handler_has_cors_headers(), test_spinr_handler_has_request_id_header(), test_spinr_handler_includes_request_id_in_body(), test_validation_handler_has_cors_headers() (+19 more)
-
 ### Community 337 - "Community 337"
-Cohesion: 0.09
-Nodes (28): execute_task(), generate_report(), list_agents(), query_knowledge(), CLI Interface for Spinr Development Agents Allows Cline and developers to intera, Execute a task through the agent system., List all registered agents., Query the knowledge base. (+20 more)
+Cohesion: 0.10
+Nodes (35): AgentTask, Task structure for agent execution., execute_task(), generate_report(), list_agents(), main(), query_knowledge(), CLI Interface for Spinr Development Agents Allows Cline and developers to intera (+27 more)
 
 ### Community 338 - "Community 338"
 Cohesion: 0.14
@@ -4507,51 +4663,51 @@ Cohesion: 0.06
 Nodes (30): Admin Panel — Production-Readiness Audit Plan v1, Admin-Specific Security Checklist (from modules/admin-panel.md — must-pass), Audit Logging, Authentication, Authorisation (RBAC), Branch Strategy, code:block1 (You are running a production-readiness audit of the Spinr ad), code:bash (git checkout claude/review-pending-audits-Pu1aP) (+22 more)
 
 ### Community 341 - "Community 341"
-Cohesion: 0.14
-Nodes (14): admin_cleanup_location_history(), admin_rollup_driver_daily(), get_audit_logs(), log_audit(), Roll up driver activity for a single day into driver_daily_stats.      Captures:, Get audit log entries with optional filters and pagination., Write a single row to the audit_logs table.      Non-raising: callers wrap this, Get audit log entries with optional filters and pagination. (+6 more)
+Cohesion: 0.12
+Nodes (21): _client_factory(), _FakeClient, _FakeResp, _osrm_payload(), Tests for the OSRM /match road provider (distance + geometry) and selection.  OS, compute_road_distance_km stays back-compat: distance float or None., Minimal async-context httpx.AsyncClient stand-in., test_compute_route_non_ok_returns_none() (+13 more)
 
 ### Community 342 - "Community 342"
-Cohesion: 0.10
-Nodes (16): Coverage-boost tests — maps_eta, metrics, validators.  These tests target the ~1, Tests for the get_client_identifier key function., Tests for the get_phone_based_key key function., TestGetClientIdentifier, TestGetPhoneBasedKey, TestInitRateLimiting, TestSubprocessorAuditMain, get_client_identifier() (+8 more)
+Cohesion: 0.05
+Nodes (34): JSONResponse, Request, _async_iter(), Coverage-boost tests — maps_eta, metrics, validators.  These tests target the ~1, Test _get_redis() directly to cover cache-hit and creation paths., Tests for the get_client_identifier key function., Tests for the get_phone_based_key key function., Exercise the rate_limit_auth decorator inner functions. (+26 more)
 
 ### Community 343 - "Community 343"
-Cohesion: 0.18
-Nodes (8): Receipt rendering — regulatory and reconciliation guarantees.  These tests pin t, Fees that calculated to $0.00 (e.g. night fee outside hours)         should not, Auto surge cap is 2.5× — must still disclose., A minimal completed-ride dict with sane defaults., _ride(), TestAreaFeeLineItems, TestReconciliation, TestSurgeDisclosure
+Cohesion: 0.10
+Nodes (15): Receipt rendering — regulatory and reconciliation guarantees.  These tests pin t, Fees that calculated to $0.00 (e.g. night fee outside hours)         should not, Auto surge cap is 2.5× — must still disclose., Persisted grand_total excludes tip; receipt total adds it back., 0.29 — the canonical int(0.29*100)=28 underflow — must round-trip         throug, A minimal completed-ride dict with sane defaults., GST (5%) and PST (6%) must each get their own row — regulatory., Combined-tax provinces (e.g. Ontario HST 13%) render a single line. (+7 more)
 
 ### Community 344 - "Community 344"
 Cohesion: 0.22
 Nodes (7): AgentTask, Any, str, Perform comprehensive code review., Analyze code quality metrics., Analyze potential bugs., Store review results in knowledge base.
 
 ### Community 345 - "Community 345"
-Cohesion: 0.15
-Nodes (13): str, _anonymise_rides(), delete_account(), delete_account_pipeda(), delete_emergency_contact(), Strip PII from all rides linked to a user (PIPEDA R-P2-46).      Ride records ar, Strip PII from completed rides linked to a user (PIPEDA R-P2-46).      Ride reco, R-P1-6 PIPEDA: Soft-delete account with a 30-day grace period (right to erasure) (+5 more)
+Cohesion: 0.11
+Nodes (28): bool, Decimal, int, str, admin_create_quest(), admin_get_quest_participants(), admin_list_quests(), admin_update_quest() (+20 more)
 
 ### Community 346 - "Community 346"
 Cohesion: 0.25
 Nodes (5): Tests for document file storage., Test storing a document file reference., Test getting a document file., Test deleting a document file., TestDocumentFileStorage
 
 ### Community 347 - "Community 347"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): `backend/core/config.py`, `backend/core/middleware.py`, `backend/dependencies.py`, `backend/dependencies.py` (security-logging wiring), `backend/routes/auth.py`, `backend/routes/auth.py` (security-logging wiring), `backend/utils/audit_logger.py` (new file), Branch 1: `sprint2/auth-secrets-hardening` (+21 more)
 
 ### Community 348 - "Community 348"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): 1. 🟠 [P1] BUILD — `security-scan`, 2. 🟠 [P1] TEST — `driver-app-test`, 3. 🟠 [P1] TEST — `backend-test`, 4. 🟠 [P1] TEST — `rider-app-test`, 5. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:bash (docker build -f backend/Dockerfile .) (+21 more)
 
 ### Community 349 - "Community 349"
-Cohesion: 0.18
-Nodes (12): admin_delete_promotion(), admin_get_promo_stats(), admin_get_promo_usage(), admin_get_promotions(), Get promo code usage/redemption history., Get promo code usage/redemption history, enriched with user name and ride ID., Get promotion statistics with daily usage data., Get promotion statistics with daily usage data. (+4 more)
+Cohesion: 0.07
+Nodes (27): 10. Duplicate rideStore Implementations, 11. No Offline Support, 12. No Request Retries, 1. Bug: clearRide() Now Clears Stops Array ✅, 2. Duplicate Screen Registration ✅, 3. Unused Code in search-destination.tsx ✅, 4. Hardcoded Payment Method, 5. Incomplete Error Handling in API Client (+19 more)
 
 ### Community 350 - "Community 350"
-Cohesion: 0.21
-Nodes (9): float, Persisted grand_total excludes tip; receipt total adds it back., 0.29 — the canonical int(0.29*100)=28 underflow — must round-trip         throug, TestReceiptTotal, Send receipt email. Uses SendGrid when configured, logs otherwise., Compute the rider-visible total without rendering HTML.      Used by send_receip, Send receipt email. Uses SendGrid when configured, logs otherwise., _receipt_total() (+1 more)
+Cohesion: 0.07
+Nodes (26): 10. Start Ride, 11. Complete Ride, 12. Ride History & Earnings, 1. Authentication Flow, 2. Ride State Machine, 3. Location Tracking, 4. WebSocket Connection, 5. Ride Offer Flow (+18 more)
 
 ### Community 351 - "Community 351"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, 3. 🟠 [P1] TEST — `driver-app-test`, 4. 🟠 [P1] BUILD — `driver-app-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T04:00:30.4473450Z FAILED tests/test_p3_admin_jwt_), code:bash (pytest <test_path> -v) (+21 more)
 
 ### Community 352 - "Community 352"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, 3. 🟠 [P1] TEST — `driver-app-test`, 4. 🟠 [P1] BUILD — `driver-app-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T04:06:34.0349243Z FAILED tests/test_p3_admin_jwt_), code:bash (pytest <test_path> -v) (+21 more)
 
 ### Community 353 - "Community 353"
@@ -4559,48 +4715,48 @@ Cohesion: 0.22
 Nodes (5): Test setting driver as online., Tests for driver availability management., Test setting driver as available., Test setting driver as unavailable., TestDriverAvailability
 
 ### Community 354 - "Community 354"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): 1. 🟠 [P1] TEST — `driver-app-test`, 2. 🟠 [P1] BUILD — `driver-app-test`, 3. 🟠 [P1] TEST — `backend-test`, 4. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T04:38:51.1405645Z FAIL __tests__/store/authStore.), code:bash (pytest <test_path> -v) (+21 more)
 
 ### Community 355 - "Community 355"
-Cohesion: 0.09
-Nodes (38): Any, Decimal, float, int, str, build_default_fares(), build_fare_breakdown_lines(), calculate_fare() (+30 more)
+Cohesion: 0.11
+Nodes (35): Any, Decimal, float, int, str, build_fare_breakdown_lines(), calculate_fare(), _d() (+27 more)
 
 ### Community 356 - "Community 356"
 Cohesion: 0.15
 Nodes (11): claim_ride_atomic(), Tests for claim_ride_atomic and the accept_ride endpoint., Tests for db_supabase.claim_ride_atomic., Tests for db_supabase.claim_ride_atomic., Successful claim (1 row updated) returns True., Race loser (0 rows updated) returns False., No supabase client configured returns False., test_already_taken_returns_false() (+3 more)
 
 ### Community 357 - "Community 357"
-Cohesion: 0.07
-Nodes (43): notify_safety_team(), Fan out a safety_incidents row to the configured alert channels.      Three side, int, str, datetime, str, _now_iso(), Tests for utils/safety_checkin_loop.py.  Covers: - Ride older than 20 min with n (+35 more)
+Cohesion: 0.12
+Nodes (29): int, str, _now_iso(), Tests for utils/safety_checkin_loop.py.  Covers: - Ride older than 20 min with n, Ride without rider_id → redis sent_key still written, push not sent., sent_key already in Redis → no second push., Push sent 30 s ago, no ok, escalate_window=90 s → no escalation yet., Push sent 120 s ago, no ok → escalate called. (+21 more)
 
 ### Community 358 - "Community 358"
-Cohesion: 0.10
-Nodes (28): app_with_ws(), _patch_firebase_fail(), _patch_jwt_fail(), WebSocket authentication tests: auth message validation, token checks, and per-u, Start a sequence of patch objects and return them for cleanup., Send a non-auth message as the very first message.      The implementation reads, Auth message with missing `token` field is treated as unauthenticated., When asyncio.wait_for raises TimeoutError the endpoint closes with 1008.      Pa (+20 more)
+Cohesion: 0.13
+Nodes (29): app_with_ws(), _patch_firebase_fail(), _patch_jwt_fail(), _patch_jwt_return(), WebSocket authentication tests: auth message validation, token checks, and per-u, Start a sequence of patch objects and return them for cleanup., Send a non-auth message as the very first message.      The implementation reads, Auth message with missing `token` field is treated as unauthenticated. (+21 more)
 
 ### Community 359 - "Community 359"
-Cohesion: 0.10
-Nodes (22): str, check_scheduled_rides(), _dispatch_scheduled_ride(), _notify_schedule_delayed(), Check for scheduled rides that need dispatching or reminders., Send a 10-minute reminder notification for an upcoming scheduled ride., Send a 10-minute reminder notification for an upcoming scheduled ride., Check for scheduled rides that need dispatching or reminders. (+14 more)
+Cohesion: 0.12
+Nodes (25): build_monitoring_ride(), Shape a ride row into the MonitoringRide payload the admin dashboard expects., str, check_scheduled_rides(), _dispatch_scheduled_ride(), _notify_schedule_delayed(), Scheduled ride dispatcher — background task that dispatches scheduled rides at t, Check for scheduled rides that need dispatching or reminders. (+17 more)
 
 ### Community 360 - "Community 360"
 Cohesion: 0.07
 Nodes (29): 10. Test Matrix, 11. Known Gaps / Follow-ups, 1. Purpose, 2. High-Level System Map, 3. Data Model (nine tables), 4. Backend Modules, 5. State Machine — `corporate_accounts.status`, 6.1 Onboarding (company signup → bookable) (+21 more)
 
 ### Community 361 - "Community 361"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): 10. Acceptance criteria, 1. Problem, 2. Good news — we are NOT starting from scratch, 3.1 Backend, 3.2 Rider-app, 3.3 Stripe publishable key delivery to client, 3. Gap — the narrow thing we actually need to build, 4. Out of scope (explicitly NOT this ticket) (+21 more)
 
 ### Community 362 - "Community 362"
-Cohesion: 0.25
-Nodes (5): bool, str, _is_valid_review_otp(), Parse REVIEW_LOGIN_ACCOUNTS into {phone: fixed_otp}.          Only entries whose, Surface a misconfigured REVIEW_LOGIN_ACCOUNTS at startup.          We do not rai
+Cohesion: 0.20
+Nodes (7): bool, str, _is_valid_review_otp(), Parse REVIEW_LOGIN_ACCOUNTS into {phone: fixed_otp}.          Only entries whose, Parse REVIEW_LOGIN_ACCOUNTS into {phone: fixed_otp}.          Only entries whose, Surface a misconfigured REVIEW_LOGIN_ACCOUNTS at startup.          We do not rai, Surface a misconfigured REVIEW_LOGIN_ACCOUNTS at startup.          We do not rai
 
 ### Community 363 - "Community 363"
-Cohesion: 0.07
+Cohesion: 0.06
 Nodes (29): 1. Overview, 2. Test Architecture, 3.1 `utils.test.ts` - Utility Functions (14 Tests), 3.2 `export-csv.test.ts` - CSV Export (6 Tests), 3.3 `authStore.test.ts` - Admin Authentication (10 Tests), 3. Test Files - Detailed Breakdown, 4. Admin Dashboard Pages - Test Coverage Map, 5. How to Add New Admin Dashboard Tests (+21 more)
 
 ### Community 364 - "Community 364"
-Cohesion: 0.29
-Nodes (7): ride, already_cancelled, invalid_status, no_drivers_available, not_found, price_mismatch, taken
+Cohesion: 0.16
+Nodes (18): float, int, str, _body(), _call_create_ride(), _fare_info(), E16: Surge boundary — multiplier changes between estimate and create  P0-4 (Test, Call create_ride with minimal mocks; returns (inserted_row_or_None, exception_or (+10 more)
 
 ### Community 365 - "Community 365"
 Cohesion: 0.07
@@ -4619,12 +4775,12 @@ Cohesion: 0.07
 Nodes (28): 1. 🟠 [P1] BUILD — `security-scan`, 2. 🟠 [P1] TEST — `backend-test`, 3. 🟠 [P1] BUILD — `backend-test`, 4. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T06:24:29.8551996Z FAILED tests/test_admin_securit), code:bash (cd rider-app && yarn build:web) (+20 more)
 
 ### Community 369 - "Community 369"
-Cohesion: 0.12
+Cohesion: 0.13
 Nodes (28): bool, MagicMock, create_payment_intent(), PaymentIntentRequest, Create a Stripe payment intent.      `amount` is validated by Pydantic (positive, Request body for POST /payments/create-intent., Create a Stripe payment intent.      `amount` is validated by Pydantic (positive, Request body for POST /payments/create-intent. (+20 more)
 
 ### Community 370 - "Community 370"
-Cohesion: 0.20
-Nodes (10): Load a rider's ride only if it is in one of allowed_states.      Raises 409 if t, Load a rider's ride only if it is in one of allowed_states.      Raises 409 if t, _require_ride_in_state_rider(), test_require_ride_in_state_rider_not_found(), Pin the rider-side cancel state guard (_require_ride_in_state_rider).      The c, Critical invariant: in_progress → cancelled MUST be rejected with 409., Cancel must succeed when ride is in searching state., Cancel must succeed when a driver has been assigned but trip not started. (+2 more)
+Cohesion: 0.21
+Nodes (7): Pin the rider-side cancel state guard (_require_ride_in_state_rider).      The c, Critical invariant: in_progress → cancelled MUST be rejected with 409., Completing an in_progress ride must pass the state guard., Cancel must succeed when ride is in searching state., Cancel must succeed when a driver has been assigned but trip not started., Cancel must be rejected with 409 when ride is already completed., TestCancelStateGuardRider
 
 ### Community 371 - "Community 371"
 Cohesion: 0.07
@@ -4635,35 +4791,35 @@ Cohesion: 0.07
 Nodes (28): 1. Overview, 2. Test Architecture, 3.1 `test_auth.py` - Authentication & Authorization, 3.2 `test_rides.py` - Ride Lifecycle, 3.3 `test_drivers.py` - Driver Management, 3.4 `test_db.py` - Database Layer, 3.5 `test_features.py` - Platform Features, 3.6 `test_documents.py` - Document Verification (+20 more)
 
 ### Community 373 - "Community 373"
-Cohesion: 0.12
-Nodes (10): Tests for surge pricing functionality., Test updating surge pricing multiplier., Test getting surge pricing for an area., Test calculating price with surge multiplier., Tests for service area functionality., Test getting all service areas., Test assigning a driver to a service area., Test point in polygon check for service area. (+2 more)
+Cohesion: 0.25
+Nodes (5): Tests for surge pricing functionality., Test updating surge pricing multiplier., Test getting surge pricing for an area., Test calculating price with surge multiplier., TestSurgePricing
 
 ### Community 374 - "Community 374"
-Cohesion: 0.11
-Nodes (26): admin_export_users(), admin_get_user_details(), admin_get_users(), admin_list_dsars(), admin_search_users(), admin_update_dsar_status(), admin_update_user_flags(), admin_update_user_status() (+18 more)
+Cohesion: 0.14
+Nodes (27): admin_export_users(), admin_get_user_details(), admin_get_users(), admin_list_dsars(), admin_search_users(), admin_update_dsar_status(), admin_update_user_flags(), admin_update_user_status() (+19 more)
 
 ### Community 375 - "Community 375"
 Cohesion: 0.20
 Nodes (6): Tests for notification functionality., Test sending a push notification., Test getting notifications for a user., Test marking a notification as read., Test registering FCM token for push notifications., TestNotifications
 
 ### Community 376 - "Community 376"
-Cohesion: 0.08
-Nodes (21): update_ride(), Unit tests for rides API and related functionality. Tests cover ride creation, u, Two simultaneous accept calls for the same ride: one wins (200), one is rejected, complete_ride must reject a ride that is still in driver_assigned state (422)., complete_ride must reject a ride that is still in driver_assigned state (422)., test_cancel_ride(), test_cancel_scheduled_ride(), test_cannot_complete_from_driver_assigned() (+13 more)
+Cohesion: 0.13
+Nodes (19): update_ride(), client(), driver_1_headers(), driver_2_headers(), Unit tests for rides API and related functionality. Tests cover ride creation, u, Two simultaneous accept calls for the same ride: one wins (200), one is rejected, complete_ride must reject a ride that is still in driver_assigned state (422)., complete_ride must reject a ride that is still in driver_assigned state (422). (+11 more)
 
 ### Community 377 - "Community 377"
-Cohesion: 0.13
-Nodes (15): bool, float, str, # IMPORTANT: Rotate this key before deploying — see docs/key-rotation.md, # IMPORTANT: Rotate this key before deploying — see docs/key-rotation.md, Sku, check_budget(), _daily_budget_usd() (+7 more)
+Cohesion: 0.10
+Nodes (27): bool, float, str, # IMPORTANT: Rotate this key before deploying — see docs/key-rotation.md, # IMPORTANT: Rotate this key before deploying — see docs/key-rotation.md, Proxy Geocoding API for lat/lng → address. 24 h Redis cache on a ~11 m grid., Proxy Geocoding API for lat/lng → address. 24 h Redis cache on a ~11 m grid., reverse_geocode() (+19 more)
 
 ### Community 378 - "Community 378"
-Cohesion: 0.07
+Cohesion: 0.09
 Nodes (27): area_fees, drivers, fare_configs, get_ride, insert_ride, service_areas, settings, users (+19 more)
 
 ### Community 379 - "Community 379"
-Cohesion: 0.33
-Nodes (6): str, get_driver_config(), Return operational settings the driver-app should honor at runtime.      Driver-, get_legal_document(), Return the active legal document for an (audience, doc_type) pair.      Falls ba, get_app_settings()
+Cohesion: 0.15
+Nodes (17): buildReceiptText(), createStyles(), fmt(), handleShareInvoice(), handleSubmit(), RideCompletedScreenContent(), showPaymentAlert(), toNum() (+9 more)
 
 ### Community 380 - "Community 380"
-Cohesion: 0.07
+Cohesion: 0.09
 Nodes (27): area_fees, drivers, fare_configs, get_ride, get_user_status, insert_ride, service_areas, settings (+19 more)
 
 ### Community 381 - "Community 381"
@@ -4671,24 +4827,24 @@ Cohesion: 0.25
 Nodes (5): Tests for saved addresses functionality., Test saving an address., Test getting saved addresses for a user., Test deleting a saved address., TestSavedAddresses
 
 ### Community 382 - "Community 382"
-Cohesion: 0.13
-Nodes (26): int, MagicMock, Decimal, str, _make_async_client_mock(), _make_mock_response(), Unit tests for send_ride_receipt_email.  Covers: - Early return when sendgrid_ap, GST (5%) and grand_total in the POST body must use correct Decimal arithmetic. (+18 more)
+Cohesion: 0.14
+Nodes (27): int, MagicMock, Decimal, str, _make_async_client_mock(), _make_mock_response(), Unit tests for send_ride_receipt_email.  Covers: - Early return when resend_api_, GST (5%) and grand_total in the POST body must use correct Decimal arithmetic. (+19 more)
 
 ### Community 383 - "Community 383"
 Cohesion: 0.07
 Nodes (27): Branch + commit, Branches — which one to work on, Code style, code:block1 (<type>(<scope>): <summary> (close P1-N)), code:block2 (python3 -c "import ast; ast.parse(open('PATH').read())"), code:block3 (You are picking up the E2E hardening track. Read), Conventions — follow these exactly, Document gaps, don't hide them (+19 more)
 
 ### Community 384 - "Community 384"
-Cohesion: 0.19
-Nodes (11): str, _make_driver(), Regression tests for utils/document_expiry.py (P0-5).  Covers: - Expired driver, A licence that expired 30 days ago must still trigger suspension.      The origi, Driver with a licence valid for 60 days must receive no suspension call., find_nearby_drivers must not return a suspended driver.      The Postgres functi, Driver whose licence expired yesterday must be suspended and disconnected., test_doc_expired_long_ago_is_still_processed() (+3 more)
+Cohesion: 0.22
+Nodes (14): str, _make_driver(), now(), Regression tests for utils/document_expiry.py (P0-5).  Covers: - Expired driver, A licence that expired 30 days ago must still trigger suspension.      The origi, Driver with a licence valid for 60 days must receive no suspension call., find_nearby_drivers must not return a suspended driver.      The Postgres functi, Driver whose licence expired yesterday must be suspended and disconnected. (+6 more)
 
 ### Community 385 - "Community 385"
 Cohesion: 0.07
 Nodes (27): 0. Immediate triage (first 15 minutes), 1. Scope assessment, 1a. Which data categories were exposed?, 1b. Estimate affected user count, 1c. Determine "real risk of significant harm" (PIPEDA threshold), 2. Contain, 3. Eradicate and recover, 4. Notification obligations (+19 more)
 
 ### Community 386 - "Community 386"
-Cohesion: 0.18
-Nodes (6): mock_settings(), Unit tests for authentication and security modules. Tests cover JWT token handli, Mock settings with test values matching the JWT_SECRET env var., Tests for passwordless authentication flow., Tests for passwordless authentication flow., TestPasswordlessAuth
+Cohesion: 0.13
+Nodes (17): int, str, Pins retry_failed_payments for the Stripe requires_action / 3DS path.      Code, If the PaymentIntent already succeeded (webhook missed), mark paid., Return the first update_one call whose $set[key] == value., PaymentIntent needs confirmation → confirm() called, status=processing., If the PaymentIntent already succeeded (webhook missed), mark paid., A cancelled PaymentIntent should not be retried — cap at MAX_RETRIES. (+9 more)
 
 ### Community 387 - "Community 387"
 Cohesion: 0.07
@@ -4707,68 +4863,68 @@ Cohesion: 0.07
 Nodes (26): 10. Rate limiter (`utils/rate_limiter.py`), 11. WebSocket pub/sub (`utils/ws_pubsub.py`), 12. Error handling (`utils/error_handling.py`), 13. Logging, 14. SMS (`sms_service.py`), 15. Features module (`features.py`), 16. Migrations (`backend/migrations/`), 17. Common tasks (+18 more)
 
 ### Community 395 - "Community 395"
-Cohesion: 0.22
-Nodes (5): Verify the allow-list filter on GET /rides/{id}., The response's `driver` object must NOT contain forbidden fields.          get_r, The response's `driver` object contains every allowed field., Rides without a driver_id should not have a `driver` key., TestRidePIIFiltering
+Cohesion: 0.13
+Nodes (11): client(), Tests that PII is stripped from ride responses returned to riders.  The driver r, Verify the allow-list filter on GET /rides/{id}., The response's `driver` object must NOT contain forbidden fields.          get_r, The response's `driver` object contains every allowed field., Rides without a driver_id should not have a `driver` key., test_allowed_fields_present(), test_driver_pii_excluded() (+3 more)
 
 ### Community 396 - "Community 396"
 Cohesion: 0.07
 Nodes (26): 10. Duplicate rideStore Implementations, 11. No Offline Support, 12. No Request Retries, 1. Bug: clearRide() Now Clears Stops Array ✅, 2. Duplicate Screen Registration ✅, 3. Unused Code in search-destination.tsx ✅, 4. Hardcoded Payment Method, 5. Incomplete Error Handling in API Client (+18 more)
 
 ### Community 397 - "Community 397"
-Cohesion: 0.07
+Cohesion: 0.08
 Nodes (26): compilerOptions, paths, strict, types, exclude, extends, include, @/* (+18 more)
 
 ### Community 398 - "Community 398"
-Cohesion: 0.10
-Nodes (22): str, SMS Service for Spinr Supports Twilio for production SMS delivery with console f, Send an SMS message.      When Twilio credentials are provided: sends real SMS v, Send an SMS message.      When Twilio credentials are provided: sends real SMS v, Send an OTP code via SMS., Send an OTP code via SMS., send_otp_sms(), send_sms() (+14 more)
+Cohesion: 0.08
+Nodes (26): str, SMS Service for Spinr Supports Twilio for production SMS delivery with console f, Send an SMS message.      When Twilio credentials are provided: sends real SMS v, Send an SMS message.      When Twilio credentials are provided: sends real SMS v, Send an OTP code via SMS., Send an OTP code via SMS., send_otp_sms(), send_sms() (+18 more)
 
 ### Community 399 - "Community 399"
-Cohesion: 0.12
-Nodes (20): DAYS, DAYS, CorporatePolicy, patchCompanyPolicy(), PaymentSourcePolicy, TimeWindowPolicy, addWindow(), Day (+12 more)
+Cohesion: 0.16
+Nodes (24): DAYS, emptyWindow(), DAYS, emptyWindow(), CorporatePolicy, patchCompanyPolicy(), PaymentSourcePolicy, TimeWindowPolicy (+16 more)
 
 ### Community 400 - "Community 400"
 Cohesion: 0.08
 Nodes (26): CQ-001 — No Audit / Security Event Logging, CQ-002 — Duplicate Push Token Registration Systems, CQ-003 — Post-Update Read-Back Verification Anti-Pattern, CQ-004 — CORS Exception Handler Missing Security Headers, FEAT-001 — No SOS / Emergency Button (Rider App), FEAT-002 — No Scheduled Rides, FEAT-003 — No Ride Receipts, FEAT-004 — No Surge Pricing / Dynamic Fare Model (+18 more)
 
 ### Community 401 - "Community 401"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (25): 1. 🟠 [P1] TEST — `rider-app-test`, 2. 🟠 [P1] TEST — `backend-test`, 3. 🟠 [P1] BUILD — `security-scan`, 4. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (cd rider-app && yarn build:web) (+17 more)
 
 ### Community 402 - "Community 402"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (25): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] TEST — `rider-app-test`, 4. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (cd rider-app && yarn build:web) (+17 more)
 
 ### Community 403 - "Community 403"
-Cohesion: 0.10
-Nodes (16): bool, float, int, str, WebSocket, Record an inbound WebSocket message for ``user_id`` against         the per-user, Record an inbound WebSocket message for ``user_id`` against         the per-user, Force-close every LOCAL WebSocket whose key matches user_id (B-P1-11). (+8 more)
+Cohesion: 0.07
+Nodes (23): bool, float, int, str, WebSocket, Record an inbound WebSocket message for ``user_id`` against         the per-user, Record an inbound WebSocket message for ``user_id`` against         the per-user, Force-close every LOCAL WebSocket whose key matches user_id (B-P1-11). (+15 more)
 
 ### Community 404 - "Community 404"
-Cohesion: 0.11
-Nodes (17): FastAPI, TestClient, _build_promo_app(), _enable_real_limiter(), Promo code endpoint rate-limit enforcement tests.  Limits (from backend/utils/ra, Rate-limit enforcement for POST /promo/validate (promo_validate_limit: 10/min)., 10 requests within a minute should all succeed (200 or 4xx from         business, The 11th request within the same minute window must return 429         with the (+9 more)
+Cohesion: 0.08
+Nodes (23): FastAPI, TestClient, RateLimitExceeded, _build_promo_app(), _enable_real_limiter(), Promo code endpoint rate-limit enforcement tests.  Limits (from backend/utils/ra, Rate-limit enforcement for POST /promo/validate (promo_validate_limit: 10/min)., 10 requests within a minute should all succeed (200 or 4xx from         business (+15 more)
 
 ### Community 406 - "Community 406"
-Cohesion: 0.09
-Nodes (20): MagicMock, str, _mock_supabase_rpc_once_then_fail(), P3-4: Concurrent wallet debit tests.  The wallet_pay_for_ride and fare_split_pay, RPC exception containing 'wallet not found' → ValueError., Two concurrent debits on a wallet that can only cover one:         the mock mirr, Three concurrent debits, only one can win — mirrors a burst retry., RPC exception containing 'insufficient_funds' → ValueError. (+12 more)
+Cohesion: 0.10
+Nodes (18): MagicMock, str, _mock_supabase_rpc_once_then_fail(), P3-4: Concurrent wallet debit tests.  The wallet_pay_for_ride and fare_split_pay, RPC exception containing 'wallet not found' → ValueError., Two concurrent debits on a wallet that can only cover one:         the mock mirr, Three concurrent debits, only one can win — mirrors a burst retry., RPC exception containing 'insufficient_funds' → ValueError. (+10 more)
 
 ### Community 407 - "Community 407"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (25): 1. What was added in this branch, 2.1 Rider user stories, 2.2 Driver user stories, 2.3 Cross-app / concurrency scenarios, 2.4 Edge cases & failure modes, 2.5 Security / abuse scenarios, 2. User stories & scenario coverage matrix, 3. Coverage summary by component (+17 more)
 
 ### Community 408 - "Community 408"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (25): 1. Symptoms, 2. Triage Checklist (do these in order, stop when you find the cause), 3.1 Check health endpoint, 3.2 Check Supabase connectivity, 3.3 Check Redis connectivity, 3.4 View live application logs, 3.5 Check recent deploys, 3.6 Check Sentry for error spike (+17 more)
 
 ### Community 409 - "Community 409"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (25): 1.1 Infrastructure, 1.2 Test data, 1.3 Access, 1. Prerequisites, 2. Stripe test cards (reference), 3.1 Scenario A — Happy path (`4242 4242 4242 4242`), 3.2 Scenario B — Card declined (`4000 0000 0000 0002`), 3.3 Scenario C — 3DS challenge (`4000 0025 0000 3155`) (+17 more)
 
 ### Community 410 - "Community 410"
-Cohesion: 0.08
-Nodes (25): chat, imHere, onMyWay, send, title, typeMessage, whereAreYou, notifications (+17 more)
+Cohesion: 0.06
+Nodes (33): chat, imHere, onMyWay, send, title, typeMessage, whereAreYou, notifications (+25 more)
 
 ### Community 411 - "Community 411"
-Cohesion: 0.08
-Nodes (25): errors, failedToLoad, networkError, serverError, tryAgain, unauthorized, unknown, notifications (+17 more)
+Cohesion: 0.06
+Nodes (33): chat, imHere, onMyWay, send, title, typeMessage, whereAreYou, errors (+25 more)
 
 ### Community 412 - "Community 412"
 Cohesion: 0.08
@@ -4779,8 +4935,8 @@ Cohesion: 0.08
 Nodes (26): subscription, cancelled, cancelledMsg, cancelMsg, cancelPlan, cancelSubscription, day, days (+18 more)
 
 ### Community 414 - "Community 414"
-Cohesion: 0.08
-Nodes (24): FastAPI, JSONResponse, Request, RateLimitExceeded, Cover the exc.limit.limit.get_expiry() failure path (lines 255-259)., TestRateLimitExceededHandler, Unit-level test for the rate-limit handler body shape so client     parsers are, Build a synthetic RateLimitExceeded for the 10/minute constraint         and ass (+16 more)
+Cohesion: 0.18
+Nodes (11): FastAPI, _app_with_auth_router(), B-P1-8 — pin the 429 rate-limit response shape across all auth gates.  Two disti, Pins the OTP lockout 429 contract. _check_otp_lockout raises     HTTPException(4, Build a stripped FastAPI app that mounts only the auth router and     wires the, Pins the response shape for slowapi-tripped 429s. /auth/logout is     rate-limit, The body is the fallback for clients running through proxies         that strip, test_otp_lockout_emits_retry_after_and_ratelimit_headers() (+3 more)
 
 ### Community 417 - "Community 417"
 Cohesion: 0.08
@@ -4803,39 +4959,39 @@ Cohesion: 0.08
 Nodes (24): 1. 🟠 [P1] TEST — `rider-app-test`, 2. 🟠 [P1] BUILD — `rider-app-test`, 3. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:00:02.6509087Z FAIL store/__tests__/rideStore.), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web) (+16 more)
 
 ### Community 422 - "Community 422"
-Cohesion: 0.33
-Nodes (4): Tests for admin user verification., Test get_admin_user with admin user., Test get_admin_user with non-admin user., TestAdminUserVerification
+Cohesion: 0.14
+Nodes (20): Any, int, str, calculate_surge_for_area(), _count_demand_in_area(), _count_supply_in_area(), get_surge_status(), Automated surge pricing engine.  Calculates demand/supply ratio per service area (+12 more)
 
 ### Community 423 - "Community 423"
-Cohesion: 0.10
-Nodes (21): Any, bool, float, int, str, _is_dispatchable_driver(), rank_by_eta_with_acceptance(), Return ``(algorithm, min_rating, search_radius_km)`` for this ride.          Rea (+13 more)
+Cohesion: 0.09
+Nodes (23): Any, bool, float, int, str, Return ``(algorithm, min_rating, search_radius_km)`` for this ride.          Rea, Online + available + verified + *present* drivers for this ride.          is_ver, Return ``(algorithm, min_rating, search_radius_km,         max_offers, use_eta)` (+15 more)
 
 ### Community 425 - "Community 425"
-Cohesion: 0.33
-Nodes (5): Tests for token refresh functionality., Test refreshing token with valid session., Tests for token refresh functionality., Test refreshing token with valid session., TestTokenRefresh
+Cohesion: 0.10
+Nodes (19): update_one(), test_approve_driver_document(), test_update_document_requirement(), test_update_expired_documents(), test_approve_driver_document(), test_get_driver_rating(), test_register_driver_success(), test_reject_driver_document() (+11 more)
 
 ### Community 427 - "Community 427"
-Cohesion: 0.40
-Nodes (5): list_staff(), List all staff members., List staff members with offset/limit pagination.      Returns a flat array (back, int, Response
+Cohesion: 0.07
+Nodes (32): create_staff(), delete_staff(), get_staff(), list_modules(), list_staff(), List all staff members., List staff members with offset/limit pagination.      Returns a flat array (back, List staff members with offset/limit pagination.      Returns a flat array (back (+24 more)
 
 ### Community 428 - "Community 428"
-Cohesion: 0.13
+Cohesion: 0.15
 Nodes (24): AsyncMock, str, ConnectionManager, _make_manager(), Regression tests for B-P3-1: concurrent asyncio.gather broadcast.  Verifies:   -, An exception from one connection is logged; others still receive the message., asyncio.TimeoutError from a hung socket is caught and logged, not raised., Connections removed mid-broadcast do not cause RuntimeError.      The snapshot t (+16 more)
 
 ### Community 429 - "Community 429"
-Cohesion: 0.11
-Nodes (14): str, _make_stripe_event(), Tests for routes/webhooks.py and routes/main.py.  webhooks.py is at 15.9% — the, When update_ride returns None (ride not found), handler raises 500 so Stripe ret, TestAllowedStripeEvents, TestStripeWebhookCheckoutNotPaid, TestStripeWebhookClaimException, TestStripeWebhookDuplicateEvent (+6 more)
+Cohesion: 0.10
+Nodes (16): str, _make_stripe_event(), Tests for routes/webhooks.py and routes/main.py.  webhooks.py is at 15.9% — the, When update_ride returns None (ride not found), handler raises 500 so Stripe ret, TestAllowedStripeEvents, TestStripeWebhookCheckoutNotPaid, TestStripeWebhookClaimException, TestStripeWebhookDuplicateEvent (+8 more)
 
 ### Community 431 - "Community 431"
 Cohesion: 0.08
 Nodes (24): Active ride lifecycle (driver side), Admin API — `/api/admin`, Authentication — `/auth`, code:json (// Request), code:json (// Request), code:json (// Request  (header: Idempotency-Key: <client-uuid>)), code:block6 (searching → driver_assigned → driver_accepted → driver_arriv), code:json ({ "type": "auth", "token": "<access_token>" }) (+16 more)
 
 ### Community 434 - "Community 434"
-Cohesion: 0.20
+Cohesion: 0.31
 Nodes (9): config, escapedSharedNM, { FileStore }, { getDefaultConfig }, isNativeComponentImport, NATIVE_COMPONENT_STUB, os, path (+1 more)
 
 ### Community 440 - "Community 440"
-Cohesion: 0.33
+Cohesion: 0.48
 Nodes (5): client, getAuthHeader, setCsrfToken, setInMemoryToken, setRefreshCallback
 
 ### Community 442 - "Community 442"
@@ -4843,8 +4999,8 @@ Cohesion: 0.08
 Nodes (24): 1. Page & Route, 2. Map Layer (Google Maps JS API), 3. WebSocket & Data Flow, 4. Detail Panel, 5. Toolbar, 6. Alert Feed, 7. New Files, 8. Out of Scope (+16 more)
 
 ### Community 443 - "Community 443"
-Cohesion: 0.09
-Nodes (18): DriverTopBar(), DriverTopBarProps, styles, defaultProps, { getByText }, mockRide, { toJSON }, { View } (+10 more)
+Cohesion: 0.12
+Nodes (20): DriverTopBar(), DriverTopBarProps, styles, defaultProps, { getByText }, mockRide, { toJSON }, { View } (+12 more)
 
 ### Community 444 - "Community 444"
 Cohesion: 0.08
@@ -4879,7 +5035,7 @@ Cohesion: 0.08
 Nodes (24): A-P2-10 · Force-Cancel Ride Not Audit-Logged, A-P2-11 · Promotion Stats Loads All Promo Usage Into Memory, A-P2-12 · Driver Ride History Loads Up to 50,000 Rides per Driver, A-P2-1 · No Multi-Factor Authentication on Admin Login, A-P2-2 · No Idle Session Timeout, A-P2-3 · Cloud Messaging Endpoint Accepts Raw `Dict[str, Any]` — No Schema Validation, A-P2-4 · Service Areas Endpoint Accepts Raw Dict on All Operations, A-P2-5 · Driver Action / Status Override Use Plain `str` (+16 more)
 
 ### Community 452 - "Community 452"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (24): compilerOptions, allowSyntheticDefaultImports, baseUrl, declaration, declarationMap, esModuleInterop, jsx, lib (+16 more)
 
 ### Community 453 - "Community 453"
@@ -4904,15 +5060,15 @@ Nodes (23): Branch 1 — `sprint6/jwt-refresh` (SEC-014, SEC-015), Branch 2 — 
 
 ### Community 458 - "Community 458"
 Cohesion: 0.19
-Nodes (12): float, str, _driver_row(), P1-9: Multi-stop E2E (R11)  The backend supports adding and removing stops on an, Adding a stop should trigger a fare recalculation., Pins remove_stop_mid_trip: stop removed by index, driver notified.      Code und, Pins add_stop_mid_trip: stop appended, driver notified via WS.      Code under t, _ride() (+4 more)
+Nodes (11): float, str, _driver_row(), P1-9: Multi-stop E2E (R11)  The backend supports adding and removing stops on an, Adding a stop should trigger a fare recalculation., Pins remove_stop_mid_trip: stop removed by index, driver notified.      Code und, Pins add_stop_mid_trip: stop appended, driver notified via WS.      Code under t, _ride() (+3 more)
 
 ### Community 459 - "Community 459"
 Cohesion: 0.08
 Nodes (22): Adding a new 429 source (NOT slowapi-mediated), Adding a new rate-limited endpoint, Backend, Client, code:json ({), code:ts (class RateLimitError extends Error {), code:bash (# /auth/logout is rate-limited to 3/minute. Burn the budget ), Endpoint inventory (+14 more)
 
 ### Community 460 - "Community 460"
-Cohesion: 0.06
-Nodes (35): ApiError, ApiErrorBody, CACHED_ENDPOINTS, cachedClient, client, fetchWithAuth(), getAuthHeader(), getStoredToken() (+27 more)
+Cohesion: 0.14
+Nodes (23): ApiError, ApiErrorBody, CACHED_ENDPOINTS, cachedClient, client, fetchWithAuth(), getAuthHeader(), getStoredToken() (+15 more)
 
 ### Community 461 - "Community 461"
 Cohesion: 0.08
@@ -4939,79 +5095,79 @@ Cohesion: 0.08
 Nodes (24): tripCompleted, anyComments, baseFare, bookingFee, distanceFare, howWasRider, rateDone, receiptDistance (+16 more)
 
 ### Community 468 - "Community 468"
-Cohesion: 0.29
+Cohesion: 0.43
 Nodes (6): ActiveRide, DriverData, Earnings, IncomingRide, Rider, RideState
 
 ### Community 469 - "Community 469"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. 🟠 [P1] BUILD — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T05:55:22.2266328Z Could not pull latest version i), code:bash (cd rider-app && yarn build:web), code:bash (docker build -f backend/Dockerfile .) (+14 more)
 
 ### Community 470 - "Community 470"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. 🟠 [P1] BUILD — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T05:56:02.5630288Z Could not pull latest version i), code:bash (cd rider-app && yarn build:web), code:bash (docker build -f backend/Dockerfile .) (+14 more)
 
 ### Community 472 - "Community 472"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. 🟠 [P1] BUILD — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T05:56:26.4182664Z Could not pull latest version i), code:bash (cd rider-app && yarn build:web), code:bash (docker build -f backend/Dockerfile .) (+14 more)
 
 ### Community 475 - "Community 475"
-Cohesion: 0.40
+Cohesion: 0.53
 Nodes (4): config, { FileStore }, { getDefaultConfig }, path
 
 ### Community 479 - "Community 479"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. 🟠 [P1] TEST — `rider-app-test`, 2. 🟠 [P1] BUILD — `rider-app-test`, 3. 🟠 [P1] TEST — `E2E tests (Playwright)`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:19:45.2494339Z FAIL store/__tests__/rideStore.), code:block2 (2026-04-28T06:19:46.1601509Z Could not pull latest version i), code:bash (pytest <test_path> -v) (+14 more)
 
 ### Community 480 - "Community 480"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. 🟠 [P1] BUILD — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:18:38.2771103Z Could not pull latest version i), code:bash (cd rider-app && yarn build:web), code:bash (docker build -f backend/Dockerfile .) (+14 more)
 
 ### Community 481 - "Community 481"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. 🟠 [P1] BUILD — `backend-test`, 2. 🟠 [P1] BUILD — `security-scan`, 3. 🟠 [P1] BUILD — `deploy-frontend`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:33:40.2944727Z Could not pull latest version i), code:bash (cd rider-app && yarn build:web), code:bash (docker build -f backend/Dockerfile .) (+14 more)
 
 ### Community 482 - "Community 482"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (21): 1. Created Separate Corporate Accounts Schema File, 2. Updated Main Schema File, 3. Created Test Suite, code:block1 (API Error: /api/v1/admin/corporate-accounts {}), code:bash (cd spinr/backend), code:bash (spinr/backend/run_test.bat), Corporate Accounts API Fix, Files Modified/Created (+13 more)
 
 ### Community 484 - "Community 484"
-Cohesion: 0.23
+Cohesion: 0.25
 Nodes (22): bool, int, Path, str, Row, auto_detect_changed(), check_append_only(), check_dangerous() (+14 more)
 
 ### Community 485 - "Community 485"
-Cohesion: 0.12
-Nodes (20): Exception, MagicMock, LogCaptureFixture, _fake_supabase(), Unit tests for backend.utils.insurance_periods (M-5b).  Compliance-grade audit l, A boom from the DB layer must never propagate — caller doesn't see it., Race / no-op transition: insert hits 23505 and close affected 0 rows., Driver goes offline while period 2 is open (ride in driver_assigned).     The pr (+12 more)
+Cohesion: 0.15
+Nodes (22): Exception, MagicMock, LogCaptureFixture, _fake_supabase(), Unit tests for backend.utils.insurance_periods (M-5b).  Compliance-grade audit l, A boom from the DB layer must never propagate — caller doesn't see it., Race / no-op transition: insert hits 23505 and close affected 0 rows., Driver goes offline while period 2 is open (ride in driver_assigned).     The pr (+14 more)
 
 ### Community 488 - "Community 488"
-Cohesion: 0.14
+Cohesion: 0.18
 Nodes (12): detox, main, name, overrides, @tootallnate/once, @types/react, packageManager, private (+4 more)
 
 ### Community 490 - "Community 490"
-Cohesion: 0.13
-Nodes (12): float, int, _crumb(), Tests for backend/utils/route_distance.py — Roads-API distance recompute.  The f, Happy path: ~7 km trip, API returns interpolated snapped points,         we sum, TestComputeRoadDistanceKm, compute_road_distance_km(), _downsample() (+4 more)
+Cohesion: 0.08
+Nodes (32): Any, float, int, str, RoadMatch, _crumb(), Tests for backend/utils/route_distance.py — Roads-API distance recompute.  The f, Happy path: ~7 km trip, API returns interpolated snapped points,         we sum (+24 more)
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
 Nodes (3): 5. Rider App — Full File Mapping, App Screens (Expo Router — file = route), Rider Stores
 
 ### Community 492 - "Community 492"
-Cohesion: 0.15
-Nodes (20): Any, Decimal, str, GST (5%) and PST (6%) must each get their own row — regulatory., Combined-tax provinces (e.g. Ontario HST 13%) render a single line., Legacy rides written before migration 46 have only tax_amount., TestTaxLineItems, _build_fare_rows() (+12 more)
+Cohesion: 0.20
+Nodes (22): Any, Decimal, float, str, _build_fare_rows(), _d(), _fmt(), generate_receipt_html() (+14 more)
 
 ### Community 493 - "Community 493"
-Cohesion: 0.67
-Nodes (3): check_scheduled_rides(), Background task: dispatches scheduled rides when their time arrives., Background task: dispatches scheduled rides when their time arrives.
+Cohesion: 0.11
+Nodes (8): Extended unit tests for routes/drivers.py.  Covers functions not exercised by te, TestGetBankAccount, TestGetCurrentSubscription, TestGetDriverBalance, TestGetDriverConfig, TestGetDriverDailyEarnings, TestGetSubscriptionPlans, TestRateRider
 
 ### Community 495 - "Community 495"
-Cohesion: 0.09
+Cohesion: 0.12
 Nodes (22): attribution, commit, pr, autoCompactEnabled, autoCompactWindow, cleanupPeriodDays, enabledPlugins, andrej-karpathy-skills@karpathy-skills@2c60614 (+14 more)
 
 ### Community 497 - "Community 497"
-Cohesion: 0.09
+Cohesion: 0.08
 Nodes (22): 1. Overview, 2. Test Architecture, 3. Driver Ride State Machine, 4.1 Ride Offer & Countdown (4 tests), 4.2 Ride Accept / Decline (3 tests), 4.3 Ride Completion & Cancellation (2 tests), 4.4 Active Ride Sync (4 tests), 4.5 State Reset (1 test) (+14 more)
 
 ### Community 499 - "Community 499"
-Cohesion: 0.22
+Cohesion: 0.31
 Nodes (8): config, { FileStore }, { getDefaultConfig }, isNativeComponentImport, isSpecsDeprecated, NATIVE_COMPONENT_STUB, path, WEB_STUBS
 
 ### Community 508 - "Community 508"
@@ -5063,12 +5219,12 @@ Cohesion: 0.09
 Nodes (21): 1. Token model, 2. OTP flow (rider / driver), 3. Refresh flow, 4. Admin auth, 5. User endpoints, 6. Security surface, 7. Function / class quick reference, 8. Common tasks — where to start (+13 more)
 
 ### Community 521 - "Community 521"
-Cohesion: 0.12
-Nodes (10): Collection, Thin collection proxy so ``db.users``, ``db.rides``, etc. work in tests.      De, Tests for db_supabase.py specific functions., Test finding nearby drivers using RPC.          conftest.py's autouse fixture wi, Test updating driver location.          Historical note: this function USED to c, Test atomic driver claiming operation., Test getting a ride by ID., Test getting rides for a specific user. (+2 more)
+Cohesion: 0.04
+Nodes (53): Collection, MockCursor, int, str, Minimal cursor stub that mirrors the old MongoDB cursor interface.      Tests cr, Thin collection proxy so ``db.users``, ``db.rides``, etc. work in tests.      De, Unit tests for database layer (db.py and db_supabase.py). Tests cover CRUD opera, Tests for user-specific database operations.      Collection delegates to db_sup (+45 more)
 
 ### Community 522 - "Community 522"
-Cohesion: 0.11
-Nodes (18): str, bool, float, str, filter_and_rank_drivers(), Pure function: filter a candidate pool and attach per-driver distance.      Retu, Pure function: filter a candidate pool and attach per-driver distance.      Retu, TestFilterAndRankDrivers (+10 more)
+Cohesion: 0.17
+Nodes (13): bool, float, str, _driver(), E2E — WAV (wheelchair-accessible vehicle) dispatch (L-P0-3).  Saskatchewan Trans, Driver rows pre-dating migration 60 have no is_wav key — treated as non-WAV., The get_rows call in match_driver_to_ride must add is_wav=True when required., When requires_wav=True the backend adds is_wav=True to the drivers query. (+5 more)
 
 ### Community 523 - "Community 523"
 Cohesion: 0.14
@@ -5103,47 +5259,47 @@ Cohesion: 0.09
 Nodes (21): 1. What shipped in this commit, 1a. Redis row-level cache (`backend/db_supabase.py`), 1b. Circuit breaker tightened (`_CircuitBreaker`), 2. How Redis helps (high-level diagrams), 2a. Before the cache, 2b. After the cache, 2c. End-to-end request flow with cache + circuit breaker + retry, 3. Extending Redis to more DB calls — the rules (+13 more)
 
 ### Community 535 - "Community 535"
-Cohesion: 0.67
-Nodes (3): 2. High-level architecture, code:json ({), Ride-billing abstraction
+Cohesion: 0.15
+Nodes (19): Any, datetime, float, str, date_cls, _period(), Unit tests for the driver daily-activity aggregator.  Empty = P1+P2 (no passenge, _ride() (+11 more)
 
 ### Community 537 - "Community 537"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): After Phase E Completes, Checklist, Checklist, Checklist, Checklist, Checklist, Checklist — verify each residual risk from threat-model register, D17 — Observability (+12 more)
 
 ### Community 834 - "Community 834"
-Cohesion: 0.09
-Nodes (20): _offer_timeout_handler(), Auto-expire a driver's ride offer if they don't accept/decline.      Sleeps for, Auto-expire a driver's ride offer if they don't accept/decline.      Sleeps for, Tests for _offer_timeout_handler — the backend-enforced offer TTL.  Also covers, Ride reassigned to a different driver → handler does nothing., Tests for routes/rides._offer_timeout_handler., Ride deleted/not found → handler does nothing., Tests for related changes in match_driver_to_ride.      Patterns mirror test_e2e (+12 more)
+Cohesion: 0.12
+Nodes (16): _offer_timeout_handler(), Auto-expire a driver's ride offer if they don't accept/decline.      Sleeps for, Auto-expire a driver's ride offer if they don't accept/decline.      Sleeps for, Auto-expire a driver's ride offer if they don't accept/decline.      Sleeps for, Tests for _offer_timeout_handler — the backend-enforced offer TTL.  Also covers, Ride reassigned to a different driver → handler does nothing., Tests for routes/rides._offer_timeout_handler., Ride deleted/not found → handler does nothing. (+8 more)
 
 ### Community 835 - "Community 835"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): 1. Create a restore branch, 1. Pre-restore snapshot, 2. Execute restore, 2. Verify branch data, 3. Extract affected rows, 3. Post-restore validation, 4. Merge into production, 4. Reconcile post-restore window (+12 more)
 
 ### Community 836 - "Community 836"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): Assets, AT-1: Drain corporate wallet master account, AT-2: Mass rider phone/address exfiltration, AT-3: Ride hijack (redirect rider to attacker location), Attack Trees (top 3), code:block1 ([Mobile apps]  <---HTTPS + App Check--->  [FastAPI backend]), code:block2 (Goal: Transfer corporate wallet balance to attacker-controll), code:block3 (Goal: Exfiltrate 10,000+ rider phones + home addresses) (+12 more)
 
 ### Community 2347 - "Community 2347"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): Assets (driver-specific), code:block1 ([Driver (user)] ─── interacts with ───▶ [Mobile device]), code:block2 (Goal: Redirect a driver's earnings to attacker's Stripe Conn), code:block3 (Goal: Claim payment for a trip that didn't happen), code:block4 (Goal: Onboard as driver under stolen identity), DAT-1: Payout redirection, DAT-2: Fake-trip earnings fraud (GPS spoofing), DAT-3: Onboarding identity fraud (+12 more)
 
 ### Community 2348 - "Community 2348"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): Assets (rider-specific), code:block1 ([Rider (user)] ─── interacts with ───▶ [Mobile device]), code:block2 (Goal: Determine a specific rider's home address), code:block3 (Goal: Transfer rider's wallet balance to attacker), code:block4 (Goal: Prevent a rider in danger from triggering SOS), Denial of Service, Elevation of Privilege, Information Disclosure (+12 more)
 
 ### Community 2349 - "Community 2349"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): Action Items by Priority, Admin Dashboard (Next.js), Backend (Python FastAPI), Comprehensive Code Review and Gap Analysis Plan, Critical Priority (Must Fix Before Production), Driver App (React Native/Expo), High Priority (Fix for Launch), Implementation Phases (+12 more)
 
 ### Community 2350 - "Community 2350"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (18): After this file, B-P2-1 · `float()` Used in Corporate Allowance Path — Cents Lost on Large Grants, B-P2-2 · Stripe Webhook Has No Event-Type Allowlist — Unknown Events Silently Marked Processed, B-P2-3 · App Check Error Logs Missing `request_id` Correlation, B-P2-4 · `audit_logs` Has RLS But No Append-Only Trigger (SOC2 CC6.2), B-P2-5 · Driver-Candidate Dispatch Filter Has No Composite Index, B-P2-6 · DSAR Export Issues 6 Sequential `get_rows` Calls — Multiplies SLA Risk, B-P2-7 · `run_sync` Uses Default Thread Pool — Concurrent DB Calls Block Each Other (+10 more)
 
 ### Community 2351 - "Community 2351"
-Cohesion: 0.10
+Cohesion: 0.09
 Nodes (20): Checklist, code:python (if ride.status in ('driver_arrived', 'trip_in_progress'):), code:python (COMPLETE_FROM_STATES = {'trip_in_progress'}), code:tsx (import { BackHandler } from 'react-native';), code:ts (await Location.requestBackgroundPermissionsAsync();), code:python (content_length = request.headers.get('content-length')), code:python (_RAW_CARD_FIELDS = {), code:python (import hmac) (+12 more)
 
 ### Community 2352 - "Community 2352"
-Cohesion: 0.13
+Cohesion: 0.14
 Nodes (13): _driver(), str, Cross-app ride-lifecycle integration test.  Simulates a full ride by driving the, Rider's view and driver's view of the same ride must agree on         the status, If the rider cancels after driver accepted, the driver must be         notified, C4 — driver cancels after accepting: rider must receive both a         WebSocket, Driver can only cancel rides they have accepted — attempting to cancel         a, Shape contracts between rider and driver apps and the backend.      These are lo (+5 more)
 
 ### Community 2353 - "Community 2353"
@@ -5151,7 +5307,7 @@ Cohesion: 0.10
 Nodes (19): 1. PII Inventory — Admin-Accessible Data, 2. Export Endpoints — Unlogged, Unlimited Bulk PII Export, 3. Sentry Configuration — Missing PII Scrubbing, 4. Backend Log Redaction, 5. Audit Log Schema Inconsistency, 6. Audit Log Integrity — No Append-Only Enforcement, 7. Audit Log Retention, 8. Data Residency (+11 more)
 
 ### Community 2354 - "Community 2354"
-Cohesion: 0.10
+Cohesion: 0.13
 Nodes (19): aliases, components, hooks, lib, ui, utils, iconLibrary, registries (+11 more)
 
 ### Community 2355 - "Community 2355"
@@ -5183,23 +5339,23 @@ Cohesion: 0.13
 Nodes (14): bool, Request, Response, str, _apply_security_headers(), _extract_user_id(), Attach the baseline security headers to a response.      Uses dict-style assignm, Attach a conservative set of security response headers to every     response. HS (+6 more)
 
 ### Community 2362 - "Community 2362"
-Cohesion: 0.08
-Nodes (28): claim_stripe_event(), mark_stripe_event_processed(), Any, bool, int, str, Request, Recursively prepare a payload for Supabase/PostgREST JSON encoding. (+20 more)
+Cohesion: 0.13
+Nodes (23): Any, bool, int, str, Request, claim_stripe_event(), fare_split_pay_share(), increment_promo_uses() (+15 more)
 
 ### Community 2363 - "Community 2363"
-Cohesion: 0.25
-Nodes (19): Any, str, driver_row(), _now(), payout_row(), promotion_row(), Factory helpers for corporate-account tests.  Kept out of conftest.py because py, Build a vehicle_types-table-shaped dict with Economy defaults. (+11 more)
+Cohesion: 0.21
+Nodes (20): int, str, _driver_for_user(), driver_report_found_item(), driver_respond(), DriverReportRequest, get_case(), _insert_system_message() (+12 more)
 
 ### Community 2364 - "Community 2364"
-Cohesion: 0.10
+Cohesion: 0.14
 Nodes (19): Regression tests for A-P0-3: GPS OOM — large row fetches in maintenance.py.  Bac, Verify maintenance.py uses delete_many directly (not get_rows+len) for cleanup., Verify presence_rows query uses a bounded limit, not an unbounded fetch.      Th, Cleanup endpoint must call delete_many (direct DB delete) — never get_rows+len w, Cleanup response contains the expected keys., A delete_many failure on the first bucket must not block the second bucket., Conceptual guard: get_rows loads full rows; count_documents uses DB aggregation., Presence rows need only driver_id; simulate the column-limited result. (+11 more)
 
 ### Community 2365 - "Community 2365"
-Cohesion: 0.14
-Nodes (13): str, _driver_row(), P1-8: Role-claim tampering guard (S3, S8) + S1 fix  S1 — Rider tries to accept o, A pure rider (no driver row) gets 404 — no driver record found., A real driver accepting a ride from a different rider must succeed         (up t, GET /drivers/earnings must always return the authenticated driver's own     earn, A caller with a valid token but no driver row gets 404, not another         driv, The rides fetched for earnings are filtered by the driver's own id,         not (+5 more)
+Cohesion: 0.10
+Nodes (18): str, _driver_row(), P1-8: Role-claim tampering guard (S3, S8) + S1 fix  S1 — Rider tries to accept o, A pure rider (no driver row) gets 404 — no driver record found., A real driver accepting a ride from a different rider must succeed         (up t, Role is always read from the DB row, never trusted from the JWT payload.      Co, A JWT carrying `role: 'driver'` for a user who is `role: 'rider'`         in the, A JWT with `role: 'admin'` for a regular DB user must not pass         `get_admi (+10 more)
 
 ### Community 2366 - "Community 2366"
-Cohesion: 0.21
+Cohesion: 0.23
 Nodes (19): bool, create_payment_sheet(), PaymentSheetRequest, Request body for POST /payments/payment-sheet., Return the three secrets needed to initialise Stripe PaymentSheet.      The mobi, Return the three secrets needed to initialise Stripe PaymentSheet.      The mobi, Request body for POST /payments/payment-sheet., ride_id branch sets idempotency key as ps-{ride_id}-{user_id}. (+11 more)
 
 ### Community 2367 - "Community 2367"
@@ -5211,11 +5367,11 @@ Cohesion: 0.10
 Nodes (19): 1. Overview, 2. Test Architecture, 3.1 `authStore.test.ts` - Authentication Store (13 Tests), 3.2 `rideStore.test.ts` - Ride Booking Store (20 Tests), 3. Test Files - Detailed Breakdown, 4. End-to-End Ride Booking Flow - Test Coverage Map, 5. How to Add New Frontend Tests, 6. Gaps & Future Tests to Add (+11 more)
 
 ### Community 2369 - "Community 2369"
-Cohesion: 0.10
+Cohesion: 0.11
 Nodes (19): compilerOptions, paths, strict, exclude, extends, include, @/*, expo-constants (+11 more)
 
 ### Community 2370 - "Community 2370"
-Cohesion: 0.10
+Cohesion: 0.15
 Nodes (19): branching_strategy, brave_search, commit_docs, granularity, graphify, enabled, milestone_branch_template, mode (+11 more)
 
 ### Community 2371 - "Community 2371"
@@ -5235,115 +5391,115 @@ Cohesion: 0.10
 Nodes (18): Checklist, code:python (from decimal import Decimal), code:python (connections = list(self.active_connections.values())  # snap), code:sql (ALTER TABLE vehicles ALTER COLUMN vin SET DATA TYPE vault.en), code:python (# Process: expiring within 7 days OR already expired), code:python (limiter = Limiter(key_func=get_ipaddr)  # reads X-Forwarded-), code:ts (await apiClient.put('/notifications/preferences', { key: val), P2-10 · Notification Settings Are Lost When Driver Reinstalls the App (+10 more)
 
 ### Community 2375 - "Community 2375"
-Cohesion: 0.14
-Nodes (10): Tests for authentication endpoints., Tests for authentication endpoints., Create test client with App Check bypassed for unit testing., Test sending OTP with missing phone number., Test sending OTP with invalid phone format., Test sending OTP with missing phone number., Test sending OTP with invalid phone format., Test verifying OTP with missing fields. (+2 more)
+Cohesion: 0.02
+Nodes (88): str, init_firebase(), Initialize Firebase Admin SDK, Initialize Firebase Admin SDK, create_jwt_token(), create_refresh_token(), generate_otp(), generate_pickup_otp() (+80 more)
 
 ### Community 2376 - "Community 2376"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. Backend Performance — N+1 and Unbounded Queries, 2. Missing Response Caching on Analytics Endpoints, 3. Frontend — Large Datasets Loaded Into Browser, 4. Float Arithmetic in Display Paths, 5. Accessibility (WCAG 2.1 AA), 6. Internationalisation (i18n), 7. Phase 6 New Findings, Admin Dashboard Audit — Phase 6: Performance, UX & Accessibility (+10 more)
 
 ### Community 2377 - "Community 2377"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): Admin Dashboard Deployment (Vercel), Backend Deployment (Railway), code:bash (# 1. Run tests), code:bash (# 1. Type check), code:bash (# Automatic via Vercel Git integration), code:bash (# Backend (.env)), code:bash (# Backend rollback (Railway) — dashboard: Deployments tab → ), Deployment Procedures (+10 more)
 
 ### Community 2378 - "Community 2378"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (18): Anti-patterns, Append-only, code:block1 (git diff --cached --name-only --diff-filter=A backend/migrat), code:block2 (ls backend/migrations/ | sort | tail -5), code:block3 (SPINR MIGRATION REVIEW — <file(s)>), Declared Impact vs diff (cross-check), Filename & ordering, Forward-compatibility (+10 more)
 
 ### Community 2379 - "Community 2379"
-Cohesion: 0.11
+Cohesion: 0.12
 Nodes (18): 10. Tax retention, 11. Declared Impact vs diff (cross-check), 1. Decimal discipline, 2. Stripe boundary, 3. Stripe idempotency, 4. Fare breakdown invariant, 5. Receipt line items (transparency is a differentiator), 6. Corporate billing priority (+10 more)
 
 ### Community 2380 - "Community 2380"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): API Standards, Auth Requirements, code:block1 (/api/v1/{resource}          # Collection), code:block2 (GET    /api/v1/rides              # List rides), code:json ({), code:json ({), code:json ({), Collection (with pagination) (+10 more)
 
 ### Community 2381 - "Community 2381"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): Also noted closed (pre-existing, not previously counted), Branch 1 — `sprint8/geofence-and-cleanup`, Branch 2 — `sprint8/ci-quality`, Branch 3 — `sprint8/mobile-tests`, Branch 4 — `sprint8/runbooks`, code:toml (line-length = 120), CQ-003 — ruff lint gate, Cumulative Programme Status (+10 more)
 
 ### Community 2382 - "Community 2382"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): A · Summary of Open Work, B · Phase E Findings by Severity, C · Top P0 — Launch Blockers (risk_score ≥ 64), D · Cross-Audit Duplicates, E · Sprint Assignment (risk-score threshold), F · Pre-Existing Rider Sprint Files — Verification Status, G · Owners Summary (after dedup), H · Regulatory Exposure (open items) (+10 more)
 
 ### Community 2383 - "Community 2383"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (9.0357841Z FAILED tests/test_p3_admin_jwt_modules.py::TestMi), code:block2 (2026-04-29T04:58:41.6193802Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2384 - "Community 2384"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T05:08:36.8160347Z FAILED tests/test_p3_admin_jwt_), code:block2 (2026-04-29T05:08:39.2986423Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2385 - "Community 2385"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T05:58:37.1513787Z FAILED tests/test_p1_token_refr), code:block2 (2026-04-29T05:58:40.2881954Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2386 - "Community 2386"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T06:21:25.1146961Z FAILED tests/test_admin_securit), code:block2 (2026-04-29T06:21:27.7898696Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2387 - "Community 2387"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T07:27:32.3829580Z FAILED tests/test_admin_securit), code:block2 (2026-04-29T07:27:35.4843990Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2388 - "Community 2388"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (7Z FAILED tests/test_admin_security.py::TestExpiredTokenReje), code:block2 (2026-04-29T07:36:37.6110750Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2389 - "Community 2389"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T07:45:59.6279802Z FAILED tests/test_admin_securit), code:block2 (2026-04-29T07:46:02.0505204Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2390 - "Community 2390"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T07:53:35.3334786Z FAILED tests/test_p1_auth_harde), code:block2 (2026-04-29T07:53:38.9828133Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2391 - "Community 2391"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T07:55:18.7067833Z FAILED tests/test_p1_auth_harde), code:block2 (2026-04-29T07:55:21.7505409Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2392 - "Community 2392"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T08:30:44.2503510Z FAILED tests/test_admin_securit), code:block2 (2026-04-29T08:30:47.4994659Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2393 - "Community 2393"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T13:20:39.9925572Z FAILED tests/test_admin_securit), code:block2 (2026-04-29T13:20:43.1926675Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2394 - "Community 2394"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T13:21:50.0581842Z FAILED tests/test_auth.py::Test), code:block2 (2026-04-29T13:21:53.1549804Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2395 - "Community 2395"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. 🟠 [P1] TEST — `backend-test`, 2. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-29T14:54:47.7510469Z FAILED tests/test_service_areas), code:block2 (2026-04-29T14:54:51.0722704Z Could not pull latest version i), code:bash (pytest <test_path> -v), code:bash (pytest -v) (+10 more)
 
 ### Community 2396 - "Community 2396"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): A · Driver App — 4 Open Items (from verification 2026-04-23), B1. Backend / dispatch, B2. Auth, B3. Frontend layout drift, B4. Product-decision drift, B5. Compliance follow-ups, B · Driver App — 17 New Issues Surfaced During Verification (not in any remediation file yet), C · Rider App — Pending Verification (+10 more)
 
 ### Community 2397 - "Community 2397"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): Checklist, Checklist, Checklist, Checklist, Checklist, Checklist, D17 — Observability, D18 — Disaster Recovery / Business Continuity (+10 more)
 
 ### Community 2398 - "Community 2398"
-Cohesion: 0.05
-Nodes (41): int, str, get_current_user(), Resolve the current user using Firebase ID token (preferred) or fallback to lega, verify_jwt_token(), delete_favorite_route(), get_favorite_routes(), Favorite routes — save and reuse frequent pickup→dropoff routes.  Riders can sav (+33 more)
+Cohesion: 0.15
+Nodes (17): int, str, delete_favorite_route(), get_favorite_routes(), Favorite routes — save and reuse frequent pickup→dropoff routes.  Riders can sav, Increment use count when rider books from a favorite. Returns the route data., Remove a favorite route., Remove a favorite route. (+9 more)
 
 ### Community 2399 - "Community 2399"
-Cohesion: 0.18
+Cohesion: 0.19
 Nodes (18): bool, Path, str, apply_migration(), _apply_migration_autocommit(), get_applied_versions(), get_db_connection(), get_migration_files() (+10 more)
 
 ### Community 2400 - "Community 2400"
-Cohesion: 0.19
+Cohesion: 0.21
 Nodes (13): Any, float, int, str, bench_create_ride(), build_mocks(), CallCounter, main() (+5 more)
 
 ### Community 2401 - "Community 2401"
-Cohesion: 0.13
-Nodes (18): confirm_payment(), Confirm payment was successful, Confirm payment was successful, Unit tests for POST /payments/confirm security fixes.  S-1: Ownership check — au, S-1: a rider who does not own the ride receives 403., S-1: the ride owner passes the ownership check and proceeds normally., S-1: non-existent ride_id raises 404 before ownership or Stripe call., R-1: a concurrent second request loses the atomic claim and gets 409. (+10 more)
+Cohesion: 0.25
+Nodes (9): Unit tests for POST /payments/confirm security fixes.  S-1: Ownership check — au, S-1: a rider who does not own the ride receives 403., S-1: the ride owner passes the ownership check and proceeds normally., S-1: non-existent ride_id raises 404 before ownership or Stripe call., R-1: a concurrent second request loses the atomic claim and gets 409., test_confirm_payment_ownership_check_allows_owner(), test_confirm_payment_ownership_check_rejects_non_owner(), test_confirm_payment_race_guard_returns_409() (+1 more)
 
 ### Community 2402 - "Community 2402"
-Cohesion: 0.19
+Cohesion: 0.22
 Nodes (17): _detect_flaky_jobs(), fetch(), _get(), _get_all_jobs(), _get_text(), main(), _NoAuthOnRedirect, _parse_next_link() (+9 more)
 
 ### Community 2403 - "Community 2403"
@@ -5351,11 +5507,11 @@ Cohesion: 0.16
 Nodes (13): init_middleware(), Initialize all middleware components, Initialize all middleware components, _fake_app(), When wildcard is configured, allow_credentials must be False         (CORS spec, Explicit allowed origins must set allow_credentials=True., Certain dev origins are always added regardless of env variables., Minimal stand-in: records add_middleware calls without importing FastAPI. (+5 more)
 
 ### Community 2404 - "Community 2404"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): audit_logs append-only contract (B-P1-7), code:sql (SELECT created_at, details), code:sql (SELECT purge_pii_retention(p_dry_run => true);), code:sql (SELECT purge_pii_retention(p_dry_run => false);), code:sql (REVOKE EXECUTE ON FUNCTION purge_pii_retention(BOOLEAN) FROM), code:sql (GRANT EXECUTE ON FUNCTION purge_pii_retention(BOOLEAN) TO se), Confirm yesterday's run happened, Dry-run (preview only — no rows mutated) (+10 more)
 
 ### Community 2405 - "Community 2405"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. When This Happens, 2. How to Check, 3. How to Clear the Lockout, 4. Escalation — Manually Send a Test OTP, 5. Prevention, 6. Escalation, code:bash (# Replace with the user's phone number in E.164 format), code:bash (railway variables --service backend) (+10 more)
 
 ### Community 2406 - "Community 2406"
@@ -5383,15 +5539,15 @@ Cohesion: 0.11
 Nodes (19): settings, account, language, notifications, title, callEmergency, dangerZone, deleteAccount (+11 more)
 
 ### Community 2412 - "Community 2412"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): 1. frontend/package.json Changes, 2. rider-app/package.json Changes, 3. driver-app/package.json, Current State Analysis, Detailed Changes Required, DevDependencies, DevDependencies, Expo Core Packages (Change from ~54.x to ~52.x) (+10 more)
 
 ### Community 2413 - "Community 2413"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): Checklist, code:typescript (// After catch block — must NOT silently swallow:), code:tsx (import { useSafeAreaInsets } from 'react-native-safe-area-co), code:tsx (import { BackHandler } from 'react-native';), code:typescript (// rideStore.ts — guard before API call:), code:python (# backend/routes/rides.py:), code:tsx (import { SOSButton } from '@shared/components/SOSButton';), code:python (async def _check_otp_lockout(phone: str) -> None:) (+10 more)
 
 ### Community 2414 - "Community 2414"
-Cohesion: 0.11
+Cohesion: 0.10
 Nodes (18): Checklist, P2 — Rider App Medium Priority: Fix Before Public Launch, ✅ R-P2-10 · Corporate Ride Flow Has No UI Entry Point, ✅ R-P2-11 · Legal/ToS Not Presented During Onboarding, ✅ R-P2-12 · become-driver.tsx — Incomplete Handoff Description (Pre-P1-11), ✅ R-P2-13 · Access Token Persisted to SecureStore — Memory-Only Pattern Not Followed, ✅ R-P2-1 · Offline Queue Only Handles Ride Creation, ✅ R-P2-22 · WalletPayRequest Has No Maximum Cap (+10 more)
 
 ### Community 2415 - "Community 2415"
@@ -5403,7 +5559,7 @@ Cohesion: 0.22
 Nodes (4): str, get_public_faqs(), Public FAQ endpoint.  Drivers and riders read FAQs without authentication. Admin, List active FAQ entries, optionally filtered by category and audience.      When
 
 ### Community 2417 - "Community 2417"
-Cohesion: 0.11
+Cohesion: 0.13
 Nodes (17): 10. Cross-origin & headers, 11. Declared Impact vs diff (cross-check), 1. Secrets & credentials, 2. PIPEDA — what must NEVER appear in logs, Sentry, or analytics, 3. Auth & JWT trust model, 4. Stripe & payments, 5. RLS & Supabase, 6. Input validation & injection (+9 more)
 
 ### Community 2418 - "Community 2418"
@@ -5423,16 +5579,20 @@ Cohesion: 0.11
 Nodes (18): 4. Wallet, payments, loyalty, promotions, `routes/addresses.py`, `routes/admin/messaging.py`, `routes/admin/promotions.py`, `routes/admin/subscriptions.py`, `routes/admin/wallet.py`, `routes/disputes.py`, `routes/favorites.py` (+10 more)
 
 ### Community 2422 - "Community 2422"
-Cohesion: 0.24
-Nodes (16): Any, Decimal, float, str, _apply(), apply_grant(), apply_reset(), apply_rollback() (+8 more)
+Cohesion: 0.13
+Nodes (28): Any, Decimal, float, str, int, str, date, _apply() (+20 more)
 
 ### Community 2423 - "Community 2423"
-Cohesion: 0.14
-Nodes (11): str, FareService, Pricing logic that depends on the database.      Routes should instantiate this, Pricing logic that depends on the database.      Routes should instantiate this, Service layer for Spinr backend.  Services contain business logic separated from, _make_db(), Tests for FareService.  These tests exercise the pure helpers directly and the c, Build a mock db that supports the flat Supabase-style interface FareService uses (+3 more)
+Cohesion: 0.19
+Nodes (11): FareService, Pricing logic that depends on the database.      Routes should instantiate this, Pricing logic that depends on the database.      Routes should instantiate this, Pricing logic that depends on the database.      Routes should instantiate this, _make_db(), Tests for FareService.  These tests exercise the pure helpers directly and the c, Build a mock db that supports the flat Supabase-style interface FareService uses, Build a mock db that supports the flat Supabase-style interface FareService uses (+3 more)
 
 ### Community 2424 - "Community 2424"
-Cohesion: 0.11
-Nodes (10): str, compute_instant_payout_fee(), Fee charged on an instant payout. Caller subtracts to get net., Tests for instant-payout (Stripe Instant Pay) in routes/drivers.py.  Covers the, Transfer succeeds, Payout fails → reversal succeeds.          Row should end in, Transfer succeeds, Payout fails, reversal also fails.          Row should end in, Step-1 transfer fails. No persist, no reversal — nothing happened., TestComputeInstantPayoutFee (+2 more)
+Cohesion: 0.12
+Nodes (13): str, compute_instant_payout_fee(), Fee charged on an instant payout. Caller subtracts to get net., Fee charged on an instant payout. Caller subtracts to get net., _bank_account(), _driver(), Tests for instant-payout (Stripe Instant Pay) in routes/drivers.py.  Covers the, Transfer succeeds, Payout fails → reversal succeeds.          Row should end in (+5 more)
+
+### Community 2425 - "Community 2425"
+Cohesion: 0.21
+Nodes (20): Any, bool, str, create_support_ticket(), create_ticket_for_complaint(), create_ticket_for_dispute(), create_ticket_for_flag(), create_ticket_for_lost_and_found() (+12 more)
 
 ### Community 2426 - "Community 2426"
 Cohesion: 0.11
@@ -5479,7 +5639,7 @@ Cohesion: 0.11
 Nodes (13): Tests for fare calculation functionality., Test distance calculation between two points., Tests for fare calculation functionality., Test distance calculation between two points., Test distance calculation for same point., Test distance calculation for same point., Test base fare calculation., Test base fare calculation. (+5 more)
 
 ### Community 2437 - "Community 2437"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): 1. Authentication Flow — Full Trace, 2. Session / Cookie Analysis, 3. Token Lifecycle & Revocation, 4. RBAC Deep-dive, 5. Password Policy, 6. Phase 2 New Findings, 7. What's Working Well, Access token cookie (`admin_token`) (+8 more)
 
 ### Community 2438 - "Community 2438"
@@ -5487,51 +5647,51 @@ Cohesion: 0.12
 Nodes (17): code:python (async def admin_resolve_dispute(dispute_id: str, resolution:), code:python (# Before:), code:python (# In GET /users, GET /drivers, GET /rides/list handlers:), code:typescript (function scrubPii(event: Sentry.Event): Sentry.Event | null ), code:sql (-- Rollback: DROP POLICY "Admin append-only audit_logs"; CRE), code:python (@router.put("/settings")), code:python (# In AdminCreditRequest / AdminDebitRequest Pydantic models,), code:python (# Add admin dependency to handler:) (+9 more)
 
 ### Community 2439 - "Community 2439"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): Admin Dashboard (`admin-dashboard/`), Authentication Flow, Backend API (`backend/`), code:block1 (┌──────────────┐     ┌──────────────┐     ┌──────────────┐), code:block2 (Rider requests ride → Backend creates ride record), code:block3 (User enters phone → Backend generates OTP), Component Details, Driver App (`driver-app/`) (+8 more)
 
 ### Community 2440 - "Community 2440"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): Backend (Critical — Tests Required), code:python (# Backend (pytest)), code:typescript (// Frontend (Jest)), code:block3 (backend/tests/), code:bash (# Backend), Frontend (Tests Recommended), Minimum Coverage Requirements, QA Engineer Role (+8 more)
 
 ### Community 2441 - "Community 2441"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): code:python (# All functions must have type hints), code:python (# ❌ No print() — use logger), code:typescript (// All props must have TypeScript interfaces), code:typescript (// ❌ No any type), Coding Standards, Forbidden Patterns, Forbidden Patterns, Git Conventions (+8 more)
 
 ### Community 2442 - "Community 2442"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): code:bash (cd backend && grep -rn "sk_live\|sk_test\|password\s*=\|secr), code:bash (cd rider-app && grep -rn "sk_live\|sk_test\|supabase.*key\|a), code:bash (cd backend && pip audit 2>&1 | tail -20), code:bash (cd rider-app && npm audit --production 2>&1 | tail -20), code:bash (cd admin-dashboard && npm audit --production 2>&1 | tail -20), code:block6 (### Security Audit Report), Security Audit Workflow, Step 1: Secrets Scan (+8 more)
 
 ### Community 2443 - "Community 2443"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): Branch 1 — Scheduled Rides (`sprint5/scheduled-rides`), Branch 2 — Ride Receipts (`sprint5/ride-receipts`), Branch 3 — Admin Fleet Map (`sprint5/admin-fleet-map`), Branch 4 — Docker Security (`sprint5/docker-security`), Branches Delivered, Issues Resolved This Sprint, Next Sprint Candidates (Sprint 6), Problem (+8 more)
 
 ### Community 2444 - "Community 2444"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): code:js (global: {), code:ts (if (item.type === 'document_expiry') router.push('/driver/do), code:yaml (===VERIFICATION-YAML===), Driver App — P3 Remediation Verification, New issues discovered (not in scope for this verification), P3-10 · Firebase Path Doesn't Issue Refresh Token, P3-1 · PII Test Only Covers 2 of 14 Forbidden Fields, P3-2 · No Test Proves Two Drivers Can't Accept the Same Ride (+8 more)
 
 ### Community 2445 - "Community 2445"
-Cohesion: 0.15
-Nodes (9): MockCursor, int, Minimal cursor stub that mirrors the old MongoDB cursor interface.      Tests cr, mock_cursor(), Tests for the MockCursor class., Test cursor is initialized with correct filter.          The field is ``.filter`, Test cursor to_list returns list of documents., Test cursor method chaining (sort, skip, limit). (+1 more)
+Cohesion: 0.26
+Nodes (5): str, filter_and_rank_drivers(), Pure function: filter a candidate pool and attach per-driver distance.      Retu, Pure function: filter a candidate pool and attach per-driver distance.      Retu, TestFilterAndRankDrivers
 
 ### Community 2446 - "Community 2446"
 Cohesion: 0.12
 Nodes (17): 3. Rides, `geo_utils.py`, `routes/admin/drivers.py`, `routes/admin/rides.py`, `routes/drivers.py`, `routes/fare_split.py`, `routes/fares.py`, `routes/rides.py` (+9 more)
 
 ### Community 2447 - "Community 2447"
-Cohesion: 0.20
+Cohesion: 0.23
 Nodes (16): float, int, str, bench_http(), bench_ws(), check_regression(), main(), make_mock_db() (+8 more)
 
 ### Community 2448 - "Community 2448"
-Cohesion: 0.23
-Nodes (13): MagicMock, Request, _fake_request(), _mock_httpx_response(), Tests for the rider-facing Google Maps proxy.  Covers the cost-control contracts, Build a minimal real Request that slowapi's isinstance check accepts., Build an httpx-like response object for unit testing., test_autocomplete_503s_when_budget_exhausted() (+5 more)
+Cohesion: 0.21
+Nodes (19): MagicMock, Request, _fake_request(), _mock_httpx_response(), Tests for the rider-facing Google Maps proxy.  Covers the cost-control contracts, Build an httpx-like response object for unit testing., Build a minimal real Request that slowapi's isinstance check accepts., Build an httpx-like response object for unit testing. (+11 more)
 
 ### Community 2449 - "Community 2449"
-Cohesion: 0.19
-Nodes (6): int, Cover lines 120-121 — corporate topup marks processed and returns scope., Webhook arrives after the synchronous /process-payment call timed out.      The, TestStripeWebhookCorporateTopupSuccess, TestStripeWebhookPaymentIntentSucceeded, TestWebhookTimeoutDivergence
+Cohesion: 0.15
+Nodes (7): int, Cover lines 120-121 — corporate topup marks processed and returns scope., Webhook arrives after the synchronous /process-payment call timed out.      The, TestStripeWebhookCheckoutSession, TestStripeWebhookCorporateTopupSuccess, TestStripeWebhookPaymentIntentSucceeded, TestWebhookTimeoutDivergence
 
 ### Community 2450 - "Community 2450"
-Cohesion: 0.12
+Cohesion: 0.11
 Nodes (16): `audit_logs` (admin actions, DSARs, SOS events), Changelog, Classification Levels, Cross-Border Data Flow, Data Classification Map, `drivers`, Log Fields — Allowed vs Forbidden, Open Gaps Against This Map (+8 more)
 
 ### Community 2451 - "Community 2451"
@@ -5547,8 +5707,8 @@ Cohesion: 0.12
 Nodes (17): ride, cancel, cancel_confirm, cancelled, completed, distance, driver_arrived, driver_assigned (+9 more)
 
 ### Community 2454 - "Community 2454"
-Cohesion: 0.18
-Nodes (8): Pure function: pick one driver from ``drivers_with_distance``.      ``last_assig, Pure function: pick one driver from ``drivers_with_distance``.      ``last_assig, select_driver_by_algorithm(), Combined applies rating floor in filter step, then picks nearest., If the last driver isn't in the current pool (e.g. went offline),         start, Combined applies rating floor in filter step, then picks nearest., If the last driver isn't in the current pool (e.g. went offline),         start, TestSelectDriverByAlgorithm
+Cohesion: 0.16
+Nodes (9): Pure function: pick one driver from ``drivers_with_distance``.      ``last_assig, Pure function: pick one driver from ``drivers_with_distance``.      ``last_assig, Pure function: pick one driver from ``drivers_with_distance``.      ``last_assig, select_driver_by_algorithm(), Combined applies rating floor in filter step, then picks nearest., If the last driver isn't in the current pool (e.g. went offline),         start, Combined applies rating floor in filter step, then picks nearest., If the last driver isn't in the current pool (e.g. went offline),         start (+1 more)
 
 ### Community 2455 - "Community 2455"
 Cohesion: 0.12
@@ -5568,7 +5728,7 @@ Nodes (15): Backend (pytest), code:block1 (backend/tests/), code:python (# Patte
 
 ### Community 2459 - "Community 2459"
 Cohesion: 0.18
-Nodes (16): 16 Audit Dimensions Framework, Spinr Audit Framework README, Audit v4 Findings: All 13 Tasks PASS (clean npm audit), Driver App Production-Readiness Audit v4, CRITICAL: Driver Rating Loads 1000 Records (14-14), CRITICAL: Math.random() FlatList Key (14-7), OTP Authentication Security, P1 Remediation: Fix Before Beta (+8 more)
+Nodes (15): 16 Audit Dimensions Framework, Audit v4 Findings: All 13 Tasks PASS (clean npm audit), Driver App Production-Readiness Audit v4, CRITICAL: Driver Rating Loads 1000 Records (14-14), CRITICAL: Math.random() FlatList Key (14-7), OTP Authentication Security, P1 Remediation: Fix Before Beta, P2 Remediation: Fix Before Public Launch (+7 more)
 
 ### Community 2460 - "Community 2460"
 Cohesion: 0.12
@@ -5623,8 +5783,8 @@ Cohesion: 0.12
 Nodes (15): Admin panel (plan ready, execution pending), Backend API (plan ready, execution pending), code:block1 (reports/audits/YYYY-MM-DD-<module>-<artefact>-v<N>.<ext>), Completion Criteria — "Complete Product", Cross-module trackers, Driver app (audit done, remediation ≈ closed), Execution Order (sequential, API-safe), FAQ (+7 more)
 
 ### Community 2473 - "Community 2473"
-Cohesion: 0.11
-Nodes (19): MagicMock, mock_db_collections(), mock_firebase_admin(), mock_rate_limiter(), mock_sms_service(), mock_supabase_client(), patch_external_dependencies(), Create a mock Supabase client for testing. (+11 more)
+Cohesion: 0.12
+Nodes (20): MagicMock, mock_db_collections(), mock_firebase_admin(), mock_rate_limiter(), mock_sms_service(), mock_supabase_client(), patch_external_dependencies(), Pytest configuration and fixtures for Spinr backend tests. This file provides sh (+12 more)
 
 ### Community 2474 - "Community 2474"
 Cohesion: 0.12
@@ -5663,16 +5823,20 @@ Cohesion: 0.12
 Nodes (15): Active Vendors, Authentication & Messaging, Build & Release, Change Log, Infrastructure, Known Gaps (triage targets), Maps & AI, Monitoring (B-P3-3) (+7 more)
 
 ### Community 2483 - "Community 2483"
-Cohesion: 0.14
+Cohesion: 0.15
 Nodes (15): build, development, preview, production, cli, version, developmentClient, distribution (+7 more)
 
 ### Community 2484 - "Community 2484"
 Cohesion: 0.12
 Nodes (16): devDependencies, @babel/core, babel-plugin-module-resolver, cross-env, eslint, eslint-config-expo, jest, jest-expo (+8 more)
 
+### Community 2485 - "Community 2485"
+Cohesion: 0.18
+Nodes (19): str, _base_patches(), _call(), Unit tests for the Stripe card branch in process_payment().  Covers:   - Success, Successful Stripe charge: ride.payment_status='paid', receipt email attempted., Verify charge_ride is called with correct ride, rider_id, total_amount., charge_ride returns 'declined' → HTTP 402, ride flagged payment_status='failed'., charge_ride returns status='failed' → HTTP 402, ride marked failed. (+11 more)
+
 ### Community 2486 - "Community 2486"
-Cohesion: 0.43
-Nodes (6): Low-balance email notification tick., test_rate_limited_within_12h(), test_resends_after_rate_limit_elapsed(), test_sends_email_when_below_threshold_and_autotopup_off(), test_skips_when_company_missing_billing_email(), run_low_balance_tick()
+Cohesion: 0.42
+Nodes (7): list_wallets_low_balance_no_autotopup(), Low-balance email notification tick., test_rate_limited_within_12h(), test_resends_after_rate_limit_elapsed(), test_sends_email_when_below_threshold_and_autotopup_off(), test_skips_when_company_missing_billing_email(), run_low_balance_tick()
 
 ### Community 2487 - "Community 2487"
 Cohesion: 0.12
@@ -5691,47 +5855,51 @@ Cohesion: 0.22
 Nodes (7): AgentTask, Any, str, Prepare for deployment., Verify deployment success., Rollback to previous version., Store deployment-specific knowledge.
 
 ### Community 2491 - "Community 2491"
-Cohesion: 0.13
+Cohesion: 0.20
 Nodes (14): category, content, created_at, id, metadata, review_date, security_score, total_issues (+6 more)
 
 ### Community 2492 - "Community 2492"
-Cohesion: 0.13
+Cohesion: 0.20
 Nodes (14): category, content, created_at, id, metadata, review_date, security_score, total_issues (+6 more)
 
 ### Community 2493 - "Community 2493"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): 1. No Secrets Exposed, 2. Tests Pass, 3. Type Safety, 4. Code Quality, 5. Lint Check, 6. Documentation Updated, 7. Commit Message Format, code:bash (git diff --cached --name-only | findstr ".env") (+6 more)
 
 ### Community 2494 - "Community 2494"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): Application (Railway / Render), Chaos / drill cadence, Checklist, code:bash (# Check for circuit breakers on external calls), Common Findings, Data export / portability, Database (Supabase / Postgres), Dimension 18 — Disaster Recovery & Business Continuity (+6 more)
 
 ### Community 2495 - "Community 2495"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): code:bash (# JavaScript dependencies), code:bash (git add reports/ audit-framework/), code:yaml (- id: "01-1"), Dimension Selection Guide, How to Run a Spinr Audit, Output Schema (REQUIRED — enforced by audit prompts), Step 1 — Set Up (5 minutes), Step 2 — Pre-Audit Scans (5 minutes) (+6 more)
 
 ### Community 2496 - "Community 2496"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): After All Sprints Are Verified, code:block1 (ROLE), code:yaml (===VERIFICATION-YAML===), code:markdown (### P0-1 · App Will Crash at Login — Wrong Database Field Na), code:block4 (| Sprint | Items | Done | Partial | Pending | Blocked | Unve), Driver App — Remediation Verification Audit, Notes for the verifier, Output Schema (REQUIRED) (+6 more)
 
 ### Community 2497 - "Community 2497"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): 1. Headline numbers, 2. P0 — Critical (fix now), 3. P1 — Before Beta (10 items), 4. P2 — Before Launch (9 items), 5. P3 — Hardening (3 items), 6. Cross-cutting observations, 7. Recommendation — what to address next, 8. Appendix — verification command transcript (+6 more)
 
 ### Community 2498 - "Community 2498"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): 10. No CSP / HSTS / X-Frame-Options on admin, 1. Pickup OTP stored as plaintext (cross-module), 2. Admin JWT in `sessionStorage` — XSS-stealable for 12 hours, 3. GPS query with `limit=1000000` — OOM in production, 4. Rider can create two active rides (double-booking race), 5. Driver with expired licence keeps driving — no auto-suspension, 6. Emergency SOS silently fails on network error, 7. Refresh-token brute-force / OTP lockout silently bypassed when Redis is down (+6 more)
 
+### Community 2499 - "Community 2499"
+Cohesion: 0.10
+Nodes (19): Admin (50+ endpoints), Admin Dashboard, API Endpoints (100+), Authentication, Business Model, CI/CD Pipeline, Directory Structure, Driver App (+11 more)
+
 ### Community 2500 - "Community 2500"
-Cohesion: 0.12
-Nodes (16): TestClient, admin_override(), Pytest configuration and fixtures for Spinr backend tests. This file provides sh, Reset the db_supabase circuit breaker to closed state before each test.      The, Reset the db_supabase circuit breaker to closed state before each test.      The, Reset in-process rate-limiter storage before each test.      The real SlowAPI Li, Reset MemoryStorage on a SlowAPI Limiter instance (if present)., Reset in-process rate-limiter storage before each test.      The real SlowAPI Li (+8 more)
+Cohesion: 0.13
+Nodes (15): TestClient, admin_override(), mock_jwt_token(), Return a mock JWT token for testing., Return a mock JWT token for testing., Reset in-process rate-limiter storage before each test.      The real SlowAPI Li, Reset MemoryStorage on a SlowAPI Limiter instance (if present)., Reset in-process rate-limiter storage before each test.      The real SlowAPI Li (+7 more)
 
 ### Community 2501 - "Community 2501"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): 1. Scope — what, where, who, 2. Capture evidence (before touching anything), 3. Stop the bleed (non-destructive first), 4. Communicate, 5. Postmortem (within 5 business days for P0/P1), 6. Durable fix, code:block1 (/incident                    # interactive — asks for severi), code:block2 (git log --oneline -20                 # recent deploys) (+6 more)
 
 ### Community 2502 - "Community 2502"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): Backend (4 files), Cleanup & Testing, code:bash (pytest backend/tests/test_cookie_auth.py -v), code:bash (git add -A), code:block3 (Phase 3: HttpOnly Token Storage), ✅ COMPLETED THIS SESSION, Frontend (1 file), Frontend (5 files) (+6 more)
 
 ### Community 2503 - "Community 2503"
@@ -5743,7 +5911,7 @@ Cohesion: 0.13
 Nodes (14): code:bash (npm install react-native-maps react-native-google-places-aut), code:json ({), code:tsx (import React from 'react';), code:tsx (import { GooglePlacesAutocomplete } from 'react-native-googl), code:bash (npm install react-native-maps-directions), code:tsx (import MapViewDirections from 'react-native-maps-directions'), Google Maps & Places API Integration Instructions, Prerequisites (+6 more)
 
 ### Community 2505 - "Community 2505"
-Cohesion: 0.13
+Cohesion: 0.12
 Nodes (14): All fixes already applied (most proven on EAS, ONE silently rejected), Build URLs from this session, code:block1 (- buildTools:  36.0.0), code:js (// rider-app/plugins/withForceCompileSdk.js), code:bash (cd C:/Users/TabUsrDskOff111/Documents/Spinrvm/spinrvm), Diagnosis (partial — didn't finish before context ran out), EAS Build — Stuck at `:app:checkReleaseAarMetadata` (compileSdk clamped), Recommended fix path (+6 more)
 
 ### Community 2506 - "Community 2506"
@@ -5751,35 +5919,39 @@ Cohesion: 0.13
 Nodes (14): Architecture, Backend, code:bash (cd backend), code:bash (# From repo root), code:bash (python3 -m unittest backend/tests/verify_db.py), code:bash (cd frontend), code:bash (npx expo start), Deployment (+6 more)
 
 ### Community 2507 - "Community 2507"
-Cohesion: 0.13
-Nodes (15): 1. Pre-Deploy Checks, 1a. Confirm staging test completed successfully, 1b. Verify the table and indexes exist on staging, 1c. Expected row counts before and after migration 65, 1d. Verify no duplicate open periods (the partial unique index prevents this, but confirm), 1e. Verify the tamper-evidence trigger blocks a DELETE, 1f. Confirm `insurance_periods.py` is deployed before or with the migration, code:bash (export SUPABASE_URL=<staging-url>) (+7 more)
+Cohesion: 0.17
+Nodes (12): 1. Pre-Deploy Checks, 1b. Verify the table and indexes exist on staging, 1c. Expected row counts before and after migration 65, 1d. Verify no duplicate open periods (the partial unique index prevents this, but confirm), 1e. Verify the tamper-evidence trigger blocks a DELETE, 1f. Confirm `insurance_periods.py` is deployed before or with the migration, code:sql (-- Table exists), code:sql (SELECT COUNT(*) FROM driver_insurance_periods;) (+4 more)
 
 ### Community 2508 - "Community 2508"
 Cohesion: 0.13
 Nodes (15): 4. Verification After Deploy, 4a. Both migrations recorded, 4b. Backfill ran (row count > 0, assuming any drivers were online), 4c. Open-period count matches online driver count, 4d. No duplicate open periods, 4e. Period-3 rows all have ride_id pointing to in_progress rides, 4f. Trigger is live — attempt a DELETE (in a transaction you will roll back), 4g. First live transition is recorded correctly (+7 more)
 
 ### Community 2509 - "Community 2509"
-Cohesion: 0.20
-Nodes (14): 55 Audit Issues (P0–P3) — All Closed, backend/utils/audit_logger.py — Structured Security Event Logger, Backend Module — FastAPI / Python 3.12, GitHub Actions CI Pipeline (13 jobs), Continuous Security Audit & Sprint Playbook, 4-Layer Continuous Audit Framework (Commit/PR/Weekly/Sprint), Maestro YAML Mobile E2E Flows, Playwright E2E Tests (Admin Dashboard) (+6 more)
+Cohesion: 0.21
+Nodes (13): 55 Audit Issues (P0–P3) — All Closed, backend/utils/audit_logger.py — Structured Security Event Logger, Backend Module — FastAPI / Python 3.12, GitHub Actions CI Pipeline (13 jobs), Continuous Security Audit & Sprint Playbook, 4-Layer Continuous Audit Framework (Commit/PR/Weekly/Sprint), Maestro YAML Mobile E2E Flows, 5-Check Pre-Commit Security Suite (+5 more)
 
 ### Community 2510 - "Community 2510"
-Cohesion: 0.20
-Nodes (14): Admin Email+Password Auth (bcrypt + sha256 upgrade), Spinr Backend (FastAPI), Auth & Users Domain, 7 Background Asyncio Loops, Dispatch Flow (match_driver_to_ride), Fare Pricing (Decimal precision), JWT Token Model, OTP Authentication Flow (+6 more)
+Cohesion: 0.22
+Nodes (13): Spinr Backend (FastAPI), Auth & Users Domain, 7 Background Asyncio Loops, Dispatch Flow (match_driver_to_ride), Fare Pricing (Decimal precision), JWT Token Model, OTP Authentication Flow, Backend Function & Class Reference Index (+5 more)
 
 ### Community 2511 - "Community 2511"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): 1. Input Validation Coverage, 2. Rate Limiting, 3. Idempotency, 4. SQL / NoSQL Injection Surface, 5. Supabase Client and RLS, 6. Sensitive-Settings Write Path, 7. Phase 4 New Findings, Admin Dashboard Audit — Phase 4: Backend Security Deep-dive (+5 more)
 
 ### Community 2512 - "Community 2512"
-Cohesion: 0.22
-Nodes (12): ALLOWED_IP_ENTRIES, buildCsp(), config, decodeJwtPayload(), generateNonce(), isIpAllowed(), isPublic(), isTokenValid() (+4 more)
+Cohesion: 0.29
+Nodes (14): ALLOWED_IP_ENTRIES, buildAllowedIpEntries(), buildCsp(), config, decodeJwtPayload(), generateNonce(), handleTrackingHost(), isIpAllowed() (+6 more)
 
 ### Community 2513 - "Community 2513"
-Cohesion: 0.03
-Nodes (78): admin_close_ticket(), admin_delete_faq(), admin_get_tickets(), admin_reset_surge_to_auto(), admin_update_faq(), admin_update_surge(), assign_driver_area(), cancel_scheduled_ride() (+70 more)
+Cohesion: 0.10
+Nodes (30): _deliver_push_now(), _is_expo_token(), bool, Return True if the token is an Expo push token (not a native FCM token)., Send a push notification via Expo's push API (for Expo-managed tokens)., Return True if the token is an Expo push token (not a native FCM token)., Send a push notification via Expo's push API (for Expo-managed tokens)., Attempt a single, immediate push delivery. Returns True on success.      Routes (+22 more)
+
+### Community 2514 - "Community 2514"
+Cohesion: 0.17
+Nodes (10): _make_db(), Tests for DispatchService.  Exercises the pure helpers directly and the class me, Minimal mock db supporting the flat Supabase-style interface DispatchService use, First driver is taken, second succeeds — walk the list., Minimal mock db supporting the flat Supabase-style interface DispatchService use, First driver is taken, second succeeds — walk the list., TestDispatchServiceAssign, TestDispatchServiceClaim (+2 more)
 
 ### Community 2515 - "Community 2515"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): code:block1 (users 1──── many rides (as rider)), Core Tables, corporate_accounts, Database, drivers, notifications, payments, promotions (+5 more)
 
 ### Community 2516 - "Community 2516"
@@ -5787,59 +5959,59 @@ Cohesion: 0.24
 Nodes (6): AgentTask, Any, str, Generate documentation., Generate API documentation., Store documentation-specific knowledge.
 
 ### Community 2517 - "Community 2517"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): API Endpoint Rules, Authentication Pattern, Backend Developer Role, Checklist Before Submitting Backend Code, code:python (# REQUIRED pattern for all endpoints), code:python (# Standard authenticated endpoint), Coding Rules, Database Rules (+5 more)
 
 ### Community 2518 - "Community 2518"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Always Required, Code Documentation Standards, code:python (# Every public function needs a docstring), code:typescript (/**), Documentation Lead Role, Documentation Review Checklist, Living Documentation Files, Python (Backend) (+5 more)
 
 ### Community 2519 - "Community 2519"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Admin Dashboard (Next.js), API Integration, Checklist Before Submitting Frontend Code, code:typescript (// REQUIRED Zustand store pattern), Coding Rules, Component Rules, File Organization, Frontend Developer Role (+5 more)
 
 ### Community 2520 - "Community 2520"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Backend Deployment Workflow, code:bash (cd backend && python -m pytest -v --tb=short), code:bash (railway variables --service backend), code:bash (railway up --service backend), code:bash (# Check deployment status), code:bash (railway redeploy --service backend), Rollback Procedure, Step 1: Pre-Deployment Checks (+5 more)
 
 ### Community 2521 - "Community 2521"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (12): Branch 1 — `sprint7/merge-sprint6-security`, Branch 2 — `sprint7/otp-lockout-redis`, Branch 3 — `sprint7/migration-runner`, Branch 4 — `sprint7/cancellation-ux-and-admin-tests`, Changes, Changes, Changes, Changes (+4 more)
 
 ### Community 2522 - "Community 2522"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): 1. Backend (`backend/`), 2. Rider App (`rider-app/`), 3. Driver App (`driver-app/`), 4. Admin Dashboard (`admin-dashboard/`), 5. Shared Package (`shared/`), 6. AI Agents (`agents/`), 7. CI/CD Pipeline (`.github/workflows/`), 8. Database & Infrastructure (+5 more)
 
 ### Community 2523 - "Community 2523"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Account / identity abuse, Checklist, code:bash (# Promo code abuse controls), Common Findings, Dimension 19 — Fraud Detection, Fraud operations, How to Test, Payment / wallet abuse (+5 more)
 
 ### Community 2524 - "Community 2524"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Audit trail, Checklist, code:bash (# Wallet delta function enforcement), Common Findings, Corporate billing, Daily reconciliation (automated), Dimension 20 — Financial Reconciliation, Dispute / chargeback accounting (+5 more)
 
 ### Community 2525 - "Community 2525"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): After All Sprints Are Verified, code:block1 (ROLE), code:yaml (===VERIFICATION-YAML===), code:markdown (### rider-P0-1 · Emergency SOS Silently Fails on Network Err), Notes for the Verifier, Output Schema (REQUIRED), Owner Taxonomy (identical to driver), Prompt (paste into a fresh agent call — one call per sprint) (+5 more)
 
 ### Community 2526 - "Community 2526"
-Cohesion: 0.33
-Nodes (4): init_firebase(), Initialize Firebase Admin SDK, Initialize Firebase Admin SDK, Test Firebase initialization.
+Cohesion: 0.13
+Nodes (8): A single tower-handoff teleport must not inflate actual_distance_km.          Re, A single tower-handoff teleport must not inflate actual_distance_km.          Re, Heavy geometry → ride_routes (upsert); rides keeps only scalars., _ride(), TestCancelRide, TestCompleteRide, TestGetRideHistory, TestStartRide
 
 ### Community 2527 - "Community 2527"
 Cohesion: 0.27
-Nodes (14): Corporate Accounts API Fix (Historical), Corporate Account Status State Machine, corporate_accounts DB Table, corporate_autotopup_loop Background Worker, corporate_low_balance_loop Background Worker, corporate_members DB Table, corporate_policies DB Table, corporate_wallet_apply_delta (Postgres RPC) (+6 more)
+Nodes (13): Corporate Accounts API Fix (Historical), Corporate Account Status State Machine, corporate_accounts DB Table, corporate_autotopup_loop Background Worker, corporate_low_balance_loop Background Worker, corporate_members DB Table, corporate_policies DB Table, corporate_wallet_apply_delta (Postgres RPC) (+5 more)
 
 ### Community 2528 - "Community 2528"
-Cohesion: 0.14
-Nodes (10): _check_license_plate(), _check_vin(), Any, str, Validate vehicle licence plate: 2–8 uppercase alphanumeric characters., Validate vehicle licence plate: 2–8 uppercase alphanumeric characters., Validate VIN: exactly 17 alphanumeric characters (I, O, Q excluded per ISO 3779), Validate VIN: exactly 17 alphanumeric characters (I, O, Q excluded per ISO 3779) (+2 more)
+Cohesion: 0.15
+Nodes (12): API_URL, getBackendUrl(), styles, client, getAuthHeader(), getStoredToken(), LoginScreen(), firebaseConfig (+4 more)
 
 ### Community 2529 - "Community 2529"
-Cohesion: 0.17
-Nodes (16): int, str, WebSocket, get_ride_eta_seconds(), _handle_driver_ws_disconnect(), heartbeat_task(), Read the row's current ``token_version`` for this connection (B-P1-11).      The, Read the row's current ``token_version`` for this connection (B-P1-11).      The (+8 more)
+Cohesion: 0.09
+Nodes (39): bool, float, int, str, WebSocket, Any, bool, datetime (+31 more)
 
 ### Community 2530 - "Community 2530"
-Cohesion: 0.14
+Cohesion: 0.19
 Nodes (13): client_with_mocks(), Tests for HttpOnly cookie-based authentication., Provide test client with all external dependencies mocked., Verify cookies are configured with correct security flags., Verify httponly and other security cookie settings are enabled., Verify cookie security configuration is set at app creation., Verify response format doesn't expose tokens in JSON body., Document that clients must use credentials: 'include' for cookie-based auth. (+5 more)
 
 ### Community 2531 - "Community 2531"
@@ -5847,31 +6019,31 @@ Cohesion: 0.19
 Nodes (8): str, Tests for PATCH /rides/{id}/notes — rider-attached post-confirm note.  Endpoint, Once the ride is in_progress the note is locked (409)., Rider can attach a note while driver is en route., Empty/whitespace input clears the column to NULL., A user other than the rider gets 403., _ride(), TestRideNotesPatch
 
 ### Community 2532 - "Community 2532"
-Cohesion: 0.20
-Nodes (12): bool, int, _call_set_available(), Unit tests for the is_available ⇒ is_online invariant in repositories/driver_rep, Build a fluent supabase mock. select(...) returns the row's online     state; up, available=True on an offline driver clamps is_available to False., available=True on an online driver stays available., The total_rides increment path also enforces the invariant. (+4 more)
+Cohesion: 0.24
+Nodes (13): bool, int, _call_set_available(), _passthrough_run_sync(), Unit tests for the is_available ⇒ is_online invariant in repositories/driver_rep, Build a fluent supabase mock. select(...) returns the row's online     state; up, available=True on an offline driver clamps is_available to False., available=True on an online driver stays available. (+5 more)
 
 ### Community 2533 - "Community 2533"
-Cohesion: 0.24
-Nodes (4): Validate GPS coordinates.      Valid ranges:     - Latitude: -90 to 90     - Lon, Validate GPS coordinates.      Valid ranges:     - Latitude: -90 to 90     - Lon, validate_coordinates(), TestValidateCoordinates
+Cohesion: 0.15
+Nodes (17): Any, bool, int, str, count_by_status(), fetch_window(), list_mirror(), mirror_count() (+9 more)
 
 ### Community 2534 - "Community 2534"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Auto-Fixes Applied Today, Backlog Health (Lens 4), CI/CD Health (Lens 2), Code Quality (Lens 3), code:bash (cd rider-app && npm audit fix && cd ../driver-app && npm aud), code:bash (git checkout 58fec396 -- docs/audit/00_SPINR_FULL_OVERVIEW.m), Executive Summary, Questions for the Team (+5 more)
 
 ### Community 2535 - "Community 2535"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): 1. Pick reviewer numbers + codes, 2. Set the backend env var (Railway), 3. Rider reviewer account — nothing to seed, 4. Driver reviewer account — pre-approve once, App Store Connect → App Review Information, code:block1 (REVIEW_LOGIN_ACCOUNTS=+13065550100:4821,+13065550101:4821), code:sql (-- after the reviewer driver has logged in once (users row e), Google Play Console → App access (+5 more)
 
 ### Community 2536 - "Community 2536"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): 2026-04-27 Sweep Results, Apply a transitive-dep fix, Cadence, code:bash (# Backend), code:jsonc ("overrides": {), Deferred CVEs, Operating, Run a full sweep (+5 more)
 
 ### Community 2537 - "Community 2537"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Alert Action (when discrepancy detected), code:python (# backend/utils/reconciliation.py (create if absent)), Cron Job, Failure Modes, Inputs, Integration with DV-4 (Idempotency Key Fix), Investigation steps, Known Edge Cases (+5 more)
 
 ### Community 2538 - "Community 2538"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): code:block1 (⚠️ Service Disruption), Communication Template, Detection, Drill, Known Dependencies, Mitigation Options (in order of preference), Option 1: Wait for Supabase recovery (most outages), Option 2: Failover to read-replica (if configured) (+5 more)
 
 ### Community 2539 - "Community 2539"
@@ -5895,35 +6067,35 @@ Cohesion: 0.14
 Nodes (14): otp, changeNumber, codeSent, codeSentMsg, failed, failedMsg, invalidCode, invalidCodeMsg (+6 more)
 
 ### Community 2544 - "Community 2544"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (13): Checklist, code:sql (UPDATE rides SET driver_id = $driver_id, status = 'driver_as), code:python (import hashlib), code:python (# Instead of:), code:tsx (import { useSafeAreaInsets } from 'react-native-safe-area-co), P0-1 · App Will Crash at Login — Wrong Database Field Name, P0-2 · App Will Crash — Broken refresh_token Function, P0-3 · Two Drivers Can Accept the Same Ride at the Same Time (+5 more)
 
 ### Community 2545 - "Community 2545"
-Cohesion: 0.14
+Cohesion: 0.13
 Nodes (12): 19-1 · Rating field-name mismatch — drivers silently unrated, 20-1 · Wallet UPDATE bypasses atomicity RPC + uses float + $set wrapper, 20-2 · Daily Stripe ↔ DB ↔ wallet reconciliation cron missing, 20-3 · `financial_events` append-only ledger table does not exist, 21-2 · Rider pickup/dropoff addresses retained in driver response, 22-2 · Supabase Canadian region attestation not on file, code:python (# Before (line 1773):), code:python (# Before:) (+4 more)
 
 ### Community 2546 - "Community 2546"
-Cohesion: 0.14
-Nodes (13): expo, install, exclude, main, name, overrides, protobufjs, @tootallnate/once (+5 more)
+Cohesion: 0.11
+Nodes (22): expo, install, exclude, main, name, overrides, protobufjs, @tootallnate/once (+14 more)
 
 ### Community 2547 - "Community 2547"
 Cohesion: 0.14
 Nodes (14): scripts, android, build:web, doctor, ios, lint, postinstall, start (+6 more)
 
 ### Community 2548 - "Community 2548"
-Cohesion: 0.15
+Cohesion: 0.24
 Nodes (12): category, content, created_at, id, metadata, priority, task_id, relevance_score (+4 more)
 
 ### Community 2549 - "Community 2549"
-Cohesion: 0.15
+Cohesion: 0.24
 Nodes (12): category, content, created_at, id, metadata, priority, task_id, relevance_score (+4 more)
 
 ### Community 2550 - "Community 2550"
-Cohesion: 0.15
+Cohesion: 0.24
 Nodes (12): category, content, created_at, id, metadata, priority, task_id, relevance_score (+4 more)
 
 ### Community 2551 - "Community 2551"
-Cohesion: 0.15
+Cohesion: 0.24
 Nodes (12): category, content, created_at, id, metadata, priority, task_id, relevance_score (+4 more)
 
 ### Community 2552 - "Community 2552"
@@ -5935,52 +6107,52 @@ Cohesion: 0.15
 Nodes (13): 6.10 Testing & CI, 6.11 Operational & DX, 6.12 Quick wins (< 1 hour each) to start immediately, 6.1 Authentication & session (highest priority), 6.2 RBAC & least privilege, 6.3 Audit logging & monitoring, 6.4 UI/UX hardening, 6.5 Security headers, CSP, transport (+5 more)
 
 ### Community 2554 - "Community 2554"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): Background tasks, Checklist, code:bash (# Check for banned logger.warning on critical paths), Common Findings, Crash reporting (mobile), Dimension 17 — Observability, How to Test, Metrics (prod SLIs) (+4 more)
 
 ### Community 2555 - "Community 2555"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): code:python (supabase.table("rides").update({...})), code:yaml (===VERIFICATION-YAML===), Driver App — P0 Remediation Verification, New issues discovered (not in scope for this verification), P0-1 · App Will Crash at Login — Wrong Database Field Name, P0-2 · App Will Crash — Broken `refresh_token` Function, P0-3 · Two Drivers Can Accept the Same Ride at the Same Time, P0-4 · Pickup Code Stored as Plain Text (+4 more)
 
 ### Community 2556 - "Community 2556"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:00:43.4096703Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2557 - "Community 2557"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:04:26.1424218Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2558 - "Community 2558"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:05:33.8690661Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2559 - "Community 2559"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:06:11.5373323Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2560 - "Community 2560"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:10:13.9290925Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2561 - "Community 2561"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:13:37.5312458Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2562 - "Community 2562"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:15:54.4119890Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2563 - "Community 2563"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. 🟠 [P1] BUILD — `backend-test`, Audit Metadata, CI Error Audit Report, code:block1 (2026-04-28T06:17:49.5698501Z Could not pull latest version i), code:bash (docker build -f backend/Dockerfile .), code:bash (cd admin-dashboard && npm run build), code:bash (cd rider-app && yarn build:web), Error Details (+4 more)
 
 ### Community 2564 - "Community 2564"
-Cohesion: 0.37
+Cohesion: 0.41
 Nodes (12): go_online(), log(), login(), main(), poll_driver_me(), int, str, Reproduce the driver "cannot go online" issue without the mobile app.  Simulates (+4 more)
 
 ### Community 2565 - "Community 2565"
-Cohesion: 0.23
-Nodes (13): Supabase Service-Role Key Rotation Guide, Database Migration to PostGIS, Backend Python Requirements, Backend Service Layer Architecture, Supabase Schema Migration Guide, DispatchService (planned), Environment Variables Reference, FareService (+5 more)
+Cohesion: 0.10
+Nodes (22): Analytics Service (Mixpanel/Amplitude), Backend (FastAPI + Supabase), Supabase Service-Role Key Rotation Guide, Backend Python Requirements, Backend Service Layer Architecture, code:bash (export PG_CONNECTION_STRING="your_connection_string"), Supabase schema & migration — Spinr, Backend Test Suite (Pytest) (+14 more)
 
 ### Community 2566 - "Community 2566"
 Cohesion: 0.15
@@ -5990,33 +6162,37 @@ Nodes (13): 6. Platform & infra, `core/config.py`, `core/lifespan.py`, `core/mid
 Cohesion: 0.17
 Nodes (11): bool, str, _make_admin_token(), An expired JWT must be rejected by the session endpoint., An expired JWT must be rejected by the session endpoint., GET /session with an expired JWT returns authenticated=false., GET /session with an expired JWT returns authenticated=false., GET /session with a fresh valid JWT returns authenticated=true. (+3 more)
 
+### Community 2568 - "Community 2568"
+Cohesion: 0.17
+Nodes (18): float, str, _filter_reachable_drivers(), Drop ghost drivers from a DB-online pool for rider-facing counts.      A driver, _make_driver(), Regression test: ghost driver filter on /rides/estimate.  Before this fix, drive, A present driver whose went_offline_at is newer than went_online_at is dropped., No drivers in → no drivers out, without touching the presence store. (+10 more)
+
 ### Community 2569 - "Community 2569"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): `.claude/` — Spinr Claude Code setup, code:block1 (.github/), code:block2 (.claude/), code:block3 (./scripts/setup-claude.sh), First-time setup, Layout, Non-goals, Permissions model (+4 more)
 
 ### Community 2570 - "Community 2570"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. Incident Summary, 2. Code-Side Status (✅ done in this commit), 3.1 Rotate the Supabase service-role key, 3.2 Scrub git history (if applicable), 3.3 Determine breach-notification obligation (PIPEDA), 3.4 Update internal trackers, 3. Human Actions Outstanding (⚠ block closure), 4. PIPEDA 72-h Clock (+4 more)
 
 ### Community 2571 - "Community 2571"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): 1. Authentication, 2. Ride Request (Rider), 3. Mid-Trip (Rider + Driver), 4. SOS / Safety, 5. Push Notifications (FCM / APNs), 6. Background Location (Driver), 7. Payments, 8. Driver Offline Guard (+4 more)
 
 ### Community 2572 - "Community 2572"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): Communication, Detection, If `RATE_LIMIT_REDIS_URL` is down, If `REDIS_URL` (OTP + session cache) is down, If `WS_REDIS_URL` (pub/sub) is down, Known Gaps (feed back into framework), Mitigation, Post-Incident (+4 more)
 
 ### Community 2573 - "Community 2573"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): Abuse / False SOS Handling, code:block1 (User taps SOS button (rider or driver)), Dispatch Response Adjustments, Known Gaps, Law Enforcement Handoff, On-Call Responder Flow (first 5 min), Post-Incident (within 72 h), Purpose (+4 more)
 
 ### Community 2574 - "Community 2574"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): Admin-Facing SLOs (operational), Alerting Channels, Backend / Infra SLIs / SLOs, Change Log, Driver-Facing SLIs / SLOs, Error Budget Policy, Measurement Infrastructure, Principles (+4 more)
 
 ### Community 2575 - "Community 2575"
-Cohesion: 0.15
-Nodes (12): errors, failedToLoad, networkError, serverError, tryAgain, unauthorized, unknown, tabs (+4 more)
+Cohesion: 0.09
+Nodes (21): errors, failedToLoad, networkError, serverError, tryAgain, unauthorized, unknown, notifications (+13 more)
 
 ### Community 2576 - "Community 2576"
 Cohesion: 0.15
@@ -6035,15 +6211,15 @@ Cohesion: 0.15
 Nodes (12): build, builder, dockerfilePath, deploy, healthcheckPath, healthcheckTimeout, numReplicas, restartPolicyMaxRetries (+4 more)
 
 ### Community 2580 - "Community 2580"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (11): Checklist, code:python (current_admin: dict = Depends(get_current_admin)), code:python (admin_router = APIRouter(dependencies=[Depends(get_current_a), code:python (user_email = current_user["phone_or_email"]  # from JWT), P0-1 · Admin Dispute Endpoints Have No Authentication, P0-2 · Admin Promo Endpoints Have No Authentication, P0-3 · /rider/work-profile/join-domain Authorization Bypass, P0-4 · /wallet/top-up — TOCTOU Race Condition (Balance Corruption) (+3 more)
 
 ### Community 2581 - "Community 2581"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): Checklist, P1 — Rider App High Priority: Fix Before Beta Testing, R-P1-10 · No i18n Library — All Strings Are Hardcoded English, R-P1-21 · createRide() Missing Idempotency Key — Double Charge on Network Retry, R-P1-23 · rideStore.test.ts Missing hydrateActiveRide, Double-Booking Guard,, R-P1-24 · rideStore.ws.test.ts Missing driver_timeout, ride_cancelled, WS/Poll Race, R-P1-25 · walletStore.test.ts Missing payWithWallet and Tip Idempotency Tests, R-P1-26 · E2E ride-booking.spec.ts Missing Rating/Tip Steps and UI Assertions (+4 more)
 
 ### Community 2582 - "Community 2582"
-Cohesion: 0.15
+Cohesion: 0.14
 Nodes (12): Checklist, P4 — Rider App Future Features: Post-Launch Roadmap, R-P4-10 · Scheduled Ride Push Reminder, R-P4-1 · In-App Navigation (Turn-by-Turn for Rider Sharing), R-P4-2 · Promo Selection UI, R-P4-3 · Ride Receipt Sharing, R-P4-4 · Dark Mode, R-P4-5 · Multi-Language Beyond French (+4 more)
 
 ### Community 2583 - "Community 2583"
@@ -6055,19 +6231,19 @@ Cohesion: 0.17
 Nodes (12): scripts, build, dev, lint, start, test, test:coverage, test:e2e (+4 more)
 
 ### Community 2585 - "Community 2585"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): Admin Dashboard Audit — Remediation Plan, code:python (# In settings.py GET handler, after fetching settings:), code:python (@router.put("/staff/{staff_id}")), code:python (# Add to top of file:), code:python (if "surge_multiplier" in allowed_fields and body.get("surge_), P0-1: Mask credentials in `GET /settings` response (F-24), P0-2: Fix privilege escalation in `PUT/DELETE /staff/{id}` (F-25), P0-3: Enforce surge cap in `fare_service.py` (F-26) (+3 more)
 
 ### Community 2586 - "Community 2586"
 Cohesion: 0.17
-Nodes (9): adminAuthIdx, backendResponse, catchAllIdx, clientResponse, configPath, headerVal, mockBackendResponse, req (+1 more)
+Nodes (11): adminAuthIdx, backendResponse, catchAllIdx, clientResponse, configPath, headerVal, makeMockCookies(), makeMockNextResponse() (+3 more)
 
 ### Community 2587 - "Community 2587"
-Cohesion: 0.27
+Cohesion: 0.35
 Nodes (11): create_incentive(), delete_incentive(), get_incentive(), incentive_claim_stats(), IncentiveCreateRequest, IncentiveUpdateRequest, list_incentives(), toggle_incentive() (+3 more)
 
 ### Community 2588 - "Community 2588"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): Admin / Operations — Table Stakes, code:markdown (## Product Manager Review — Iteration [N]), Driver Experience — Table Stakes, Features Every Top Rideshare App Has (Uber, Lyft, Bolt, Careem, DiDi), Output Format, Product Manager — Rideshare Industry Expert, Rider Experience — Table Stakes, Rideshare Industry Knowledge (+3 more)
 
 ### Community 2589 - "Community 2589"
@@ -6075,139 +6251,143 @@ Cohesion: 0.17
 Nodes (11): Architecture Overview, code:mermaid (graph TB), code:mermaid (erDiagram), Conclusion, Current Implementation:, Database Schema (PostgreSQL), Executive Summary, Key Tables with Relationships: (+3 more)
 
 ### Community 2590 - "Community 2590"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): code:yaml (===VERIFICATION-YAML===), Driver App — P4 Remediation Verification, New issues discovered (not in scope for this verification), P4-1 · AI Support Bot (Gemini), P4-2 · In-App FAQ Screen, P4-3 · 4 Missing App Screens, P4-4 · Enable Firebase App Check, P4-5 · Maestro E2E Flows for Core Ride Scenarios (+3 more)
 
 ### Community 2591 - "Community 2591"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): Per-Item Verification, Rider App — P0 Sprint Verification (2026-04-24), rider-P0-1 · Emergency SOS silently fails on network error, rider-P0-2 · OfflineBanner overlaps notch / status bar, rider-P0-3 · OTP stored in plaintext on ride creation, rider-P0-4 · Hardware back button exits active ride, rider-P0-5 · Double-booking via rapid taps on book button, rider-P0-6 · Home-screen SOS button is fake / shows false confirmation (+3 more)
 
 ### Community 2592 - "Community 2592"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2593 - "Community 2593"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2594 - "Community 2594"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2595 - "Community 2595"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2596 - "Community 2596"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2597 - "Community 2597"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2598 - "Community 2598"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2599 - "Community 2599"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2600 - "Community 2600"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2601 - "Community 2601"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2602 - "Community 2602"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2603 - "Community 2603"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2604 - "Community 2604"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2605 - "Community 2605"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2606 - "Community 2606"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2607 - "Community 2607"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2608 - "Community 2608"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2609 - "Community 2609"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2610 - "Community 2610"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2611 - "Community 2611"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2612 - "Community 2612"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. 🟠 [P1] TEST — `backend-test`, Audit Metadata, CI Error Audit Report, code:bash (pytest <test_path> -v), code:bash (pytest -v), Error Details, Errors Found, Executive Summary (+3 more)
 
 ### Community 2613 - "Community 2613"
-Cohesion: 0.21
+Cohesion: 0.22
 Nodes (10): FastAPI, cleanup_database(), init_database(), lifespan(), Initialize database connection and verify it is reachable.      The supabase-py, Cleanup database connections on shutdown., Manage application lifespan events, configure_stripe() (+2 more)
 
+### Community 2614 - "Community 2614"
+Cohesion: 0.13
+Nodes (7): _crumb(), _FakeClient, _FakeNoMatchClient, _FakeNoMatchResp, _FakeResp, test_osrm_no_match_is_likely_spoofed_without_google_fallback(), test_validate_trip_route_prefers_osrm_match()
+
 ### Community 2615 - "Community 2615"
-Cohesion: 0.33
-Nodes (3): str, generate_ride_code(), Return a fresh SPR-XXXXXX code using a crypto-strong RNG.
+Cohesion: 0.25
+Nodes (4): str, generate_ride_code(), Human-readable short codes for ride rows.  rides.id stays a UUID (foreign keys,, Return a fresh SPR-XXXXXX code using a crypto-strong RNG.
 
 ### Community 2616 - "Community 2616"
-Cohesion: 0.35
+Cohesion: 0.38
 Nodes (11): derive_driver_onboarding_status(), _has_profile(), _has_vehicle(), _parse_date(), Any, bool, datetime, str (+3 more)
 
 ### Community 2617 - "Community 2617"
-Cohesion: 0.05
-Nodes (53): str, float, int, Request, str, AppSettings, FareConfig, SavedAddress (+45 more)
+Cohesion: 0.03
+Nodes (84): admin_list_legal_documents(), admin_upsert_legal_document(), Admin CRUD for per-audience legal documents (Terms of Service + Privacy Policy)., Return every per-audience legal document row., Create or update an (audience, doc_type) row in one shot.      Body: { audience:, admin_get_heatmap_settings(), admin_get_settings(), admin_reveal_setting() (+76 more)
 
 ### Community 2618 - "Community 2618"
-Cohesion: 0.17
-Nodes (7): Send a message to a client, possibly on a different machine.          When ``ws_, Write ``message`` to the socket for ``client_id`` on THIS machine only., Broadcast to every admin client across the fleet.          Fans out via Redis pu, Emit a unified ``ride_status_changed`` event for a ride transition.          Bot, Emit a unified ``ride_status_changed`` event for a ride transition.          Rid, Deliver ``message`` to every local socket whose key starts with         ``prefix, Deliver ``message`` to every local socket whose key starts with         ``prefix
+Cohesion: 0.21
+Nodes (9): RootLayout(), metadata, AnalyticsWrapper(), AuthInitializer(), ThemeProvider(), Tooltip(), TooltipContent(), TooltipProvider() (+1 more)
 
 ### Community 2619 - "Community 2619"
-Cohesion: 0.29
+Cohesion: 0.36
 Nodes (11): str, _make_http_mocks(), _ok_status(), Unit tests for utils/loop_alert.py.  Pins:   - No HTTP call when webhook_url is, Return (cm_mock, inner_client_mock) for patching httpx.AsyncClient.      httpx.A, _stale_status(), test_logs_error_on_post_failure(), test_no_call_when_no_stale_loops() (+3 more)
 
 ### Community 2620 - "Community 2620"
-Cohesion: 0.24
-Nodes (9): MagicMock, Exception, When the DB write fails during Firebase auth, the endpoint must raise     HTTPEx, Return a firebase_admin.auth stub whose verify_id_token returns payload., When the DB write fails during Firebase auth, the endpoint must raise     HTTPEx, Return a firebase_admin.auth stub whose verify_id_token returns payload., TestFirebaseAuthDbFailureRaises503, Firebase + legacy JWT both failing produces an error, never auth_success. (+1 more)
+Cohesion: 0.18
+Nodes (11): MagicMock, Exception, _noop_limit_factory(), Regression tests for backend P1 auth-hardening items.  B-P1-1: FIREBASE_DRIVER_A, When the DB write fails during Firebase auth, the endpoint must raise     HTTPEx, Return a firebase_admin.auth stub whose verify_id_token returns payload., When the DB write fails during Firebase auth, the endpoint must raise     HTTPEx, Return a firebase_admin.auth stub whose verify_id_token returns payload. (+3 more)
 
 ### Community 2621 - "Community 2621"
-Cohesion: 0.30
+Cohesion: 0.33
 Nodes (11): MagicMock, str, _fake_intent(), _make_ride(), Unit tests for payment_retry double-charge guard.  Verifies that: 1. A Stripe PI, When Stripe reports the PI as 'requires_payment_method', the loop must:       -, When stripe.PaymentIntent.retrieve raises a StripeError, the loop must:       -, When Stripe reports the PI as 'succeeded', the loop must:       - Update the DB (+3 more)
 
 ### Community 2622 - "Community 2622"
-Cohesion: 0.23
-Nodes (11): Unit tests for backend/utils/stuck_ride_sweeper.py., When UPDATE returns 0 rows (another replica claimed it), no WS or push is sent., Import and return the _sweep coroutine after patches are in place., A searching ride older than 5 min is claimed and WS event is sent., An in_progress ride is never returned by the WHERE clause and never touched., A searching ride less than 5 min old is excluded by the lt() cutoff., _sweep(), test_in_progress_ride_not_cancelled() (+3 more)
+Cohesion: 0.11
+Nodes (13): get_driver_documents(), Get all documents uploaded by the current driver., Get all documents uploaded by the current driver., Unit tests for document management functionality. Tests cover document requireme, Tests for document expiry tracking., Test checking for expiring documents., Test marking expired documents., Regression tests for bugs that were previously found and fixed. (+5 more)
 
 ### Community 2623 - "Community 2623"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): Auth, Code Quality, Insurance Periods, Location / Privacy, Money / Payments, Output Format, /review — Pre-Commit Code Review for spinr, Safety (+3 more)
 
 ### Community 2624 - "Community 2624"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): code:block1 (# Surge multiplies the distance and time components ONLY — n), Common pitfalls, Corporate billing, Domain — Payments, Fare breakdown, Key files, Money arithmetic — hard rules, Receipts (+3 more)
 
 ### Community 2625 - "Community 2625"
@@ -6215,11 +6395,11 @@ Cohesion: 0.17
 Nodes (12): 1.1 Project Memory Files, 1.2 Settings Files, 1.3 Slash Commands (`.claude/commands/*.md`), 1.4 Hooks (`.claude/hooks/` + `.git/hooks/`), 1.5 Launch Configurations (`.claude/launch.json`), 1.6 MCP Servers & Plugins, 1.7 Subagent Definitions (`.claude/agents/*.md`), `~/.claude/` other state (+4 more)
 
 ### Community 2626 - "Community 2626"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 6.1 Rule → Regulatory Regime, 6.2 Coverage Assessment, Appendix A — Quick Reference, Appendix B — Glossary, Appendix C — Remediation Checklist, Claude Configuration Audit — spinr, code:bash (# 1. Install pre-commit hook (P0-002)), Executive Summary (+3 more)
 
 ### Community 2627 - "Community 2627"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1 · Private Bug Bounty, 2 · Coordinated Disclosure (SECURITY.md), 3 · Third-Party Pen-Test, 4 · PCI-DSS ASV Scan, 5 · Red-Team Exercise, 6 · Tabletop Exercises, code:block1 (Targets:), External Security Testing Program (+3 more)
 
 ### Community 2628 - "Community 2628"
@@ -6235,8 +6415,8 @@ Cohesion: 0.17
 Nodes (12): home, accept, decline, gettingLocation, go, goOffline, goOnline, noRideRequests (+4 more)
 
 ### Community 2631 - "Community 2631"
-Cohesion: 0.17
-Nodes (12): resolutions, expo-modules-core, postcss, protobufjs, react, react-dom, @react-native-async-storage/async-storage, @react-native-community/netinfo (+4 more)
+Cohesion: 0.08
+Nodes (29): reactNativeDirectoryCheck, expo, doctor, install, exclude, main, name, overrides (+21 more)
 
 ### Community 2632 - "Community 2632"
 Cohesion: 0.17
@@ -6267,19 +6447,19 @@ Cohesion: 0.17
 Nodes (11): API Configuration, Autocomplete Implementation, Dependencies Installed, Google Maps & Places API Integration - COMPLETE, 📋 Implementation Summary, ✅ Integration Status: FULLY IMPLEMENTED, 🎯 Key Improvements Made, Map Implementation (+3 more)
 
 ### Community 2639 - "Community 2639"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): 1. Verify the Supabase project region, 2. Obtain written DPA from Supabase, 3. File the attestation, 4. Set the environment variable, 5. Verify the checklist at next privacy review, Background, code:block1 (SUPABASE_REGION=ca-central-1), Contact (+3 more)
 
 ### Community 2640 - "Community 2640"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): code:bash (# Edit node_modules/@stripe/stripe-react-native/android/grad), Files in this directory, Option B — Kotlin 2.1.20 strategy (RN's intended default), See also, Trade-offs, Verifying ksp version availability, When to use this strategy, Why not just use this from the start? (+3 more)
 
 ### Community 2641 - "Community 2641"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): A-PE-P3-1 · Build Output Not Scanned for Secrets, A-PE-P3-2 · NEXT_PUBLIC_API_URL: Add Localhost Fallback Warning, A-PE-P3-3 · lucide-react SVG Rendering — Upgrade to Latest, A-PE-P3-4 · Sentry Release Tag Already Added (Verify Integration), A-PE-P3-5 · Vendor Register (PIPEDA DPA Inventory), A-PE-P3-6 · noopener on target="_blank" Links, A-PE-P3-7 · Service Worker Usage Policy (Documentation), Already Implemented in This Session (+3 more)
 
 ### Community 2642 - "Community 2642"
-Cohesion: 0.17
+Cohesion: 0.15
 Nodes (11): Checklist, code:typescript (minimumDate={new Date(Date.now() + 15 * 60 * 1000)} // at le), P3 — Rider App Hardening: Fix Before Scale, R-P3-1 · Rate Limiting on Rider-Specific Endpoints, R-P3-2 · FCM Token Rotation Not Handled, R-P3-3 · Driver Location Marker Not Memoized, R-P3-4 · Activity FlatList Not Paginated, R-P3-5 · Home Screen Fires Too Many Requests on Mount (+3 more)
 
 ### Community 2643 - "Community 2643"
@@ -6287,8 +6467,8 @@ Cohesion: 0.17
 Nodes (12): common, back, cancel, close, confirm, done, error, loading (+4 more)
 
 ### Community 2644 - "Community 2644"
-Cohesion: 0.17
-Nodes (12): errors, ride, unknown, wallet, already_cancelled, invalid_status, no_drivers_available, not_found (+4 more)
+Cohesion: 0.29
+Nodes (7): ride, already_cancelled, invalid_status, no_drivers_available, not_found, price_mismatch, taken
 
 ### Community 2645 - "Community 2645"
 Cohesion: 0.17
@@ -6302,84 +6482,88 @@ Nodes (12): common, back, cancel, close, confirm, done, error, loading (+4 more)
 Cohesion: 0.17
 Nodes (9): After _LOGIN_MAX_FAILURES failures the account is locked (HTTP 423)., After _LOGIN_MAX_FAILURES failures the account is locked (HTTP 423)., Mock Redis to report failure threshold reached → expect 423., Mock Redis to report failure threshold reached → expect 423., When _is_account_locked returns False, login proceeds normally (401 on bad creds, When _is_account_locked returns False, login proceeds normally (401 on bad creds, _record_login_failure must be called when credentials are wrong., _record_login_failure must be called when credentials are wrong. (+1 more)
 
-### Community 2648 - "Community 2648"
-Cohesion: 0.27
-Nodes (4): _async_iter(), Cover the Redis-connected branches of redis_client.py helpers.      We mock _get, Async generator for mock scan_iter., TestRedisClientRedisPaths
-
 ### Community 2649 - "Community 2649"
-Cohesion: 0.17
-Nodes (6): Tests for OTP record operations., Test inserting an OTP record via Collection.insert_one delegation., Test finding OTP by phone and code via Collection.find_one delegation., Test verifying an OTP record via Collection.update_one delegation., Test deleting expired OTP records via Collection.delete_one delegation., TestOTPRecordOperations
+Cohesion: 0.22
+Nodes (17): _atan2_pos(), _clamp(), main(), _over(), Render the Spinr spiral mark centered in a size×size RGBA buffer.      Uses the, Emit the Spinr spiral mark as a scalable SVG (same geometry as the PNGs).      I, Source-over compositing. dst/src premultiplied-free, alpha in [0,1]., render_mark() (+9 more)
 
 ### Community 2650 - "Community 2650"
 Cohesion: 0.40
 Nodes (3): get_legal_settings(), Return the current Terms of Service + Privacy Policy text.      Falls back to a, Return the current Terms of Service + Privacy Policy text.      Falls back to a
+
+### Community 2651 - "Community 2651"
+Cohesion: 0.11
+Nodes (17): 1. What shipped in this commit, 1a. Redis row-level cache (`backend/db_supabase.py`), 1b. Circuit breaker tightened (`_CircuitBreaker`), 2. How Redis helps (high-level diagrams), 2a. Before the cache, 2b. After the cache, 2c. End-to-end request flow with cache + circuit breaker + retry, 3. Extending Redis to more DB calls — the rules (+9 more)
 
 ### Community 2652 - "Community 2652"
 Cohesion: 0.17
 Nodes (7): Tests for ride status update functionality., Tests for ride status update functionality., Test updating ride status., Test updating ride with driver assignment., Test completing a ride., Test cancelling a ride., TestRideStatusUpdates
 
 ### Community 2653 - "Community 2653"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): code:block1 (Rider: Alex Chen), Data Used (Realistic), Design Question, Key Design Decisions, Recommendation, Rider Booking — Sketch 005, Saskatchewan Regulatory Compliance, Stages Covered (+2 more)
 
 ### Community 2654 - "Community 2654"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): code:block1 (Rider: Alex Chen), Data Used (Realistic), Design Question, Key Design Decisions, Recommendation, Rider Active Ride — Sketch 006, Safety Coverage (per CLAUDE.md principle: SOS within 2 taps), Saskatchewan Regulatory Compliance (+2 more)
 
+### Community 2655 - "Community 2655"
+Cohesion: 0.21
+Nodes (15): admin_create_faq(), admin_delete_faq(), admin_get_faqs(), admin_get_notifications(), admin_send_notification(), admin_update_faq(), FaqCreateRequest, FaqUpdateRequest (+7 more)
+
 ### Community 2656 - "Community 2656"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): New Feature Development Workflow, Step 1: Understand Requirements, Step 2: Plan Implementation, Step 3: Database Changes (if needed), Step 4: Backend Implementation, Step 5: Frontend Implementation, Step 6: Write Tests, Step 7: Security Review (+2 more)
 
 ### Community 2657 - "Community 2657"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): code:bash (git diff --name-only HEAD~1), Documentation Update Workflow, Step 1: Identify What Changed, Step 2: Update API Reference, Step 3: Update Database Schema, Step 4: Update Architecture, Step 5: Update Deployment Guide, Step 6: Update Code Documentation (+2 more)
 
 ### Community 2658 - "Community 2658"
-Cohesion: 0.22
-Nodes (11): Analytics Service (Mixpanel/Amplitude), Backend (FastAPI + Supabase), Backend Test Suite (Pytest), CI/CD Pipeline (GitHub Actions), Cloudinary Image Integration, Code Review Report (spinrApp 2026-03-17), disputes.py (Payment Dispute Endpoints), Enhanced Error Handling Framework (+3 more)
+Cohesion: 0.25
+Nodes (14): str, _alert_admins_payment_exhausted(), notify_driver_payout_failed(), payment_retry_loop(), _pod_id(), Payment retry — automatically retries failed ride payments with exponential back, Mark driver payouts that exceeded retry attempts as failed (8-5).      Replay-sa, Background loop that retries failed payments every RETRY_INTERVAL_SECONDS. (+6 more)
 
 ### Community 2659 - "Community 2659"
-Cohesion: 0.18
-Nodes (10): 16. Financial & Business Risk Eliminated, 19. Next Sprint Candidates, 5. Sprint 1 — CI/CD Hardening & Infrastructure Security, Branches Delivered, Document Index, Equivalent Consulting Value, Fortune 100 Security Audit, Hardening Sprint Programme & Continuous Security Framework, Key Outcomes (+2 more)
+Cohesion: 0.17
+Nodes (10): 15. Before vs. After Comparison, 16. Financial & Business Risk Eliminated, 19. Next Sprint Candidates, App Maturity Level, code:block13 (Before:  [██░░░░░░░░] ~20% — MVP prototype with critical sec), Document Index, Equivalent Consulting Value, Fortune 100 Security Audit, Hardening Sprint Programme & Continuous Security Framework (+2 more)
 
 ### Community 2660 - "Community 2660"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Branch 1 — `sprint9/e2e-playwright`, Branch 2 — `sprint9/e2e-maestro`, Branch 3 — `sprint9/accessibility`, code:block1 (npm ci → install Chromium → next build → next start & wait-o), code:bash (# Install Maestro CLI), code:tsx (<button), Issues Closed, Pre-commit Hook Results (+2 more)
 
 ### Community 2661 - "Community 2661"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): 15. Testing Coverage Map, 18. Architecture Decision Records (ADRs), 3. Application Surface Map, 8. Shared Package — Full File Mapping, Architecture Reference, Integration Guide & Alignment Document, code:block3 (spinr/), Coverage by Surface, Spinr — Comprehensive Tech Stack & File Mapping (+2 more)
 
 ### Community 2662 - "Community 2662"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Checklist, Client-Side Validation, Dimension 04 — Input Validation & Sanitisation, File Uploads, GPS & Location Fields, Monetary Fields, Phone & Identity Fields, Schema-Level Validation (+2 more)
 
 ### Community 2663 - "Community 2663"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Button Placement & Touch Targets, Checklist, Dimension 05 — Android & iOS UI/UX Quality, Font & Typography, Information Hierarchy, Keyboard Handling, Maps & GPS, Platform-Specific (+2 more)
 
 ### Community 2664 - "Community 2664"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Backend Tests (pytest), Checklist, CI Integration, Coverage Thresholds, Dimension 09 — Test Coverage, E2E Tests (Maestro), Mobile Tests (Jest + React Native Testing Library), PII / Compliance Tests (+2 more)
 
 ### Community 2665 - "Community 2665"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Backend Query Performance, Backend Scalability, Checklist, Component Re-Render Prevention, Dimension 14 — Performance & Scalability, Image Loading, JS Bundle & Startup (React Native), List Performance (React Native) (+2 more)
 
 ### Community 2666 - "Community 2666"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Android Specific, Checklist, Cognitive Accessibility, Colour & Contrast, Dimension 15 — Accessibility (WCAG 2.1 / AODA), Dynamic Text Scaling, iOS Specific, Motor Accessibility (+2 more)
 
 ### Community 2667 - "Community 2667"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): 1. OTP Digit Count — 4 Digits Is Approved, 2. Hard-Coded Dev Values — Intentional, Not a Bug, 3. Scope Boundaries, 4. Canadian Market Context, 5. Architecture Decisions — Do Not Reflag, 6. Severity Decision Guide, 7. Incident → Audit Feedback Rule, 8. Auditor Independence (+2 more)
 
 ### Community 2668 - "Community 2668"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Admin-Specific Security Checklist (Updated with Audit Results), Applicable Dimensions, Audit Logging, Audit Results (2026-04-26), Authentication, Authorisation, Data Access, Known Admin Routes (21 files confirmed) (+2 more)
 
 ### Community 2669 - "Community 2669"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Applicable Dimensions, Audit Checklist When Ready, Audit Plan Files, Confirmed Structure, Corporate Ride Flows, Key Areas to Audit (rider-specific), Module: Rider App, Pre-Audit Setup (+2 more)
 
 ### Community 2670 - "Community 2670"
@@ -6387,31 +6571,31 @@ Cohesion: 0.18
 Nodes (10): Canonical Regulatory Reference, code:block1 (audit-framework/), Completed Audits, Folder Structure, How to Run an Audit, Quick start (5 minutes to set up), Severity Scale, Spinr Audit Framework (+2 more)
 
 ### Community 2671 - "Community 2671"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): 1. Source Audits, 2. Remediation Item Counts (actionable, by module × sprint), 3. Severity-Weighted Module Risk, 4. Cross-Module Severity Distribution, 5. Cross-Module Themes, 6. Cross-Audit Duplicates (avoid double-counting), 7. Verification Status, 8. Companion Document (+2 more)
 
 ### Community 2672 - "Community 2672"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): 10. Where to look first — cheat sheet, 2. Users, 5. Corporate B2B, 8. Migrations (numbered), 9. Background loops summary, Backend Reference — Function & Class Index, Conventions, `routes/admin/staff.py` (+2 more)
 
 ### Community 2673 - "Community 2673"
-Cohesion: 0.24
+Cohesion: 0.27
 Nodes (10): float, _make_conn(), B-P3-1: tests for socket_manager.broadcast() and _deliver_broadcast_local() per-, Build a fake WebSocket whose send_json takes `send_delay` seconds., A connection whose send hangs longer than the timeout must be     skipped withou, Same contract for the prefix-scoped local fan-out used by     broadcast_to_admin, Sanity check: when no connection is stuck, every connection gets     the message, test_broadcast_propagates_message_to_all_healthy_connections() (+2 more)
 
 ### Community 2674 - "Community 2674"
-Cohesion: 0.22
-Nodes (7): str, Pins `GET /rides/active` as the reconnect state-recovery mechanism.      When a, The rider reconnects right after the driver accepted — must see         driver_a, After ride completes mid-disconnect, reconnect must not restore a         stale, A ride still in 'searching' is active from the rider's perspective —         the, _ride(), TestActiveRideHttpRecovery
+Cohesion: 0.17
+Nodes (8): ActivityScreen(), FilterType, RideHistory, fetchData(), formatDate(), getVehicleType(), onRefresh(), styles
 
 ### Community 2675 - "Community 2675"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): /adr — Architecture Decision Record, code:block1 (/adr "Use Redis Streams instead of pub/sub for WS fan-out"), code:block2 (# ADR-NNNN: <Title>), Conventions, Do NOT, Template (written to `docs/adr/NNNN-slug.md`), Usage, What it does (+2 more)
 
 ### Community 2676 - "Community 2676"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Common pitfalls, Domain — Safety, Driver-rider chat, Emergency contacts, Incident reports, Insurance period transitions (audit-critical), Key files, Night ride protections (+2 more)
 
 ### Community 2677 - "Community 2677"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Accessibility, Common pitfalls, Driver classification (contractor, not employee), Driver onboarding — eligibility gate, Insurance periods (SGI commercial layer), Provincial reporting (periodic), Regulatory — Saskatchewan, Right-to-delete (PIPEDA × Saskatchewan Transportation Act) (+2 more)
 
 ### Community 2678 - "Community 2678"
@@ -6419,7 +6603,7 @@ Cohesion: 0.18
 Nodes (10): 1. Backend Deployment (Railway - Recommended), 2. Frontend Deployment (Vercel), 3. Driver App Deployment (Vercel), 4. Admin Dashboard Deployment (Vercel), Alternative: Backend Deployment (Render), CI/CD for Railway, code:bash (railway variables set \), code:bash (railway up --service backend) (+2 more)
 
 ### Community 2679 - "Community 2679"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): CI Security Gates, code:yaml (rules:), code:yaml (# backend/pytest.ini), Coverage Floor (G10), Gate Matrix, Implementation Checklist, PR-Blocking Severity Mapping, Relationship to Audit Framework (+2 more)
 
 ### Community 2680 - "Community 2680"
@@ -6427,24 +6611,24 @@ Cohesion: 0.18
 Nodes (11): Delta — 2026-04-25 (PR #51 rollout), Executive Summary Update, N-001 (Advisory) — Session model diverges from `settings.json` pin, N-002 (P1) — `claude-review.yml` permanently fails without `ANTHROPIC_API_KEY` secret, N-003 (P2) — `CLAUDE.md` 3× expansion increases session token budget, N-004 (P2) — 4 new slash commands not yet exercised in any transcript, N-005 (info) — Pre-commit hook patched with meta-doc exclude list, New Findings (+3 more)
 
 ### Community 2681 - "Community 2681"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Annual DPA Review, Breach Notification Chain, Change Log, code:block1 (Vendor notification), Current Vendor Sub-Processor Tree (authoritative as of 2026-04-24), Data Processing Agreement (DPA) Register, Open Items, Register (+2 more)
 
 ### Community 2682 - "Community 2682"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Cadence, code:bash (# 1. Pull the current upstream image. This downloads bytes, ), code:dockerfile (# Builder stage), code:bash (git checkout -b chore/docker-base-pin-YYYYMMDD), Docker Image Pinning — Runbook, Procedure: add or refresh the SHA256 digest, Related, Threat model (+2 more)
 
 ### Community 2683 - "Community 2683"
-Cohesion: 0.18
-Nodes (10): ⚠️ Codebase async/sync pattern (read before implementing any Supabase code), code:python (async def some_helper(...) -> ...:), code:python (def _fn():), code:ts (// admin-dashboard/src/lib/api.ts), code:tsx (import {), code:bash (git add admin-dashboard/src/lib/api.ts admin-dashboard/src/a), Corporate B2B — Plan 2: Master Wallet + Stripe, Done criteria (Plan 2) (+2 more)
+Cohesion: 0.25
+Nodes (6): ⚠️ Codebase async/sync pattern (read before implementing any Supabase code), code:python (async def some_helper(...) -> ...:), code:python (def _fn():), Corporate B2B — Plan 2: Master Wallet + Stripe, Done criteria (Plan 2), Handoff to Plan 3
 
 ### Community 2684 - "Community 2684"
-Cohesion: 0.18
-Nodes (10): 10. Canadian tax, 11. Testing, 12. Regional-expansion architecture (deliberate choices), 14. Migration, 15. Acceptance criteria (summary), 9. Reporting, Corporate Accounts (B2B) — Design Spec, Monthly statement (PDF, auto-generated 1st of month) (+2 more)
+Cohesion: 0.17
+Nodes (10): 10. Canadian tax, 11. Testing, 12. Regional-expansion architecture (deliberate choices), 14. Migration, 15. Acceptance criteria (summary), 2. High-level architecture, code:json ({), Corporate Accounts (B2B) — Design Spec (+2 more)
 
 ### Community 2685 - "Community 2685"
 Cohesion: 0.18
-Nodes (10): main, name, overrides, react, react-dom, @tootallnate/once, @types/react, packageManager (+2 more)
+Nodes (8): build_default_fares(), _fd(), Round a numeric value to 2 decimal places via Decimal to avoid float drift., Build a default fare entry per vehicle type.      Pure function — no DB or exter, Convert any numeric value to a 2-decimal-place float (backward-compat alias for, Build a default fare entry per vehicle type.      Pure function — no DB or exter, TestBuildDefaultFares, TestFd
 
 ### Community 2686 - "Community 2686"
 Cohesion: 0.18
@@ -6471,11 +6655,11 @@ Cohesion: 0.18
 Nodes (11): wallet, amount, balance, noTransactions, recentActivity, recipientPhone, title, topUp (+3 more)
 
 ### Community 2692 - "Community 2692"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): code:bash (# Edit node_modules/@stripe/stripe-react-native/android/grad), Correct mechanism for the Stripe pin, Decision criteria to leave Option A again, Files in this directory, Option A — Kotlin 2.0.21 strategy, See also, Trade-offs vs Option C, When to use this strategy (+2 more)
 
 ### Community 2693 - "Community 2693"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): Active, Constraints, Context, Core Value, Key Decisions, Out of Scope, Requirements, Spinr (+2 more)
 
 ### Community 2694 - "Community 2694"
@@ -6483,59 +6667,63 @@ Cohesion: 0.18
 Nodes (11): code:python (# Notify admins that a driver came online), code:python (except WebSocketDisconnect:), code:bash (cd backend), code:bash (git add backend/socket_manager.py backend/routes/websocket.p), code:python (async def broadcast_to_admins(self, message: dict):), code:python (from routes.admin.monitoring import router as monitoring_rou), code:python (app.include_router(monitoring_router, prefix="/api")), code:python (# If connecting as driver, ensure user has a driver profile) (+3 more)
 
 ### Community 2695 - "Community 2695"
-Cohesion: 0.18
+Cohesion: 0.17
 Nodes (10): A-PE-P2-1 · Backend Must Set HttpOnly Cookie (No Client-Side Cookie Writes), A-PE-P2-2 · CSRF Protection on State-Changing Admin Endpoints, A-PE-P2-3 · ESLint Major Version Upgrade (9 → 10), A-PE-P2-4 · uuid Moderate Vulnerabilities, A-PE-P2-5 · Sentry DSN Region — US Ingestion for Canadian PII, A-PE-P2-6 · Structured Server-Side Logging (pino), A-PE-P2-7 · Vercel PR Deploy Branch Protection, Already Implemented in This Session (+2 more)
 
 ### Community 2696 - "Community 2696"
 Cohesion: 0.18
 Nodes (11): 0. Checklist (the gates), Backend infrastructure, Code, Communications, Driver supply, Observability, Operations, Payments (+3 more)
 
+### Community 2697 - "Community 2697"
+Cohesion: 0.26
+Nodes (11): useIsMobile(), Sidebar(), SidebarContent(), SidebarContext, SidebarFooter(), SidebarGroup(), SidebarHeader(), SidebarItem() (+3 more)
+
 ### Community 2698 - "Community 2698"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Admin Monitoring — Sketch 007, code:block1 (20 active rides:), Design Question, Dispatcher Workflow (Variant C), Key Design Decisions, Realistic Data, Recommendation, Stages Covered (+1 more)
 
 ### Community 2699 - "Community 2699"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Architecture Rules (Spinr-Specific), Authority, Before Merging ANY Code, Project Components Owned, Quality Gates — Every Change Must Pass, Responsibilities, Tech Lead Role, Tech Stack (+1 more)
 
 ### Community 2700 - "Community 2700"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): API Security, Authentication, Database Security (Supabase), Dependency Security, Incident Response, Mobile App Security, Payment Security (PCI Compliance), Secrets Management (+1 more)
 
 ### Community 2701 - "Community 2701"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Bug Fix Workflow, code:python (# Backend test example), Step 1: Reproduce the Bug, Step 2: Root Cause Analysis, Step 3: Implement the Fix, Step 4: Write Regression Test, Step 5: Verify Fix, Step 6: Update Documentation (+1 more)
 
 ### Community 2702 - "Community 2702"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): 7 Iterations, Agents, code:block1 (/review), Continuous Improvement, Key Principles, Multi-Agent Strategic Review Workflow, Output, Trigger (+1 more)
 
 ### Community 2703 - "Community 2703"
-Cohesion: 0.20
-Nodes (10): app_settings Supabase Table, Backend Canonical DB Schema Reference, fare_configs DB Table, Heatmap Data API Endpoint, Leaflet.heat Plugin, Heat Map Implementation Plan, ride_payment_sources DB Table, rides DB Table (+2 more)
+Cohesion: 0.11
+Nodes (16): app_settings Supabase Table, Driver location history, Fare configs, Rides, Service areas, Settings, Spinr backend – canonical table and column names, Vehicle types (+8 more)
 
 ### Community 2704 - "Community 2704"
 Cohesion: 0.20
 Nodes (10): 4. Methodology, Phase 0 — Bootstrap & inventory (≤ 30 min), Phase 1 — Static analysis & SAST (≤ 2 h), Phase 2 — Authentication, session, RBAC (≤ 3 h), Phase 3 — DAST / functional walkthrough (≤ 4 h), Phase 4 — Backend security deep-dive (≤ 3 h), Phase 5 — Data protection, privacy, logging (≤ 2 h), Phase 6 — Performance, UX, accessibility, i18n (≤ 3 h) (+2 more)
 
 ### Community 2705 - "Community 2705"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Cancellation Policies, Checklist, code:sql (UPDATE rides SET driver_id=$1, status='driver_assigned'), Dimension 07 — State Machine & Dispatch, Dispatch Algorithm, OTP / Pickup Verification, Race Condition Prevention, Severity Guide (+1 more)
 
 ### Community 2706 - "Community 2706"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Checklist, code:python (idempotency_key=f"ride-{ride_id}-{driver_id}"), Dimension 08 — Payments & Earnings, PaymentIntent Security, Payout Flow, PCI-DSS Compliance, Severity Guide, Testing (+1 more)
 
 ### Community 2707 - "Community 2707"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Checklist, Data Retention, Database Access Controls, Dimension 12 — Compliance: PII, PCI-DSS & Data Retention, Document Expiry & Compliance, Document Storage, PII Field Stripping (Rider-Facing Responses), PIPEDA / Canadian Privacy Law (+1 more)
 
 ### Community 2708 - "Community 2708"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): App Store / Play Store, Checklist, Dimension 16 — Internationalisation & Localisation (i18n/l10n), Dynamic Content, Layout & Typography for French, Locale Detection, Severity Guide, String Formatting (+1 more)
 
 ### Community 2709 - "Community 2709"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Data classification (referenced by Dimension 12), Federal, How to use, Industry standards, Municipal, Per-module applicability (quick index), Provincial — Saskatchewan (expand per-province on entry), Safety / screening (+1 more)
 
 ### Community 2710 - "Community 2710"
@@ -6543,27 +6731,35 @@ Cohesion: 0.20
 Nodes (9): 1. Apply Schema Changes, 2. Verify Backend, 3. Start Server, code:bash (SUPABASE_URL=your_project_url), code:bash (python3 -m backend.tests_smoke_supabase), code:bash (python3 -m backend.server), Database Migration Instructions, Prerequisites (+1 more)
 
 ### Community 2711 - "Community 2711"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Backend Service Layer, code:block1 (┌───────────────┐    ┌──────────────────┐    ┌─────────────┐), code:python (@api_router.get("/fares")), Conventions, Migration plan, Naming, The contract, What does NOT belong here (+1 more)
 
+### Community 2712 - "Community 2712"
+Cohesion: 0.13
+Nodes (14): Benefits of This Approach, Fix for SearchDestinationScreen Autocomplete Implementation, FOR DROPOFF (replace lines 314-348):, FOR PICKUP (replace lines 276-310):, Issues to Fix, Keep These Essential Parts:, Key Changes Needed, Remove These Functions: (+6 more)
+
 ### Community 2713 - "Community 2713"
-Cohesion: 0.20
-Nodes (3): test_admin_manual_topup_creates_payment_intent(), test_topup_rejects_if_company_not_active(), test_topup_rejects_if_no_stripe_customer()
+Cohesion: 0.19
+Nodes (8): _extract_signed_url(), Any, Pull the URL out of supabase-py's create_signed_url() response, tolerating     b, Pull the URL out of supabase-py's create_signed_url() response, tolerating     b, Pins the fix for Railway 500 "'dict' object has no attribute 'data'".     supaba, The old supabase-py shape: APIResponse.data.signed_url., Hybrid shape: object wrapper, dict payload., TestExtractSignedUrl
+
+### Community 2714 - "Community 2714"
+Cohesion: 0.13
+Nodes (8): float, ratio < 0.5 → 1.0× (no surge)., ratio == 1.2 falls into [1.2, 2.0) → 1.75×., test_ratio_at_third_threshold_returns_fourth_tier(), test_ratio_below_first_threshold_returns_normal(), ratio_to_multiplier(), Map a demand/supply ratio to a surge multiplier tier., Map a demand/supply ratio to a surge multiplier tier.
 
 ### Community 2715 - "Community 2715"
-Cohesion: 0.06
-Nodes (66): DriverPublicView, Safe subset of driver fields exposed to riders — no PII., Safe subset of driver fields exposed to riders — no PII., Ride, Load a rider's ride only if it is in one of allowed_states.      Raises 409 if t, Get rider's current active/pending ride (if any). Used on app launch to resume., Get rider's past rides for the activity tab with cursor-based pagination.      P, Fetch details of a specific ride (+58 more)
+Cohesion: 0.05
+Nodes (104): bool, float, int, RideRatingRequest, CreateRideRequest, DriverPublicView, Any, float (+96 more)
 
 ### Community 2716 - "Community 2716"
-Cohesion: 0.29
+Cohesion: 0.31
 Nodes (8): main(), CI Error Audit — main orchestrator (local dev / manual run entry point).  Usage, _run(), run_full_audit(), int, Path, str, Smoke-test publish/subscribe when Redis is not configured (in-process mode).
 
 ### Community 2717 - "Community 2717"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): code:block1 (/fare-audit                  # audits staged + unstaged chan), code:block2 (SPINR MONEY AUDIT — <scope>), Do NOT, /fare-audit — Deep Fare & Payment Audit, Money-relevant paths (auto-included when no args), Output, Usage, What it does (+1 more)
 
 ### Community 2718 - "Community 2718"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): code:block1 (/migration-check                          # audits newly-add), code:block2 (SPINR MIGRATION REVIEW — <file(s)>), Do NOT, /migration-check — Supabase Migration Safety Review, Output, Usage, What gets checked, What it does (+1 more)
 
 ### Community 2719 - "Community 2719"
@@ -6571,11 +6767,11 @@ Cohesion: 0.20
 Nodes (9): Accessibility Compliance, Automated Enforcement, Compliance Status (as of 2026-04-09), Known Warnings (non-critical, tracked), Mobile Accessibility, Resources, Runtime scanning — @axe-core/playwright, Standard (+1 more)
 
 ### Community 2720 - "Community 2720"
-Cohesion: 0.20
-Nodes (9): 2. Deploy Order, code:bash (# From repo root, pointing at production credentials:), code:sql (SELECT version, applied_at FROM schema_migrations), code:block9 (Migration 64  →  Migration 65  →  (no restart required)), Confirm both are recorded after apply, Deploy Runbook: Migrations 64 & 65 — Driver Insurance Periods, How migrations are applied in this repo, Mandatory sequence (+1 more)
+Cohesion: 0.29
+Nodes (7): 2. Deploy Order, code:bash (# From repo root, pointing at production credentials:), code:sql (SELECT version, applied_at FROM schema_migrations), code:block9 (Migration 64  →  Migration 65  →  (no restart required)), Confirm both are recorded after apply, How migrations are applied in this repo, Mandatory sequence
 
 ### Community 2721 - "Community 2721"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): ⚠️ Codebase async/sync pattern (read before implementing any Supabase code), code:python (async def some_helper(...) -> ...:), code:python (def _fn():), code:bash (git add admin-dashboard/src/app/dashboard/corporate-accounts), Corporate B2B — Plan 3: Employee Allowances & Work Profile, Done criteria (Plan 3), Handoff to Plan 4 (policy engine), ⚠️ Route mounting note (+1 more)
 
 ### Community 2722 - "Community 2722"
@@ -6623,8 +6819,8 @@ Cohesion: 0.20
 Nodes (9): become_driver, go_to_home, submitted_msg, submitted_title, home, book_ride, nearby_drivers, schedule_ride (+1 more)
 
 ### Community 2733 - "Community 2733"
-Cohesion: 0.20
-Nodes (10): login, and, continue, phoneLabel, phonePlaceholder, privacyPolicy, subtitle, termsOfService (+2 more)
+Cohesion: 0.26
+Nodes (14): Any, datetime, str, close_linked_records(), When Zoho tickets close, close the linked Spinr records (reverse sync).      Cal, _map_ticket(), _name(), _parse() (+6 more)
 
 ### Community 2734 - "Community 2734"
 Cohesion: 0.20
@@ -6635,11 +6831,11 @@ Cohesion: 0.20
 Nodes (10): rideOffer, acceptRide, decline, dropoff, dropoffLocation, fare, newRideRequest, pickup (+2 more)
 
 ### Community 2736 - "Community 2736"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): A-P4-1 · Document Requirements Configuration UI, A-P4-2 · Payout Management Page, A-P4-3 · Password Complexity + Common-Password Blacklist, A-P4-4 · Cursor Pagination on Pending Documents Endpoint, After this file, Checklist, code:python (# backend/utils/password_policy.py), code:python (@router.get("/drivers/pending-documents")) (+1 more)
 
 ### Community 2737 - "Community 2737"
-Cohesion: 0.20
+Cohesion: 0.18
 Nodes (9): Checklist, P4-1 · Build an AI Support Bot (Gemini), P4-2 · Add an In-App FAQ Screen, P4-3 · Create 4 Missing App Screens, P4-4 · Enable Firebase App Check (Device Security Verification), P4-5 · Add End-to-End Test Flows for Core Ride Scenarios, P4-6 · Add GDPR Data Export for Drivers, P4-7 · Wire T4A / Earnings CSV Download to the UI (+1 more)
 
 ### Community 2738 - "Community 2738"
@@ -6647,15 +6843,15 @@ Cohesion: 0.20
 Nodes (5): A second connect() for the same client_id overwrites the old socket —         th, Server sends a WS event to a disconnected client — must not crash.          This, When Redis pub/sub is unavailable, delivery falls back to local dict., Pins the connect → disconnect → reconnect lifecycle of ConnectionManager.      C, TestConnectionManagerReconnect
 
 ### Community 2739 - "Community 2739"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): code:block1 (Rider: Sarah M. ★4.9), Data Used (Realistic), Design Question, Driver Home — Sketch 001, Key Decisions, Recommendation, States Covered, Variants
 
 ### Community 2740 - "Community 2740"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): 1. ruff (Python backend — `backend/routes/admin/`), 2. TypeScript (`tsc --noEmit`), 3. ESLint (`npm run lint` — Next.js ESLint config), 4. npm audit, 5. pip-audit (Python backend), 6. Phase 1 New Findings, Admin Dashboard Audit — Phase 1: SAST Results, Run result: FIXED during this phase
 
 ### Community 2741 - "Community 2741"
-Cohesion: 0.22
+Cohesion: 0.27
 Nodes (8): dompurify, name, overrides, axios, jspdf, postcss, private, version
 
 ### Community 2742 - "Community 2742"
@@ -6663,35 +6859,35 @@ Cohesion: 0.22
 Nodes (9): code:python (async def get_analytics_overview(...):), P3-1: Implement Next.js `middleware.ts` with proper auth (F-17), P3-2: Add CSP without `unsafe-inline`/`unsafe-eval` (F-05), P3-3: Add IP restriction for admin surface (F-06), P3-4: Add `/analytics` response caching (F-50), P3-5: Fix WCAG 2.1 AA violations (F-51, F-52, F-53, F-54), P3-6: Fix admin stats endpoint serial queries (F-49), P3-7: Add row-count cap to export endpoints (F-43) (+1 more)
 
 ### Community 2743 - "Community 2743"
-Cohesion: 0.36
+Cohesion: 0.32
 Nodes (6): testAdminLogin(), [lat, lng], masked, redactCoords(), redactEmail(), redactPhone()
 
 ### Community 2744 - "Community 2744"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Appendix: File-Level Risk Summary, DOC-001 — No API Documentation, DOC-002 — No Incident Response Runbook, DOC-003 — No Architecture Decision Records (ADRs), Executive Summary, Issue Categories, P3 — Low (Post-Launch Hardening), Spinr — Security & Product Audit: Gap Analysis Report
 
 ### Community 2745 - "Community 2745"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): 2026-04-18 · v1.0 (Baseline), 2026-04-19 · v1.1, 2026-04-23 · v1.2, 2026-04-24 · v1.3, 90-Day Re-Run Rule, Audit Framework — Changelog, Process for Adding a New Checklist Item to an Existing Dimension, Process for Adding a New Dimension
 
 ### Community 2746 - "Community 2746"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Backend Endpoints, Checklist, Dimension 01 — Feature Completeness, Missing Screen Checklist (common omissions), Screens & Navigation, Severity Guide, State Machine, User Flows
 
 ### Community 2747 - "Community 2747"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Checklist, Client-Side Token Storage, Dimension 02 — Authentication & Session Management, JWT Tokens, OTP / Login Flow, Refresh Tokens, Session Management, Severity Guide
 
 ### Community 2748 - "Community 2748"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Backend Error Responses, Checklist, Client-Side Resilience, Database Resilience, Dimension 10 — Error Handling & Resilience, Offline Handling, React Error Boundaries, Severity Guide
 
 ### Community 2749 - "Community 2749"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Checklist, CI/CD Security, CORS, Dimension 11 — Security Headers, CORS & CI Pipeline, Rate Limiting, Security Headers (verify all are set), Severity Guide, Startup Validation
 
 ### Community 2750 - "Community 2750"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Audit Phases Overview, Branch Strategy, code:bash (# ── AUDIT BRANCH (already created) ────────────────────────), code:bash (# 1. Dependency vulnerabilities), Ground Rules (read before starting any phase), Pre-Audit Scans (run before Phase A), Remediation Sprints Overview, Rider App — Production-Readiness Audit Plan v1
 
 ### Community 2751 - "Community 2751"
@@ -6699,35 +6895,35 @@ Cohesion: 0.22
 Nodes (4): Tests for admin vehicle-type illustration_url persistence.  The upload endpoint, Admin can clear the override by passing "" — stored as None., Omitting the field must NOT overwrite — supports partial updates., TestVehicleTypeIllustrationPersistence
 
 ### Community 2752 - "Community 2752"
-Cohesion: 0.31
-Nodes (7): FirebaseAppCheckMiddleware, Enforce Firebase App Check on every API request.      Reads the ``X-Firebase-App, Enforce Firebase App Check on every API request.      Reads the ``X-Firebase-App, B-P2-3: tests for App Check log lines including request_id.  Contract:   - When, If request.state.request_id isn't set (e.g. middleware ordering bug),     the lo, test_missing_request_id_falls_back_to_dash(), test_missing_token_log_includes_request_id()
+Cohesion: 0.18
+Nodes (12): DeprecatedRootPathMiddleware, _Request, _Response, Add X-Spinr-Deprecated: true header and emit a WARNING log for any     request t, BaseHTTPMiddleware, FirebaseAppCheckMiddleware, Enforce Firebase App Check on every API request.      Reads the ``X-Firebase-App, Enforce Firebase App Check on every API request.      Reads the ``X-Firebase-App (+4 more)
 
 ### Community 2753 - "Community 2753"
-Cohesion: 0.16
+Cohesion: 0.17
 Nodes (10): Regression tests for the scheduled-ride dispatch fixes (CR-1, CR-2).  CR-1: crea, check_scheduled_rides must read rows in status='scheduled'., check_scheduled_rides must read rows in status='scheduled'., If the rider has a live trip, the scheduled→searching claim collides         wit, check_scheduled_rides must read rows in status='scheduled'., If another replica already flipped the row, update_one returns None         and, If another replica already flipped the row, update_one returns None         and, If another replica already flipped the row, update_one returns None         and (+2 more)
 
 ### Community 2754 - "Community 2754"
-Cohesion: 0.28
-Nodes (8): str, attest_device(), Verify device integrity on go-online. Flags emulators and suspicious devices., Server-side device integrity verification.  Validates device attestation signals, Evaluate device trust level. Returns {"trusted": bool, "risk_tier": str, "reason, Store attestation result for admin visibility and pattern detection., _record_attestation(), verify_device()
+Cohesion: 0.11
+Nodes (13): Compatibility shim for the removed ``db`` module.  Upstream commit ``33f252b4``, Identity passthrough kept for legacy callers.      The original implementation c, serialize_doc(), str, check_user(), main(), promote_user(), TestDBWrapper (+5 more)
 
 ### Community 2755 - "Community 2755"
-Cohesion: 0.25
-Nodes (8): bytes, object, str, _fmt_money(), generate_t4a_pdf(), T4A PDF generator – CRA Statement of Fees for Services.  Generates a CRA-style T, Coerce value to a two-decimal-place string, e.g. '3521.75'., Return a CRA-style T4A PDF as raw bytes (starts with b'%PDF').      Parameters
+Cohesion: 0.18
+Nodes (4): _driver(), TestDeclineRide, TestDestinationMode, TestUpdateLocationBatch
 
 ### Community 2756 - "Community 2756"
-Cohesion: 0.44
+Cohesion: 0.49
 Nodes (8): ClassifiedError, classify(), _classify_log_chunk(), _job_to_surface(), main(), Classify CI failure signals from a GitHub Actions run into structured errors.  I, Any, str
 
 ### Community 2757 - "Community 2757"
-Cohesion: 0.39
-Nodes (7): _build_cr_list(), FixRecommendation, FixStep, Generate fix recommendations for classified CI errors.  Safe fixes (CI config on, _recommend(), Any, str
+Cohesion: 0.44
+Nodes (8): _build_cr_list(), FixRecommendation, FixStep, main(), Generate fix recommendations for classified CI errors.  Safe fixes (CI config on, _recommend(), Any, str
 
 ### Community 2758 - "Community 2758"
-Cohesion: 0.44
+Cohesion: 0.49
 Nodes (8): assess(), _assess_error(), _get_changed_files_from_git(), main(), _map_files_to_surfaces(), Assess the impact / blast radius of classified CI errors.  Input:  classified_er, Any, str
 
 ### Community 2759 - "Community 2759"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Common pitfalls, Domain — Dispatch, Key files, Matching algorithm (current), Offer timeout, Performance targets, Race conditions to guard, WS events (dispatch domain)
 
 ### Community 2760 - "Community 2760"
@@ -6735,19 +6931,19 @@ Cohesion: 0.22
 Nodes (9): 1. HttpOnly Token Storage, code:python (def test_login_sets_httponly_cookies():), code:typescript (test('login stores token in cookie, not localStorage', async), Current State, Files to Modify, Risk Mitigation, Rollout Plan, Root Cause (+1 more)
 
 ### Community 2761 - "Community 2761"
-Cohesion: 0.22
-Nodes (8): Backend (9 files), code:python (# BEFORE (OLD)), File: `backend/routes/admin/auth.py`, Frontend (7 files across 3 apps), P3: HttpOnly Token Storage — Detailed Implementation Guide, Security Review Checklist, Step 4: Admin Auth Routes, Summary: All Files Changed
+Cohesion: 0.29
+Nodes (5): code:python (import json), File: `backend/utils/cookie_manager.py` (NEW), P3: HttpOnly Token Storage — Detailed Implementation Guide, Security Review Checklist, Step 1: Backend Cookie Manager
 
 ### Community 2762 - "Community 2762"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (7): B. Backend env vars (Railway), code:bash (# After deploy, the startup log should NOT contain any of:), H. Saskatoon service area geofence, M. Day-of launch sequence, O. Post-launch monitoring (first 7 days), Saskatoon Launch — Checklist + Procedures, Sign-off
 
 ### Community 2763 - "Community 2763"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): code:bash (npm install), code:bash (npx expo start), code:bash (npm run reset-project), Get a fresh project, Get started, Join the community, Learn more, Welcome to your Expo app 👋
 
 ### Community 2764 - "Community 2764"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Community Hubs (Navigation), Corpus Check, God Nodes (most connected - your core abstractions), Graph Report - .  (2026-05-02), Knowledge Gaps, Suggested Questions, Summary, Surprising Connections (you probably didn't know these)
 
 ### Community 2765 - "Community 2765"
@@ -6767,8 +6963,8 @@ Cohesion: 0.22
 Nodes (9): loyalty, history, lifetime, noHistory, points, redeem, redeemSuccess, tier (+1 more)
 
 ### Community 2769 - "Community 2769"
-Cohesion: 0.22
-Nodes (9): notifications, allCaughtUp, markAllRead, markReadError, markReadErrorBody, noNotifications, title, unreadCount (+1 more)
+Cohesion: 0.16
+Nodes (11): charge_ride returns succeeded → process_payment returns 200., charge_ride returns declined → process_payment returns 402., charge_ride returns declined → process_payment returns 402., charge_ride returns failed (ops error) → process_payment returns 402 payment_err, charge_ride returns failed (ops error) → process_payment returns 402 payment_err, HTTP surface tests for process_payment — verifies that charge_ride     outcomes, Ensure routes.rides is loaded into sys.modules before patching.          conftes, HTTP surface tests for process_payment — verifies that charge_ride     outcomes (+3 more)
 
 ### Community 2770 - "Community 2770"
 Cohesion: 0.22
@@ -6807,7 +7003,7 @@ Cohesion: 0.22
 Nodes (8): Baseline: Sprint 9 Audit (2026-04-09), How to Add a New Finding, Open — Dependencies, Open — MEDIUM, Open — Pre-Production Gate (Phase 5 SEC-1), Phase 5 Checklist, Resolved, Spinr — Open Items Tracker
 
 ### Community 2779 - "Community 2779"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): Active Phase, Blockers, Key Facts for Next Session, Next Actions, Open Follow-Up Items (not blocking Phase 3 but worth tracking), Phase Progress, Recent Work (2026-05-03 → 2026-05-10), Spinr — GSD Project State
 
 ### Community 2780 - "Community 2780"
@@ -6815,19 +7011,19 @@ Cohesion: 0.22
 Nodes (9): code:python (# backend/tests/test_corporate_low_balance.py), code:bash (pytest backend/tests/test_corporate_low_balance.py -v), code:python (async def list_wallets_low_balance_no_autotopup() -> list[di), code:python ("""Low-balance email notifications for corporate wallets wit), code:python (# backend/features.py — add near send_push_notification if a), code:python (from utils.corporate_low_balance import run_low_balance_tick), code:bash (pytest backend/tests/test_corporate_low_balance.py -v), code:bash (git add backend/utils/corporate_low_balance.py backend/db_su) (+1 more)
 
 ### Community 2781 - "Community 2781"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): After this file, B-P3-1 · WebSocket `broadcast()` Is Sequential — Blocks Event Loop at Scale, B-P3-2 · Background Loops Have No Jitter — Synchronized DB Wake Spikes, B-P3-3 · No Scheduled Sub-Processor Monitoring Cadence (PIPEDA disclosure drift), Checklist, code:python (async def broadcast(self, msg: dict) -> None:), code:python (await asyncio.sleep(interval * (0.9 + random.random() * 0.2)), P3 — Backend Hardening: Post-Launch Stability and Resilience
 
 ### Community 2782 - "Community 2782"
-Cohesion: 0.22
-Nodes (8): code:block1 (reports/), code:block2 (reports/audits/YYYY-MM-DD-<scope>-<version>.txt), Findings Summary (as of 2026-04-18), Folder Structure, How to Use This, Naming Convention for Future Audits, Spinr Audit Reports, What Was Audited
+Cohesion: 0.24
+Nodes (6): AgentTask, Any, str, Store security-specific knowledge., Perform security review., Scan for vulnerabilities.
 
 ### Community 2783 - "Community 2783"
-Cohesion: 0.22
-Nodes (9): resolutions, expo-modules-core, postcss, protobufjs, @react-native-async-storage/async-storage, @react-native-community/netinfo, @tootallnate/once, @types/react (+1 more)
+Cohesion: 0.25
+Nodes (10): createStyles(), formatDate(), getHistoryIcon(), getTierColor(), LoyaltyData, LoyaltyHistoryItem, LoyaltyScreen(), REWARD_TIERS (+2 more)
 
 ### Community 2784 - "Community 2784"
-Cohesion: 0.22
+Cohesion: 0.20
 Nodes (8): code:bash (npm install), code:bash (npx expo start), code:bash (npm run reset-project), Get a fresh project, Get started, Join the community, Learn more, Welcome to your Expo app 👋
 
 ### Community 2785 - "Community 2785"
@@ -6847,20 +7043,20 @@ Cohesion: 0.22
 Nodes (7): Logout must actually revoke the refresh token., Logout must actually revoke the refresh token., POST /logout with a refresh token must invoke revoke_refresh_token., POST /logout with a refresh token must invoke revoke_refresh_token., Logout with no refresh token is a no-op (clears CSRF cookie)., Logout with no refresh token is a no-op (clears CSRF cookie)., TestLogoutInvalidatesToken
 
 ### Community 2789 - "Community 2789"
-Cohesion: 0.25
-Nodes (17): get_dashboard_health(), Concise operational health for uptime checkers and ops dashboards.      Returns, Concise operational health for uptime checkers and ops dashboards.      Returns, Concise operational health for uptime checkers and ops dashboards.      Returns, bool, int, MagicMock, str (+9 more)
+Cohesion: 0.19
+Nodes (9): str, _driver_row(), End-to-end ride-lifecycle smoke suite.  Exercises the full happy-path a ride tra, Smoke-test the routes are mounted and respond — no real DB required.      We don, Smoke-test the routes are mounted and respond — no real DB required.      We don, Canonical ride row shared by every state in the lifecycle., POST /drivers/rides/{id}/accept must transition searching → driver_accepted, _ride_row() (+1 more)
 
 ### Community 2790 - "Community 2790"
-Cohesion: 0.14
-Nodes (17): bool, Tests for utils/retention_purge.py — B-P1-6 daily PII purge loop.  The Postgres, CLAUDE.md: never silently swallow DB errors. The wrapper logs     via logger.exc, Scheduling math: should always return a positive sleep duration,     never sleep, Two replicas calling redis_set_nx with the same key — the first     wins, the se, Happy path: rpc returns a JSONB dict, the function returns it     verbatim and f, Dev/test without SUPABASE_URL — should not raise, returns None., If the rpc response is shaped differently (PostgREST upgrade,     schema drift), (+9 more)
+Cohesion: 0.07
+Nodes (47): str, bool, float, int, str, Auto-top-up scheduled tick for corporate wallets., Two replica instances processing the same wallet simultaneously must     produce, test_concurrent_replicas_use_same_stripe_idempotency_key() (+39 more)
 
 ### Community 2791 - "Community 2791"
-Cohesion: 0.67
-Nodes (3): auth_headers(), Return authorization headers with mock JWT token., Return authorization headers with mock JWT token.
+Cohesion: 0.26
+Nodes (4): Validate monetary amount.      Args:         amount: Amount to validate, Validate monetary amount.      Args:         amount: Amount to validate, validate_monetary_amount(), TestValidateMonetaryAmount
 
 ### Community 2792 - "Community 2792"
-Cohesion: 0.22
-Nodes (5): Tests for user-specific database operations.      Collection delegates to db_sup, Test finding a user by ID., Test finding a user that doesn't exist., Test finding a user by phone number., TestUserCollection
+Cohesion: 0.15
+Nodes (12): 0. The question this answers, 1. What we owe SGI / the province, 2.1 Distance, written on ride completion, 2.2 Insurance periods (the SGI-relevant linkage), 2. What we capture today (data inventory), 3. Retention — what survives, and for how long, 4. Gaps — what is NOT built, 5. Open questions (blocking implementation) (+4 more)
 
 ### Community 2793 - "Community 2793"
 Cohesion: 0.22
@@ -6868,15 +7064,15 @@ Nodes (5): Tests for driver-specific database operations., Test finding availabl
 
 ### Community 2794 - "Community 2794"
 Cohesion: 0.22
-Nodes (5): Tests for ride-specific database operations., Test finding a ride by ID via Collection.find_one delegation., Test finding rides by status — Collection.find returns a MockCursor., Test counting rides via Collection.count_documents delegation., TestRideCollection
+Nodes (11): appendSpy, docs, existing, mockCacheGet, mockCacheRemove, mockCacheSet, mockDelete, mockGet (+3 more)
 
 ### Community 2795 - "Community 2795"
-Cohesion: 0.22
-Nodes (5): Tests for the Collection class., Test collection is initialized with correct name., Test collection find returns a cursor., Test collection find with empty filter., TestCollection
+Cohesion: 0.15
+Nodes (12): build, builder, dockerfilePath, deploy, healthcheckPath, healthcheckTimeout, numReplicas, restartPolicyMaxRetries (+4 more)
 
 ### Community 2796 - "Community 2796"
-Cohesion: 0.22
-Nodes (5): Tests for driver API endpoints., Test getting driver profile endpoint., Test updating driver availability endpoint.          Smoke test — the route may, Test admin endpoint for getting nearby drivers.          Smoke test — route path, TestDriverEndpoints
+Cohesion: 0.08
+Nodes (15): Unit tests for driver-related functionality. Tests cover driver registration, av, Tests for driver document management., Test uploading driver document., Test approving driver document., Test rejecting driver document., Tests for driver API endpoints., Test getting driver profile endpoint., Test updating driver availability endpoint.          Smoke test — the route may (+7 more)
 
 ### Community 2797 - "Community 2797"
 Cohesion: 0.22
@@ -6895,19 +7091,19 @@ Cohesion: 0.22
 Nodes (5): Pin the memory-bound contract: when a user has no more sockets     on this machi, User has rider + driver sockets. Closing one must NOT drop         the bucket —, The B-P1-11 kick path closes every socket for a user. The         bucket should, Defensive: if active_connections somehow contained a key not         matching {c, TestBucketCleanup
 
 ### Community 2801 - "Community 2801"
-Cohesion: 0.29
-Nodes (7): admin_get_settings(), _mask_credentials(), Get all settings. Credential fields are masked — use /settings/reveal/{field} to, Return a copy of the settings dict with credential values masked., Return a copy of the settings dict with credential values masked., Get all settings. Credential fields are masked — use /settings/reveal/{field} to, Any
+Cohesion: 0.30
+Nodes (10): ComplaintsTab, DisputesTab, FaqsTab, FlagsTab, LegalDocumentsTab, LostAndFoundTab, SupportPage(), TabLoader() (+2 more)
 
 ### Community 2802 - "Community 2802"
-Cohesion: 0.25
-Nodes (7): 1.1 In-scope surfaces, 1.2 Out-of-scope (explicitly), 1.3 Functional scope — every dashboard feature must be exercised, 1. Scope, 5. Dimensions, Admin Dashboard — Comprehensive Audit Prompt, Table of Contents
+Cohesion: 0.22
+Nodes (7): 5. Dimensions, 8.1 How to use this prompt, 8.2 Maintenance, 8. Ready-to-Run Prompt, Admin Dashboard — Comprehensive Audit Prompt, code:block7 (===== BEGIN PROMPT =====), Table of Contents
 
 ### Community 2803 - "Community 2803"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): Checklist, Concurrency Safety, Dimension 06 — Real-Time Features (WebSocket & GPS), GPS Tracking, Redis Pub/Sub (Multi-Server), Severity Guide, WebSocket Connection
 
 ### Community 2804 - "Community 2804"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): AI Support Bot, Checklist, Dimension 13 — Notifications, AI Support & Knowledge Base, Knowledge Base & FAQ, Notification Infrastructure, Push Notification Coverage (all cases), Severity Guide
 
 ### Community 2805 - "Community 2805"
@@ -6918,12 +7114,20 @@ Nodes (8): 1. Auth, identity, session, `dependencies.py`, `routes/admin/auth.py`
 Cohesion: 0.25
 Nodes (8): 7. Admin ops, `routes/admin/analytics.py`, `routes/admin/documents.py`, `routes/admin/faqs.py`, `routes/admin/maintenance.py`, `routes/admin/monitoring.py`, `routes/admin/settings.py`, `routes/admin/support.py`
 
+### Community 2807 - "Community 2807"
+Cohesion: 0.17
+Nodes (11): API Configuration, Autocomplete Implementation, Dependencies Installed, Google Maps & Places API Integration - COMPLETE, 📋 Implementation Summary, ✅ Integration Status: FULLY IMPLEMENTED, 🎯 Key Improvements Made, Map Implementation (+3 more)
+
+### Community 2808 - "Community 2808"
+Cohesion: 0.17
+Nodes (9): When Stripe declines the rider's card at trip completion, the system     must le, When Stripe declines the rider's card at trip completion, the system     must le, Wallet pay at completion: balance decreases, ride marked paid., Wallet pay at completion: balance decreases, ride marked paid., If the wallet can't cover fare + tip, payment returns 400 and         the ride's, If the wallet can't cover fare + tip, payment returns 400 and         the ride's, Card decline → payment_status='failed', response surfaces card_declined code., Card decline → payment_status='failed', response surfaces card_declined code. (+1 more)
+
 ### Community 2809 - "Community 2809"
-Cohesion: 0.25
-Nodes (7): Driver location history, Fare configs, Rides, Service areas, Settings, Spinr backend – canonical table and column names, Vehicle types
+Cohesion: 0.24
+Nodes (5): Push notification is fired as a background task after WS broadcast., Rider sends on a searching ride — no recipient, so no push., FCM requires all data values to be strings., current_user with name=null must not raise AttributeError in sender_name resolut, TestChatPushNotifications
 
 ### Community 2810 - "Community 2810"
-Cohesion: 0.57
+Cohesion: 0.64
 Nodes (7): run_migrations.sh script, apply_file(), error(), info(), is_applied(), MIGRATION_FILES, warn()
 
 ### Community 2811 - "Community 2811"
@@ -6935,16 +7139,16 @@ Cohesion: 0.25
 Nodes (8): Architecture, code:block10 (1. Client calls POST /rides/{ride_id}/rate (includes tip amo), code:python (def process_payment(ride_id: str, tip_amount: Decimal, idemp), code:typescript (function generateIdempotencyKey(rideId: string): string {), code:python (# BEFORE (broken):), Fix: Add Idempotency, Issue 1: Type Mismatch (Float vs Decimal), Issue 2: Payment Settlement State
 
 ### Community 2813 - "Community 2813"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): Architecture Diagram, code:block18 (┌─ Rider/Driver Auth ────┐), Definition of Done, Executive Summary, P0 Security/Safety Findings — Architecture Blueprint, Risk Assessment, Success Criteria
 
 ### Community 2814 - "Community 2814"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): 1 · Instant rollback via Vercel UI (< 2 min), 2 · Rollback via GitHub (if Vercel UI is unavailable), 3 · Rollback checklist, 4 · Database migrations that shipped with the bad deploy, 5 · Branch protection requirements (GitHub), Admin Dashboard — Rollback Runbook, code:bash (# Find the last good commit SHA from git log)
 
 ### Community 2815 - "Community 2815"
-Cohesion: 0.25
-Nodes (7): code:typescript (// src/app/dashboard/monitoring/ride-panel.tsx), code:bash (git add src/app/dashboard/monitoring/ride-panel.tsx), code:block39 (# admin-dashboard/.env.local), File Map, Live Monitoring Page Implementation Plan, Post-Implementation: Add Google Maps API Key, Task 9: Frontend — Ride Panel Component
+Cohesion: 0.22
+Nodes (7): code:typescript (// src/app/dashboard/monitoring/driver-panel.tsx), code:bash (git add src/app/dashboard/monitoring/driver-panel.tsx), code:block39 (# admin-dashboard/.env.local), File Map, Live Monitoring Page Implementation Plan, Post-Implementation: Add Google Maps API Key, Task 8: Frontend — Driver Panel Component
 
 ### Community 2816 - "Community 2816"
 Cohesion: 0.25
@@ -6956,7 +7160,7 @@ Nodes (8): support, chat, chatPlaceholder, faq, howCanWeHelp, submitReport, subm
 
 ### Community 2818 - "Community 2818"
 Cohesion: 0.25
-Nodes (8): vehicle, color, make, model, plate, title, type, year
+Nodes (7): BecomeDriverScreen(), styles, uploadFile(), BecomeDriverScreen(), DocState, Requirement, STEPS
 
 ### Community 2819 - "Community 2819"
 Cohesion: 0.25
@@ -6979,7 +7183,7 @@ Cohesion: 0.25
 Nodes (8): support, chat, chatPlaceholder, faq, howCanWeHelp, submitReport, submitting, title
 
 ### Community 2824 - "Community 2824"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): CI Integration, code:bash (curl -Ls "https://get.maestro.mobile.dev" | bash), code:bash (# Run a single flow), Maestro E2E Flows, Prerequisites, Requirements, Running flows
 
 ### Community 2825 - "Community 2825"
@@ -6995,11 +7199,11 @@ Cohesion: 0.25
 Nodes (8): code:python (# backend/tests/test_corporate_company_routes.py), code:bash (pytest backend/tests/test_corporate_company_routes.py -v), code:python (# backend/dependencies/company_guard.py), code:python (# backend/routes/corporate_company.py), code:python (try:), code:bash (pytest backend/tests/test_corporate_company_routes.py -v), code:bash (git add backend/routes/corporate_company.py backend/dependen), Task 6: Company-admin endpoints — members, invites, allowances, domains
 
 ### Community 2828 - "Community 2828"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): A-PE-P1-1 · Refresh Token Persisted in sessionStorage — XSS Stealable, A-PE-P1-2 · Cookie SameSite=Lax on Admin Token, A-PE-P1-3 · Sentry beforeSend Does Not Scrub URL Path Entity IDs, Already Implemented in This Session, Checklist, code:typescript (// In beforeSend, after query_string scrub:), Phase E · P1 — Admin Before-Beta (Phase E Findings)
 
 ### Community 2829 - "Community 2829"
-Cohesion: 0.25
+Cohesion: 0.22
 Nodes (7): After this file, B-P0-1 · Driver Rating Endpoint Crashes 500 on First-Ever Rating, B-P0-2 · Rider Cannot Pay After Driver Completes the Ride (state-string mismatch), Checklist, code:python (average_rating = driver.get('rating', 5.0)  # baseline befor), code:python (# backend/models/ride_status.py), P0 — Backend Critical: Fix Before Any Device Testing
 
 ### Community 2830 - "Community 2830"
@@ -7015,24 +7219,28 @@ Cohesion: 0.25
 Nodes (7): Contact, In-Scope Surfaces, Out of Scope, Reporting a Vulnerability, Rewards, Safe Harbor, Security Policy
 
 ### Community 2833 - "Community 2833"
-Cohesion: 0.25
+Cohesion: 0.28
 Nodes (7): compilerOptions, baseUrl, paths, strict, extends, include, *
 
 ### Community 2834 - "Community 2834"
 Cohesion: 0.25
 Nodes (7): Completed / Verified Implemented, Critical Issues (Must Fix), High Priority, Low Priority, Medium Priority, Open Branches (Unmerged Work), Spinr TODO List
 
+### Community 2835 - "Community 2835"
+Cohesion: 0.25
+Nodes (6): getTipAmount(), handleSubmit(), RateRideScreen(), styles, TIP_OPTIONS, { width }
+
 ### Community 2836 - "Community 2836"
 Cohesion: 0.06
-Nodes (23): float, int, str, _decode(), _mint(), A token with no module access is still structurally valid., Admin tokens bypass the DB lookup and return claims directly., admin-001 (env-seeded super admin) has no DB row — claims are trusted directly. (+15 more)
+Nodes (30): float, int, str, _decode(), _mint(), P3-6: Admin JWT module-gating integration tests.  Admin JWTs carry a `modules` c, A token with no module access is still structurally valid., Admin tokens bypass the DB lookup and return claims directly. (+22 more)
 
 ### Community 2837 - "Community 2837"
-Cohesion: 0.33
-Nodes (4): Tests for async helper functions., Test running sync function in async context., Test run_sync handles exceptions properly., TestAsyncHelpers
+Cohesion: 0.27
+Nodes (6): createStyles(), ErrorScreen(), ErrorScreenProps, NetworkErrorScreen(), NotFoundScreen(), UnauthorizedScreen()
 
 ### Community 2838 - "Community 2838"
-Cohesion: 0.16
-Nodes (10): DeprecatedRootPathMiddleware, metrics(), _metrics_token(), _Request, _Response, str, Bearer token required to scrape /metrics, from METRICS_AUTH_TOKEN env.      Empt, Add X-Spinr-Deprecated: true header and emit a WARNING log for any     request t (+2 more)
+Cohesion: 0.25
+Nodes (8): health(), _loguru_sentry_sink(), metrics(), _metrics_token(), str, Bearer token required to scrape /metrics, from METRICS_AUTH_TOKEN env.      Empt, Bearer token required to scrape /metrics, from METRICS_AUTH_TOKEN env.      Empt, _MetricsResponse
 
 ### Community 2839 - "Community 2839"
 Cohesion: 0.25
@@ -7047,23 +7255,23 @@ Cohesion: 0.29
 Nodes (7): 14. Real-Time Communication Layer, code:block10 (Module scope (driver-app/app/_layout.tsx):), code:block8 (backend/socket_manager.py), code:block9 (Connection lifecycle:), Driver App WebSocket (`driver-app/hooks/useWebSocket.ts`), FCM Push (Driver App — all 3 states), WebSocket Architecture
 
 ### Community 2842 - "Community 2842"
-Cohesion: 0.29
-Nodes (7): 7.1 Directory layout (all artifacts committed), 7.2 Finding template (use in REPORT.md), 7.4 Severity rubric, 7.5 Ground rules (from `audit-framework/ground-rules.md`, condensed), 7. Deliverables, code:block1 (docs/audit/admin-dashboard/), code:markdown (### FND-<NN>: <short title>)
+Cohesion: 0.17
+Nodes (12): 7.1 Directory layout (all artifacts committed), 7.2 Finding template (use in REPORT.md), 7.3 Reference commands the audit agent will run, 7.4 Severity rubric, 7.5 Ground rules (from `audit-framework/ground-rules.md`, condensed), 7. Deliverables, code:block1 (docs/audit/admin-dashboard/), code:markdown (### FND-<NN>: <short title>) (+4 more)
 
 ### Community 2843 - "Community 2843"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): Applicable Dimensions, Key Files (most important to read), Known Approved Decisions (do not re-flag), Module: Driver App, Previous Audits, Screens Inventory
 
 ### Community 2844 - "Community 2844"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): DONE (8), PARTIAL (4), PENDING (5), Per-Item Verification, Rider App — P2a Sprint Verification (first 17 of 33), Verification YAML
 
 ### Community 2845 - "Community 2845"
-Cohesion: 0.29
-Nodes (5): Request, health_check(), Main router aggregator Import all route modules and combine them here, Liveness + readiness probe used by Railway health checks and the     post-deploy, Liveness + readiness probe used by Railway health checks and the     post-deploy
+Cohesion: 0.32
+Nodes (6): Request, health_check(), Main router aggregator Import all route modules and combine them here, Liveness + readiness probe used by Railway health checks and the     post-deploy, Liveness + readiness probe used by Railway health checks and the     post-deploy, root()
 
 ### Community 2846 - "Community 2846"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): code:block1 (Build fails →), Cold storage: alternative Android build strategies, Decision tree, Mirror in driver-app, Why this exists, Index
 
 ### Community 2847 - "Community 2847"
@@ -7087,35 +7295,39 @@ Cohesion: 0.29
 Nodes (7): code:diff (# P0-001 + P0-003 + P0-005 + P2-006: prune settings.local.js), code:diff (# P0-002: install pre-commit hook (one-line setup)), code:diff (# P0-004: correct the attribution trailer), code:diff (# P0-006: un-swap launch.json), P0 — Fix in this sprint, P2 — Cleanup backlog, Phase 9 — Remediation Plan (P0/P1/P2)
 
 ### Community 2852 - "Community 2852"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): ⚠️ Codebase async/sync pattern (read before implementing any Supabase code), code:python (async def some_helper(...) -> ...:), code:python (fake_resp = MagicMock(data=[{"id": "c1"}], count=1)), Corporate B2B — Plan 1: DB Foundation + Super-admin + KYB Queue, Done criteria (Plan 1), Handoff to Plan 2
 
 ### Community 2853 - "Community 2853"
-Cohesion: 0.29
+Cohesion: 0.32
 Nodes (6): client, configuration_version, project_info, project_id, project_number, storage_bucket
 
+### Community 2854 - "Community 2854"
+Cohesion: 0.25
+Nodes (8): buf, mockPost, mockRemoveItem, mockSetItem, _pt(), pts, retries, uploadLocationBatch()
+
 ### Community 2855 - "Community 2855"
-Cohesion: 0.29
-Nodes (7): reactNativeDirectoryCheck, expo, doctor, install, exclude, exclude, listUnknownPackages
+Cohesion: 0.18
+Nodes (10): build, builder, dockerfilePath, deploy, healthcheckPath, healthcheckTimeout, restartPolicyMaxRetries, restartPolicyType (+2 more)
 
 ### Community 2856 - "Community 2856"
-Cohesion: 0.29
-Nodes (6): Canonical Replacement, ⚠️ DEPRECATED — Do Not Use, References, Removal Timeline, Web Builds, Why
+Cohesion: 0.20
+Nodes (9): Architecture Overview, Conclusion, Current Implementation:, Database Schema (PostgreSQL), Executive Summary, Key Tables with Relationships:, Recommendations:, Security Considerations (+1 more)
 
 ### Community 2857 - "Community 2857"
 Cohesion: 0.29
 Nodes (6): ✅ Completed Items, Current Status Analysis, Google Maps & Places API Integration Gap Analysis, ⚠️ Notes, Summary, 📋 Verification Checklist
 
 ### Community 2858 - "Community 2858"
-Cohesion: 0.52
+Cohesion: 0.61
 Nodes (6): setup-claude.sh script, fail(), ok(), skip(), step(), warn()
 
 ### Community 2859 - "Community 2859"
-Cohesion: 0.29
-Nodes (7): chat, imHere, onMyWay, send, title, typeMessage, whereAreYou
+Cohesion: 0.33
+Nodes (5): str, find_service_area_for_point(), Return the first service area whose polygon contains (lat, lng), or None.      P, Return the first service area whose polygon contains (lat, lng), or None.      P, TestFindServiceArea
 
 ### Community 2860 - "Community 2860"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): Current State, Key Blocker (from previous session), Next Steps, Remaining Work, Session Pause — Sync Complete, Work Completed
 
 ### Community 2861 - "Community 2861"
@@ -7151,15 +7363,15 @@ Cohesion: 0.29
 Nodes (7): code:python (# backend/tests/test_corporate_allowance_reset.py), code:bash (pytest backend/tests/test_corporate_allowance_reset.py -v), code:python (# backend/utils/allowance_reset.py), code:python (try:), code:bash (pytest backend/tests/test_corporate_allowance_reset.py -v), code:bash (git add backend/utils/allowance_reset.py backend/main.py bac), Task 9: Monthly allowance reset job
 
 ### Community 2869 - "Community 2869"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): A-P0-1 · Admin JWT Stored in `sessionStorage` — Accessible to Any XSS Payload, A-P0-2 · Admin Access Token TTL Is 12 Hours — Half a Workday Window for Stolen Tokens, A-P0-3 · GPS Points Query Uses `limit=1000000` — Will OOM in Production, After this file, Checklist, P0 — Admin Critical: Fix Before Any Browser Testing
 
 ### Community 2870 - "Community 2870"
-Cohesion: 0.29
+Cohesion: 0.25
 Nodes (6): Backend Phase E Remediation — Full Status, P0 — Fix Before Any Beta Testing (All ✅), P1 — Fix Before Beta Launch (All ✅), P2 — Fix Before Public Launch (All ✅), P3 — Hardening (Open — Low Priority), Summary
 
 ### Community 2871 - "Community 2871"
-Cohesion: 0.29
+Cohesion: 0.32
 Nodes (6): client, configuration_version, project_info, project_id, project_number, storage_bucket
 
 ### Community 2872 - "Community 2872"
@@ -7169,6 +7381,10 @@ Nodes (7): account_suspended, invalid_credentials, otp_expired, otp_invalid, otp
 ### Community 2873 - "Community 2873"
 Cohesion: 0.29
 Nodes (7): documents_expired, documents_pending, documents_rejected, not_available, offline, subscription_required, driver
+
+### Community 2874 - "Community 2874"
+Cohesion: 0.36
+Nodes (8): Rider-app work-profile route tests.  Use `app.dependency_overrides` to fake `get, rider_override(), test_accept_invite_returns_404_when_token_not_found(), test_accept_invite_route_returns_company_and_member(), test_allowance_request_rate_limit_returns_409(), test_auto_match_returns_matches(), test_balance_returns_remaining(), test_work_profile_lists_active_memberships()
 
 ### Community 2875 - "Community 2875"
 Cohesion: 0.29
@@ -7210,6 +7426,10 @@ Nodes (5): Tests for scheduled ride functionality., Test creating a scheduled ri
 Cohesion: 0.29
 Nodes (5): Tests for ride dispute functionality., Test creating a dispute for a ride., Tests for ride dispute functionality., Test resolving a dispute., TestRideDisputes
 
+### Community 2886 - "Community 2886"
+Cohesion: 0.24
+Nodes (7): Activity, DriverActivity(), fmtDuration(), Phase, PHASE_LABEL, Ride, todayRegina()
+
 ### Community 2887 - "Community 2887"
 Cohesion: 0.33
 Nodes (6): 14. Cumulative Programme Metrics, Audit Scorecard — Final, CI Pipeline Expansion, Documentation Created, Git Activity, Test Coverage Built from Zero
@@ -7235,44 +7455,44 @@ Cohesion: 0.33
 Nodes (6): 3.1 Security & compliance, 3.2 Reliability & operability, 3.3 Product & revenue, 3.4 Engineering health, 3.5 Concrete, measurable outcomes (success metrics), 3. Benefits
 
 ### Community 2893 - "Community 2893"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (5): Applicable Dimensions, Audited Routes, Key Files, Module: Backend API, Routes Not Yet Fully Audited
 
 ### Community 2894 - "Community 2894"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (5): Checklist, code:[language] (// Before:), [Item code] · [Short title], [Next item], [P0/P1/P2/P3/P4] — [Group Name]: [When to Fix]
 
 ### Community 2895 - "Community 2895"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (5): DONE (10), PARTIAL (1), PENDING (5), Rider App — P2b Sprint Verification (items 18–33 of 33), Verification YAML
 
 ### Community 2896 - "Community 2896"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (5): code:sql (-- On storage.objects), `driver-documents` (private), `kyb-documents` (private), `ride-snapshots` (public), Supabase Storage Buckets
 
 ### Community 2897 - "Community 2897"
-Cohesion: 0.40
-Nodes (5): get_service_areas(), _project_public(), Public service-areas endpoint.  Drivers and riders can read active service areas, List active service areas available for driver registration and ride booking., List active service areas available for driver registration and ride booking.
+Cohesion: 0.38
+Nodes (8): createStyles(), { height: SCREEN_H }, MINUTES, MONTH_NAMES, Props, SchedulePicker(), toDateStr(), WEEK_DAYS
 
 ### Community 2898 - "Community 2898"
-Cohesion: 0.38
-Nodes (6): get_all_corporate_accounts(), main(), Test the corporate accounts database functions, Test the API route directly, test_api_route(), test_corporate_accounts()
+Cohesion: 0.48
+Nodes (5): main(), Test the corporate accounts database functions, Test the API route directly, test_api_route(), test_corporate_accounts()
 
 ### Community 2899 - "Community 2899"
 Cohesion: 0.33
 Nodes (5): Admin Dashboard — Playwright, App IDs, code:bash (cd admin-dashboard), E2E Testing Guide, Mobile Apps — Maestro
 
 ### Community 2900 - "Community 2900"
-Cohesion: 0.33
-Nodes (6): Driver App npm Audit Report (13 vulns), Driver App npm Audit Report Final (53 vulns), Driver App npm Audit Report v3 (14 vulns), Vulnerability: send <0.19.0 XSS template injection, Vulnerability: tar <=7.5.10 path traversal (high), Vulnerability: undici <=6.23.0 (high severity)
+Cohesion: 0.20
+Nodes (9): Blast radius on the existing app, CarPlay & Android Auto — integration strategy, External approvals (start early — weeks of lead time), Implemented: Android Auto live map ("Path B look, Path A cost"), Integration model (separate vs integrated), iOS CarPlay — dormant, Library decision — evidence, TL;DR (+1 more)
 
 ### Community 2901 - "Community 2901"
-Cohesion: 0.33
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.48
+Nodes (5): fs, path, setOrAppend(), { withDangerousMod }, withForceCompileSdk()
 
 ### Community 2902 - "Community 2902"
-Cohesion: 0.33
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.48
+Nodes (5): fs, path, setOrAppend(), { withDangerousMod }, withKspVersion()
 
 ### Community 2903 - "Community 2903"
 Cohesion: 0.33
@@ -7287,11 +7507,11 @@ Cohesion: 0.33
 Nodes (5): home, nearbyDrivers, scheduledRides, searchPlaceholder, whereToGo
 
 ### Community 2906 - "Community 2906"
-Cohesion: 0.33
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.48
+Nodes (5): fs, path, setOrAppend(), { withDangerousMod }, withStripeAndroidPin()
 
 ### Community 2907 - "Community 2907"
-Cohesion: 0.33
+Cohesion: 0.29
 Nodes (5): Design Direction, Design Principles, Reference Points, Sketches, Spinr — Sketch Manifest
 
 ### Community 2908 - "Community 2908"
@@ -7359,12 +7579,12 @@ Cohesion: 0.33
 Nodes (6): code:python (# backend/tests/test_corporate_allowance_requests.py), code:bash (pytest backend/tests/test_corporate_allowance_requests.py -v), code:python (# Append inside corporate_company.py imports:), code:bash (pytest backend/tests/test_corporate_allowance_requests.py -v), code:bash (git add backend/routes/corporate_company.py backend/tests/te), Task 8: Admin approve/deny for allowance requests
 
 ### Community 2924 - "Community 2924"
-Cohesion: 0.33
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.48
+Nodes (5): fs, path, setOrAppend(), { withDangerousMod }, withForceCompileSdk()
 
 ### Community 2925 - "Community 2925"
-Cohesion: 0.33
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.48
+Nodes (5): fs, path, setOrAppend(), { withDangerousMod }, withKspVersion()
 
 ### Community 2926 - "Community 2926"
 Cohesion: 0.33
@@ -7390,20 +7610,28 @@ Nodes (6): 5. Admin Dashboard (Next.js), Components:, Issues Identified:, Key Pa
 Cohesion: 0.20
 Nodes (6): A-P3-8: Security tests for admin auth and RBAC scenarios.  Covers six critical s, A deactivated staff member cannot log in even with correct password., A deactivated staff member cannot log in even with correct password., staff.is_active=False → 403 even when password matches., staff.is_active=False → 403 even when password matches., TestDeactivatedStaffRejected
 
+### Community 2932 - "Community 2932"
+Cohesion: 0.36
+Nodes (8): ActiveRide, DailyEarning, DriverState, EarningsSummary, IncomingRide, RideState, TripEarning, useDriverStore
+
 ### Community 2933 - "Community 2933"
 Cohesion: 0.33
 Nodes (4): Tests for Twilio integration., Test Twilio client initialization., Test Twilio message creation parameters., TestTwilioIntegration
 
 ### Community 2934 - "Community 2934"
-Cohesion: 0.33
-Nodes (4): Tests for SMS retry logic., Test SMS retry logic on failure., Test SMS retry exhaustion., TestSMSRetry
+Cohesion: 0.20
+Nodes (9): Architecture, Backend, Deployment, Frontend, Key Features, Notes, Project Structure, Setup Instructions (Local Development) (+1 more)
+
+### Community 2935 - "Community 2935"
+Cohesion: 0.22
+Nodes (9): 3. Rider App (Expo/React Native), 4. Frontend Web (Expo Router), 6. Shared Configuration, Component Analysis, Configuration:, Issues Identified:, Key Screens:, Key Structure: (+1 more)
 
 ### Community 2936 - "Community 2936"
-Cohesion: 0.40
+Cohesion: 0.47
 Nodes (4): code:bash (npm run dev), Deploy on Vercel, Getting Started, Learn More
 
 ### Community 2937 - "Community 2937"
-Cohesion: 0.60
+Cohesion: 0.67
 Nodes (4): BACKEND_URL, clearSessionCookies(), POST(), verifyCsrf()
 
 ### Community 2938 - "Community 2938"
@@ -7411,27 +7639,27 @@ Cohesion: 0.21
 Nodes (8): int, Response, str, Set HTTP-only authentication token cookie.          Args:             response:, Set HTTP-only refresh token cookie.         Longer TTL; used only for token rota, Clear authentication token cookie., Clear refresh token cookie., Clear all authentication cookies (logout).
 
 ### Community 2939 - "Community 2939"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): ADR-001: Supabase as the managed Postgres provider, Consequences, Context, Decision
 
 ### Community 2940 - "Community 2940"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): ADR-002: Expo SDK for both mobile apps, Consequences, Context, Decision
 
 ### Community 2941 - "Community 2941"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): ADR-003: FastAPI as the backend framework, Consequences, Context, Decision
 
 ### Community 2942 - "Community 2942"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): ADR-004: Transparent in-process Redis fallback for dev/test, Consequences, Context, Decision
 
 ### Community 2943 - "Community 2943"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): ADR-005: Dual auth: Firebase ID token + short-lived HS256 JWT, Consequences, Context, Decision
 
 ### Community 2944 - "Community 2944"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): ADR-006: Railway as the primary hosting platform, Consequences, Context, Decision
 
 ### Community 2945 - "Community 2945"
@@ -7483,803 +7711,803 @@ Cohesion: 0.40
 Nodes (5): 7. Admin Dashboard — Full File Mapping, Admin Components, Admin Lib / Utilities, Admin Tests, App Pages (Next.js App Router)
 
 ### Community 2957 - "Community 2957"
-Cohesion: 0.40
-Nodes (5): 7.3 Reference commands the audit agent will run, code:bash (# Every admin route), code:bash (# Frontend), code:bash (# Start stack), code:bash (python3 -c "from graphify.watch import _rebuild_code; from p)
+Cohesion: 0.33
+Nodes (6): buildCarScreen(), CarRow, CarScreenModel, dropoff(), pickup(), riderName()
 
 ### Community 2958 - "Community 2958"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): PARTIAL summary, Per-Item Verification, Rider App — P4 Sprint Verification (10 items), Verification YAML
 
 ### Community 2959 - "Community 2959"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2960 - "Community 2960"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2961 - "Community 2961"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2962 - "Community 2962"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2963 - "Community 2963"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2964 - "Community 2964"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2965 - "Community 2965"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2966 - "Community 2966"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2967 - "Community 2967"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2968 - "Community 2968"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2969 - "Community 2969"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2970 - "Community 2970"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2971 - "Community 2971"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2972 - "Community 2972"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2973 - "Community 2973"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2974 - "Community 2974"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2975 - "Community 2975"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2976 - "Community 2976"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2977 - "Community 2977"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2978 - "Community 2978"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2979 - "Community 2979"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2980 - "Community 2980"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2981 - "Community 2981"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2982 - "Community 2982"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2983 - "Community 2983"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2984 - "Community 2984"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2985 - "Community 2985"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2986 - "Community 2986"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2987 - "Community 2987"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2988 - "Community 2988"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2989 - "Community 2989"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2990 - "Community 2990"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2991 - "Community 2991"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2992 - "Community 2992"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2993 - "Community 2993"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2994 - "Community 2994"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2995 - "Community 2995"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2996 - "Community 2996"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2997 - "Community 2997"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2998 - "Community 2998"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 2999 - "Community 2999"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3000 - "Community 3000"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3001 - "Community 3001"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3002 - "Community 3002"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3003 - "Community 3003"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3004 - "Community 3004"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3005 - "Community 3005"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3006 - "Community 3006"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3007 - "Community 3007"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3008 - "Community 3008"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3009 - "Community 3009"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3010 - "Community 3010"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3011 - "Community 3011"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3012 - "Community 3012"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3013 - "Community 3013"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3014 - "Community 3014"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3015 - "Community 3015"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3016 - "Community 3016"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3017 - "Community 3017"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3018 - "Community 3018"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3019 - "Community 3019"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3020 - "Community 3020"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3021 - "Community 3021"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3022 - "Community 3022"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3023 - "Community 3023"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3024 - "Community 3024"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3025 - "Community 3025"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3026 - "Community 3026"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3027 - "Community 3027"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3028 - "Community 3028"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3029 - "Community 3029"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3030 - "Community 3030"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3031 - "Community 3031"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3032 - "Community 3032"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3033 - "Community 3033"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3034 - "Community 3034"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3035 - "Community 3035"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3036 - "Community 3036"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3037 - "Community 3037"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3038 - "Community 3038"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3039 - "Community 3039"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3040 - "Community 3040"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3041 - "Community 3041"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3042 - "Community 3042"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3043 - "Community 3043"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3044 - "Community 3044"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3045 - "Community 3045"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3046 - "Community 3046"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3047 - "Community 3047"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3048 - "Community 3048"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3049 - "Community 3049"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3050 - "Community 3050"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3051 - "Community 3051"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3052 - "Community 3052"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3053 - "Community 3053"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3054 - "Community 3054"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3055 - "Community 3055"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3056 - "Community 3056"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3057 - "Community 3057"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3058 - "Community 3058"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3059 - "Community 3059"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3060 - "Community 3060"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3061 - "Community 3061"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3062 - "Community 3062"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3063 - "Community 3063"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3064 - "Community 3064"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3065 - "Community 3065"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3066 - "Community 3066"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3067 - "Community 3067"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3068 - "Community 3068"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3069 - "Community 3069"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3070 - "Community 3070"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3071 - "Community 3071"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3072 - "Community 3072"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3073 - "Community 3073"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3074 - "Community 3074"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3075 - "Community 3075"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3076 - "Community 3076"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3077 - "Community 3077"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3078 - "Community 3078"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3079 - "Community 3079"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3080 - "Community 3080"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3081 - "Community 3081"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3082 - "Community 3082"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3083 - "Community 3083"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3084 - "Community 3084"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3085 - "Community 3085"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3086 - "Community 3086"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3087 - "Community 3087"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3088 - "Community 3088"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3089 - "Community 3089"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3090 - "Community 3090"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3091 - "Community 3091"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3092 - "Community 3092"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3093 - "Community 3093"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3094 - "Community 3094"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3095 - "Community 3095"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3096 - "Community 3096"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3097 - "Community 3097"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3098 - "Community 3098"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3099 - "Community 3099"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3100 - "Community 3100"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3101 - "Community 3101"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3102 - "Community 3102"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3103 - "Community 3103"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3104 - "Community 3104"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3105 - "Community 3105"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3106 - "Community 3106"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3107 - "Community 3107"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3108 - "Community 3108"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3109 - "Community 3109"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3110 - "Community 3110"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3111 - "Community 3111"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3112 - "Community 3112"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3113 - "Community 3113"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3114 - "Community 3114"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3115 - "Community 3115"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3116 - "Community 3116"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3117 - "Community 3117"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3118 - "Community 3118"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3119 - "Community 3119"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3120 - "Community 3120"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3121 - "Community 3121"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3122 - "Community 3122"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3123 - "Community 3123"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3124 - "Community 3124"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3125 - "Community 3125"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3126 - "Community 3126"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3127 - "Community 3127"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3128 - "Community 3128"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3129 - "Community 3129"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3130 - "Community 3130"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3131 - "Community 3131"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3132 - "Community 3132"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3133 - "Community 3133"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3134 - "Community 3134"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3135 - "Community 3135"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3136 - "Community 3136"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3137 - "Community 3137"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3138 - "Community 3138"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3139 - "Community 3139"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3140 - "Community 3140"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3141 - "Community 3141"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3142 - "Community 3142"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3143 - "Community 3143"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3144 - "Community 3144"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3145 - "Community 3145"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3146 - "Community 3146"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3147 - "Community 3147"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3148 - "Community 3148"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3149 - "Community 3149"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3150 - "Community 3150"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3151 - "Community 3151"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3152 - "Community 3152"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Audit Metadata, CI Error Audit Report, Errors, Executive Summary
 
 ### Community 3153 - "Community 3153"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): After rotation, Steps, Supabase Service-Role Key Rotation, Why this matters
 
 ### Community 3154 - "Community 3154"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): Backend Documentation, Domain docs, Lookup, Subsystems with their own docs
 
 ### Community 3156 - "Community 3156"
-Cohesion: 0.50
-Nodes (3): str, get_request_id(), set_request_context()
+Cohesion: 0.53
+Nodes (4): str, get_log_context(), get_request_id(), set_request_context()
 
 ### Community 3157 - "Community 3157"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): code:block1 (Plan: <task name>), Output format, /plan — Decompose before coding, Steps
 
 ### Community 3158 - "Community 3158"
@@ -8331,19 +8559,19 @@ Cohesion: 0.40
 Nodes (5): code:bash (cp .claude/hooks/pre-commit .git/hooks/pre-commit), Phase 7 — Persona-Specific Views, View A — New-Developer Onboarding, View B — Security Engineer Perspective, View C — Tech Lead Perspective
 
 ### Community 3170 - "Community 3170"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): How to update this register, Open items, Sub-processor inventory, Vendor Register — PIPEDA DPA Inventory
 
 ### Community 3171 - "Community 3171"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): code:bash (rm patches/@react-native+gradle-plugin+0.85.2.patch), code:js (const KSP_VERSION = '2.1.20-2.0.1';), How to switch FROM Option C TO Option B, Option B — Kotlin 2.1.20 strategy (driver-app)
 
 ### Community 3172 - "Community 3172"
-Cohesion: 0.40
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.53
+Nodes (4): fs, path, { withDangerousMod }, withGradleWrapper()
 
 ### Community 3173 - "Community 3173"
-Cohesion: 0.40
+Cohesion: 0.53
 Nodes (4): Tier 1 — Summary, Tier 2 — Impact, Tier 3 — Compliance flags, Tier 4 — Verification
 
 ### Community 3174 - "Community 3174"
@@ -8351,19 +8579,19 @@ Cohesion: 0.80
 Nodes (4): test_pre_commit.sh script, _fail(), _pass(), _run_gate()
 
 ### Community 3175 - "Community 3175"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (5): languages, en, es, fr, zh
 
 ### Community 3176 - "Community 3176"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (5): nearbyDrivers, scheduledRides, searchPlaceholder, whereToGo, home
 
 ### Community 3177 - "Community 3177"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (5): nearbyDrivers, scheduledRides, searchPlaceholder, whereToGo, home
 
 ### Community 3178 - "Community 3178"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (5): languages, en, es, fr, zh
 
 ### Community 3179 - "Community 3179"
@@ -8387,20 +8615,24 @@ Cohesion: 0.40
 Nodes (5): code:python (# backend/tests/test_corporate_e2e_members.py), code:bash (pytest backend/tests/test_corporate_membership_schemas.py \), code:bash (pytest backend/tests/ -v --ignore=backend/tests/test_corpora), code:bash (git add backend/tests/test_corporate_e2e_members.py backend/), Task 11: e2e test — member lifecycle with money movement
 
 ### Community 3184 - "Community 3184"
-Cohesion: 0.40
+Cohesion: 0.33
 Nodes (4): After this file, Inventory, P4 — Backend Future / Backlog, When to add an item here
 
 ### Community 3185 - "Community 3185"
-Cohesion: 0.40
-Nodes (5): payment, failed, insufficient_funds, method_invalid, refund_failed
+Cohesion: 0.13
+Nodes (15): errors, payment, system, unknown, wallet, failed, insufficient_funds, method_invalid (+7 more)
 
 ### Community 3186 - "Community 3186"
-Cohesion: 0.40
-Nodes (5): system, database, internal, rate_limited, service_unavailable
+Cohesion: 0.36
+Nodes (4): log, Index(), createLogger(), Logger
 
 ### Community 3187 - "Community 3187"
-Cohesion: 0.40
-Nodes (3): fs, path, { withDangerousMod }
+Cohesion: 0.53
+Nodes (4): fs, path, { withDangerousMod }, withGradleWrapper()
+
+### Community 3188 - "Community 3188"
+Cohesion: 0.53
+Nodes (4): computeFareBreakdown(), computeFareFromRide(), FareBreakdownInput, FareBreakdownResult
 
 ### Community 3189 - "Community 3189"
 Cohesion: 0.40
@@ -8433,10 +8665,6 @@ Nodes (5): 7. Admin portal (company-facing), Notifications, Roles, Screens, Supe
 ### Community 3196 - "Community 3196"
 Cohesion: 0.17
 Nodes (7): Tests for document validation., Test validating PDF file type., Test validating image file type., Test validating invalid file type., Test validating file size., Test validating file extension., TestDocumentValidation
-
-### Community 3197 - "Community 3197"
-Cohesion: 0.40
-Nodes (3): Tests for the main DB wrapper., Test all expected collections exist on db object., TestDBWrapper
 
 ### Community 3198 - "Community 3198"
 Cohesion: 0.50
@@ -8491,31 +8719,39 @@ Cohesion: 0.50
 Nodes (4): 2.1 Why the admin dashboard specifically, 2.2 Threat model (one-page summary), 2.3 Why now, 2. Rationale
 
 ### Community 3211 - "Community 3211"
-Cohesion: 0.50
-Nodes (4): 8.1 How to use this prompt, 8.2 Maintenance, 8. Ready-to-Run Prompt, code:block7 (===== BEGIN PROMPT =====)
+Cohesion: 0.33
+Nodes (5): DataPoint, EarningsLineChart(), EarningsLineChartProps, styles, { width: SCREEN_WIDTH }
 
 ### Community 3212 - "Community 3212"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): Highlights, Rider App — P1a Sprint Verification (items 1–17 of 33), Verification YAML
 
 ### Community 3213 - "Community 3213"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): Highlights, Rider App — P1b Sprint Verification (items 18–33 of 33), Verification YAML
 
 ### Community 3214 - "Community 3214"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): Per-Item Verification, Rider App — P3 Sprint Verification (8 items), Verification YAML
 
+### Community 3215 - "Community 3215"
+Cohesion: 0.22
+Nodes (8): 1. Backend Deployment (Railway - Recommended), 2. Frontend Deployment (Vercel), 3. Driver App Deployment (Vercel), 4. Admin Dashboard Deployment (Vercel), Alternative: Backend Deployment (Render), CI/CD for Railway, Deployment Guide: Vercel + Railway (or Render), Troubleshooting
+
+### Community 3216 - "Community 3216"
+Cohesion: 0.22
+Nodes (8): conflictError, err, error, mockCompletedRide, mockEarnings, mockHistory, mockIncomingRide, state
+
 ### Community 3217 - "Community 3217"
-Cohesion: 0.50
-Nodes (4): brace-expansion Security Vulnerability (moderate), Driver App npm Audit Report, picomatch ReDoS Vulnerability (high), undici Security Vulnerabilities (high)
+Cohesion: 0.28
+Nodes (4): AccountScreen(), formatPhone(), getBackendUrl(), styles
 
 ### Community 3218 - "Community 3218"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): Cold storage: alternative Android build strategies (driver-app), Differences from rider-app, Index
 
 ### Community 3219 - "Community 3219"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): Output Format, /status — spinr Project Health Dashboard, What to Check
 
 ### Community 3220 - "Community 3220"
@@ -8539,20 +8775,24 @@ Cohesion: 0.50
 Nodes (4): 5.1 Token Consumption at Session Start, 5.2 Settings File Sizes, 5.3 Hook Execution Time, Phase 5 — Context Budget & Performance
 
 ### Community 3225 - "Community 3225"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): Admin PWA / Service Worker Policy, Constraints, Review checklist for any SW PR
 
 ### Community 3226 - "Community 3226"
-Cohesion: 0.50
+Cohesion: 0.40
 Nodes (3): code:bash (cp build-options/option-a-kotlin-2.0.21/@react-native+gradle), How to switch FROM Option C TO Option A, Option A — Kotlin 2.0.21 strategy (driver-app)
 
+### Community 3227 - "Community 3227"
+Cohesion: 0.60
+Nodes (3): REQUIRED_PERMISSIONS, { withAndroidManifest }, withNotifeePermissions()
+
 ### Community 3228 - "Community 3228"
-Cohesion: 0.50
+Cohesion: 0.60
 Nodes (3): fs, path, target
 
 ### Community 3229 - "Community 3229"
-Cohesion: 0.50
-Nodes (4): Item, pytest_collection_modifyitems(), Auto-skip collected items belonging to known-stale test classes.      Matching i, Auto-skip collected items belonging to known-stale test classes.      Matching i
+Cohesion: 0.22
+Nodes (9): notifications, allCaughtUp, markAllRead, markReadError, markReadErrorBody, noNotifications, title, unreadCount (+1 more)
 
 ### Community 3230 - "Community 3230"
 Cohesion: 0.50
@@ -8594,17 +8834,25 @@ Nodes (4): Authentication Flow:, Driver Location Updates:, Integration Points, R
 Cohesion: 0.50
 Nodes (4): Critical Issues:, Issues & Improvements Summary, Low Priority:, Medium Priority:
 
+### Community 3240 - "Community 3240"
+Cohesion: 0.22
+Nodes (8): Google Maps & Places API Integration Instructions, Prerequisites, Step 1: Install Dependencies, Step 2: Configure App (app.json), Step 3: Implement Map Component, Step 4: Implement Autocomplete, Step 5: Directions (Routing), Step 6: Backend Verification
+
 ### Community 3242 - "Community 3242"
 Cohesion: 0.67
 Nodes (3): code:typescript (// Change setAuthCookie():), code:typescript (import { NextRequest, NextResponse } from 'next/server';), P1-1: Add `HttpOnly` to admin access token cookie (F-02)
+
+### Community 3245 - "Community 3245"
+Cohesion: 0.22
+Nodes (8): Baseline: Sprint 9 Audit (2026-04-09), How to Add a New Finding, Open — Dependencies, Open — MEDIUM, Open — Pre-Production Gate (Phase 5 SEC-1), Phase 5 Checklist, Resolved, Spinr — Open Items Tracker
 
 ### Community 3246 - "Community 3246"
 Cohesion: 0.67
 Nodes (3): 11. Sprint 7 — Security Consolidation, Cancellation UX & Admin Tests, Branches Delivered, Key Technical Details
 
 ### Community 3247 - "Community 3247"
-Cohesion: 0.67
-Nodes (3): 15. Before vs. After Comparison, App Maturity Level, code:block13 (Before:  [██░░░░░░░░] ~20% — MVP prototype with critical sec)
+Cohesion: 0.22
+Nodes (8): Cut over to Fly-primary, Fail back to Railway, Fly.io app setup, One-time: deploy commands run automatically, Railway + Fly.io failover (Cloudflare CNAME cutover), Requirements, Safety checks, Shared Redis behind a DNS alias
 
 ### Community 3248 - "Community 3248"
 Cohesion: 0.67
@@ -8614,13 +8862,25 @@ Nodes (3): 1. Platform Overview, code:block1 (srikumarimuddana-lab/spinr        
 Cohesion: 0.18
 Nodes (6): Tests for document API endpoints., Test getting document requirements endpoint.          The autouse supabase patch, Test uploading document endpoint.          Smoke test — route path may differ be, Test getting driver documents endpoint., Test admin document review endpoint., TestDocumentEndpoints
 
+### Community 3250 - "Community 3250"
+Cohesion: 0.22
+Nodes (7): Direct handler tests — bypass FastAPI middleware so we can pin the     actual gu, Direct handler tests — bypass FastAPI middleware so we can pin the     actual gu, Active-ride guard: second create for the same rider → 409., Active-ride guard: second create for the same rider → 409., Idempotency-Key guard: replay returns the original ride., Idempotency-Key guard: replay returns the original ride., TestDuplicateRideRequestGuardHandler
+
+### Community 3251 - "Community 3251"
+Cohesion: 0.22
+Nodes (7): When the rider confirms a ride 30s after seeing an estimate, the     confirmed f, When the rider confirms a ride 30s after seeing an estimate, the     confirmed f, If the first create succeeded at surge=1.5 and the client retries         with t, If the first create succeeded at surge=1.5 and the client retries         with t, Surge-lock via estimate_token (P0-4 CLOSED).          Scenario: rider gets estim, Surge-lock via estimate_token (P0-4 CLOSED).          Scenario: rider gets estim, TestSurgeBoundaryConsistency
+
+### Community 3252 - "Community 3252"
+Cohesion: 0.22
+Nodes (7): Tests for ride sharing functionality., Test generating a share token for trip tracking., Tests for ride sharing functionality., Test generating a share token for trip tracking., Test share trip data structure., Test share trip data structure., TestRideSharing
+
 ### Community 3256 - "Community 3256"
 Cohesion: 0.67
 Nodes (3): code:typescript (import axios, { AxiosError } from 'axios'), File: `rider-app/utils/apiClient.ts`, Step 6: Axios Client — withCredentials
 
 ### Community 3257 - "Community 3257"
-Cohesion: 0.67
-Nodes (3): code:python (import json), File: `backend/utils/cookie_manager.py` (NEW), Step 1: Backend Cookie Manager
+Cohesion: 0.46
+Nodes (6): dismissRideOfferNotification(), displayRideOfferNotification(), ensureNotifeeReady(), NotifeeAction, parseRideOfferEvent(), RideOfferDisplayData
 
 ### Community 3258 - "Community 3258"
 Cohesion: 0.67
@@ -8643,8 +8903,8 @@ Cohesion: 0.67
 Nodes (3): code:typescript (// src/app/dashboard/monitoring/alert-feed.tsx), code:bash (git add src/app/dashboard/monitoring/alert-feed.tsx), Task 7: Frontend — Alert Feed Component
 
 ### Community 3263 - "Community 3263"
-Cohesion: 0.67
-Nodes (3): code:typescript (// src/app/dashboard/monitoring/driver-panel.tsx), code:bash (git add src/app/dashboard/monitoring/driver-panel.tsx), Task 8: Frontend — Driver Panel Component
+Cohesion: 0.43
+Nodes (6): DocumentRequirement, DocumentState, DriverDocument, useDocumentStore, isAxiosError(), RNFileDescriptor
 
 ### Community 3264 - "Community 3264"
 Cohesion: 0.67
@@ -8670,53 +8930,213 @@ Nodes (3): code:typescript (router.replace('/(driver)' as any)   // become-drive
 Cohesion: 0.67
 Nodes (3): code:block8 (play-service-account.json), code:yaml (- name: Check for private vars in EXPO_PUBLIC_), ✅ R-P2-16 · Rider-App CI Missing EXPO_PUBLIC_ Scan; play-service-account.json Not in .gitignore
 
+### Community 3272 - "Community 3272"
+Cohesion: 0.29
+Nodes (6): activeRide, cachedRide, liveRide, makeActiveRide(), resetStore(), state
+
+### Community 3273 - "Community 3273"
+Cohesion: 0.25
+Nodes (7): location, mockEstimates, mockRide, state, stop, updated, vehicle
+
 ### Community 3274 - "Community 3274"
 Cohesion: 0.67
 Nodes (3): 13. v2+ roadmap (deferred items), v2 (~3 months post v1), v3
 
+### Community 3275 - "Community 3275"
+Cohesion: 0.25
+Nodes (7): 1. Configure Saskatchewan (build the data), 2. Wire the backend, 3. Test it, 4. Troubleshooting, Deploy on Railway, End-to-end (backend → OSRM), Self-hosted OSRM — Saskatchewan map-matching for billable distance
+
+### Community 3276 - "Community 3276"
+Cohesion: 0.25
+Nodes (7): Contact, In-Scope Surfaces, Out of Scope, Reporting a Vulnerability, Rewards, Safe Harbor, Security Policy
+
+### Community 3277 - "Community 3277"
+Cohesion: 0.25
+Nodes (5): Tests for driver location tracking., Test updating driver location.          The RPC had a text/uuid type mismatch so, Test finding nearby drivers.          conftest.py's autouse fixture wires ``clie, Test finding nearby drivers when none available., TestDriverLocation
+
+### Community 3380 - "Community 3380"
+Cohesion: 0.25
+Nodes (5): Tests for driver registration functionality., Sample driver registration data., Test successful driver registration., Test driver registration with missing required fields., TestDriverRegistration
+
 ### Community 3381 - "Community 3381"
-Cohesion: 0.02
-Nodes (63): API_URL, getAuthHeader(), getStoredToken(), styles, styles, handleBookRide(), PAYMENT_METHODS, styles (+55 more)
+Cohesion: 0.09
+Nodes (10): styles, styles, styles, { width }, Index(), RootLayout(), styles, RideCompletedScreen() (+2 more)
 
 ### Community 3382 - "Community 3382"
-Cohesion: 0.22
-Nodes (7): Tests for session management., Test that session ID is included in JWT token., Tests for session management., Test session invalidation logic., Test that session ID is included in JWT token., Test session invalidation logic., TestSessionManagement
+Cohesion: 0.25
+Nodes (5): Tests for driver statistics., Test getting driver ride count., Test calculating driver average rating., Test driver rating calculation., TestDriverStats
+
+### Community 3383 - "Community 3383"
+Cohesion: 0.25
+Nodes (5): Arrive is only legal from driver_accepted or driver_arrived (idempotent)., Start transitions driver_arrived → in_progress. Must verify rider OTP., Complete is only legal from in_progress. Completing a completed ride → 409., Walk the ride through every legal state and assert each hop persists., TestRideLifecycleHappyPath
+
+### Community 3385 - "Community 3385"
+Cohesion: 0.25
+Nodes (5): Tests for service area functionality., Test getting all service areas., Test assigning a driver to a service area., Test point in polygon check for service area., TestServiceAreas
+
+### Community 3386 - "Community 3386"
+Cohesion: 0.54
+Nodes (7): _patches(), Tests for GET /rides/{id}/live-route — OSRM route line + ETA for the live map., _ride(), test_empty_when_no_driver_position(), test_empty_when_not_active(), test_in_progress_routes_to_dropoff(), test_pre_trip_routes_to_pickup()
 
 ### Community 3387 - "Community 3387"
 Cohesion: 0.25
-Nodes (8): int, str, admin_get_disputes(), get_dispute(), Get a specific dispute by ID., Get a specific dispute by ID., Get all disputes with optional status filter., Get all disputes with optional status filter.
+Nodes (5): Tests for related changes in match_driver_to_ride.      Patterns mirror test_e2e, Ride row with any null lat/lng must abort before driver lookup., new_ride_assignment WS payload carries the per-offer countdown., _offer_timeout_handler must also send ride_offer_expired to the driver., TestDispatchHardening
 
 ### Community 3388 - "Community 3388"
-Cohesion: 0.32
-Nodes (5): Exercise the rate_limit_auth decorator inner functions., TestRateLimitAuthDecorator, rate_limit_auth(), Rate limit decorator for authentication endpoints.      Args:         requests:, Rate limit decorator for authentication endpoints.      Args:         requests:
+Cohesion: 0.25
+Nodes (7): Completed / Verified Implemented, Critical Issues (Must Fix), High Priority, Low Priority, Medium Priority, Open Branches (Unmerged Work), Spinr TODO List
+
+### Community 3390 - "Community 3390"
+Cohesion: 0.29
+Nodes (7): 1. Backend (Fast API), API Endpoints (49 endpoints):, Database Schema:, Issues Identified:, Key Files:, Strengths:, Technology Stack:
+
+### Community 3391 - "Community 3391"
+Cohesion: 0.52
+Nodes (5): Decimal, _authoritative_ride_charge(), _q2(), Quantize a money value to 2dp (HALF_UP). Decimal-only — never float., Server-authoritative amount the rider owes for a ride: grand_total + tip.      `
 
 ### Community 3392 - "Community 3392"
-Cohesion: 0.25
-Nodes (5): Test creating an FAQ., Test getting FAQs by category., Test updating an FAQ., Tests for FAQ functionality., TestFAQs
+Cohesion: 0.09
+Nodes (14): Unit tests for features module. Tests cover support tickets, FAQs, surge pricing, Test creating an FAQ., Test getting FAQs by category., Test updating an FAQ., Tests for emergency contact functionality., Test adding an emergency contact., Test getting emergency contacts for a user., Tests for corporate account functionality. (+6 more)
+
+### Community 3393 - "Community 3393"
+Cohesion: 0.38
+Nodes (5): Regression test for backend/features.py :: admin_reset_surge_to_auto.  With the, Reset-to-auto must set surge_source=auto, surge_active and surge_enabled., Unknown area still 404s and writes nothing., test_reset_to_auto_404_when_area_missing(), test_reset_to_auto_enables_surge_gate()
+
+### Community 3394 - "Community 3394"
+Cohesion: 0.29
+Nodes (6): ✅ Completed Items, Current Status Analysis, Google Maps & Places API Integration Gap Analysis, ⚠️ Notes, Summary, 📋 Verification Checklist
+
+### Community 3395 - "Community 3395"
+Cohesion: 0.38
+Nodes (4): _is_dispatchable_driver(), Return True iff this driver row should be considered for dispatch.      Excludes, Return True iff this driver row should be considered for dispatch.      Excludes, TestIsDispatchableDriver
+
+### Community 3396 - "Community 3396"
+Cohesion: 0.33
+Nodes (6): 2. Driver App (Expo/React Native), Issues Identified:, Key Features:, Key Screens:, State Management:, Technology Stack:
+
+### Community 3397 - "Community 3397"
+Cohesion: 0.33
+Nodes (6): 5. Admin Dashboard (Next.js), Components:, Issues Identified:, Key Pages:, Strengths:, Technology Stack:
+
+### Community 3398 - "Community 3398"
+Cohesion: 0.47
+Nodes (4): handleBookRide(), PAYMENT_METHODS, styles, PaymentConfirmScreen()
+
+### Community 3399 - "Community 3399"
+Cohesion: 0.73
+Nodes (4): _fake_resp(), test_list_companies_by_status_filter(), test_record_kyb_decision(), test_update_company_status()
+
+### Community 3400 - "Community 3400"
+Cohesion: 0.40
+Nodes (4): Tests for the ride state-machine guard in routes/drivers.py.  These pin the C-RI, Sanity check: no source-state allowlist should include terminals., Sanity check: no source-state allowlist should include terminals., test_state_constants_are_disjoint_from_terminal()
+
+### Community 3401 - "Community 3401"
+Cohesion: 0.67
+Nodes (4): onRideRated(), shouldShowRatingPrompt(), showAppRatingPrompt(), trackCompletedRide()
+
+### Community 3402 - "Community 3402"
+Cohesion: 0.33
+Nodes (5): Regression: a Redis outage on the ephemeral driver-location cache must not block, A raising redis_set must not propagate out of the cache write., Happy path still writes the 60 s location cache key., test_update_driver_location_swallows_redis_error(), test_update_driver_location_writes_cache_when_redis_ok()
+
+### Community 3403 - "Community 3403"
+Cohesion: 0.33
+Nodes (5): Guard invariants that only break under concurrency., Guard invariants that only break under concurrency., One driver gets 200, the loser gets 409 — never both 200., One driver gets 200, the loser gets 409 — never both 200., TestRideLifecycleConcurrency
+
+### Community 3404 - "Community 3404"
+Cohesion: 0.33
+Nodes (5): End-to-end proof that POST /rides uses the token's surge rather     than re-read, End-to-end proof that POST /rides uses the token's surge rather     than re-read, When token surge=1.5 and service_area surge=1.0 are in conflict,         the rid, When token surge=1.5 and service_area surge=1.0 are in conflict,         the rid, TestCreateRideHonorsEstimateToken
+
+### Community 3405 - "Community 3405"
+Cohesion: 0.40
+Nodes (4): ADR-007: Fly.io primary with Railway as warm standby (DNS cutover), Consequences, Context, Decision
+
+### Community 3406 - "Community 3406"
+Cohesion: 0.40
+Nodes (3): LOGO, Props, styles
+
+### Community 3407 - "Community 3407"
+Cohesion: 0.40
+Nodes (3): LOGO, Props, styles
 
 ### Community 3410 - "Community 3410"
 Cohesion: 0.67
 Nodes (3): 1. Overview, Explicitly out of v1 (deferred to v2+, see §12), What this spec covers (v1)
 
+### Community 3411 - "Community 3411"
+Cohesion: 0.50
+Nodes (4): Admin Dashboard:, Backend:, Dependencies Summary, Mobile Apps:
+
+### Community 3412 - "Community 3412"
+Cohesion: 0.50
+Nodes (4): Authentication Flow:, Driver Location Updates:, Integration Points, Ride Booking Flow:
+
+### Community 3413 - "Community 3413"
+Cohesion: 0.50
+Nodes (4): Critical Issues:, Issues & Improvements Summary, Low Priority:, Medium Priority:
+
+### Community 3414 - "Community 3414"
+Cohesion: 0.50
+Nodes (4): 1.1 In-scope surfaces, 1.2 Out-of-scope (explicitly), 1.3 Functional scope — every dashboard feature must be exercised, 1. Scope
+
+### Community 3417 - "Community 3417"
+Cohesion: 0.83
+Nodes (3): smoke-test.sh script, fail(), pass()
+
+### Community 3418 - "Community 3418"
+Cohesion: 0.50
+Nodes (3): devDependencies, commitlint, @commitlint/config-conventional
+
+### Community 3419 - "Community 3419"
+Cohesion: 0.50
+Nodes (4): code:ts (// admin-dashboard/src/lib/api.ts), code:tsx (import {), code:bash (git add admin-dashboard/src/lib/api.ts admin-dashboard/src/a), Task 10: Admin dashboard — wallet panel on company detail page
+
+### Community 3424 - "Community 3424"
+Cohesion: 0.67
+Nodes (3): 5. Sprint 1 — CI/CD Hardening & Infrastructure Security, Branches Delivered, Key Outcomes
+
+### Community 3425 - "Community 3425"
+Cohesion: 0.67
+Nodes (3): Backend (9 files), Frontend (7 files across 3 apps), Summary: All Files Changed
+
+### Community 3426 - "Community 3426"
+Cohesion: 0.67
+Nodes (3): code:python (# BEFORE (OLD)), File: `backend/routes/admin/auth.py`, Step 4: Admin Auth Routes
+
+### Community 3428 - "Community 3428"
+Cohesion: 0.67
+Nodes (3): code:typescript (// src/app/dashboard/monitoring/ride-panel.tsx), code:bash (git add src/app/dashboard/monitoring/ride-panel.tsx), Task 9: Frontend — Ride Panel Component
+
+### Community 3429 - "Community 3429"
+Cohesion: 0.67
+Nodes (3): 1a. Confirm staging test completed successfully, code:bash (export SUPABASE_URL=<staging-url>), code:bash (python backend/scripts/migrate.py)
+
+### Community 3430 - "Community 3430"
+Cohesion: 0.67
+Nodes (3): 9. Reporting, Monthly statement (PDF, auto-generated 1st of month), On-demand exports
+
+### Community 3431 - "Community 3431"
+Cohesion: 0.67
+Nodes (3): Reset the db_supabase circuit breaker to closed state before each test.      The, Reset the db_supabase circuit breaker to closed state before each test.      The, reset_db_circuit_breaker()
+
 ## Knowledge Gaps
-- **11096 isolated node(s):** `$schema`, `builder`, `dockerfilePath`, `startCommand`, `healthcheckPath` (+11091 more)
+- **10484 isolated node(s):** `_comment`, `command`, `args`, `SUPABASE_URL`, `SUPABASE_ACCESS_TOKEN` (+10479 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **1961 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **1979 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `useTheme()` connect `Community 115` to `Community 128`, `Community 20`, `Community 23`, `Community 158`, `Community 161`, `Community 443`, `Community 191`, `Community 64`, `Community 70`, `Community 206`, `Community 82`, `Community 84`, `Community 85`, `Community 96`, `Community 103`, `Community 104`, `Community 240`, `Community 245`, `Community 252`?**
-  _High betweenness centrality (0.012) - this node is a cross-community bridge._
-- **Why does `Sidebar()` connect `Community 206` to `Community 115`, `Community 99`?**
-  _High betweenness centrality (0.009) - this node is a cross-community bridge._
-- **Why does `SpinrException` connect `Community 5` to `Community 2`, `Community 6`, `Community 9`, `Community 138`, `Community 18`, `Community 147`, `Community 148`, `Community 279`, `Community 153`, `Community 28`, `Community 157`, `Community 34`, `Community 42`, `Community 53`, `Community 56`, `Community 2620`, `Community 2366`, `Community 336`, `Community 210`, `Community 83`, `Community 90`, `Community 95`, `Community 98`, `Community 106`, `Community 369`, `Community 370`, `Community 124`?**
-  _High betweenness centrality (0.009) - this node is a cross-community bridge._
+- **Why does `get_current_user()` connect `Community 0` to `Community 130`, `Community 5`, `Community 7`, `Community 140`, `Community 146`, `Community 2836`, `Community 24`, `Community 57`, `Community 2363`, `Community 2365`, `Community 3391`, `Community 2375`, `Community 83`, `Community 345`, `Community 90`, `Community 2398`, `Community 97`, `Community 106`, `Community 107`, `Community 111`, `Community 114`, `Community 377`, `Community 125`?**
+  _High betweenness centrality (0.011) - this node is a cross-community bridge._
+- **Why does `SpinrException` connect `Community 56` to `Community 0`, `Community 5`, `Community 6`, `Community 138`, `Community 18`, `Community 148`, `Community 279`, `Community 153`, `Community 2715`, `Community 28`, `Community 157`, `Community 34`, `Community 3250`, `Community 3251`, `Community 53`, `Community 3383`, `Community 57`, `Community 2620`, `Community 2366`, `Community 3391`, `Community 3400`, `Community 3403`, `Community 3404`, `Community 336`, `Community 2769`, `Community 83`, `Community 90`, `Community 95`, `Community 98`, `Community 2789`, `Community 106`, `Community 369`, `Community 114`, `Community 370`, `Community 2808`, `Community 124`?**
+  _High betweenness centrality (0.010) - this node is a cross-community bridge._
+- **Why does `HTTPException` connect `Community 90` to `Community 0`, `Community 130`, `Community 131`, `Community 5`, `Community 6`, `Community 138`, `Community 140`, `Community 145`, `Community 146`, `Community 2838`, `Community 279`, `Community 24`, `Community 25`, `Community 2587`, `Community 28`, `Community 35`, `Community 427`, `Community 49`, `Community 52`, `Community 308`, `Community 2617`, `Community 2362`, `Community 2366`, `Community 63`, `Community 3391`, `Community 2375`, `Community 204`, `Community 78`, `Community 83`, `Community 345`, `Community 2398`, `Community 95`, `Community 97`, `Community 2791`, `Community 233`, `Community 235`, `Community 107`, `Community 111`, `Community 369`, `Community 114`, `Community 374`, `Community 377`, `Community 125`?**
+  _High betweenness centrality (0.010) - this node is a cross-community bridge._
 - **Are the 183 inferred relationships involving `HTTPException` (e.g. with `get_driver_acceptance_rates()` and `admin_login()`) actually correct?**
   _`HTTPException` has 183 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 186 inferred relationships involving `SpinrException` (e.g. with `AuthResponse` and `bool`) actually correct?**
-  _`SpinrException` has 186 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 229 inferred relationships involving `HTTPException` (e.g. with `get_driver_acceptance_rates()` and `admin_login()`) actually correct?**
-  _`HTTPException` has 229 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 203 inferred relationships involving `str` (e.g. with `break_glass_access()` and `admin_create_document_requirement()`) actually correct?**
-  _`str` has 203 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 187 inferred relationships involving `SpinrException` (e.g. with `AuthResponse` and `bool`) actually correct?**
+  _`SpinrException` has 187 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 6 inferred relationships involving `useTheme()` (e.g. with `ErrorFallback()` and `Sidebar()`) actually correct?**
+  _`useTheme()` has 6 INFERRED edges - model-reasoned connections that need verification._
+- **What connects `_comment`, `command`, `args` to the rest of the system?**
+  _15329 weakly-connected nodes found - possible documentation gaps or missing edges._

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,12447 +1,9632 @@
 {
   "test_admin_endpoints.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app.config.ts": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/jest.config.js": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/jest.setup.js": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/metro.config.js": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/eslint.config.js": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/babel.config.js": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/styles/index.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/otp.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/legal.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/report-safety.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/documents.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/_layout.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/login.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/become-driver.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/vehicle-info.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/profile-setup.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/index.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/addresses.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/tax-documents.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/ride-detail.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/settings.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/notifications.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/subscription.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/_layout.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/payout.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/payout-history.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/chat.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/help.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/quests.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/faq.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/emergency-contacts.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/app/driver/referral.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/i18n/index.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/hooks/useDriverDashboard.ts": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/store/questStore.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/store/documentStore.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/store/driverStore.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/store/languageStore.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/store/__tests__/driverStore.config.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/store/__tests__/driverStore.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/__tests__/store/driverStore.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/__tests__/components/TripCompletedPanel.test.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/__tests__/components/ActiveRidePanel.test.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/__tests__/components/RideOfferPanel.test.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/types/index.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/scripts/reset-project.js": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/index.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/DriverTopBar.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/CarMarker.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/charts/EarningsLineChart.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/charts/EarningsBarChart.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/panels/IdlePanel.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/panels/RideOfferPanel.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/dashboard/index.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/dashboard/ActiveRidePanel.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/dashboard/TripCompletedPanel.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/dashboard/DriverTopBar.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/dashboard/MapControls.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/components/dashboard/DriverIdlePanel.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/__mocks__/@shared/config/spinr.config.js": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/__mocks__/@shared/api/client.js": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app.config.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/playwright.config.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/jest.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/metro.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/eslint.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/babel.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/e2e/fixtures.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/e2e/ride-booking.spec.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/e2e/smoke.spec.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/otp.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/ride-in-progress.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/manage-cards.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/loyalty.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/driver-arrived.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/saved-places.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/legal.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/wallet.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/report-safety.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/settings.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/notifications.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/chat-driver.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/payment-confirm.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/_layout.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/promotions.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/support.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/ride-details.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/login.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/become-driver.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/ride-completed.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/profile-setup.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/ride-options.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/driver-arriving.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/ride-status.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/privacy-settings.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/search-destination.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/emergency-contacts.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/pick-on-map.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/scheduled-rides.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/index.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/(tabs)/account.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/(tabs)/_layout.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/(tabs)/activity.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/app/(tabs)/index.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/hooks/useRiderSocket.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/web/stubs/react-native-maps-directions.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/web/stubs/react-native-maps.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/store/walletStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/store/rideStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/store/__tests__/rideStore.test.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/store/__tests__/walletStore.test.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/store/__tests__/rideStore.ws.test.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/scripts/reset-project.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/components/FreeCancelTimer.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/onboarding_status.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/seed_vehicle_types.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/settings_loader.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/documents.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/db.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/validators.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/schemas.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/features.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/diagnose_nearby_drivers.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/logging_utils.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/socket_manager.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/make_admin.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/server.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/supabase_client.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/test_corporate_accounts.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/db_supabase.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests_smoke_supabase.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/test_dns.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/sms_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/check_permissions.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/geo_utils.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/list_users.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/schemas/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/schemas/corporate.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/dependencies/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/dependencies/company_guard.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/surge_engine.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/redis_client.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/document_expiry.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/scheduled_rides.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/ws_pubsub.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/error_handling.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/rate_limiter.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/payment_retry.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/allowance_reset.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/cloudinary.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/email_receipt.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/corporate_low_balance.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/crypto.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/analytics.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/corporate_autotopup.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/demand_forecast.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/utils/quest_tracker.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/corporate_membership_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/dispatch_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/corporate_allowance_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/fare_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/corporate_wallet_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/_factories.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_status.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_error_handling.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_stripe_customer.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_kyb_upload.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_fare_split.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_payments_pci_guard.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_allowance_requests.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_ride_messages.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_webhook.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/perf_baseline.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_db.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_wallet_routes.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/conftest.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_admin_routes.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_auth_send_otp.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_geo_utils.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_b2b_schema.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_sanitize_string.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/verify_db.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_location_batch.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_loyalty.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_e2e_members.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_membership_db_helpers.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_allowance_reset.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_ride_accept_flow.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_sms.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_claim_ride.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_e2e_foundation.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_low_balance.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_membership_schemas.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_wallet.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_schemas.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_documents.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_ride_pii.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_wallet_view.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_db_helpers.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_admin_routes_auth.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_validators.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_autotopup.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_offer_timeout.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_wallet_freeze.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_rides.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_quests.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_rider_routes.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_ride_state_machine.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_websocket_auth_ack.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_features.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/perf_post_rides.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_auth.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_e2e_wallet.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_kyb.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_admin_stats.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_wallet_config.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_company_routes.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_corporate_wallet_bootstrap.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/test_drivers.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/services/test_corporate_allowance_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/services/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/services/test_dispatch_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/services/test_fare_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/services/test_corporate_membership_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/tests/services/test_corporate_wallet_service.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/favorites.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/auth.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/websocket.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/fare_split.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/loyalty.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/corporate_rider.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/fares.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/users.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/main.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/corporate_wallet.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/support.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/corporate_accounts.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/promotions.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/notifications.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/corporate_company.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/wallet.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/payments.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/rides.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/drivers.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/addresses.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/disputes.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/settings.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/quests.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/webhooks.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/messaging.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/documents.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/staff.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/auth.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/maintenance.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/users.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/faqs.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/monitoring.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/subscriptions.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/service_areas.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/support.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/promotions.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/wallet.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/rides.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/analytics.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/drivers.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/vehicle_fleet.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/routes/admin/settings.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/core/middleware.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/core/config.py": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/core/lifespan.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/core/security.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/scripts/run_migrations.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/scripts/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/scripts/migrate.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/config/index.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/config/firebaseConfig.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/config/spinr.config.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/assets/carImage.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/assets/generate-car.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/validators/index.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/validators/__tests__/validators.test.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/cache/index.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/api/upload.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/api/client.ts": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/api/cachedClient.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/api/offlineQueue.ts": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/utils/logger.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/utils/appRating.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/services/errorReporting.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/services/firebase.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/store/locationStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/store/authStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/theme/index.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/theme/ThemeContext.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/analytics/index.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/types/expo-linear-gradient.d.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/AppMap.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/SOSButton.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/OfflineBanner.tsx": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/ErrorBoundary.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/CarMarker.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/ErrorScreen.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/AppMap.web.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/components/CustomAlert.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "tests/__init__.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "tests/test_rate_limits.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/next.config.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/vitest.config.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/playwright.config.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/sentry.server.config.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/eslint.config.mjs": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/postcss.config.mjs": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/vitest.setup.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/sentry.client.config.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/e2e/login.spec.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/e2e/auth.setup.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/e2e/dashboard.spec.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/layout.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/error.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/not-found.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/track/[rideId]/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/register/driver/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/layout.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/earnings/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/settings/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/live/[id]/live-map.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/live/[id]/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-stats-cards.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-list.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-flag-form.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-complaint-form.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-route-map.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-ui-helpers.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/rides/_components/ride-lost-found.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/notifications/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/surge/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/users/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/corporate-accounts/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/corporate-accounts/kyb-queue/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/allowance-dialog.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/disputes/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/staff/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/_tabs/disputes.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/_tabs/complaints.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/_tabs/flags.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/_tabs/lost-and-found.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/_tabs/tickets.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/support/_components/service-area-select.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/vehicle-types/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/_components/driver-charts.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/_components/driver-stats-cards.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/_components/area-stats-table.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/_components/driver-action-bar.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/drivers/_components/driver-timeline.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/forecast/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/service-areas/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/quests/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/audit-logs/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/subscriptions/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/promotions/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/heatmap/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/analytics/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/documents/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/alert-feed.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/types.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/monitoring-map.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/ride-panel.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/driver-panel.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/dashboard/monitoring/toolbar.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/app/login/page.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/hooks/use-monitoring-socket.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/hooks/use-mobile.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/lib/utils.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/lib/api.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/lib/export-csv.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/lib/__tests__/api.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/lib/__tests__/utils.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/lib/map/maplibre-base.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/store/authStore.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/__tests__/setup.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/__tests__/login.test.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/__tests__/lib/utils.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/__tests__/lib/export-csv.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/__tests__/store/authStore.test.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/heat-map.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/driver-map.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/sidebar.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/geofence-map.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/theme-provider.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/sheet.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/dropdown-menu.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/select.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/input.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/tooltip.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/alert-dialog.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/textarea.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/tabs.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/table.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/sidebar.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/card.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/toast.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/toaster.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/separator.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/use-toast.ts": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/avatar.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/badge.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/switch.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/dialog.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/button.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/alert.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/src/components/ui/label.tsx": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/orchestrator.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/code_reviewer.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/registry.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/documenter.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/cli.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/examples.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/__init__.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/base_agent.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/frontend_agent.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/knowledge_base.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/tester.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/security_agent.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/backend_agent.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/deployer.py": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app.config.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/test-places.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/jest.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/jest.setup.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/metro.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/eslint.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/babel.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/test-maps.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/e2e/auth.test.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/e2e/jest.config.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/e2e/init.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/config/index.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/config/firebaseConfig.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/config/supabase.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/config/spinr.config.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/otp.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/ride-in-progress.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/driver-arrived.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/rate-ride.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/report-safety.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/chat-driver.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/payment-confirm.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/_layout.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/support.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/login.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/become-driver.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/ride-completed.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/profile-setup.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/ride-options.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/driver-arriving.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/ride-status.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/search-destination.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/index.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/(tabs)/account.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/(tabs)/_layout.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/(tabs)/activity.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/app/(tabs)/index.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/api/upload.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/api/client.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/store/documentStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/store/driverStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/store/rideStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/store/authStore.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/__tests__/store/rideStore.test.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/__tests__/store/authStore.test.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/types/expo-linear-gradient.d.ts": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/scripts/reset-project.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/components/AppMap.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/components/AppMap.web.tsx": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/__mocks__/@shared/cache.js": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "scripts/code_review_helper.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "scripts/manage_admin.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "scripts/validate_code_review.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "scripts/run_code_review.py": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "TESTING_AND_ENHANCEMENTS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "INTEGRATION_COMPLETE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "TODO.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "READINESS_REPORT.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "INSTRUCTIONS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "DRIVER_APP_ANALYSIS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "GAP_ANALYSIS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "CLAUDE.md": {
-    "mtime": 1776615551.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "AUTOCOMPLETE_FIX_GUIDE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "README.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "validation_output.txt": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "DEPLOYMENT.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "CODE_ANALYSIS_REPORT.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "CODE_REVIEW_REPORT.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "ANALYSIS_REPORT.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "ARCHITECTURE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/final_audit.txt": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/audit_report_final.txt": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/final_audit_v4.txt": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/final_audit_v3.txt": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/README.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/audit_report.txt": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/README.md": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/tsc-errors.txt": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/SUPABASE_MIGRATION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/requirements.txt": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/SCHEMA.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/CORPORATE_ACCOUNTS_FIX.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/README_MIGRATION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/services/README.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/docs/key-rotation.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "plans/expo-sdk-52-downgrade-spec.md": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "plans/heatmap_implementation_plan.md": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "plans/expo-sdk-54-migration-plan.md": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/CORPORATE_B2B.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/ENVIRONMENT_VARIABLES.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/ACCESSIBILITY.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/E2E_TESTING.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/plans/2026-04-05-rider-app-ui-richness.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/plans/2026-04-16-corporate-b2b-plan-1-foundation.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/plans/2026-04-16-corporate-b2b-plan-2-wallet-stripe.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/plans/2026-04-13-live-monitoring-page.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/plans/2026-04-18-corporate-b2b-plan-3-employee-allowances.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/specs/2026-04-05-rider-app-ui-richness-design.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/specs/2026-04-15-corporate-accounts-b2b-design.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/superpowers/specs/2026-04-13-live-monitoring-page-design.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/runbooks/api-down.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/runbooks/driver-not-receiving-rides.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/runbooks/otp-lockout-false-positive.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/runbooks/stripe-webhook-failure.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/INFRASTRUCTURE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/ADMIN_AND_OPS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/WALLET_AND_PAYMENTS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/AUTH_AND_USERS.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/README.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/REFERENCE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/RIDES_AND_DISPATCH.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/backend/ARCHITECTURE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/02_SPRINT_PLAN.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/06_PROJECT_SUMMARY.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/03_SPRINT_1_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/00_SPINR_FULL_OVERVIEW.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/12_SPRINT_9_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/14_CONTINUOUS_AUDIT_PLAYBOOK.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/16_TOOLS_AND_LANGUAGES_BY_MODULE.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/04_SPRINT_2_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/10_SPRINT_7_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/15_TECH_STACK_AND_FILE_MAPPING.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/08_SPRINT_5_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/11_SPRINT_8_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/09_SPRINT_6_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/05_SPRINT_3_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/07_SPRINT_4_COMPLETION.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/01_AUDIT_GAPS_REPORT.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/audit/daily/2026-04-11.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/testing/DRIVER_APP_TESTING.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/testing/ADMIN_DASHBOARD_TESTING.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/testing/BACKEND_TESTING.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "docs/testing/FRONTEND_RIDER_TESTING.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/README.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "agents/README.md": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/tsc_errors.txt": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/README.md": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/DEPRECATED.md": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/README.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/remediation/P0-critical-fix-now.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/remediation/P4-future-features.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/remediation/P3-hardening.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/remediation/P2-before-launch.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/remediation/P1-before-beta.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/audits/task14-performance-scalability.txt": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "reports/audits/2026-04-18-driver-app-production-readiness-v4.txt": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/README.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/ground-rules.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/modules/admin-panel.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/modules/driver-app.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/modules/rider-app.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/modules/backend-api.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/11-security-headers-cors.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/04-input-validation.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/02-authentication.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/07-state-machine.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/06-real-time.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/01-feature-completeness.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/14-performance-scalability.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/09-test-coverage.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/12-compliance-pii-pci.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/16-i18n-localisation.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/10-error-handling.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/13-notifications-ai-faq.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/08-payments.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/05-ui-ux-android-ios.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/dimensions/15-accessibility-wcag.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/templates/remediation-group.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/templates/audit-output.txt": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "audit-framework/templates/run-audit.md": {
-    "mtime": 1776615234.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/react-logo@3x.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/icon.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/favicon.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/react-logo.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/car-top.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/partial-react-logo.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/car_marker.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/app-image.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/car-top-3d.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/react-logo@2x.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "driver-app/assets/images/adaptive-icon.png": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/react-logo@3x.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/icon.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/favicon.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/react-logo.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/car-top.svg": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/partial-react-logo.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/app-image.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/car-top-3d.svg": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/react-logo@2x.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "rider-app/assets/images/adaptive-icon.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_233c5166.jpeg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_6c9ab677.jpeg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_90fce351.jpeg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/assets/car-top.svg": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "shared/assets/car_marker.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/public/window.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/public/globe.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/public/file.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/public/vercel.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "admin-dashboard/public/next.svg": {
-    "mtime": 1776532909.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/react-logo@3x.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/icon.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/favicon.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/react-logo.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/partial-react-logo.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/splash-image.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/app-image.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/react-logo@2x.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "frontend/assets/images/adaptive-icon.png": {
-    "mtime": 1776532910.0,
-    "ast_hash": "",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/railway.json": {
-    "mtime": 1779512836.3507798,
-    "ast_hash": "7f57435666870539fc22772f63c5f66d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/package.json": {
-    "mtime": 1779512836.345595,
-    "ast_hash": "5d362e15898bc7e319cff00a27e527c9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/commitlint.config.js": {
-    "mtime": 1779512835.493595,
-    "ast_hash": "d25424fd0aa2ec88ef4a6bec88209cc0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/test_admin_endpoints.py": {
-    "mtime": 1779512836.4982045,
+    "mtime": 1780622913.7165337,
     "ast_hash": "d8b65840b73bb7283af5d9acbbf06434",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/shared/package.json": {
-    "mtime": 1780060957.360439,
-    "ast_hash": "e3ef3afb035d4e5eb4ee8d85ed9fdfa8",
+  "driver-app/app.config.ts": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "f62beab626314942fecafd901517e931",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/shared/tsconfig.build.json": {
-    "mtime": 1779512836.4952376,
-    "ast_hash": "ca4fccb53f013814929234f4f6bd66ee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/tsconfig.json": {
-    "mtime": 1779512836.4952376,
-    "ast_hash": "2c5edb08f364b31cefd75adb0e43264b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/index.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "58c15b467fc58256fb7c0b6534c90dd4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/expo-linear-gradient.d.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "d78e0c6b1f9fd5b8e39c6590c77ea44d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/api/pagination.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "87442b2fd1b518f4b349602432c922b0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/api/money.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "4a93a5fa14dca3a118292ea36b269793",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/api/user.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "e1752117f75f10b0e892e0fce4a89b35",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/api/ride.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "5baeceadd921262b136a1fec5c2e6384",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/api/wsEvents.ts": {
-    "mtime": 1779512836.4961061,
-    "ast_hash": "217d9c835d88ef3278c1a89d0b72953a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/types/api/errors.ts": {
-    "mtime": 1779512836.4958105,
-    "ast_hash": "485a3e8c4365d8b6ce7f949b01335bbc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/ErrorBoundary.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "3be9f0a786daa3310f154f41a3d4a706",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/AppMap.web.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "da1c74747977ca2a0fd87000c9e50d4c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/SOSButton.tsx": {
-    "mtime": 1780060957.360439,
-    "ast_hash": "43bc5511ba762e92a8c2fff1fa7b0817",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/ErrorScreen.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "6a7f92a44da7daaa08127dc8041fe778",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/AppMap.tsx": {
-    "mtime": 1779512836.4873166,
-    "ast_hash": "6a5a78c571487f1a5cf92b7db6dedecc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/SupportScreen.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "7b4c6ed5da42cadc68d84e3294df096d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/CarMarker.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "265b07330fb939da44a512add3441a49",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/FormScreen.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "123fa1f65dc9b65318302f85b16f46db",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/OfflineBanner.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "b005ec7d37a443b02e621aff06f1a15c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/components/CustomAlert.tsx": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "f4ecb9e359e68aea9001f742bc717b3f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/config/index.ts": {
-    "mtime": 1779512836.490134,
-    "ast_hash": "ea419a0d2f54822d72ca00b0f41879ef",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/config/spinr.config.ts": {
-    "mtime": 1780060957.360439,
-    "ast_hash": "ef5b6639bd902c25f166121d89b8489a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/config/firebaseConfig.ts": {
-    "mtime": 1779512836.4886806,
-    "ast_hash": "35f53ebd648e7c95e6a474008248c08a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/hooks/usePlacesAutocomplete.ts": {
-    "mtime": 1779512836.490713,
-    "ast_hash": "6e6a47cf9cdb1f99b191e2e1657cbee8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/hooks/queries/index.ts": {
-    "mtime": 1779512836.490713,
-    "ast_hash": "3f53fd9d72e29edac072bf6c07bca6f1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/hooks/queries/driverQueries.ts": {
-    "mtime": 1779512836.4904888,
-    "ast_hash": "370c1b1aab111a5d892a41f4970b234b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/hooks/queries/notificationQueries.ts": {
-    "mtime": 1779512836.490713,
-    "ast_hash": "81eac51a0c16019e5660500d50a4018f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/cache/index.ts": {
-    "mtime": 1780060957.360439,
-    "ast_hash": "5bd65e6f1c1f61ef8d478ac56a375362",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/services/errorReporting.ts": {
-    "mtime": 1779512836.490713,
-    "ast_hash": "bcff86585cf82bec1dad93a9b50563da",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/services/firebase.ts": {
-    "mtime": 1780060957.360439,
-    "ast_hash": "56fa5939beb76ba3f51717003a00cf77",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/assets/generate-car.js": {
-    "mtime": 1779512836.4873166,
-    "ast_hash": "de93a99f805296bf0880e9a3e660a0c4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/assets/carImage.ts": {
-    "mtime": 1779512836.4873166,
-    "ast_hash": "d14a794ca62658c6a5d4bd4a0a155aa9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/upload.ts": {
-    "mtime": 1779512836.4861226,
-    "ast_hash": "5340715021ad353c52ea2a340722f384",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/offlineQueue.ts": {
-    "mtime": 1779512836.4861226,
-    "ast_hash": "455a2b622c63595a28e7322a5d802a12",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/cachedClient.ts": {
-    "mtime": 1779512836.4861226,
-    "ast_hash": "555b1285ee10036da166c38672201f1a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/client.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "2310f1d2980969a869b8195741ddf093",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/places.ts": {
-    "mtime": 1779512836.4861226,
-    "ast_hash": "13ee45b153114fb90db4156c7af16cfa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/queryClient.ts": {
-    "mtime": 1779512836.4861226,
-    "ast_hash": "23806d439c3bb3d75b125ff4eca18fde",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/__tests__/client.refresh.test.ts": {
-    "mtime": 1779512836.4861226,
-    "ast_hash": "7fbe45f6af02d4594090cec345ac199a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/api/__tests__/client.authHeader.test.ts": {
-    "mtime": 1779512836.486053,
-    "ast_hash": "c086893240b292ee276bdbcfe48f39f1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/theme/index.ts": {
-    "mtime": 1779512836.4952376,
-    "ast_hash": "17dab9c8746e0f2b18f5f94326d4fa4e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/theme/ThemeContext.tsx": {
-    "mtime": 1779512836.4948633,
-    "ast_hash": "ba484affbf1bdd2e5b889b56873a4a40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/validators/index.ts": {
-    "mtime": 1779512836.4982045,
-    "ast_hash": "bf60e0bceb0339e9193e0fa43eb15057",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/validators/__tests__/validators.test.ts": {
-    "mtime": 1779512836.4982045,
-    "ast_hash": "07ca54cc3f6aa17ed79a3dc4d1fc118d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/build-types/peer-deps.d.ts": {
-    "mtime": 1779512836.4873166,
-    "ast_hash": "0ba95d0c0d96adaf21dfa724b5e9716f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/store/locationStore.ts": {
-    "mtime": 1779512836.4948633,
-    "ast_hash": "a7cd09002438d3ac9611abf337160f20",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/store/authStore.ts": {
-    "mtime": 1779512836.4942355,
-    "ast_hash": "11bc8aa4287fbbc554bb3c393ee9a735",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/utils/responsive.ts": {
-    "mtime": 1779512836.4972806,
-    "ast_hash": "acb55534d85b43108c938d23503a10f8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/utils/placesSession.ts": {
-    "mtime": 1779512836.4972806,
-    "ast_hash": "7cd335c7eb085ab7e6603319b7f94f47",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/utils/appRating.ts": {
-    "mtime": 1779512836.4972806,
-    "ast_hash": "9548064b95d31306cdb9004a95d576b0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/utils/logger.ts": {
-    "mtime": 1779512836.4972806,
-    "ast_hash": "25d899175710a44e2ed17eb3d03fa96d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/utils/pii.ts": {
-    "mtime": 1779512836.4972806,
-    "ast_hash": "9799a5d0ab496d266c0dfd885264ab3e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/utils/__tests__/pii.test.ts": {
-    "mtime": 1779512836.4972806,
-    "ast_hash": "9947fb714c804a724392ad41a9151935",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/analytics/index.ts": {
-    "mtime": 1779512836.4851162,
-    "ast_hash": "d42088ae4c55653ae343fea177bd26bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/jest.config.js": {
-    "mtime": 1779512835.6129005,
+  "driver-app/jest.config.js": {
+    "mtime": 1780622912.790269,
     "ast_hash": "25e76eb7e05c628ce51832a789105224",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/eslint.config.js": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "560a864580ad8107fbbf8d6d452c82fe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/babel.config.js": {
-    "mtime": 1779512835.585595,
-    "ast_hash": "71c5ff1bf6fa664731b7fd2193664b10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/expo_52_deps.json": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "06c1d8db25ee6d33f151619319b4133d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/expo_53_deps.json": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "9b8d77c959817b6fc470660ae4d706c8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/vercel.json": {
-    "mtime": 1779512835.634645,
-    "ast_hash": "61bd31a2b0ac08f10f13c932b32d6ca1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/jest.setup.js": {
-    "mtime": 1779512835.6129005,
+  "driver-app/jest.setup.js": {
+    "mtime": 1780622912.790269,
     "ast_hash": "2938cf0710eb6bfa944168d3e9cdd14d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/app.config.ts": {
-    "mtime": 1780060957.312439,
-    "ast_hash": "72dca9eecd24e5d0ed2214c44063a9ae",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/config.ts": {
-    "mtime": 1779512835.600906,
-    "ast_hash": "4a1da2ebee7c1dd27459cf18a04668e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/google-services.json": {
-    "mtime": 1779512835.6055949,
-    "ast_hash": "acb9398a931c04fdd1300bfbe79f9aa9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/screens_versions.json": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "5c823bdad1668f0aa71afb6546296b40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/metro.config.js": {
-    "mtime": 1779512835.6129005,
+  "driver-app/metro.config.js": {
+    "mtime": 1780622912.7930238,
     "ast_hash": "e412f03b67ccb67bf129352920d7fa72",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/package.json": {
-    "mtime": 1780060957.340439,
-    "ast_hash": "46eac8c44552403c3a8fc88258835767",
+  "driver-app/eslint.config.js": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "560a864580ad8107fbbf8d6d452c82fe",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/eas.json": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "f7adad9ae17b65907d17bfc32b3923c8",
+  "driver-app/babel.config.js": {
+    "mtime": 1780622912.7730236,
+    "ast_hash": "71c5ff1bf6fa664731b7fd2193664b10",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/expo_52_real_deps.json": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "4951dcfb743835c9df5fd18e719dbf07",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/playwright.config.ts": {
-    "mtime": 1779512835.623162,
-    "ast_hash": "92730e2dc0348a0ebecd3b2019725834",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/tsconfig.json": {
-    "mtime": 1779512835.629595,
-    "ast_hash": "10ea991732cf3a9543d70f3334cb4bb4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/types/index.ts": {
-    "mtime": 1780060957.340439,
-    "ast_hash": "1a2cfdd9142c63c873da3b6e689e20a5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/AlertDialog.tsx": {
-    "mtime": 1780060957.316439,
-    "ast_hash": "2c1bac05ea2d82efad0522edc56cea8e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/index.ts": {
-    "mtime": 1779512835.598292,
-    "ast_hash": "9fb12cabb5491150948122fbef14e435",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/ScreenHeader.tsx": {
-    "mtime": 1779512835.5941417,
-    "ast_hash": "660ebef1b0e27a2c071ac01d98fbeebd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/DriverTopBar.tsx": {
-    "mtime": 1779512835.5941417,
-    "ast_hash": "8c9cc09b2a75d73c8aa9fa7225b3ddca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/CarMarker.tsx": {
-    "mtime": 1779512835.5923378,
-    "ast_hash": "e42fcd7fe98b83ba1c3f77387c775dd3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/SafeRefreshControl.tsx": {
-    "mtime": 1779512835.5941417,
-    "ast_hash": "223519c324dcf38f20bb64f345b28e88",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/activity/ActivityView.tsx": {
-    "mtime": 1780060957.316439,
-    "ast_hash": "9ec281231bcc90e44acf4b3f482780ad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/panels/RideOfferPanel.tsx": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "6666d5015efa551ad41c5c7073429854",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/panels/IdlePanel.tsx": {
-    "mtime": 1779512835.598292,
-    "ast_hash": "d1286bc1a69f2333eadf6dd077203ce6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/dashboard/index.ts": {
-    "mtime": 1779512835.598292,
-    "ast_hash": "25e11b957ff6adca3b5231298aa765ea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/dashboard/ActiveRidePanel.tsx": {
-    "mtime": 1780060957.316439,
-    "ast_hash": "1ba9c726d447c2eab89ff3700e76c7e0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/dashboard/TripCompletedPanel.tsx": {
-    "mtime": 1780060957.316439,
-    "ast_hash": "80d15bbb667f3745ddb2ef9a02f0085d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/dashboard/DriverTopBar.tsx": {
-    "mtime": 1779512835.598292,
-    "ast_hash": "52767b7e90d69b49bb534650d3728698",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/dashboard/DriverIdlePanel.tsx": {
-    "mtime": 1779512835.598292,
-    "ast_hash": "a9388dc67005d25b88c4ff7548d2a54f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/dashboard/MapControls.tsx": {
-    "mtime": 1779512835.598292,
-    "ast_hash": "5a074ac85556878b1dc40999413f4af2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/charts/EarningsBarChart.tsx": {
-    "mtime": 1779512835.596387,
-    "ast_hash": "9de81eaf98d151b7342f0ab9a27ba28f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/components/charts/EarningsLineChart.tsx": {
-    "mtime": 1779512835.597433,
-    "ast_hash": "09533ef0f246c1a472b154324c187e0f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/store-assets/metadata.json": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "f2b67e61ac1b54f0562d585d0f19bdee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/useDriverDashboard.ts": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "ca6ae41ba82e77336a070a36dfd77c1e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/useToast.ts": {
-    "mtime": 1779512835.6098118,
-    "ast_hash": "5830e53ced939424d677a39185b56440",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/useRideOfferSound.ts": {
-    "mtime": 1779512835.6098118,
-    "ast_hash": "8a10e687740f988373447969383995d1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/useAuth.ts": {
-    "mtime": 1779512835.6098118,
-    "ast_hash": "4e419a3b5da53062bc47aeadc446ec1f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/__tests__/useDriverDashboard.chat.test.ts": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "c3e8be64535b8fa43644f7ff4bfc95d4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/__tests__/goOnlinePermission.test.ts": {
-    "mtime": 1779512835.6088247,
-    "ast_hash": "6a375875d3103080e171197836b43d72",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/hooks/__tests__/locationBatch.test.ts": {
-    "mtime": 1779512835.6098118,
-    "ast_hash": "4a2789c0948ed3dab4b4e45578b38a1c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/services/notifeeService.ts": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "47f2f70ef051f48fdece65acb8f41042",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__mocks__/expoWinter.js": {
-    "mtime": 1779512835.5528538,
-    "ast_hash": "64e09ba341e550784c724f369684eda0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__mocks__/expo-winter-noop.js": {
-    "mtime": 1779512835.5528538,
-    "ast_hash": "3f347a3031deea0b74235013e6bf27b5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__mocks__/expo-winter-runtime.js": {
-    "mtime": 1779512835.5528538,
-    "ast_hash": "1c5c938bef3c07774f1614c30b20c62a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__mocks__/@shared/config/spinr.config.js": {
-    "mtime": 1779512835.5528538,
-    "ast_hash": "d87c9a39e05dcf4cd5054a0fc4cb9bea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__mocks__/@shared/api/client.js": {
-    "mtime": 1779512835.5528538,
-    "ast_hash": "6e25eb7d4d50f23cc4cbf2facc4a3ca4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/vehicle-info.tsx": {
-    "mtime": 1779512835.573595,
-    "ast_hash": "7cf0aac986db22bead0664bf8d29a0b0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/legal.tsx": {
-    "mtime": 1779512835.5695949,
-    "ast_hash": "979d235f344bde89fd76ebd34523b678",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/otp.tsx": {
-    "mtime": 1779512835.5695949,
-    "ast_hash": "107e5c2a21f96871ea045cd24e50e62a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/login.tsx": {
-    "mtime": 1779512835.5695949,
-    "ast_hash": "3d0154ec6091918fa6288c805545bcf6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/profile-setup.tsx": {
-    "mtime": 1779512835.5695949,
-    "ast_hash": "b827afd201c049c67664761a950b45aa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/_layout.tsx": {
-    "mtime": 1780060957.312439,
-    "ast_hash": "a08debfbf10c5b5a5aad65cef570c6c1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/report-safety.tsx": {
-    "mtime": 1779512835.5695949,
-    "ast_hash": "b81b5f4ac23a2bbd5ce5712f52e7f576",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/become-driver.tsx": {
-    "mtime": 1779512835.561115,
-    "ast_hash": "0fb42bac0f2e9205cf39d8a44b0b3939",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/index.tsx": {
-    "mtime": 1779512835.5695949,
-    "ast_hash": "1844e21ca6f1d6984cc2aca6b3bf8442",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/documents.tsx": {
-    "mtime": 1779512835.561115,
-    "ast_hash": "9526599b431195d13f4e07636a959d91",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/quests.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "7bc01827a1324058bec8ad677d2ff708",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/addresses.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "8f8bf6da0d3f85059acb28bcd34333a9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/ride-detail.tsx": {
-    "mtime": 1780060957.316439,
-    "ast_hash": "2da2d0c5fd0fb70e9f3be502c189dd40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/subscription.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "d8ac44d740b0bf6117303f717b205cb9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/referral.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "60faf55b986a0c9f6aa69a13f64d1ec3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/tax-documents.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "cdb7b7fc8cac7b47a43c7cb5a8acbfb6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/faq.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "ac353ea9e5e6df3ea76863e0b93fc5d0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/help.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "794232037dee6c166e971a5f6c41ff8b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/payout-history.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "d943b8fd9d18730350550853f62f4ce4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/settings.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "d7d276ec76d51edc3b0355dfa9cd102e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/payout.tsx": {
-    "mtime": 1779512835.565595,
-    "ast_hash": "6b045234a9308bfa9005ee67d93fa46d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/_layout.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "694ffffc982fbe8c9a504af8203d2843",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/chat.tsx": {
-    "mtime": 1780060957.312439,
-    "ast_hash": "264374200abbc99e85304919009bb47e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/emergency-contacts.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "67d39ee4cab1b54f6ddb9ad789ea54a7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/notifications.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "567db85c1bb26a6cc370931b752caafa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/(tabs)/activity.tsx": {
-    "mtime": 1780060957.312439,
-    "ast_hash": "50ff1bf032e752733c0846c929370bd1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/(tabs)/_layout.tsx": {
-    "mtime": 1779512835.5627124,
-    "ast_hash": "147630fcfd90bc0e67621db901e4c824",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/(tabs)/earnings.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "74028479505e22e906c5c11294c2b999",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/(tabs)/rides.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "5b3ea7f8a232c7afebc485262e4bbc92",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/(tabs)/index.tsx": {
-    "mtime": 1780060957.312439,
-    "ast_hash": "0e29e5d8351436a212d60ecb2c1d3d27",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/app/driver/(tabs)/profile.tsx": {
-    "mtime": 1779512835.5636559,
-    "ast_hash": "f4101753438a56126a5c0701986dc470",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__tests__/components/ActiveRidePanel.test.tsx": {
-    "mtime": 1779512835.5535948,
-    "ast_hash": "374fbf3fa2cf377899b158fd9026bf00",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__tests__/components/RideOfferPanel.test.tsx": {
-    "mtime": 1779512835.5574512,
-    "ast_hash": "9307ea2bbd846e850beb6c1602b30096",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__tests__/components/TripCompletedPanel.test.tsx": {
-    "mtime": 1779512835.5574512,
-    "ast_hash": "e85c0d74b1072bbdb54517f79d9bfdee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__tests__/store/authStore.initialize.test.ts": {
-    "mtime": 1779512835.5574512,
-    "ast_hash": "f20587ea5bef7853eb4e82224a5a246e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__tests__/store/driverStore.wav.test.ts": {
-    "mtime": 1779512835.5586083,
-    "ast_hash": "e5df02af226a6a92c79d7c1e44a3e000",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/__tests__/store/driverStore.test.ts": {
-    "mtime": 1779512835.5586083,
-    "ast_hash": "2e3c36e1386da8b0491e7cfd2a7e5386",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/api/client.ts": {
-    "mtime": 1779512835.5586083,
-    "ast_hash": "332eb10b51e8fca51f82bc3e4e78f182",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/scripts/dedupe-shared-nm.js": {
-    "mtime": 1780060957.340439,
-    "ast_hash": "a74c92c255724eaf4bd08c91e200b038",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/scripts/reset-project.js": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "55e9a46ae7c35eb0340e956473beaed2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/styles/index.ts": {
-    "mtime": 1779512835.629595,
+  "driver-app/styles/index.ts": {
+    "mtime": 1780622912.8010237,
     "ast_hash": "58805aeae37ada35e2f7b1867d052881",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/documentStore.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "4145536065b4853a273679122391d198",
+  "driver-app/app/otp.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "107e5c2a21f96871ea045cd24e50e62a",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/driverStore.ts": {
-    "mtime": 1780060957.340439,
-    "ast_hash": "a8368461c8fe07881550fd36d35fd884",
+  "driver-app/app/legal.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "979d235f344bde89fd76ebd34523b678",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/questStore.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "b9ed634938ff6c49acfa78cea55d9702",
+  "driver-app/app/report-safety.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "7fe676337197b39ff397e111904e0e0b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/languageStore.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "530505feee97cb6e4b772eb08aacb597",
+  "driver-app/app/documents.tsx": {
+    "mtime": 1780622912.754837,
+    "ast_hash": "9526599b431195d13f4e07636a959d91",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/documentStore.test.ts": {
-    "mtime": 1779512835.628401,
-    "ast_hash": "15819e49ad25ec9f9d9f083edffda144",
+  "driver-app/app/_layout.tsx": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "7f79b083a958388170e10ed20e136c01",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/driverStore.config.test.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "439711882b28ed44a285dca58f5118c0",
+  "driver-app/app/login.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "3d0154ec6091918fa6288c805545bcf6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/questStore.test.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "acdcaa4f2ae7c01cb75765589f4f5588",
+  "driver-app/app/become-driver.tsx": {
+    "mtime": 1780622912.754837,
+    "ast_hash": "0fb42bac0f2e9205cf39d8a44b0b3939",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/driverStore.restart.test.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "820aec92aa1b4b7e0ca1f8ad7b835912",
+  "driver-app/app/vehicle-info.tsx": {
+    "mtime": 1780622912.7650237,
+    "ast_hash": "7cf0aac986db22bead0664bf8d29a0b0",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/driverStore.test.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "fc4e4427c513cf0fcb08c23a382ee086",
+  "driver-app/app/profile-setup.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "b827afd201c049c67664761a950b45aa",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/driverStore.chat.test.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "8451b7951c57e8ad8e30a33ff0e2acf8",
+  "driver-app/app/index.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "38bbf8218f48be995b84d34f8c19b93a",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/store/__tests__/driverStore.reconnect.test.ts": {
-    "mtime": 1779512835.629292,
-    "ast_hash": "0e323f71875a494e5d1599b5a54653d2",
+  "driver-app/app/driver/addresses.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "c0081c4076a3ebe972a13510ea2a99c4",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/__stubs__/emptyNativeComponent.js": {
-    "mtime": 1779512835.5528538,
-    "ast_hash": "2f3d1a73eac1104259f9bfd70dd740d3",
+  "driver-app/app/driver/tax-documents.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "cdb7b7fc8cac7b47a43c7cb5a8acbfb6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/lib/alert.ts": {
-    "mtime": 1779512835.6129005,
-    "ast_hash": "7947b66bf3f5620b42e41ecd408b38cf",
+  "driver-app/app/driver/ride-detail.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "101ef7e53c2be293b0ca0ec6cb97929b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/complete-trip.spec.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "a77ff43520ec4df426fc68ca2299cb38",
+  "driver-app/app/driver/settings.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "d7d276ec76d51edc3b0355dfa9cd102e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/ride-offer.spec.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "dff8bb2bb0152aa90b95b99abf0df67a",
+  "driver-app/app/driver/notifications.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "44c0981475db14d04cfa18a71740793b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/fixtures.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "060738bd5d443c8bed1b370306c3b4cd",
+  "driver-app/app/driver/subscription.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "d8ac44d740b0bf6117303f717b205cb9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/cancellation.spec.ts": {
-    "mtime": 1779512835.600906,
-    "ast_hash": "02aeb4bb15e47e99fc9854f56e718dd5",
+  "driver-app/app/driver/_layout.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "694ffffc982fbe8c9a504af8203d2843",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/payout.spec.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "5100a6551c0531f691e608179767b7de",
+  "driver-app/app/driver/payout.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "fb16c84db0cc1a55d31c513f7ff2fc0a",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/verify-otp.spec.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "3a0297c379be51392309c09b53abac83",
+  "driver-app/app/driver/payout-history.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "3456ab544c529c55127bf85529f2f6c8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/smoke.spec.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "ce16e8413bd31cfabe0ddf093a577021",
+  "driver-app/app/driver/chat.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "9785d2b505ae4f792e997370a4db8afb",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/e2e/online-toggle.spec.ts": {
-    "mtime": 1779512835.6022294,
-    "ast_hash": "0cc1da04a3ad9eadcdec328816e8748b",
+  "driver-app/app/driver/help.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "17ee078d0f68aaf4e745908584ccfaf1",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/utils/apiClient.ts": {
-    "mtime": 1779512835.629595,
-    "ast_hash": "b6db9544c58201226b7109c95006535f",
+  "driver-app/app/driver/quests.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "7bc01827a1324058bec8ad677d2ff708",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/utils/deviceIntegrity.ts": {
-    "mtime": 1779512835.634645,
-    "ast_hash": "38e9a614668b0f5fe20059d2c62152a0",
+  "driver-app/app/driver/faq.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "ac353ea9e5e6df3ea76863e0b93fc5d0",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/utils/crashlytics.ts": {
-    "mtime": 1779512835.634645,
-    "ast_hash": "7c49848a3d85464cc1c3886138bbae45",
+  "driver-app/app/driver/emergency-contacts.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "67d39ee4cab1b54f6ddb9ad789ea54a7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/utils/backgroundLocation.ts": {
-    "mtime": 1779512835.634645,
-    "ast_hash": "c927e527cede0cc1a5e0381ecd336319",
+  "driver-app/app/driver/referral.tsx": {
+    "mtime": 1780622912.7610238,
+    "ast_hash": "87622095902949fe13864f3b24f05207",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/utils/sensorIntegrity.ts": {
-    "mtime": 1779512835.634645,
-    "ast_hash": "a3024b7ab8a25be149a1a3c8ca9738b4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/utils/locationIntegrity.ts": {
-    "mtime": 1779512835.634645,
-    "ast_hash": "0739482cee427e8b7efcd2bf7523ca9e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/plugins/withGradleWrapper.js": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "cd06c3416afeb58b540db031f28984b2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/plugins/withKspVersion.js": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "294b659519942c76651bd9eb45cdad94",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/plugins/withNotifeePermissions.js": {
-    "mtime": 1779512835.625026,
-    "ast_hash": "c4e09a4099ee172a2d0bd70168024569",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/plugins/withForceCompileSdk.js": {
-    "mtime": 1779512835.623162,
-    "ast_hash": "3035bd1fa442ca2fe8e901e0d9865500",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/i18n/index.ts": {
-    "mtime": 1779512835.6129005,
+  "driver-app/i18n/index.ts": {
+    "mtime": 1780622912.790269,
     "ast_hash": "4b64ba3ea40ee2f5859967d2f4419b7b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/i18n/fr.json": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "a6d670102bfc5068d775ecbae8a528eb",
+  "driver-app/hooks/useDriverDashboard.ts": {
+    "mtime": 1780622912.7890236,
+    "ast_hash": "8514833a9680e0f1f587fd7ec7898eb3",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/i18n/en.json": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "a3bc40ce60542bbcd59d5fb1312147cf",
+  "driver-app/store/questStore.ts": {
+    "mtime": 1780622912.8010237,
+    "ast_hash": "b9ed634938ff6c49acfa78cea55d9702",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/i18n/es.json": {
-    "mtime": 1780060957.320439,
-    "ast_hash": "ef6aae4081717adf6c142fdc587472cb",
+  "driver-app/store/documentStore.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "4145536065b4853a273679122391d198",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/cli.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "34b609d1a48fc78ff0fbdc1285472ee5",
+  "driver-app/store/driverStore.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "7da3e5426f33b67c6f1621026b26f7b8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/knowledge_base.py": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "7c5e22e3e2e08442c44ecba600a1d3b2",
+  "driver-app/store/languageStore.ts": {
+    "mtime": 1780622912.8010237,
+    "ast_hash": "530505feee97cb6e4b772eb08aacb597",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/tester.py": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "e3c5405b1cc011db960bf92723237e8c",
+  "driver-app/store/__tests__/driverStore.config.test.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "439711882b28ed44a285dca58f5118c0",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/deployer.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "aa071c21c5b15148e826b24c09c6b88d",
+  "driver-app/store/__tests__/driverStore.test.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "af2c0735448ab261244c4b0c657375d5",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/__init__.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "df5c7cda93ae6eef39e0f9252131a7be",
+  "driver-app/__tests__/store/driverStore.test.ts": {
+    "mtime": 1780622912.7529967,
+    "ast_hash": "c2f0d3a07f3fd2ff72845763ec9cfd75",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/examples.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "0bee432b5135be13d479583bb521ccc3",
+  "driver-app/__tests__/components/TripCompletedPanel.test.tsx": {
+    "mtime": 1780622912.752061,
+    "ast_hash": "e85c0d74b1072bbdb54517f79d9bfdee",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/backend_agent.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "3a643c1b7ade582778233a1a02a4db5d",
+  "driver-app/__tests__/components/ActiveRidePanel.test.tsx": {
+    "mtime": 1780622912.7517262,
+    "ast_hash": "374fbf3fa2cf377899b158fd9026bf00",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/code_reviewer.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "73753939d8e5246f59e5bcd3276e7bb8",
+  "driver-app/__tests__/components/RideOfferPanel.test.tsx": {
+    "mtime": 1780622912.752061,
+    "ast_hash": "9307ea2bbd846e850beb6c1602b30096",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/frontend_agent.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "325d2654c5357a4a7d328d6a5d131210",
+  "driver-app/types/index.ts": {
+    "mtime": 1780622912.8010237,
+    "ast_hash": "1a2cfdd9142c63c873da3b6e689e20a5",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/agents/registry.py": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "918400348b9eda23e04465b0231d7c9f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/orchestrator.py": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "34854372568677ef086027c9a95e39a7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/security_agent.py": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "1d2720f964a3f4c8e502e2aefb1a0f89",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/documenter.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "bb983f3444926213f45a1dc4927a131a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/base_agent.py": {
-    "mtime": 1779512835.2837265,
-    "ast_hash": "ba0257c85294da5206598b0ac9040d22",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/knowledge/tasks/a40d5f66-6bbf-42d5-89b3-bea02d3fb3bb.json": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "00a99de0b3d0ecd07bbdbe965a25a044",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/knowledge/tasks/486bac5e-ae47-42df-8abd-321d31c9cd9e.json": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "3ccaa2483652894b5a6efb699bf6b6bc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/knowledge/tasks/2eb1f62d-b48d-4bbe-a599-738ae73e4e31.json": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "efd93259bfc805a215e2098b9d05e049",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/knowledge/tasks/218df452-5459-40a6-a1ed-6ccd139270d7.json": {
-    "mtime": 1779512835.2869105,
-    "ast_hash": "a347133d4d1da8d26e3fe51dd27e641c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/knowledge/reviews/977d6de2-21c1-413b-b26f-1fb87c109814.json": {
-    "mtime": 1779512835.2869105,
-    "ast_hash": "343688d164626d7912a3792e706bef74",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/knowledge/reviews/36e10a57-f590-4e0f-b64e-456d13974f1d.json": {
-    "mtime": 1779512835.2862718,
-    "ast_hash": "11a82c38ae6d089117eeb41e7d75d56d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.husky/pre-commit": {
-    "mtime": 1779512834.9498193,
-    "ast_hash": "b2d1fffc776e858ae24c812e2adc6f5e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.husky/commit-msg": {
-    "mtime": 1779512834.945595,
-    "ast_hash": "699bed54039a19ca8ff630af76b1a6df",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/eslint.config.mjs": {
-    "mtime": 1779512835.1716375,
-    "ast_hash": "d5525cb3bc78427130b265d1740f25b8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/components.json": {
-    "mtime": 1779512835.1703293,
-    "ast_hash": "9d220183f9dc57492600d841853d7ec6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/vitest.setup.ts": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "5d8184f1d28fd84dea8f32de71678db0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/next.config.ts": {
-    "mtime": 1779512835.1716375,
-    "ast_hash": "1f1d1da01ca24208d948e9b5601a72d4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/sentry.client.config.ts": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "8ec3c1f05aa48af34a15a1f97103ea4d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/vercel.json": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "0bb4f16ffcaaf82cb39eedccf1482ba4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/vitest.config.ts": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "1f0c3cff4fb1b9b6a23ff921038d67fd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/package.json": {
-    "mtime": 1779512835.173595,
-    "ast_hash": "f7dd3599e8e9361b8218dbcbb0ccbe48",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/sentry.server.config.ts": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "d8457011626f412398f55c07eab0d430",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/playwright.config.ts": {
-    "mtime": 1779512835.173595,
-    "ast_hash": "a05df95e789039c77af4dc41884afd76",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/tsconfig.json": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "a82953c22d718fd70b3e62a268dc57e6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/postcss.config.mjs": {
-    "mtime": 1779512835.177595,
-    "ast_hash": "239f3ebf717465dc636818a1a619398d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/middleware.ts": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "199ab38f0f711ba19a3ca6af1a96dc01",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/sidebar.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "43203eeea7363391966d983318bd29e7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/analytics-wrapper.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "11a97ff97f0029e8733ad95733dd3f27",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/heat-map.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "05965a1ad22f1556a085ffe90c3c370e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/auth-initializer.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "c3e89b2a1b34380bc8988a8dc5d3b477",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/driver-map.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "acf8a197d264e71ccc09ef1e3f71d71a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/analytics-provider.tsx": {
-    "mtime": 1779512835.2638202,
-    "ast_hash": "499c212fc5c0dbfc3a9659b115c101f1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/theme-provider.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "96f1e695c8498a71db8de5f4ad62e89a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/mfa-enroll-dialog.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "034be91ed4238a49bcacfa13d5973f33",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/geofence-map.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "b843cc9901f061fd96a7c0971168db98",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/tooltip.tsx": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "17aeef2e263039ea21914a51d71e290f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/button.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "c146cd1d6f1e0d54e4a7bb5f15a0834b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/sidebar.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "0a3a11eec8c3f49c18d5dcf6fa7ccb03",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/pagination.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "96684761fda78e4f695fa247b538373b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/use-toast.ts": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "5673838018ccf115b53c9230e1a33795",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/textarea.tsx": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "04f9af2a78672f7018b16db2bcec5036",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/dropdown-menu.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "388aafcad8a41631e3ce2efbbbc3d0a4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/tabs.tsx": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "6dcceea6a7c4551cba3009b58f1c9e21",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/toast.tsx": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "870993f2ea4c544b4d9a49a2c536e2d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/avatar.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "03163772efa93ff00e813142e35eaeb6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/dialog.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "d04a6c9cfef3709a491429478b4556e3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/badge.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "752d1eea34a44e1becd88c82c5aa1016",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/toaster.tsx": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "cec0538ec0287ee66b3a3955cd92e821",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/label.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "e7e0c4ad98f3485ecd3c0ca516d0a8bf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/alert-dialog.tsx": {
-    "mtime": 1779512835.265361,
-    "ast_hash": "81621b30c6628012c8185d2eef72d692",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/alert.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "d4b3e9e4e501c34b4cdec8f9860f0f35",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/sheet.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "bb3ca0588bd13d790f9ab6a159f6bdeb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/use-crud-toast.ts": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "2030a221a44357ae279312d9f76a1f41",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/input.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "6666f8369b53c79d39be8060dc6c4ce5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/switch.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "5c8ed3ecdb9e461c52a3d07d50050728",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/card.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "a6752f4d1da504c7f03196d90cde4b2c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/table.tsx": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "531bf830b5f3b399abe3fd453157cdb7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/select.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "6a0e07cd58ac996abcb87ff5bb702c05",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/components/ui/separator.tsx": {
-    "mtime": 1779512835.265595,
-    "ast_hash": "a27e39c797c6856cf5843b7b84d81cff",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/hooks/use-mobile.ts": {
-    "mtime": 1779512835.269595,
-    "ast_hash": "fa5910fcabb30a06b1e810c9dac3324a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/hooks/useAdminLocation.ts": {
-    "mtime": 1779512835.2753062,
-    "ast_hash": "d120c2b0f78875251569890eaec3b557",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/hooks/useRequireModule.ts": {
-    "mtime": 1779512835.2753062,
-    "ast_hash": "79bac263614702a25021f6383f6bce67",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/hooks/use-monitoring-socket.ts": {
-    "mtime": 1779512835.2753062,
-    "ast_hash": "cfd783265ea4ffb0cf189c388cd8bb63",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/hooks/usePlacesAutocomplete.ts": {
-    "mtime": 1779512835.2753062,
-    "ast_hash": "e04eade0262b87a5e0ec70ff9092abb4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/error.tsx": {
-    "mtime": 1779512835.2587378,
-    "ast_hash": "7d7f1b32583e4f50600ce37aec08ec0c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/page.tsx": {
-    "mtime": 1779512835.2587378,
-    "ast_hash": "cfd4842cc6996290e7d8ef4b709fcecd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/not-found.tsx": {
-    "mtime": 1779512835.2587378,
-    "ast_hash": "aee12c16d22d01d27962282429fe2c33",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/layout.tsx": {
-    "mtime": 1779512835.2587378,
-    "ast_hash": "14f44fddf1334099184f508bd8112949",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/403/page.tsx": {
-    "mtime": 1779512835.1895773,
-    "ast_hash": "00df4c5d7d654ff8f1ea3e9aa3fcf727",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/api/admin/auth/logout/route.ts": {
-    "mtime": 1779512835.1909752,
-    "ast_hash": "4aafa07830b16f6c0fcfc14d97d4b7f7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/api/admin/auth/refresh/route.ts": {
-    "mtime": 1779512835.1925468,
-    "ast_hash": "5d2a566f7adf2212aab7192a34df0f01",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/api/admin/auth/mfa/challenge/route.ts": {
-    "mtime": 1779512835.1925468,
-    "ast_hash": "6e64f857e474b90128b6a9ad6ce665c7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/api/admin/auth/login/route.ts": {
-    "mtime": 1779512835.1909752,
-    "ast_hash": "e3ac72465620859bd14ee1d57c987a1c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/api/auth/set-cookie/route.ts": {
-    "mtime": 1779512835.1941164,
-    "ast_hash": "45d2dfeacc55937d0257076aada9f6b1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/register/driver/page.tsx": {
-    "mtime": 1779512835.262706,
-    "ast_hash": "4fbaf1b4c1cc55bd15bbe6f2532c90c2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/login/page.tsx": {
-    "mtime": 1779512835.2587378,
-    "ast_hash": "4892d0f21fb367b4e30ffb39cb597266",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/track/[rideId]/page.tsx": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "344c7f7b1f5988f0ee4bfe1eacf96e04",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/loading.tsx": {
-    "mtime": 1779512835.2316754,
-    "ast_hash": "338d880761e267925a7558b35ccb2e42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/error.tsx": {
-    "mtime": 1779512835.2290857,
-    "ast_hash": "b03bbedf28f8bef489051c44f915c4db",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/page.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "2e386b6d714ffbd008e7cd9f361d48ba",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/layout.tsx": {
-    "mtime": 1779512835.2316754,
-    "ast_hash": "8e61268a822b3aae6fcf4d46548b1260",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/users/loading.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "754a26ddd0793570dd139facd960dcc9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/users/page.tsx": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "43328d12e5b1651c7d8dc29eeb525e39",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/loading.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "305711c728e576d6be3758fe360c3c64",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/driver-panel.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "99e137249d831d76c7a525efb77b1496",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/page.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "62f5fd163c5eff79974e16689dc1ae13",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/ride-panel.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "5e92ea86a2a16d973a3a85384d3a32f8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/toolbar.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "4b2f28fcbc65c22919801107fcc8fce3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/monitoring-map.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "95508cba6aa86cdd1805e1aa7e8772a9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/types.ts": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "b1d8504eb9160a10c51454315143629b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/alert-feed.tsx": {
-    "mtime": 1779512835.2316754,
-    "ast_hash": "3f2028b2c28354f8a076c8ec3dd5ba5f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "f77396d7817b0a121cb0f03f68418c3d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/vehicle-types/page.tsx": {
-    "mtime": 1779512835.2587378,
-    "ast_hash": "7f9f6a01846be2cb0a5bb5021816f406",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/audit-logs/page.tsx": {
-    "mtime": 1779512835.2021341,
-    "ast_hash": "ad01025b0834a131fbed2964f78028d9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/disputes/page.tsx": {
-    "mtime": 1779512835.2071285,
-    "ast_hash": "b05284c2aabdc76202d30ceac668c879",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/earnings/page.tsx": {
-    "mtime": 1779512835.2264805,
-    "ast_hash": "fdce1c529f40fce3558767415228096d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/earnings/payouts/page.tsx": {
-    "mtime": 1779512835.2290857,
-    "ast_hash": "5e96b5d7af268008a90976c2724e5aee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/earnings/payouts/[id]/page.tsx": {
-    "mtime": 1779512835.2290857,
-    "ast_hash": "74560eca3847311ffb74a64303b3388b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/safety/page.tsx": {
-    "mtime": 1779512835.2470255,
-    "ast_hash": "fc998671c234c320eb48373c71070dff",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/notifications/page.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "64037ee62e42cfd8f57b4092047a7586",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/settings/loading.tsx": {
-    "mtime": 1779512835.2470255,
-    "ast_hash": "f7c3f2520a655d1e4a14db92ec263506",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/settings/page.tsx": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "fba8aad67d7eb24f8f243f5483cf5c30",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/staff/page.tsx": {
-    "mtime": 1779512835.2502646,
-    "ast_hash": "f4dc02f55d33888b4b120f923682ee57",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/surge/page.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "5d099dc4e51504db0aa562f9c0b683b9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/forecast/page.tsx": {
-    "mtime": 1779512835.2316754,
-    "ast_hash": "a748365e5b075ea2a69e5c9f1303b277",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/loading.tsx": {
-    "mtime": 1779512835.2240927,
-    "ast_hash": "e9bf3b0d9612bc602093386fb18b0526",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/page.tsx": {
-    "mtime": 1779512835.2240927,
-    "ast_hash": "cc297410531f144cc9a1f7c839c8fced",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/expiring/loading.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "fef6eb7c6693c9caa4e0a7fc06d144cc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/expiring/page.tsx": {
-    "mtime": 1779512835.2240927,
-    "ast_hash": "8ee01b45e2758469e545f66293e02645",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/driver-timeline.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "65ced6d1008d4bd27c27d35ba4938101",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "68ec7d3ec7888a1f4aed3b9b11b3216f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/area-stats-table.tsx": {
-    "mtime": 1779512835.220249,
-    "ast_hash": "c9198f0ca836d96dcdbfc959651f2de4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/driver-stats-cards.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "e7d53b053d396f4e09a115b1adec1951",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/document-reviewer.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "df6ae1c81e7754b9e157b116637fd18b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/driver-action-bar.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "27fc81e9e31836f22db29fda7fedf0ad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/_components/driver-charts.tsx": {
-    "mtime": 1779512835.2212796,
-    "ast_hash": "56c646b2f0b6f2e91422c904c2a21cc6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/queue/loading.tsx": {
-    "mtime": 1779512835.2264805,
-    "ast_hash": "08432c3dd37951bfeb7772174ad98ace",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/queue/page.tsx": {
-    "mtime": 1779512835.2264805,
-    "ast_hash": "8c91a6e603b3164a2dfb7410b8e068d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/drivers/queue/_components/queue-stats.tsx": {
-    "mtime": 1779512835.2264805,
-    "ast_hash": "93800c6fddb68180093af7a9408fd1da",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/promotions/loading.tsx": {
-    "mtime": 1779512835.2347572,
-    "ast_hash": "528cdf4fff167fc25542674beabbee31",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/promotions/page.tsx": {
-    "mtime": 1779512835.239655,
-    "ast_hash": "4dfff30ea8fa48b628679c6b69e60767",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/corporate-accounts/page.tsx": {
-    "mtime": 1779512835.2071285,
-    "ast_hash": "6270ff9c7e4549926b0dfc5f3efc00e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/page.tsx": {
-    "mtime": 1779512835.2071285,
-    "ast_hash": "c9eb9caa9f21c6c51a4d6e50eb5caf03",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/policy/page.tsx": {
-    "mtime": 1779512835.2071285,
-    "ast_hash": "b6affa1560cd073bb85afb7112d6329a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/allowance-dialog.tsx": {
-    "mtime": 1779512835.2057414,
-    "ast_hash": "40001be2d21a196f5aa43caccb2efe5e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/page.tsx": {
-    "mtime": 1779512835.2071285,
-    "ast_hash": "16976880f27423daf8fb8ed54baab4b6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/corporate-accounts/kyb-queue/page.tsx": {
-    "mtime": 1779512835.2071285,
-    "ast_hash": "5d5b09f5e6b01c5d1cef39c10d40848e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/loading.tsx": {
-    "mtime": 1779512835.2470255,
-    "ast_hash": "ff85eb847728e64125071c5a812b6d9c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/page.tsx": {
-    "mtime": 1779512835.2470255,
-    "ast_hash": "f86db91949dbef18d82b9fe8e3d152d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-list.tsx": {
-    "mtime": 1780060957.252439,
-    "ast_hash": "8c04404e7404c6b770c0d77b78f3aad0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "9b9d870b2bc040ff0276e0c4f53e08e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-complaint-form.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "71d19a7ec7c815b25da82455f6bdf959",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-lost-found.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "8994403203e08d08cfa7dfa109c1881f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-stats-cards.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "57d7b7e9778f1e55218dc72d35e0ac10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-route-map.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "aedd78d803833f1b55022646344df836",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx": {
-    "mtime": 1780060957.252439,
-    "ast_hash": "cc759806bba0bc64abd8b0c590f6f7b7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/create-ride-modal.tsx": {
-    "mtime": 1779512835.241218,
-    "ast_hash": "9806579f4b4ba7c4bb67d20f124dea42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-flag-form.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "fa4dfce309094a64b4267c7b8b4c5a90",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/_components/ride-ui-helpers.tsx": {
-    "mtime": 1779512835.2419562,
-    "ast_hash": "af608b47c42a818373ce4478601b828a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/live/[id]/page.tsx": {
-    "mtime": 1779512835.2470255,
-    "ast_hash": "a930cfd369bcb9db9449336360852ec0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/rides/live/[id]/live-map.tsx": {
-    "mtime": 1779512835.2461963,
-    "ast_hash": "4032ef74d3b3f24303a084c03b3a2934",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/page.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "819fbbb22c76c484dc58461397ca922e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/lost-and-found.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "cdac7311d3da1f4a8f141596fe00b811",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/faqs.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "383db4f689d0d7e1a155e92c46ec88b4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/legal-documents.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "36e2bbd754366e3c5a28b8ad26bde189",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/complaints.tsx": {
-    "mtime": 1779512835.2531407,
-    "ast_hash": "8fac0688001d1f3097208ffbf889c26d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/tickets.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "8ad5b82a2ac42482968e8beac947ce45",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/flags.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "205f3e92567c6f4ef1eecdfeae66a341",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_tabs/disputes.tsx": {
-    "mtime": 1779512835.2549691,
-    "ast_hash": "480e47037c749f5aa30f000c5132e8ca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/support/_components/service-area-select.tsx": {
-    "mtime": 1779512835.2531407,
-    "ast_hash": "eb5c7559f5cb3a3fc47aa4824ac655b2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/heatmap/page.tsx": {
-    "mtime": 1779512835.2316754,
-    "ast_hash": "37cdb94887b02120f806d565a8fc95bc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/quests/page.tsx": {
-    "mtime": 1779512835.239655,
-    "ast_hash": "eb2ea0b97af5638647eff114244a7a58",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/service-areas/page.tsx": {
-    "mtime": 1780060957.256439,
-    "ast_hash": "290789935a88c31b2cfc0263d693db18",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/faqs/loading.tsx": {
-    "mtime": 1779512835.2290857,
-    "ast_hash": "7bd351fb0a437c0d7f61d356c8579eee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/faqs/page.tsx": {
-    "mtime": 1779512835.2316754,
-    "ast_hash": "1facecde1dbd2cc61bcb8be688b87bac",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx": {
-    "mtime": 1779512835.2021341,
-    "ast_hash": "7923e886cfdf3f78e7c21dc8ed4adfc0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/subscriptions/page.tsx": {
-    "mtime": 1779512835.2502646,
-    "ast_hash": "7bf52167ed3102097486194d686ca3fa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/documents/page.tsx": {
-    "mtime": 1779512835.213595,
-    "ast_hash": "aa7ff33e55ecb530df721206e60c6928",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/documents/requirements/page.tsx": {
-    "mtime": 1779512835.2188935,
-    "ast_hash": "ddcb1b00fc15a5a2fdaff67db3f205a1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/analytics/loading.tsx": {
-    "mtime": 1779512835.2017198,
-    "ast_hash": "689c1f7de4da85b45e98db15856da033",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/dashboard/analytics/page.tsx": {
-    "mtime": 1779512835.2021341,
-    "ast_hash": "e986ab1347941f908221e31020c51974",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/page.tsx": {
-    "mtime": 1779512835.197595,
-    "ast_hash": "c32f5370a7dbfec9b567d8964f973ed1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/layout.tsx": {
-    "mtime": 1779512835.197595,
-    "ast_hash": "2b89aca3fd18af8079583fcc52d5f868",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/page.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "ebc480d774a0832955980a7b7a305cdb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/layout.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "0ae2a987d75c34cc6a087e37408e97c4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/overview/page.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "02f4d6f49e9c0cf93b5a7cf1b76036cd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/activity/page.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "49678bdebdbafa0e1cb20a454de2afbd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/policy/page.tsx": {
-    "mtime": 1779512835.197595,
-    "ast_hash": "5f8cb8bf8a08101a1606842f50345977",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/settings/page.tsx": {
-    "mtime": 1779512835.197595,
-    "ast_hash": "abb1553f7f327050e7f971d94965c19e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/billing/page.tsx": {
-    "mtime": 1780060957.252439,
-    "ast_hash": "358303b159de5362ffdf0b83821bd96a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/allowances/page.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "8c508e3192a91c5d109aea786295fb91",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/members/page.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "59f8ace8bc9b546ceaeb257c990c995d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/app/company-portal/[id]/allowance-requests/page.tsx": {
-    "mtime": 1779512835.194836,
-    "ast_hash": "70b9bb3db1c2025dd80d72f16747491b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/setup.ts": {
-    "mtime": 1779512835.1875684,
-    "ast_hash": "30fa13ccc15ab8bdf326d8decb1553fc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/login.test.tsx": {
-    "mtime": 1779512835.1875684,
-    "ast_hash": "b4f794fa08d4d83d226a2804c01fd7a4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/api/set-cookie.test.ts": {
-    "mtime": 1779512835.1861215,
-    "ast_hash": "6e89a8979a38b2f9bc2b9d919d185872",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/api/admin-auth-refresh.test.ts": {
-    "mtime": 1779512835.1848972,
-    "ast_hash": "603e66bad68fd6579e0ab43ff068f343",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/store/authStore.test.ts": {
-    "mtime": 1779512835.1875684,
-    "ast_hash": "01895241394f6bb54b80f0fac85dac0e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/lib/utils.test.ts": {
-    "mtime": 1779512835.1875684,
-    "ast_hash": "0039006a506e7652f72d251cc117851a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/lib/export-csv.test.ts": {
-    "mtime": 1779512835.1861215,
-    "ast_hash": "44bd4146b5c862731be0344c510c4b5a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/__tests__/dashboard/pages.smoke.test.tsx": {
-    "mtime": 1779512835.1861215,
-    "ast_hash": "ff5c629ba80b56489e7c37c6167b948c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/store/authStore.ts": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "53530ee7d5e205e507937df98339bc44",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/utils.ts": {
-    "mtime": 1779512835.2773826,
-    "ast_hash": "dc778c4009748a6e57159e2956c4de05",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/api.ts": {
-    "mtime": 1779512835.2773826,
-    "ast_hash": "a25d4176f19aabb16fb9dc760ea16ac7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/export-csv.ts": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "055e35647e504a745fac40ddfd5e637f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/logger.ts": {
-    "mtime": 1779512835.2773826,
-    "ast_hash": "52ac7cfec8a70e31a679a0cc6d395721",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/pii.ts": {
-    "mtime": 1779512835.2773826,
-    "ast_hash": "c5c9ec1a49b722c6b2800d02b7b77480",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/__tests__/api.test.ts": {
-    "mtime": 1779512835.2766366,
-    "ast_hash": "e6164d3998a8a6679a5a258c76853914",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/__tests__/utils.test.ts": {
-    "mtime": 1779512835.2773826,
-    "ast_hash": "9445337e37f58168f9dc8c3563e9cdc2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/src/lib/map/maplibre-base.ts": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "337ad2d01cfcd38060f908cae6bfd880",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/scripts/test-railway-login.ts": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "cda4c26b3121dfacb48471dbc6ff80e2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/e2e/auth-fixture.ts": {
-    "mtime": 1779512835.1703293,
-    "ast_hash": "e40d23f6ef9e0ba9c94a779ef64ca10f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/e2e/ride-management.spec.ts": {
-    "mtime": 1779512835.1716375,
-    "ast_hash": "5952a66d92e78a64a0b58afa7c09cca4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/e2e/login.spec.ts": {
-    "mtime": 1779512835.1716375,
-    "ast_hash": "408b02158ccd56c536722a9a656a2be8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/e2e/auth.setup.ts": {
-    "mtime": 1779512835.1716375,
-    "ast_hash": "aac3dc1a8bb7237201f217c53599d628",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/e2e/dashboard.spec.ts": {
-    "mtime": 1779512835.1716375,
-    "ast_hash": "a3b4194dbf3f6e2fcbc38712fec6e9c9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/jest.config.js": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "3699d08d52ac397e56d4d45067509781",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/eslint.config.js": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "560a864580ad8107fbbf8d6d452c82fe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/babel.config.js": {
-    "mtime": 1779512836.1815948,
-    "ast_hash": "441a2e78a2cb4b522a8c18b3ca198a0e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/test-maps.js": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "035382ca9386112d715f42f65bd94129",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/vercel.json": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "61bd31a2b0ac08f10f13c932b32d6ca1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/jest.setup.js": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "ae2383489e922d9ad1a18217d4c3055b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app.config.ts": {
-    "mtime": 1779512836.1635082,
-    "ast_hash": "8a8793b93d1de39c9cea8d27c777f2bf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/test-places.js": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "9594ea443cfcd44acc25b43e3380e4a6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/metro.config.js": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "ea33c940558dd5ee461eb3a8c8ba1af5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/package.json": {
-    "mtime": 1779512836.189595,
-    "ast_hash": "bd2d83ac0f696b62ccaba1e1331a58d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/eas.json": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "db157175390123f4c1bb471193584748",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/tsconfig.json": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "f81cae1f27a5d1365cd00a117a40cdf8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/types/expo-linear-gradient.d.ts": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "d78e0c6b1f9fd5b8e39c6590c77ea44d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/components/AppMap.web.tsx": {
-    "mtime": 1779512836.1864703,
-    "ast_hash": "21a9794c39e8856c84b1a56535af59d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/components/AppMap.tsx": {
-    "mtime": 1779512836.1815948,
-    "ast_hash": "ec5da6d586010f7605492a3473cb2455",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/config/index.ts": {
-    "mtime": 1779512836.1872866,
-    "ast_hash": "10260a0410e6c9d745764a1b5ad728c2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/config/spinr.config.ts": {
-    "mtime": 1779512836.1872866,
-    "ast_hash": "c030c0c32fdb9856ef3af6f83d2f460a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/config/firebaseConfig.ts": {
-    "mtime": 1779512836.1864703,
-    "ast_hash": "fb731565b0e3a24652dee9b248bfacc3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/config/supabase.ts": {
-    "mtime": 1779512836.1872866,
-    "ast_hash": "423c3e4ac9ddbf0249344060c2be40fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/__mocks__/@shared/cache.js": {
-    "mtime": 1779512836.1612556,
-    "ast_hash": "39b30c27c3f7cdde1146ba153933d951",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/ride-in-progress.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "523dfdb07cfecb9c14467d1a06200203",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/otp.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "dca3867c919865698a73f3733c4a5ba7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/login.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "04dc8267773f153e772fcab96936ab95",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/support.tsx": {
-    "mtime": 1779512836.169595,
-    "ast_hash": "70919d217ec9ff612f7b2d0bd13f2b99",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/search-destination.tsx": {
-    "mtime": 1780060957.348439,
-    "ast_hash": "ee63027b9df0827136c202db99c3bca3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/driver-arriving.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "29574aa759122c38a3f74b0cae5d677e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/rate-ride.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "f9c94adc93c46d813fac00d7850c1994",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/profile-setup.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "030287ffcbb84b75907615cea9a315de",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/ride-options.tsx": {
-    "mtime": 1779512836.169595,
-    "ast_hash": "c54e1adac934543e08d1c9f193a40d5f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/_layout.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "f134aeaa8aa5b67441589ededa7d12d9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/ride-status.tsx": {
-    "mtime": 1779512836.169595,
-    "ast_hash": "39f1f9abbf27588459ee6dd6d65e4c3d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/report-safety.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "88f9458d68eae0aea616c79e4656976b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/chat-driver.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "4a3a37c2318cfe7bc97a0e2157d5fb71",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/become-driver.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "688d1f1c229be6b6289b113c7b532afd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/ride-completed.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "2e526f3f229f8a3eb5f15fa6e2cbf5a9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/payment-confirm.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "6fd22f9c60a6100921a92b723ae80453",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/driver-arrived.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "ac809532db02c653c00988fafb308d26",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/index.tsx": {
-    "mtime": 1779512836.1655948,
-    "ast_hash": "7a09956e142d2dff81bfd3a07d454b01",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/(tabs)/activity.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "19b74cf3b4b0d4acddcc09245b1f04bf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/(tabs)/account.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "64b112e6fdacd68d90d2421da5f0b8ed",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/(tabs)/_layout.tsx": {
-    "mtime": 1779512836.1643736,
-    "ast_hash": "83119bc18428a4755b9677d5d3cdf367",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/app/(tabs)/index.tsx": {
-    "mtime": 1779512836.1645088,
-    "ast_hash": "1c72a01e0372cb461294575d007aeb99",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/__tests__/store/authStore.test.ts": {
-    "mtime": 1779512836.1617975,
-    "ast_hash": "e6a7fe384d8e0eb7efb18536319b05b7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/__tests__/store/rideStore.test.ts": {
-    "mtime": 1779512836.1623797,
-    "ast_hash": "989e2f0b95b1474fe80c26f81415e1e6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/api/upload.ts": {
-    "mtime": 1779512836.1635082,
-    "ast_hash": "313fac4317c28e6410bd3bdce19dfdad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/api/client.ts": {
-    "mtime": 1779512836.1623797,
-    "ast_hash": "58396cdc53ee0f4e2c598c807b1bc52b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/scripts/reset-project.js": {
-    "mtime": 1779512836.189595,
+  "driver-app/scripts/reset-project.js": {
+    "mtime": 1780622912.797825,
     "ast_hash": "55e9a46ae7c35eb0340e956473beaed2",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/store/documentStore.ts": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "e2e0acb1ce2720af5d890141763fe283",
+  "driver-app/components/index.ts": {
+    "mtime": 1780622912.7810237,
+    "ast_hash": "9fb12cabb5491150948122fbef14e435",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/store/driverStore.ts": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "53911514a04f904af95d453586bf40fd",
+  "driver-app/components/DriverTopBar.tsx": {
+    "mtime": 1780622912.7764652,
+    "ast_hash": "8c9cc09b2a75d73c8aa9fa7225b3ddca",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/store/rideStore.ts": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "a1b98ede9920618e9783f2f801f89119",
+  "driver-app/components/CarMarker.tsx": {
+    "mtime": 1780622912.7764652,
+    "ast_hash": "e42fcd7fe98b83ba1c3f77387c775dd3",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/store/authStore.ts": {
-    "mtime": 1779512836.189595,
-    "ast_hash": "e44356b22899217d46261fa15c464b39",
+  "driver-app/components/charts/EarningsLineChart.tsx": {
+    "mtime": 1780622912.7787383,
+    "ast_hash": "09533ef0f246c1a472b154324c187e0f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/e2e/jest.config.js": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "1014c07225f031764442e190c9f2ff1a",
+  "driver-app/components/charts/EarningsBarChart.tsx": {
+    "mtime": 1780622912.7770238,
+    "ast_hash": "9de81eaf98d151b7342f0ab9a27ba28f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/e2e/.detoxrc.json": {
-    "mtime": 1779512836.1872866,
-    "ast_hash": "ccd716148a144bf8796a8d7aa1d27492",
+  "driver-app/components/panels/IdlePanel.tsx": {
+    "mtime": 1780622912.7810237,
+    "ast_hash": "d1286bc1a69f2333eadf6dd077203ce6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/e2e/init.js": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "0639738366949befda70603b31870dbb",
+  "driver-app/components/panels/RideOfferPanel.tsx": {
+    "mtime": 1780622912.7820277,
+    "ast_hash": "92bd4154eff3e22c27169b5fa1b663e7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/e2e/auth.test.tsx": {
-    "mtime": 1779512836.1883333,
-    "ast_hash": "bb5c421353bf68d23ce3bf1e571278e3",
+  "driver-app/components/dashboard/index.ts": {
+    "mtime": 1780622912.7810237,
+    "ast_hash": "25e11b957ff6adca3b5231298aa765ea",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/db_supabase.py": {
-    "mtime": 1779512835.3030884,
-    "ast_hash": "1e6b2977edde3d3dd8d927d71bd73866",
+  "driver-app/components/dashboard/ActiveRidePanel.tsx": {
+    "mtime": 1780622912.7787383,
+    "ast_hash": "804b1743d98e1b8fe1e122b5575fab08",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/documents.py": {
-    "mtime": 1780060957.264439,
-    "ast_hash": "39f7a501e5e506654533d86079eca800",
+  "driver-app/components/dashboard/TripCompletedPanel.tsx": {
+    "mtime": 1780622912.7800071,
+    "ast_hash": "80d15bbb667f3745ddb2ef9a02f0085d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/test_batch.json": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "561a8f800522535e0f3e1268737b111d",
+  "driver-app/components/dashboard/DriverTopBar.tsx": {
+    "mtime": 1780622912.7800071,
+    "ast_hash": "97e5a2bf8d0dd5ecd67d5f3058b3cc1d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/list_users.py": {
-    "mtime": 1779512835.3074508,
-    "ast_hash": "0c18a6ab66acfd452a6f9dc3528c2cbb",
+  "driver-app/components/dashboard/MapControls.tsx": {
+    "mtime": 1780622912.7800071,
+    "ast_hash": "5a074ac85556878b1dc40999413f4af2",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/geo_utils.py": {
-    "mtime": 1779512835.3074508,
-    "ast_hash": "c986ee20c955b706b383ea3eca166ce7",
+  "driver-app/components/dashboard/DriverIdlePanel.tsx": {
+    "mtime": 1780622912.7800071,
+    "ast_hash": "bba17d9596642b3ad5b4eb8585e33681",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/check_permissions.py": {
-    "mtime": 1779512835.300226,
-    "ast_hash": "c5b8281a730e113bb4063b6ce1d03c24",
+  "driver-app/__mocks__/@shared/config/spinr.config.js": {
+    "mtime": 1780622912.7501986,
+    "ast_hash": "d87c9a39e05dcf4cd5054a0fc4cb9bea",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/__init__.py": {
-    "mtime": 1779512835.300226,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+  "driver-app/__mocks__/@shared/api/client.js": {
+    "mtime": 1780622912.7501986,
+    "ast_hash": "6e25eb7d4d50f23cc4cbf2facc4a3ca4",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/supabase_schema.sql": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "b15a9447b4416eec58afc0ac7059966d",
+  "rider-app/app.config.ts": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "cae002eb2d9eb515df5ded24fcd54f22",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/settings_loader.py": {
-    "mtime": 1779512835.377595,
-    "ast_hash": "c0703df89d0ee10680b93696039e3af6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/socket_manager.py": {
-    "mtime": 1779512835.377595,
-    "ast_hash": "44a030b8553c043f41c61254ef968f8b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/supabase_client.py": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "824cdd5355223cb2f90541fb905e0f31",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/schemas.py": {
-    "mtime": 1780060957.296439,
-    "ast_hash": "2619793c93797db93563b9f2b3101bfa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/make_admin.py": {
-    "mtime": 1779512835.3074508,
-    "ast_hash": "b33fd9909fa36725df86b0deb480a998",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/diagnose_nearby_drivers.py": {
-    "mtime": 1779512835.3058493,
-    "ast_hash": "a897522c7eda72cdece062c50b8586f6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests_smoke_supabase.py": {
-    "mtime": 1779512835.445595,
-    "ast_hash": "2793d072fb80a2a361d6c3b4fb73de50",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/supabase_rls.sql": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "42b978a3f292716a0e5e1db82f9bbc20",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/onboarding_status.py": {
-    "mtime": 1779512835.3387961,
-    "ast_hash": "9bbd949c1592fd7c42a8fa13a72d1dc6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/validators.py": {
-    "mtime": 1779512835.493595,
-    "ast_hash": "68e131c093dfc28f2faf9b1b5bacb75b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/seed_vehicle_types.py": {
-    "mtime": 1779512835.3745186,
-    "ast_hash": "38f448a3050b40a088580b50bfed8eaf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/test_batch_dict.json": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "781a07fd315652759a4cba3dda2cb29e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/diagnose_driver_ws.py": {
-    "mtime": 1779512835.3058493,
-    "ast_hash": "7455747f5ff0e9cefbdc0d61d4633457",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/logging_utils.py": {
-    "mtime": 1779512835.3074508,
-    "ast_hash": "027f7c5d82da46e1fde5a82370710c55",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/features.py": {
-    "mtime": 1780060957.264439,
-    "ast_hash": "0026bfa833f3b4902a305a7dd59afc66",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/test_dns.py": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "38c0384ccc5e8fa935c03d05fbcdc96e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/server.py": {
-    "mtime": 1780060957.296439,
-    "ast_hash": "038939b90c6d20683104828312074d79",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/db.py": {
-    "mtime": 1779512835.3030884,
-    "ast_hash": "45f14f40c3f11764a3f6f1c4b5144766",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/sms_service.py": {
-    "mtime": 1779512835.377595,
-    "ast_hash": "cfc2e4bc93a2b94809caa76819472939",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/test_corporate_accounts.py": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "b688b28aa1d2b46224b654331b07f626",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/sql/01_postgis_schema.sql": {
-    "mtime": 1779512835.377595,
-    "ast_hash": "c26505bef4531294e7c5a680619d0c13",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/sql/04_rides_admin_overhaul.sql": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "a5a1c3540270be12fd2a35f17ebdf685",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/sql/03_features.sql": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "3b9ec15ca156739324f250630a8cd111",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/sql/02_add_updated_at.sql": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "1e49c375b71505913585476622ac0ac6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/dependencies/__init__.py": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "5f000517c82023b301fda6183318aee8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/dependencies/company_guard.py": {
-    "mtime": 1779512835.3058493,
-    "ast_hash": "d209ffc40ed78bf61e4ef3389c21dba3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/corporate_membership_service.py": {
-    "mtime": 1779512835.3773954,
-    "ast_hash": "ca5e1c6bfc784312f4a57f4b444839a8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/corporate_allowance_service.py": {
-    "mtime": 1779512835.3773954,
-    "ast_hash": "8b60fc2d26e7a82593a3ad04da12e432",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/fare_service.py": {
-    "mtime": 1780060957.3004391,
-    "ast_hash": "4b4b0761ff9ab64cffac26dcbd861da8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/__init__.py": {
-    "mtime": 1779512835.3773954,
-    "ast_hash": "bdc70707b94c91f5f239f71222d66ad8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/dispatch_service.py": {
-    "mtime": 1780060957.3004391,
-    "ast_hash": "35da97a27c1e221d864915de96dea126",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/stripe_kyc_sync.py": {
-    "mtime": 1779512835.377595,
-    "ast_hash": "b2adddd7ea3033d541c1447e8aa7030b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/cancellation_service.py": {
-    "mtime": 1779512835.3773954,
-    "ast_hash": "2536a9421e4e5c77de5d037599aefff4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/payment_service.py": {
-    "mtime": 1780060957.3004391,
-    "ast_hash": "062ec7af8edba3fa3cc22c28dcce6a2c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/corporate_policy_service.py": {
-    "mtime": 1779512835.3773954,
-    "ast_hash": "f04d3e35525e6db160fd9f3f1f0c0791",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/corporate_wallet_service.py": {
-    "mtime": 1779512835.3773954,
-    "ast_hash": "749f22397a497a9fd8263658b93914a2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/schemas/__init__.py": {
-    "mtime": 1779512835.369595,
-    "ast_hash": "d53896253012f97c8d3904e2326b2a13",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/schemas/corporate.py": {
-    "mtime": 1779512835.3733928,
-    "ast_hash": "a564b98058547329676f1d8d929aee63",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/driver_repo.py": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "b3da1200089213e249fee4d6bc974c60",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/ride_repo.py": {
-    "mtime": 1779512835.3400013,
-    "ast_hash": "5c4208d2caa839368cfc2e3517e29b89",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/__init__.py": {
-    "mtime": 1779512835.3387961,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/corporate_repo.py": {
-    "mtime": 1779512835.3400013,
-    "ast_hash": "60e053b60c3591d165cd313b67aa89a0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/_base.py": {
-    "mtime": 1779512835.3400013,
-    "ast_hash": "7e040b598b3484415b2c94825b09386d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/wallet_repo.py": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "aeb5cf414c4703c1f28328429b0abc48",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/repositories/auth_repo.py": {
-    "mtime": 1779512835.3400013,
-    "ast_hash": "bf5b94fca49b1db57af0072898a4d17c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/13_driver_notes.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "3fd7e833ba9f47eba94f187446fcae4b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/76_push_retry_queue.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "6c10cf852148e190381cba026d45c80d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/18_admin_staff.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "64b4d9d4ebbde9c469402245f5167444",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/75_service_area_for_point_rpc.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "8ff8ac47460323d20e0afcf3655ad980",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/89_rides_ride_metrics.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "e4ffe29dc12eb9a6d4f8f092aa116676",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/54_gps_daily_rollup_fn.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "9c3d187628883cdd02e692a6939a00e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/10_disputes_table.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "a65ecb317da9905e3a0cfe33a885a004",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/54_add_rides_assigned_at.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "a02bb4fd6c3faf3303660d06a0374380",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/21_loyalty.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "420e5ecd1f5bb01a1dddf048558afc80",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/61_drivers_total_ratings.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "1b6cc4c06f5f586e24080792350a8f99",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/56_admin_staff_security_columns.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "33536754c6f2415bb95a3c742387294f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/51_loyalty_unique_and_promo_atomic_increment.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "22a4955ac98ca3c6d2cea127e8f68043",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/112_lost_and_found_add_contact_method.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "bfd314e02e1c25d6639aaf66b29a54fe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/53_rides_one_active_per_rider.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "d99d6bc07159fcc6f76a0616d2317531",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/81_service_areas_missing_columns.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "0d2becb8266903ab301293c79faf2a82",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/28_corporate_wallet_rpc.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "d36d8540b2120cae8f2d6c778626dfbb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/40_rides_ride_code.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "251da8abd01305c9ef4e664398dfb3a8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/106_backfill_surge_enabled.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "7499b2c432f182065d782a6cfcfe4f21",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/10b_service_area_driver_matching.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "30f97f65a065e5b57269e830dd0975e3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/95_settings_safety_alert_emails.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "840a4a10d80b118ebe659667fddeb6be",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/47_users_profile_image_status.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "4af3a662625e32414eb7be3a7d62561b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/08_complete_schema.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "df3f5c67afca52f64513015e31918cbf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/02_dynamic_documents.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "e955c46aa7b9a9e474e7d1afc008810d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/15_ride_aggregate_columns.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "79dadd4c5e90425035a3bf219b4e9be6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/84_audit_logs_missing_columns.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "e394abbb40f8570f938471a63fa25d84",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/106_settings_dispatch_globals.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "6601221b49170a6de12250b19d70a03a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/05_corporate_accounts.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "33a3eba7b30533eb711311559afbf10d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/04_stripe_payments.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "be7b5221224dcfc04b444bbe2d134745",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/69b_lost_and_found_concurrent_indexes.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "86db1ef86f67323078cc438a0979fd9f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/16_driver_daily_stats.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "b4888674b80d015267d9d3449e89647d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/97_driver_intent_timestamps.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "3ae174201d3887d7d239fb822cf05830",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/12_driver_lifecycle_status.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "6dc443a6c74af4c2c7b11fd6f749f52b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/80_service_areas_vehicle_pricing.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "39dd88f4dce7f509b979d73645df476b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/56_audit_logs_delete_lockdown.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "48750c6634f7514ca607d01b8078137f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/51_audit_logs_lockdown.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "f9dd10c30529016dc072d74612879f10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/11_driver_needs_review.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "cccc42827ebe729baa45d3457745294c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/50_wallet_atomic_rpcs.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "a69087d23b43a11770a83cc5127acd12",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/81_rides_cancellation_fee_columns.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "6de998c04af872e99c457bf7a3b42adc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/111_wallet_pay_for_ride_security_hardening.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "3b9fae7ed6d14d18f399373f22fe4f63",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/29_wallet_fks_and_admin_types.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "4ceb5fbce175fc3841585eea99bd4aa3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/48_notifications_tables.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "63a6d4db68e4b879623f2a337ad70680",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/55_find_nearby_drivers_suspended_filter.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "39175c19b6063b32cbfd98af9e6ec0fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/82_rides_discount_columns.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "ed08ed63b0db37af456337b88aa5fdf2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/94_safety_incidents.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "4eec35e589ee8ebd6b19d7d056838f29",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/57_purge_pii_retention_regression_fix.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "05904853c70b88d81ed285da89c3dd15",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/68_complaints_table.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "0671bf3353bcdee583cb0d084bc5f924",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/46_rides_fees_and_taxes.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "ff8a36bf09cb01d7edbe74982183dde9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/107_wallet_pay_idempotent.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "117cd0b6040e1b48a6d2b0f666260909",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/72_wav_dispatch_composite_idx.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "3a76935f364f508f4219b3ee5851237c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/98_create_ride_messages.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "38620693855644b61d0edb494a8aec16",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/105_service_areas_timezone.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "c04002bc8a8813353615c7badc2105ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/101_users_add_is_rider.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "fd5a08834dc8578190356bdae10db052",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/37_rides_cancellation_fields.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "5161b0c4d03e303c89292b975c3933c6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/57_audit_logs_schema_standardization.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "537c80c6e601a8a23507ace9fdee1390",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/07_promotions_extra_columns.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "2b7c748697f5ee110c76d94db25e547e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/87_rides_payment_exhausted_alert.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "5cd9fc7c8a38b114e3c4ff06b6f69aa1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/80_fix_match_and_claim_driver_type.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "680a722cd8a32712719d9ce7b9c95a7b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/20_quests.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "7f65d018189a6c283839454490ff082f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/44_rides_idempotency_key.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "7cdb224a4b89932d2cc46d29cd588368",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/52_fare_split_pay_rpc.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "f4fda241212458eb687692b8e8b07a71",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/39_rides_phase_polylines_durations.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "0514f75d3e8eaeeb85a8e672b1e4131e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/91_driver_documents_expiry_date.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "9b1aec3ea1c7669b94df3d6352006b1f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/33_soft_delete_columns.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "a736f647f8b7b47f4d41685c56421865",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/24_schema_migrations.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "ba1fa83d9192626b49815afeba871d50",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/59_reconciliation_discrepancies.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "136624f6d35f26c64ed43d1c803127c8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/34_rides_performance_indexes.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "7ef6f9f874552df00dfca2bda7a222ba",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/65_backfill_driver_insurance_periods.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "39d30eadd103240ce295f3960fcbbace",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/113_drivers_add_heading.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "6d149cc9d05c5abb829a44e54f43d79c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/29_corporate_allowance_rpc.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "34ddc222cb5a588496302b5b2855cad3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/08_service_area_subregions.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "4e600254d71fcd78b45a4be1c1ede5ad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/69a_lost_and_found_repair_schema.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "d9234e5d142422ed27356e3654aadb98",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/03_corporate_accounts_heatmap.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "6038f30b3ae76c956b53aa2ebc3c02c0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/96_driver_ride_incentives.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "ba4e843ddfbce0f5201748ffcd8360ee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/06_cloud_messaging.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "ef78e2a6870438dd38134ab15f2f98ad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/55_drivers_dispatch_partial_index.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "4d4e1ca00238bb8cca3defa94ecff7b1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/110_wallet_pay_for_ride_tip_atomic.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "877e14a859f1377134c0779f84c1fa20",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/43_service_areas_surge_source.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "d2e3a1c0c4e614c7096c97843ff8b786",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/30_identity_audit.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "2679efdbd9be4eeab4551ffb4a117a83",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/28_requirement_key.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "434ef1d26e26ecca1727291aa4a716bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/103_backfill_incentive_claims.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "a0a752d60fe4539b7fc9617c395b201c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/100_batch_dispatch.sql": {
-    "mtime": 1780060957.264439,
-    "ast_hash": "6c311ba4b52017bc27dda53a0d3e5c66",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/77_match_and_claim_driver.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "68b8776875f1ad801b8d712e0175acd5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/78_fix_pii_function_search_path.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "0419ab5a63258807a82e729c405e1c92",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/38_rides_cancellation_attribution.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "3c720c9d439a0f661398de869e03dac1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/63_phase3b_field_alignment.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "3233a44e1bdd61b7a46d2689ed73f555",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/36_rides_corporate_member_id.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "9b27e03e3d45c67976ec17e0beaa6444",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/69_lost_and_found_table.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "b08fb17efd9eaf9f7d42194e38262815",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/45_drivers_doc_expiry_warned_at.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "0b15bdb0c227cddfbd25318500cfaf0b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/19_wallet.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "d858fed6e1e222d8b39e88907680c2d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/22_stripe_events.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "399d6ed190b47799d2fc27c1945d29be",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/55_drivers_dispatch_composite_index.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "757f082353f3f26761db5588a382a559",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/01_add_driver_user_id.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "03690ff2b80f642ddb6edd041a76dbdd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/23_profile_image_url.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "d7fab103f46fac3f0e0bb28e349a21c3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/84_drop_service_areas_fee_columns.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "d348a97f2d4a26ac6e64b8b3eab7163f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/93_settings_missing_columns.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "5a59b2387c20f50d5fce2a6f17633bab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/09_subscription_plans.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "fbd7bad29fc8fb589d0a8e35ff24d42e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/85_drivers_add_is_suspended.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "3d915a96f4825c1bb97b15fd62252cee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/109_wallet_pay_missing_ride_guard.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "8a6ff84b84daf9a3488cb3deb0122320",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/50_audit_logs_append_only.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "c1ce6d88817d94d5a29df4787a046e04",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/64_driver_insurance_periods.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "d643bbe209013dd6539f3b087bfda72c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/96_payouts_instant_reversal.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "0681b8e6bcd8c0ff051f48ea7bb6e4b3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/60_wav_dispatch.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "9439d4c615c9d100fdd08bc72d9ac319",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/92_payouts_instant.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "01486319605881ae19caa28aeb78426f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/66_users_deletion_columns.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "7fb0c50077b22b0d8ee57a8fbefd6fd9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/58_financial_events.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "9a067a38b63fba5baf82ca2ea5a5a548",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/92_drivers_stripe_kyc_mirror.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "074aa6210fa9c1a1885c026c64c79fef",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/52_admin_staff_mfa.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "bda6a34469016f27379333eeee0d2ec6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/57_fix_retention_purge_audit_insert.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "da4c9e795d19bcc0fb97fdfd020d7b29",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/79_add_missing_query_indexes.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "896fbc28c96b6aba551587efd8229bc1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/00_schema_migrations_table.sql": {
-    "mtime": 1779512835.3074508,
-    "ast_hash": "53f6ea41dc1872ecbafccc6fd61958e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/49_legal_documents.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "0c131377f016c9d36134b792ff5380cb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/17_corporate_accounts_fk.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "397148402e9df6d22972bc9c3a865d6b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/54_dispatch_round_robin_index.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "d4efb8fbabe0ad676e749ed7bbee629b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/41_rides_route_snapshot_url.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "ff05902cab975a3784b4a8dad94f5891",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/88_stripe_disputes.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "7ee4a66e1e116c2aaaf9a4ac6ba21a2d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/91_driver_location_history_accuracy_fk.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "38da834b00d5be29b1acd43f64603f37",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/48_faqs_audience.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "cfdf6207bc52262ea59c1b1ca3858c8e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/26_rls_coverage_gap.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "6516d4d5dad040ce3f486a9319850593",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/27_corporate_b2b_v1.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "ae3691c64d5ef398e591286a077927fd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/90_rides_fare_breakdown_snapshot.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "dd3e093ec3802e3a10bb60d71ad4e98f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/86_promotions_free_ride.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "38f194ef3cf984ece01d6554907a14a4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/52_loyalty_dedup_constraint.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "e5b13f982f60838de7d1d9c2cf4b2a3f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/67_fix_purge_pii_retention_actor_id.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "cf3df9955d068aaa794063849eff32b3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/56_purge_dsar_pending_deletions.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "a9848cbbf17ff22b7612d923a2683574",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/104_rides_driver_earnings_snapshot.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "76e8271077d4b780f4bb07080ccde4f4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/71_ride_history_indexes.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "8bb98bdb4bfe164fe898ea9bb986548d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/70_fix_financial_events_rls.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "1943c37c125dff6cc6607968c5a9afc9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/83_promotions_unique_code_per_area.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "4a10a74a01a999f4c9442852bd638694",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/31_driver_dedup_and_constraints.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "1d9165a719e89adb2aefd1af291e5908",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/50_pii_retention_purge.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "a9ebcd1ebf8a94d14831054cc54c65d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/62_ride_preferences.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "1a6b5c38e9a8b6e81d837f30ae163a17",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/73_fix_document_url_legacy_path.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "ed061659e7ac5e5a6ab1e57190c1192b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/51_audit_logs_remove_user_email.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "c5a9438de5d946bf80b6d68e59aa7b5d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/58_drivers_gst_bn.sql": {
-    "mtime": 1779512835.321595,
-    "ast_hash": "77be78f8b11533ad3b2e6286fee81a4f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/14_driver_activity_log.sql": {
-    "mtime": 1779512835.310179,
-    "ast_hash": "6c333c9497431cba24241bd3109f6ef1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/83_admin_media_assets.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "63c1db80f9782e62e02ddd4bf55c2a4b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/82_promotions_schema_and_service_area.sql": {
-    "mtime": 1779512835.3295949,
-    "ast_hash": "99e038438d45bdb1933fb843868eca25",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/51_promo_atomic_increment.sql": {
-    "mtime": 1779512835.317595,
-    "ast_hash": "2e8100779f0c7a600b1c77e64aece218",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/42_drivers_last_status_changed_at.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "c4d13d1ba690e9999c31569b79225260",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/100_rides_planned_route_polyline.sql": {
-    "mtime": 1780060957.264439,
-    "ast_hash": "e44ee9ff069fe4aa65858b9ac48e5dc9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/32_encrypt_sensitive_fields.sql": {
-    "mtime": 1779512835.3135948,
-    "ast_hash": "44d7100a2ed15c3206af322175612d6c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/99_cloud_messages_jsonb_columns.sql": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "7a342cd04a4eae39c27cdd6d8eaaa8ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/108_wallet_pay_ride_id_text_cast.sql": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "7f71db555534bd0521248477c41c9bb2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/migrations/74_correct_total_rides.sql": {
-    "mtime": 1779512835.325595,
-    "ast_hash": "0d2d91883ad339ce5356e2c19c092c36",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/scripts/__init__.py": {
-    "mtime": 1779512835.3733928,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/scripts/run_migrations.sh": {
-    "mtime": 1779512835.3745186,
-    "ast_hash": "e4ad930364059a8e0c3330ee52826ef6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/scripts/check_migration.py": {
-    "mtime": 1779512835.3745186,
-    "ast_hash": "0973e59901a7a627220dc8d52d93273c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/scripts/run_migrations.py": {
-    "mtime": 1779512835.3745186,
-    "ast_hash": "fda215ea2bcb7ebd5af70983b371a076",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/scripts/migrate.py": {
-    "mtime": 1779512835.3745186,
-    "ast_hash": "d5b15b340efac2b6dcf089164ca411d5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/models/ride_status.py": {
-    "mtime": 1779512835.3387961,
-    "ast_hash": "a4bc2ca74a17e7bc42c47239973d2ba1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/models/__init__.py": {
-    "mtime": 1779512835.333595,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_stripe_customer.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "549b29a53277f1db26f3f69025b2b0f3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_db_executor.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "de20eba796b222d5ccaaf446ee0a0fa8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_websocket_auth_ack.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "d2de469375444b9919910e9e4f24472e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p2_chat.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "1152e35cb87346590d4b9c3cbafe49e6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_drivers_extended.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "8ee55dd21461a619fb91c1cea2417d49",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_auth.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "2fbc5ff1a4fb23fc4af38eb191386511",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_broadcast_timeout.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "063152c02cf23145cba3629ef3c4cd37",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_loop_alert.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "8c8b82d6673f778b9867031561e97a56",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_coverage_boost.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "fb9ad555ea385238aaa2e60e8ba4cfca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/perf_rides_after.json": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "928d256e1e32687dc5fb47eca15e5453",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/verify_db.py": {
-    "mtime": 1779512835.445595,
-    "ast_hash": "bf5cd8fc0a5d21083f3b434cbb5b574a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_logout_all.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "ffc7f9beae68d13588773eb39de33f2c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_utils_extended.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "cd204cc25d02e74b4ea43af78c2ccc51",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_audit_logs_lockdown.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "939b8be284fc4ee8bc71eef0b1b641a5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_status.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "81f77386aca5630f7cfe854e11d39691",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p1_ws_reconnect.py": {
-    "mtime": 1779512835.4215949,
-    "ast_hash": "ece6f6d352116d14677cc10cf29df823",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_analytics_503.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "0904b7e1ed6a36b9c37b1a29be353c43",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_webhook.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "cf38accafeabd8da439269814a20f5bc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_wallet_freeze.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "14cf7e4c353a3f2f2bc2667de70dac45",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_set_driver_available_invariant.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "572be300127f630ee884d1c66e19ef96",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_csrf_middleware.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "5bc1d563742de259ec4ccc3fd643e7c6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_loyalty.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "030909aadd1680e75236d9fb27942318",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_ride_messages.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "751937febe5706140235297e2485c3de",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e2e_cancellation.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "784e9ccf1fe8e1403ff54e684426eda0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_rides.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "89a26bc5ca2421d6fa2ae3aff70c6b29",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e8_duplicate_ride.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "6be7f789b827c183db2ab99eb185d18b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p2_corporate_decimal.py": {
-    "mtime": 1779512835.4215949,
-    "ast_hash": "e8228e8d44178e666ac290ae5b3a1bc6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_t4a_annual_job.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "68b5cabe350d79adb6a638169a93896f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_allowance_requests.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "8f515fcda7260475a923e9ee41a4ec09",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_claim_ride.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "f59167c8171026b39e147c796f5f2835",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_promo_rate_limit.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "164abcdde05832e2d2d6933ded187ca7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_route_distance.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "f6b5bd147a933c0e1a6d7b24013e3966",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_db_helpers.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "94e6e801bae306d2b9b60eddb93317ae",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_cookie_auth.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "900e9b4f750ba5c45da30242a0655036",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_rider_routes.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "784aae85907bc4ae1f4c3ec50a2eeff4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p2_promo_wallet_loyalty.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "faff7a2c18db91d44de9c9aff282369f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_replay_safety_payment_loops.py": {
-    "mtime": 1779512835.433595,
-    "ast_hash": "e43fd2288afced086fa7280cc71a026d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p0_ship_blockers.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "2479b08b4c4ff80e923b8dea1c5db6a8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_db.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "40783789607fccd854c9a6d02f739190",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_payments_stripe_error_specificity.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "6dcecee31c4d30a9dd9a3914fe0e6eac",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_schemas.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "042cf4d6d7bb3758156053ba45ef4033",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_allowance_reset.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "9574e3d43527ade20815d769200b5102",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_error_response_sanitisation.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "4c04ab049de84431da57c96dbb1accee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/__init__.py": {
-    "mtime": 1779512835.38261,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_messaging_fan_out.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "51ac5fd5c4501916ce3bae4121b1b5f5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p1_multi_stop.py": {
-    "mtime": 1779512835.4215949,
-    "ast_hash": "9f4847f3f0fffb8c353f217d363d74f2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_websocket_auth.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "0121c4526ae86d55e60a8b632aec157c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_rides_notes_patch.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "33d3ff85fb6c337011ae9bca972c3d73",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_surge_reset_to_auto.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "aeed6ce67dda329164c0d1f136777f34",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p1_security.py": {
-    "mtime": 1779512835.4215949,
-    "ast_hash": "1542da87b6dd34e949633386875daf2c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/perf_post_rides.py": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "b396988ffa491389618dced8d2cd1970",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_e2e_wallet.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "ff36e6e5cc9b669071abd93536ecc5e3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_ride_state_machine.py": {
-    "mtime": 1779512835.433595,
-    "ast_hash": "fb7294c0fd2c149fc47e394193478f10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_b2b_schema.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "ab60d31f0d4c6778c4655a7c451cff04",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_appcheck_request_id.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "55fa92ef87ce5eefdb58b9edb7c3b6ea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_promo_concurrency.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "82f1e465919f804422886e7ed6c0380c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_payment_retry.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "bc99daebf744302a41f31d35bde18e80",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_rides_extended.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "32bdd1e261ebf925aaa5d3d1f535ac90",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_ride_accept_flow.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "e732d6fde2156d565c5d2e8cfd021527",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_process_payment_card.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "f11cfb4333905b04414faa6edf8ccf71",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_sms.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "3e5a348b1c504373015a120640bca09c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_background_location.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "170a150c8398ab26aa698c021ca5b71f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_security.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "df2c49bae4598db56f39cc6a5a3087ae",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_coverage_rides.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "1088d8a92c7bc40a5fa419853133262c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p2_payout_t4a.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "1789b12cf5c0589f83b21c56bf6a0d40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_coverage_payments.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "a95ba1ca165ed2c94e5ef034e8ea40a4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_receipt_line_items.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "e43f29909e6139ed6b89d9d808580632",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_vehicle_illustration.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "63e8519e003170b6b1211aed02dc2e1c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p1_auth_hardening.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "643920b1e9ddbad9bbcaecf7d0a31632",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_dsar_export_gather.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "fd2726b1a75997f91c76feb61199a135",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/_factories.py": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "955f642f967adc1f124be17733fad9c9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_logout_revocation.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "704cae3fe2319de1ff0571190060fb35",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_webhooks_main.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "a64cd3ba49fc8be8f96ee26d2488b9cc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_surge_bypass.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "e149aa64d3fe6c24782d541fdca381db",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_membership_schemas.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "90c6892362700b5501423f5ff0649b31",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p0_rating_and_payment.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "54e75e25173e8f771214dacde60376ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_business_logic.py": {
-    "mtime": 1780060957.3004391,
-    "ast_hash": "31605fa51e6bcb6080a3d65b08e0c30a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_payment_sheet.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "1042134b8379bacd460594436976cef4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_auth_send_otp.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "25b6578ed1efa350e06572483f5e5a57",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_instant_payout.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "0fa0827a998aa412d045e12e0289fb50",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_surge_engine.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "429708d550e48bfa5a09a4916959e625",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_push_notifications.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "1b5efd034e712141e46c0579a7e16873",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_wallet_config.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "4e58bedd3bb54e2e71e0720fb833abd9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_wallet_view.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "faac35d7550770aa096339143ac68855",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_features.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "c43c1cbc162801828357b120f38de820",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e2e_wav_dispatch.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "7d4b33a6f1bd103e8230499ba70a8a5d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_ws_broadcast.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "faec8d1865d1fc61e9b8a2161cffd789",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e16_surge_boundary.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "0e0909282ace532897ab7a3b9db70d9e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_b_p0_2.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "00ea5ba3356f8647fde29ad1e6ae1fc9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_rate_limit_response_shape.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "c23ebbca6b1cc3d772f33c3f6da20604",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_kyb.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "301bb885f6b7c77caae219426434edc9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_e2e_members.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "f04fdd220e7cc15cec8ed82f84f55dea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_safety_checkin_loop.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "9d72ff4b60f228adb68e73bca8873750",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_ride_history_pagination.py": {
-    "mtime": 1779512835.433595,
-    "ast_hash": "f92bbc2ec22409790fdcbc221d8bda92",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p1_driver_offline.py": {
-    "mtime": 1779512835.4215949,
-    "ast_hash": "467ef24108fac54d6c0ca6dbf5e23616",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_stripe_card_payment.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "f45a040e60aa75c9c38765ace3638400",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_scheduled_dispatch_cr.py": {
-    "mtime": 1780075431.3606343,
-    "ast_hash": "31e0e9725db8ac7998dac618bc88c081",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_money_decimal.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "47dc3d4f9c0462d4cea1eb8d8dc57cf5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_websocket_per_user_rate_limit.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "bbd9b5bc06425cde2f2da8c6482049b0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p2_scheduled_rides.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "6cca9dfde8c861748a2033fef0420004",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_otp_crypto.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "3883511ec1f76e6481e17c189bd40ca7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p2_sos.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "0e5427e5cf35816992fd0b068dde6530",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_error_handling.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "d242ec6a63706511c541aeef8c219bca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_retention_purge.py": {
-    "mtime": 1779512835.433595,
-    "ast_hash": "d922a390a82de9e176a68e5651dd5714",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_sanitize_string.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "f30d3d2195587b53b21fa4e1458289d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_admin_routes.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "433e32ac3461fe5a610088d1eaef415e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_extended.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "c50e1d7b5799c89de3008813f0781bfe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p1_cors.py": {
-    "mtime": 1779512835.4215949,
-    "ast_hash": "44c23294ae914877d5f0b76846204284",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e2e_ride_lifecycle.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "22d12972bd2be78d2a715577727a11f5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/perf_baseline.py": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "b83226ae301d4b3777340ede21acb497",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_admin_jwt_modules.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "ef0ad3f7ff3ae00e31764b36b60257c0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_e2e_foundation.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "5d68d5748eb472a9c4592be6409b8e43",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_ride_pii.py": {
-    "mtime": 1779512835.433595,
-    "ast_hash": "d19c81371cfe6b68d12bc3b3372bce0a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_company_routes.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "9ebf70bef53d8cc9a2c730220018ea9c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_ride_payment.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "309c5e31f478fb58b9053672d3b92ef8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_quests.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "61bc2a7023a2c37ab2e7296871ceb319",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_stuck_ride_sweeper.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "41296fd7926e7e4d0b2d74e74e8aa525",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_low_balance.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "9fa0824aab21b679090fc6ac330e9317",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_wallet_routes.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "03bba69ea5358de1777f923655d2db47",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_validators.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "a090ce93637a9ec2dfe3f627fb3fc41a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_payments_pci_guard.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "65e2f057329a348f866b3239532ef380",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_maps_proxy.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "d66344e2c88bc5e42f59da4860bb5f92",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_money_serialization.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "c48b65d2838368c7ed060de4a9c05ab9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_insurance_periods.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "9382d8a32256924d6168a9dbbc50598a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_fares.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "d7e354add727931d31d032aead4a1644",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_wav_dispatch.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "707cb5becdefd86718b32dfefa784fec",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_membership_db_helpers.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "5680ab6a5945344d3600ecd499167d4e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_schema_contract.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "918ddf766b16bc5297e22559ddea0d26",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_location_batch.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "499557ec3bd35a86d55ae7da4f1bbef8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_pii_redaction.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "61edf1a6d6a5e4b2b22f000bd1606a75",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_service_areas_public.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "8b6a9351dbea33000514d79fa5d7af02",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e2e_sos_flow.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "b4aea93cb4e64899fd02e21cc5487530",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_fare_split.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "6c1dccdf06ce266fed409ea457b8b0d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_kyb_upload.py": {
-    "mtime": 1779512835.397595,
-    "ast_hash": "91f7fba8f27b4f8cf6853b733c16b17b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_stripe_reconcile.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "b0fd91a7d64ceed38f69c9023e945adc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e4_d10_payment_3ds_quests.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "efa993f26d39ccbe9ec46f65200b2edd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/conftest.py": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "78002a646a32d82c709caadb276929f2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_wallet_bootstrap.py": {
-    "mtime": 1779512835.4015949,
-    "ast_hash": "2fa09129fb05946378a86502288299e2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_drivers.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "7bd8eb8a2efffb73ef0c10435c9fadb2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_document_expiry.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "da388d55c121c8186ab4152a21154b44",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_stats.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "387bdda7e427e4888904b910bf886fb9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_receipt_email.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "eeab0e6f4683552c169936f2e788cf54",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_geo_utils.py": {
-    "mtime": 1779512835.413595,
-    "ast_hash": "9908adefb12f42b14bed6d0e79bf71ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_monitoring_health.py": {
-    "mtime": 1779512835.417595,
-    "ast_hash": "87490a6363912c80d19ee5f64d3b7bdc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_rate_driver.py": {
-    "mtime": 1779512835.429595,
-    "ast_hash": "df1de3d2bb23f3a90b8c41470fbc3612",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_routes_auth.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "992aa72482dd24caa9c3d73d1f91c2be",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_admin_rbac.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "4f5cdafb2dfb6fd439ec9051935f8a38",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_addresses_favorites_safety_disputes.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "03afcaaab747d123a0a209bb4fd3193c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_wallet.py": {
-    "mtime": 1779512835.4415948,
-    "ast_hash": "5a1360739dafd5532db584e9027353fc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_stripe_charge.py": {
-    "mtime": 1779512835.437595,
-    "ast_hash": "a1ad8f2c2330242b84787d738a298e1a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/perf_rides_before.json": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "ff624efaeb2ececffb622aebb9b7d1f0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_db_supabase_helpers.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "ec61103974d3df539045f6ed9e970a06",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_loop_jitter_metrics.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "f48c173a6a47e34ecda33422817363e2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_p3_wallet_concurrency.py": {
-    "mtime": 1779512835.425595,
-    "ast_hash": "803e486511c259cf5a067e7d708a05b0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_a_p0_3_gps_oom.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "faa7bb0f799381db3d6776524c5388ee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e2e_payment_guard.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "c927e48e85f6563efa652e41298e0c41",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_offer_timeout.py": {
-    "mtime": 1780060957.304439,
-    "ast_hash": "c7dd458f6ab053108e587511907d88eb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_documents.py": {
-    "mtime": 1779512835.4055948,
-    "ast_hash": "4ab03d2046a37d18476d3589f2bc8fd5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_e2e_rating_regression.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "64b5b05caee2324c330f82236d785195",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_dsar_export.py": {
-    "mtime": 1779512835.409595,
-    "ast_hash": "ee8c78600ea00570b600aa2f6d4d0bc9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/test_corporate_autotopup.py": {
-    "mtime": 1779512835.393595,
-    "ast_hash": "ffcf0ab6c7748e190de318b404899590",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/test_corporate_policy_service.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "2334033529227ed829b2b1dee688246f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/test_fare_service.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "2bfaec5a5295abdf3322ee203d848dbf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/test_corporate_wallet_service.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "923066e6907c99251318b11eac361b16",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/__init__.py": {
-    "mtime": 1779512835.3890615,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/test_dispatch_service.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "56aa7434337325249bcf16b80af397d0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/test_corporate_membership_service.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "4ebffc8f8462e485c58501b78683b0a6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/services/test_corporate_allowance_service.py": {
-    "mtime": 1779512835.3899248,
-    "ast_hash": "c1c366ad8289060d9871be01d6f01189",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/routes/__init__.py": {
-    "mtime": 1779512835.385965,
-    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/tests/routes/test_payments.py": {
-    "mtime": 1779512835.3890615,
-    "ast_hash": "6a2e87fd500ac3020d396f3be7502920",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/core/csrf.py": {
-    "mtime": 1779512835.3030884,
-    "ast_hash": "51db9649f2146b54ba599eab487120d9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/core/config.py": {
-    "mtime": 1780060957.260439,
-    "ast_hash": "f97ce44ef8e0140c9ef9dc4fd6c3c33a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/core/middleware.py": {
-    "mtime": 1779512835.3030884,
-    "ast_hash": "49b1bcab99242c24474c731d99021f21",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/core/lifespan.py": {
-    "mtime": 1779512835.3030884,
-    "ast_hash": "3720a440f807d45b81d7966c8e9c9895",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/core/security.py": {
-    "mtime": 1779512835.3030884,
-    "ast_hash": "9edd71151535e5f2c6869c7383785636",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/maps_budget.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "e503ef5668391e3e6ff50e7bff4605a8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/stripe_charge.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "d4445c1c30115ccad80b36b2f11fb350",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/route_validation.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "760c9702da0d3234b9603741388b0233",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/stripe_config.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "d38ef335346bb9e9be1917106b8f6305",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/quest_tracker.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "9f0dc9aef30f0c7905003a3748648a0f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/allowance_reset.py": {
-    "mtime": 1779512835.473595,
-    "ast_hash": "14d06657a7c8994f8d90b69c56788e11",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/surge_engine.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "a7f6bef3a0141af00897bfc974292ad7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/route_snapshot.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "cf6d7b1007707fa9c72880d263567438",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/location_integrity.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "dc0d91d7b0aa74c4de16fbb7f77289f8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/rate_limiter.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "923af8cb1a49bdb039608df4460167d7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/pii.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "68d4eee59bec572ede0928ce4dc9e19d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/demand_forecast.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "648a2fceb02657e34d0ba8d93af4c349",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/document_expiry.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "0656a05e124c8d68d406e7fcb720d958",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/crypto.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "80430dcf919ea3df1047058027be0186",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/stripe_reconcile.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "861a5f6e6aa05102ff921abfb603b1e9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/metrics.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "c736cac096acae933bfb1c096bdc48aa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/deadline.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "a8da50fae6d90c74f8547abcd18d82b7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/route_distance.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "e20996e5c2d6e577e0282514c4e0084c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/loop_alert.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "aef314623f2f3788460ed94167e47a9b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/driver_presence.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "d3c56f65861a84583119f73abb473057",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/corporate_low_balance.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "2a864937c8e176e1c7a970b7fdcc9e7f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/t4a_pdf.py": {
-    "mtime": 1779512835.493595,
-    "ast_hash": "181fa96cb77ba1415e26d52f17ac17eb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/payment_retry.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "ca1a102b378531e529702bdb6e424b75",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/idempotency.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "c15c4477539cefa82c062a03d1a128ee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/datetime_utils.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "bf7fe8293828877e7793354a833117dd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/corporate_autotopup.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "0592851dbd5446968fcf58c85d5384e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/money.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "268ffcab8ec44c13d7fcf131632dd128",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/email_receipt.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "a5aed1e76f911ca292f1076b1880aa8d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/log_context.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "f7930dbcf3b157ad0cecada6b9add030",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/presence_sweeper.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "c88a0c28d6e06e8695bbd61e7c3b981c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/error_keys.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "1d2dbb1dcdb36646515f26b02c653190",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/stuck_ride_sweeper.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "42d549ed81b0a111cf586fde97afe065",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/driver_online.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "a4e6aba19a7457ec6df915e12c16e8dc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/cloudinary.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "ba0b3f7b422013394f3a8cc8f955185e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/reconciliation.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "1538da964a8e29fe8e239fc4d200b536",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/analytics.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "44c177415fe8d84ae05a5079a7cad69c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/insurance_periods.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "b7e5a7ae27ec831e1d61053839ca38be",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/scheduled_rides.py": {
-    "mtime": 1780075461.896636,
-    "ast_hash": "b10d7548b6bd6f45ec428b0490aab8f2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/push_retry.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "0f94e3b5bc59d3a5dd4a00c65acd2764",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/device_attestation.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "d91bc4c46daab48c853143e841f136b5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/subprocessor_audit.py": {
-    "mtime": 1779512835.493595,
-    "ast_hash": "ea5f5f90c5cb490b48e0f557fd785a68",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/ws_pubsub.py": {
-    "mtime": 1779512835.493595,
-    "ast_hash": "53ff31c4ac93f387b7551e3731026371",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/maps_eta.py": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "342f5d9db4dbde9554ccf956a0fd9935",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/safety_checkin_loop.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "c0e450c5b98be46b8361c385a25a8c11",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/loop_monitor.py": {
-    "mtime": 1779512835.481595,
-    "ast_hash": "9ba4afe8ddf930aa8a4c581694088fc8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/retention_purge.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "ad1fc0c5c5fb41839a53dd82052bcc19",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/cookie_manager.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "3a01afc6f253bc3da07322b2278647d9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/redis_client.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "4b91b159cbc42670cbdb9e107912eae3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/receipt_email.py": {
-    "mtime": 1779512835.485595,
-    "ast_hash": "16bec92c68f5ebac86b9be47d772673d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/ride_code.py": {
-    "mtime": 1779512835.489595,
-    "ast_hash": "89c4698636dd13b63d2a132b571d020c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/t4a_annual_job.py": {
-    "mtime": 1779512835.493595,
-    "ast_hash": "c8a6a3aa18174712fe7861149c55ced0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/error_handling.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "b604e199ecd252fc2efb9a89fa4b3c4f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/utils/audit_logger.py": {
-    "mtime": 1779512835.4788048,
-    "ast_hash": "c97d061b719f3aea2e467b300d3f437c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/corporate_wallet.py": {
-    "mtime": 1779512835.353595,
-    "ast_hash": "f4cb83d11232345e9aa53f7058169fcf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/users.py": {
-    "mtime": 1779512835.3655949,
-    "ast_hash": "bd6feacf10306eda0e1af28d04cdb59e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/main.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "e541f5c040589736887d85e8f3ed9b77",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/corporate_accounts.py": {
-    "mtime": 1779512835.353595,
-    "ast_hash": "8c388e79fa7157027b3000e9d441a8ce",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/wallet.py": {
-    "mtime": 1780060957.296439,
-    "ast_hash": "5f620621c3dbf15399b4d77b462204cc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/auth.py": {
-    "mtime": 1780060957.2804391,
-    "ast_hash": "3ac79fdc0254dd43b2f50093dd1c67d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/corporate_rider.py": {
-    "mtime": 1779512835.353595,
-    "ast_hash": "cd1894485164abf894bd9626079c0429",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/faqs.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "74de9ccec437bdf3655abed5f542732e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/fares.py": {
-    "mtime": 1780060957.288439,
-    "ast_hash": "dc5209550759eeee12e8c237deac1c42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/__init__.py": {
-    "mtime": 1779512835.341595,
-    "ast_hash": "8cfa82f9528ab69af20da281fb226c54",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/quests.py": {
-    "mtime": 1779512835.361595,
-    "ast_hash": "4d0fcbf574f91a7866c319abee8350c3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/corporate_company.py": {
-    "mtime": 1779512835.353595,
-    "ast_hash": "29ffeea9d87c210b0fb861a85e5cb7fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/settings.py": {
-    "mtime": 1779512835.3655949,
-    "ast_hash": "c2b6d3210a43b25ffa0bda8886e3f443",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/drivers.py": {
-    "mtime": 1780060957.288439,
-    "ast_hash": "4bba297c4834f005b78387dff5ccff3a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/service_areas.py": {
-    "mtime": 1780060957.296439,
-    "ast_hash": "25e3c6b0552f3930e084a3afc46f38e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/fare_split.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "c76f24656189a1e9114e335666780264",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/support.py": {
-    "mtime": 1779512835.3655949,
-    "ast_hash": "b62ea1c6e4c9c72931285753dd6c5413",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/promotions.py": {
-    "mtime": 1780060957.292439,
-    "ast_hash": "bfabe79cff3ce036d48eefaf253a7be5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/legal_documents.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "b37474101a472d47331d8fd2540037e7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/disputes.py": {
-    "mtime": 1779512835.353595,
-    "ast_hash": "3661971124269f4df4b52e51d0f3600a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/payments.py": {
-    "mtime": 1780060957.292439,
-    "ast_hash": "574069dc973daefaef10ad4d7b7ea73f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/websocket.py": {
-    "mtime": 1780060957.296439,
-    "ast_hash": "924b6b2b138980fa1f488cd2b81f733e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/webhooks.py": {
-    "mtime": 1780060957.296439,
-    "ast_hash": "96a6b9e28db2d8a0e05e0daa144b628a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/safety.py": {
-    "mtime": 1779512835.3655949,
-    "ast_hash": "780a892ce07233c92a1763547a356dee",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/loyalty.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "293f9319b084d5a9bcba037f44cc0566",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/favorites.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "b6fcf243de4c4e2b59a344cfdb850ec6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/addresses.py": {
-    "mtime": 1779512835.3467543,
-    "ast_hash": "86f261343e10f43d4509ec9b20e1f43a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/notifications.py": {
-    "mtime": 1780060957.288439,
-    "ast_hash": "c443021feb70c86280160f918b57ab1d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/rides.py": {
-    "mtime": 1780079382.8982062,
-    "ast_hash": "e114513bd1e8e6824fd9808ec2e17767",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/maps_proxy.py": {
-    "mtime": 1779512835.357595,
-    "ast_hash": "f2c6f8270fe18359c855bd04f84341f3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/users.py": {
-    "mtime": 1780060957.276439,
-    "ast_hash": "955657cd2f8bfedf69eba821642bbc6d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/vehicle_fleet.py": {
-    "mtime": 1780060957.276439,
-    "ast_hash": "7e69ed4a76b46f216bad6f908e801691",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/wallet.py": {
-    "mtime": 1779512835.353595,
-    "ast_hash": "028d400a35595eac7a529fe978d2af27",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/documents.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "985c75b8781e12a0b06d1d49958e0207",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/auth.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "b34b7791d2da1f60ae5ce160bd8d7f1d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/maintenance.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "605b5d9ba627d74ef291958461cb5a43",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/incentives.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "e2b9abb95a38c0a287faa9d2657ed3e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/faqs.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "77efafe1fe4b6dd37285e8afdf175826",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/monitoring.py": {
-    "mtime": 1780068382.502458,
-    "ast_hash": "97ae5e95a67c7ba5aead4a933746ef2a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/__init__.py": {
-    "mtime": 1780060957.268439,
-    "ast_hash": "098f7cda51e8929bc6111f9cb8d3a1e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/subscriptions.py": {
-    "mtime": 1779512835.3495948,
-    "ast_hash": "2baacc0396a60eccc0b172e198405733",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/messaging.py": {
-    "mtime": 1780060957.272439,
-    "ast_hash": "81b0e351df6fae2e4f44d3c16fc5da29",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/settings.py": {
-    "mtime": 1780060957.276439,
-    "ast_hash": "a41d1f49f5e10cf8709cf4b7860d1238",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/staff.py": {
-    "mtime": 1779512835.3495948,
-    "ast_hash": "a9a64d91083fc977c50ff799c65df9c1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/drivers.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "bc83dc62ac348dc0df55487612b22c52",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/service_areas.py": {
-    "mtime": 1780060957.276439,
-    "ast_hash": "3f63e29f7355bbdcb47a72defb55f912",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/support.py": {
-    "mtime": 1779512835.3495948,
-    "ast_hash": "c3d2940e8c95e05fecc53b7ea74098c5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/promotions.py": {
-    "mtime": 1779512835.3495948,
-    "ast_hash": "a1d20d9764e5286524573bb2674d46f3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/legal_documents.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "5dda35b2e5e23230c7985afb8c47bb10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/safety.py": {
-    "mtime": 1780060957.272439,
-    "ast_hash": "9d15ac6134c24679a2ebe76cf064f140",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/analytics.py": {
-    "mtime": 1779512835.3473976,
-    "ast_hash": "a772475e733c67a96bd9ef76043a6f5d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/routes/admin/rides.py": {
-    "mtime": 1780060957.272439,
-    "ast_hash": "70daf67da406c6725e3a3f8e1749b807",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/jest.config.js": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "aa5398b011a90ddee91b5c51a5ef3e23",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/eslint.config.js": {
-    "mtime": 1779512836.4544551,
-    "ast_hash": "560a864580ad8107fbbf8d6d452c82fe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/babel.config.js": {
-    "mtime": 1779512836.445595,
-    "ast_hash": "4a31ab02ed499e19cb923c7de298b8f9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/vercel.json": {
-    "mtime": 1779512836.4741797,
-    "ast_hash": "61bd31a2b0ac08f10f13c932b32d6ca1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app.config.ts": {
-    "mtime": 1780060957.348439,
-    "ast_hash": "b9a5e8a7a3ba86fb38345057ee9c023b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/config.ts": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "5c4bae5b1756e6782cef33c1f6fd9152",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/google-services.json": {
-    "mtime": 1779512836.4544551,
-    "ast_hash": "184167dff8205a0290133613b50f10f6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/metro.config.js": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "5d441f5111789fe1db6ff1e6f17f7b4e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/package.json": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "609b351ca53c8dc6a035e1bf82911adc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/eas.json": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "2f864ab7445e68a8acee3518638174f7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/jest-setup-expo.js": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "aabb97f36641c878470d783161bb32d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/playwright.config.ts": {
-    "mtime": 1779512836.465047,
+  "rider-app/playwright.config.ts": {
+    "mtime": 1780622913.6927516,
     "ast_hash": "191c58d5a912083b0fd45300b40829a8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/tsconfig.json": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "a528cec8b7ac144d967cb6c8a8befdb7",
+  "rider-app/jest.config.js": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "aa5398b011a90ddee91b5c51a5ef3e23",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/components/FreeCancelTimer.tsx": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "9d52259a05e869b9a2593103da93ddb7",
+  "rider-app/metro.config.js": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "5d441f5111789fe1db6ff1e6f17f7b4e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/components/ConfirmSheet.tsx": {
-    "mtime": 1779512836.4506917,
-    "ast_hash": "8a64ba56f53a13868bb1f03aaf9ddb08",
+  "rider-app/eslint.config.js": {
+    "mtime": 1780622913.6884718,
+    "ast_hash": "560a864580ad8107fbbf8d6d452c82fe",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/components/Toast.tsx": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "e89729066809a987620c8adc9239daf4",
+  "rider-app/babel.config.js": {
+    "mtime": 1780622913.6850238,
+    "ast_hash": "4a31ab02ed499e19cb923c7de298b8f9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/components/SkeletonBox.tsx": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "569b16772766c8f79adc68d63877f7e8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/components/CustomToggle.tsx": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "0eff93aff8de03a02d820937728e75bc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/components/SchedulePicker.tsx": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "7b87d83cdbf06b6d30a7e207503ee68d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/components/SafeBottomSheet.tsx": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "0196324f30b678187f610e237a1d4b34",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store-assets/metadata.json": {
-    "mtime": 1779512836.4658892,
-    "ast_hash": "e821cbabae80ed06bf5b085dd8e1cce6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/useRideStatusNotification.ts": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "4cdd3f964a29c66401055f2e0263351e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/useSpinrPaymentSheet.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "8ab9fdf06e3807ff5b9c51c76b7ae80c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/useScheduledRideReminder.ts": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "24e4639790932f5b6bb1572b62161c3a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/useRiderSocket.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "d8367cf73d0fb4391ed3532a69c017b7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/useAuth.ts": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "450b2e140c137a07beffd341cde8b213",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/useAppResumeKey.ts": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "00bd9d26f4e2bf812f8d79f29094235c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/__tests__/useRiderSocket.reconnect.test.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "b4305e8ead72f5cbd0507ac3d9e32680",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/__tests__/useScheduledRideReminder.test.ts": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "ff7de18da908f18332c6c3b344225965",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/__tests__/useRiderSocket.chat.test.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "60169a76b7db9a6a8e601ffdb9512dd4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/hooks/__tests__/useSpinrPaymentSheet.test.ts": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "676d901a52d8bd6a9cbb12cecca5d91d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/constants/geo.ts": {
-    "mtime": 1779512836.4520485,
-    "ast_hash": "e4106d7aa605f8b5d896b5022b214876",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/constants/rideStatus.ts": {
-    "mtime": 1779512836.453849,
-    "ast_hash": "a07432ec10dbefcde0407a44fc92f63d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__mocks__/expoWinter.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "64e09ba341e550784c724f369684eda0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__mocks__/expo-winter-stub.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "d73a7de76297a634a5fa6f3afac17286",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__mocks__/expo-winter-noop.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "3f347a3031deea0b74235013e6bf27b5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__mocks__/expo-jest-setup.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "7d23d650767b44dfd60cc27666f1d311",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__mocks__/expo-winter-runtime.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "1c5c938bef3c07774f1614c30b20c62a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__mocks__/@react-native-firebase/crashlytics.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "3681020bfae07368815d75bf8fb75024",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/web/stubs/react-native-maps-directions.js": {
-    "mtime": 1779512836.4757264,
-    "ast_hash": "e717f1501413f867f12992b324990430",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/web/stubs/react-native-maps.js": {
-    "mtime": 1779512836.4761894,
-    "ast_hash": "cc545e3a08ba4a1410965cc27364a4da",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/work-allowance-request.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "23f118ee93d399146c0fa31ff1bc9c33",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/saved-places.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "1539e374ce9f820ccffd1509f35a094e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/ride-in-progress.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "61a0d1ea7aca5fbac614e7cbee7c5fe1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/legal.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "b67df1d5563911f77ab96b572ea8fc24",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/otp.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "48ce1a8cdf6ea8dcdf4924f7168ed0f2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/login.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "242501fe4935c6c6cc8478884e9e3004",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/support.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "3af2a8cb9cd959b2c5cd74c53e135a30",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/ride-tracking-webview.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "92f8215bf9d3feaf2e5287e9ecbb60b6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/manage-cards.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "c5b9a824e082fd8137f492e36a2832bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/privacy-settings.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "4b4691c1afe1311a19e50d0c38b5da13",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/settings.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "df329512f3474234379054bbacada5fc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/search-destination.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "4df18ae96f8c7c7ac9c36c5e80838ab8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/scheduled-rides.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "5eee1881104e6ee73d5a0d0b2ad0486b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/pick-on-map.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "9f9397118fb646c5b7bb9a3333136ed6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/driver-arriving.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "6a0f47e1de7e184d03676975b00e4880",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/ride-details.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "b560f23e5d8a88cf3bcb2a85787f7686",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/profile-setup.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "e43dbfa47ded50d7dfc10eace1c1e771",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/ride-options.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "090189522223698a82d11ba1e4576f8a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/wallet.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "1512a47362d511ba6a6a3bf39e2347b4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/_layout.tsx": {
-    "mtime": 1780076742.5047083,
-    "ast_hash": "bbe5929506ffbc781dd6b676b9ee32a4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/confirm-pickup.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "2f4d8b2d043a655bca8a7c108ac498c5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/accessibility.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "c7c655dcb6cd88d760da067744165fb4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/ride-status.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "144646a2c83c767579472f0f1d475e73",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/report-safety.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "ac2877b4144fd81aae62abcd0b42f5ef",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/chat-driver.tsx": {
-    "mtime": 1780060957.348439,
-    "ast_hash": "4ef4fa80c513a13608e15354bae2872b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/promotions.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "1e0ef159a8277f3dc77d58923cde9e7b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/become-driver.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "b0fa686ffa64e8245ca9fd480c53080c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/ride-completed.tsx": {
-    "mtime": 1780060957.352439,
-    "ast_hash": "0025e727de256a684841d68f444f2513",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/loyalty.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "00e79467119f723051332f7b4a68bf55",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/payment-confirm.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "0e3392a4c2aae1542935215291f27f26",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/emergency-contacts.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "e7110f1107c9421028d7a408fb6f1038",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/work-profile.tsx": {
-    "mtime": 1779512836.433595,
-    "ast_hash": "b631f9384edaa4a87f4637dc660a5671",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/driver-arrived.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "39fa5f1cf19f0324cc29e4cd46716753",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/index.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "8499c03025f9da7d3708f2777d1f6e86",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/notifications.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "0493d3a473d365fa64bfeca09ba156dc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/(tabs)/activity.tsx": {
-    "mtime": 1780060957.348439,
-    "ast_hash": "c6359ffdfe574c0089dab1fae17088fa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/(tabs)/account.tsx": {
-    "mtime": 1779512836.4302964,
-    "ast_hash": "7f854a40bd29f74c596920e77b4ace42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/(tabs)/_layout.tsx": {
-    "mtime": 1779512836.430247,
-    "ast_hash": "e3c748f818a307178fa243d3cbc999e0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/app/(tabs)/index.tsx": {
-    "mtime": 1780060957.348439,
-    "ast_hash": "97f9826a402b304ff0a57b702fb3ce66",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__tests__/errorI18nCoverage.test.ts": {
-    "mtime": 1779512836.4290733,
-    "ast_hash": "5d43a4ac0ba45afa528f7bc1d83f77dc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__tests__/auth.integration.ts": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "bcfcd4055257dcb704af5fae01d2e835",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__tests__/httponly-cookies.e2e.ts": {
-    "mtime": 1779512836.4290733,
-    "ast_hash": "306b5749584efa263da380b11ac6a8fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__tests__/rideStore-wav-gating.test.ts": {
-    "mtime": 1779512836.4290733,
-    "ast_hash": "c2b8a698e63f6f664a4f43438ebf398b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/scripts/reset-project.js": {
-    "mtime": 1779512836.4658892,
-    "ast_hash": "55e9a46ae7c35eb0340e956473beaed2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/toastStore.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "5b274a67cb3f00038941cf7ff0ba3430",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/rideStore.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "468be75d5d8964b79ea058be8109b1b9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/walletStore.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "29772ba6d19ad69b4cd61335b980d5c4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/workProfileStore.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "c5b460c681bdb60badf4b4bd7f8a7349",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/walletStore.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "2d69f8c09dcf5d3cdd55ed5b65d24bc6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.chat.test.ts": {
-    "mtime": 1780060957.356439,
-    "ast_hash": "871216dd1e71ed68ac3d847e5b2e593c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.stops.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "02477f8b34237884b5a3ecc257bd8e12",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.promo.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "626eca0bf53413db75967ac6c5fd8f5c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.restart.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "23763edc065509d275ab0382bbde1ad2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.ws.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "958ac1cf2a5e8d4dfc331e18bd48f0b8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "bd6471602df852a5ed22e4d0493e0224",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.sos.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "156e3e25db69a61f8e93edd81f617bf7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/store/__tests__/rideStore.wav.test.ts": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "2d9ed63c243105e2f77efb6c97ba9546",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/__stubs__/emptyNativeComponent.js": {
-    "mtime": 1779512836.4272268,
-    "ast_hash": "8d3d47729c7f49e2dda08c5b56386b30",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/lib/alert.ts": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "808a21068a58ed95f37764c9e186ce83",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/e2e/rating-submission.spec.ts": {
-    "mtime": 1779512836.4544551,
-    "ast_hash": "8ad43eca240da629d58cee3544029b4e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/e2e/fixtures.ts": {
-    "mtime": 1779512836.4544551,
+  "rider-app/e2e/fixtures.ts": {
+    "mtime": 1780622913.6884718,
     "ast_hash": "8d80ef7d4ea437a108be2cf5ae86cb69",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/e2e/cancellation.spec.ts": {
-    "mtime": 1779512836.453849,
-    "ast_hash": "630c4e7f32ae31584b6ca75cd84067b2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/e2e/ride-booking.spec.ts": {
-    "mtime": 1779512836.4544551,
+  "rider-app/e2e/ride-booking.spec.ts": {
+    "mtime": 1780622913.6884718,
     "ast_hash": "e8e229b8628eb31259cc854a78eeff36",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/e2e/payment-completion.spec.ts": {
-    "mtime": 1779512836.4544551,
-    "ast_hash": "385b7ae054251f01d18c1c02edfd5b5e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/e2e/smoke.spec.ts": {
-    "mtime": 1779512836.4544551,
+  "rider-app/e2e/smoke.spec.ts": {
+    "mtime": 1780622913.6884718,
     "ast_hash": "55112daa56ce130be9aa8298cbfbb440",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/build-options/option-a-kotlin-2.0.21/withStripeAndroidPin.js": {
-    "mtime": 1779512836.4506917,
-    "ast_hash": "af2611e886e7d733537823e23a204ee6",
+  "rider-app/app/otp.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "48ce1a8cdf6ea8dcdf4924f7168ed0f2",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/utils/apiClient.ts": {
-    "mtime": 1779512836.4741797,
-    "ast_hash": "c80a34b7821ea60f7c01369c5cdd04ae",
+  "rider-app/app/ride-in-progress.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "f7ae92ac6ca726eb886b364865ceebac",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/utils/crashlytics.ts": {
-    "mtime": 1779512836.4741797,
-    "ast_hash": "7c49848a3d85464cc1c3886138bbae45",
+  "rider-app/app/manage-cards.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "c5b9a824e082fd8137f492e36a2832bd",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/utils/fareBreakdown.ts": {
-    "mtime": 1779512836.4741797,
-    "ast_hash": "25f0601e3971e24668c52ebd2c777701",
+  "rider-app/app/loyalty.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "00e79467119f723051332f7b4a68bf55",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/utils/attemptRidePayment.ts": {
-    "mtime": 1779512836.4741797,
-    "ast_hash": "9e5aa1642dde3fec2d5574a51ef5b74b",
+  "rider-app/app/driver-arrived.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "b00ef4f5e28586a94aac5254c9931a92",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/utils/__tests__/attemptRidePayment.test.ts": {
-    "mtime": 1779512836.4741797,
-    "ast_hash": "c7322a6fdeb9dc41616146b6844115ed",
+  "rider-app/app/saved-places.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "1539e374ce9f820ccffd1509f35a094e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/plugins/withGradleWrapper.js": {
-    "mtime": 1779512836.4658892,
-    "ast_hash": "cd06c3416afeb58b540db031f28984b2",
+  "rider-app/app/legal.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "b67df1d5563911f77ab96b572ea8fc24",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/plugins/withKspVersion.js": {
-    "mtime": 1779512836.4658892,
-    "ast_hash": "294b659519942c76651bd9eb45cdad94",
+  "rider-app/app/wallet.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "1512a47362d511ba6a6a3bf39e2347b4",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/plugins/withForceCompileSdk.js": {
-    "mtime": 1779512836.465047,
-    "ast_hash": "1ab5050a2e844fbf7b5804fff4bef273",
+  "rider-app/app/report-safety.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "ac2877b4144fd81aae62abcd0b42f5ef",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/index.ts": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "8556f2702243542fb405b68c961dc353",
+  "rider-app/app/settings.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "df329512f3474234379054bbacada5fc",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/en-CA.json": {
-    "mtime": 1779512836.4564226,
-    "ast_hash": "f0ef3744fdaaf76c48a66824eea37a45",
+  "rider-app/app/notifications.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "0493d3a473d365fa64bfeca09ba156dc",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/fr.json": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "e68c4163d92047f8c4246b984488ea44",
+  "rider-app/app/chat-driver.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "4ef4fa80c513a13608e15354bae2872b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/fr-CA.json": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "0c2a15749cabf99cfafac9866cdec919",
+  "rider-app/app/payment-confirm.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "0e3392a4c2aae1542935215291f27f26",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/en.json": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "702cf38c6a2a2c1e508a4530901ab5fb",
+  "rider-app/app/_layout.tsx": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "24534e5335699472c34048fba9cc9032",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/es.json": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "6eb920fde511108377a78fdc315f5043",
+  "rider-app/app/promotions.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "1e0ef159a8277f3dc77d58923cde9e7b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/i18n/zh.json": {
-    "mtime": 1779512836.4578571,
-    "ast_hash": "72b71efc1ebdafefa00f63518ba8e932",
+  "rider-app/app/support.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "3af2a8cb9cd959b2c5cd74c53e135a30",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/test-results/.last-run.json": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "ff6d5dab1dfd50cea584142bc288ce9e",
+  "rider-app/app/ride-details.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "b560f23e5d8a88cf3bcb2a85787f7686",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/setup-claude.sh": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "3d97f2276e4799065d8468eef7d1a46f",
+  "rider-app/app/login.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "242501fe4935c6c6cc8478884e9e3004",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/manage_admin.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "0ef8e7451b9c88044ce2b493ff24d68b",
+  "rider-app/app/become-driver.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "b0fa686ffa64e8245ca9fd480c53080c",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/apply_supabase_schema.sh": {
-    "mtime": 1779512836.4761894,
-    "ast_hash": "0a5498b56550de56b284b092b8410bc0",
+  "rider-app/app/ride-completed.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "a9625b0e34bcb2c0c8a80ec3651b64cd",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/code_review_helper.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "288a707af28f321e5356e2b8a3541f14",
+  "rider-app/app/profile-setup.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "e43dbfa47ded50d7dfc10eace1c1e771",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/validate_code_review.py": {
-    "mtime": 1779512836.4840124,
-    "ast_hash": "408c09d694940899d9c7382ba6599194",
+  "rider-app/app/ride-options.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "c125d5e69fa3e5892173435333114fb9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/run_code_review.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "df48fb0a4a09b48b524e19fe1e98e836",
+  "rider-app/app/driver-arriving.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "4464ac1f3e2f7769f7817c40aac4f47e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/create_github_issue.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "5309c8ee3d9b413370ed390ea9ab2bf3",
+  "rider-app/app/ride-status.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "af4129ad5674a2e26b9f2c41ca2a9dfb",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/change_request_generator.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "f19ca92c4722b4fa8c0ba0bda78b0e51",
+  "rider-app/app/privacy-settings.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "4b4691c1afe1311a19e50d0c38b5da13",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/error_classifier.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "7a396ec6615e3094ec85c78e97cdeee5",
+  "rider-app/app/search-destination.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "4df18ae96f8c7c7ac9c36c5e80838ab8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/__init__.py": {
-    "mtime": 1779512836.4798808,
-    "ast_hash": "3e313de07e493d79708ff5e743fff5bf",
+  "rider-app/app/emergency-contacts.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "e7110f1107c9421028d7a408fb6f1038",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/impact_assessor.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "1740d4604709901abd4bd5f00103110c",
+  "rider-app/app/pick-on-map.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "9f9397118fb646c5b7bb9a3333136ed6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/audit_runner.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "455ff1e34603d6416a88fa27e299d79a",
+  "rider-app/app/scheduled-rides.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "5eee1881104e6ee73d5a0d0b2ad0486b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/report_generator.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "a4037c14136c6479a9b261fb8b667b27",
+  "rider-app/app/index.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "71969b8a8767b2c13b31e80db78299ac",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/fix_recommender.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "d8a3f971c6d1549ba06de24db1738b0a",
+  "rider-app/app/(tabs)/account.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "9d1bfb293cd980e19581d18077dfef25",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/ci-audit/fetch_run_data.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "d1b1768e87f7e5f2f66f66335a920305",
+  "rider-app/app/(tabs)/_layout.tsx": {
+    "mtime": 1780622913.6691182,
+    "ast_hash": "e3c748f818a307178fa243d3cbc999e0",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/smoke/full_stack_smoke.py": {
-    "mtime": 1779512836.4799705,
-    "ast_hash": "7f3680596bf358dc1b93164620df0f74",
+  "rider-app/app/(tabs)/activity.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "3f025b3cec14764dc4961ea67c788bc7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/scripts/smoke/stripe_charge_smoke.py": {
-    "mtime": 1779512836.4840124,
-    "ast_hash": "78f5530a40dd4d2a8aefcad550101d65",
+  "rider-app/app/(tabs)/index.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "97f9826a402b304ff0a57b702fb3ce66",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/tests/test_cross_app_ride_lifecycle.py": {
-    "mtime": 1779512836.5003667,
-    "ast_hash": "e7ae30008a75709d53f6d01b5f2560c0",
+  "rider-app/hooks/useRiderSocket.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "d8367cf73d0fb4391ed3532a69c017b7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/tests/__init__.py": {
-    "mtime": 1779512836.4995322,
+  "rider-app/web/stubs/react-native-maps-directions.js": {
+    "mtime": 1780622913.7008486,
+    "ast_hash": "e717f1501413f867f12992b324990430",
+    "semantic_hash": ""
+  },
+  "rider-app/web/stubs/react-native-maps.js": {
+    "mtime": 1780622913.7010438,
+    "ast_hash": "cc545e3a08ba4a1410965cc27364a4da",
+    "semantic_hash": ""
+  },
+  "rider-app/store/walletStore.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "29772ba6d19ad69b4cd61335b980d5c4",
+    "semantic_hash": ""
+  },
+  "rider-app/store/rideStore.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "3a1b9f7633ef534c6f18f0034f3b80ac",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "bd6471602df852a5ed22e4d0493e0224",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/walletStore.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "2d69f8c09dcf5d3cdd55ed5b65d24bc6",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.ws.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "e2fc9a9604ff508b3ba346db1c6273f4",
+    "semantic_hash": ""
+  },
+  "rider-app/scripts/reset-project.js": {
+    "mtime": 1780622913.6933837,
+    "ast_hash": "55e9a46ae7c35eb0340e956473beaed2",
+    "semantic_hash": ""
+  },
+  "rider-app/components/FreeCancelTimer.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "9d52259a05e869b9a2593103da93ddb7",
+    "semantic_hash": ""
+  },
+  "backend/onboarding_status.py": {
+    "mtime": 1780622912.562677,
+    "ast_hash": "9bbd949c1592fd7c42a8fa13a72d1dc6",
+    "semantic_hash": ""
+  },
+  "backend/seed_vehicle_types.py": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "38f448a3050b40a088580b50bfed8eaf",
+    "semantic_hash": ""
+  },
+  "backend/settings_loader.py": {
+    "mtime": 1780622912.6050236,
+    "ast_hash": "53872a083d486e1e7405c97e8b8b32fb",
+    "semantic_hash": ""
+  },
+  "backend/documents.py": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "39f7a501e5e506654533d86079eca800",
+    "semantic_hash": ""
+  },
+  "backend/db.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "45f14f40c3f11764a3f6f1c4b5144766",
+    "semantic_hash": ""
+  },
+  "backend/validators.py": {
+    "mtime": 1780622912.7050238,
+    "ast_hash": "68e131c093dfc28f2faf9b1b5bacb75b",
+    "semantic_hash": ""
+  },
+  "backend/schemas.py": {
+    "mtime": 1780622912.5970237,
+    "ast_hash": "5298412831d25b12cc350280cce1b690",
+    "semantic_hash": ""
+  },
+  "backend/features.py": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "706e97180bb5fac8e3ddc88ffa29074a",
+    "semantic_hash": ""
+  },
+  "backend/diagnose_nearby_drivers.py": {
+    "mtime": 1780622912.5293024,
+    "ast_hash": "a897522c7eda72cdece062c50b8586f6",
+    "semantic_hash": ""
+  },
+  "backend/logging_utils.py": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "027f7c5d82da46e1fde5a82370710c55",
+    "semantic_hash": ""
+  },
+  "backend/__init__.py": {
+    "mtime": 1780622912.525735,
     "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/tests/test_rate_limits.py": {
-    "mtime": 1779512836.5003667,
+  "backend/socket_manager.py": {
+    "mtime": 1780674257.884494,
+    "ast_hash": "3a21fcd03faa4310a39b7f396c55e3d3",
+    "semantic_hash": ""
+  },
+  "backend/make_admin.py": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "b33fd9909fa36725df86b0deb480a998",
+    "semantic_hash": ""
+  },
+  "backend/server.py": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "a60a019f0f14a0de5924a3b01ab97e1e",
+    "semantic_hash": ""
+  },
+  "backend/supabase_client.py": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "824cdd5355223cb2f90541fb905e0f31",
+    "semantic_hash": ""
+  },
+  "backend/test_corporate_accounts.py": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "b688b28aa1d2b46224b654331b07f626",
+    "semantic_hash": ""
+  },
+  "backend/db_supabase.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "1e6b2977edde3d3dd8d927d71bd73866",
+    "semantic_hash": ""
+  },
+  "backend/tests_smoke_supabase.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "2793d072fb80a2a361d6c3b4fb73de50",
+    "semantic_hash": ""
+  },
+  "backend/test_dns.py": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "38c0384ccc5e8fa935c03d05fbcdc96e",
+    "semantic_hash": ""
+  },
+  "backend/sms_service.py": {
+    "mtime": 1780622912.6050236,
+    "ast_hash": "cfc2e4bc93a2b94809caa76819472939",
+    "semantic_hash": ""
+  },
+  "backend/check_permissions.py": {
+    "mtime": 1780622912.525735,
+    "ast_hash": "c5b8281a730e113bb4063b6ce1d03c24",
+    "semantic_hash": ""
+  },
+  "backend/geo_utils.py": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "c986ee20c955b706b383ea3eca166ce7",
+    "semantic_hash": ""
+  },
+  "backend/list_users.py": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "0c18a6ab66acfd452a6f9dc3528c2cbb",
+    "semantic_hash": ""
+  },
+  "backend/schemas/__init__.py": {
+    "mtime": 1780622912.5970237,
+    "ast_hash": "d53896253012f97c8d3904e2326b2a13",
+    "semantic_hash": ""
+  },
+  "backend/schemas/corporate.py": {
+    "mtime": 1780622912.598436,
+    "ast_hash": "a564b98058547329676f1d8d929aee63",
+    "semantic_hash": ""
+  },
+  "backend/dependencies/__init__.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "5f000517c82023b301fda6183318aee8",
+    "semantic_hash": ""
+  },
+  "backend/dependencies/company_guard.py": {
+    "mtime": 1780622912.5293024,
+    "ast_hash": "d209ffc40ed78bf61e4ef3389c21dba3",
+    "semantic_hash": ""
+  },
+  "backend/utils/surge_engine.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "a7f6bef3a0141af00897bfc974292ad7",
+    "semantic_hash": ""
+  },
+  "backend/utils/redis_client.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "109ffc4fbd8d5384ab2922243a60e4a4",
+    "semantic_hash": ""
+  },
+  "backend/utils/document_expiry.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "0656a05e124c8d68d406e7fcb720d958",
+    "semantic_hash": ""
+  },
+  "backend/utils/scheduled_rides.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "b10d7548b6bd6f45ec428b0490aab8f2",
+    "semantic_hash": ""
+  },
+  "backend/utils/ws_pubsub.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "53ff31c4ac93f387b7551e3731026371",
+    "semantic_hash": ""
+  },
+  "backend/utils/error_handling.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "b604e199ecd252fc2efb9a89fa4b3c4f",
+    "semantic_hash": ""
+  },
+  "backend/utils/rate_limiter.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "923af8cb1a49bdb039608df4460167d7",
+    "semantic_hash": ""
+  },
+  "backend/utils/payment_retry.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "ca1a102b378531e529702bdb6e424b75",
+    "semantic_hash": ""
+  },
+  "backend/utils/allowance_reset.py": {
+    "mtime": 1780622912.6890237,
+    "ast_hash": "14d06657a7c8994f8d90b69c56788e11",
+    "semantic_hash": ""
+  },
+  "backend/utils/cloudinary.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "ba0b3f7b422013394f3a8cc8f955185e",
+    "semantic_hash": ""
+  },
+  "backend/utils/email_receipt.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "260ea6cfaa61fb0292cd800b2b326fde",
+    "semantic_hash": ""
+  },
+  "backend/utils/corporate_low_balance.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "2a864937c8e176e1c7a970b7fdcc9e7f",
+    "semantic_hash": ""
+  },
+  "backend/utils/crypto.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "80430dcf919ea3df1047058027be0186",
+    "semantic_hash": ""
+  },
+  "backend/utils/analytics.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "44c177415fe8d84ae05a5079a7cad69c",
+    "semantic_hash": ""
+  },
+  "backend/utils/corporate_autotopup.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "0592851dbd5446968fcf58c85d5384e4",
+    "semantic_hash": ""
+  },
+  "backend/utils/demand_forecast.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "648a2fceb02657e34d0ba8d93af4c349",
+    "semantic_hash": ""
+  },
+  "backend/utils/quest_tracker.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "9f0dc9aef30f0c7905003a3748648a0f",
+    "semantic_hash": ""
+  },
+  "backend/services/corporate_membership_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "ca5e1c6bfc784312f4a57f4b444839a8",
+    "semantic_hash": ""
+  },
+  "backend/services/__init__.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "bdc70707b94c91f5f239f71222d66ad8",
+    "semantic_hash": ""
+  },
+  "backend/services/dispatch_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "7af21612af4361b4648e76e9a9b76894",
+    "semantic_hash": ""
+  },
+  "backend/services/corporate_allowance_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "8b60fc2d26e7a82593a3ad04da12e432",
+    "semantic_hash": ""
+  },
+  "backend/services/fare_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "25e5dfea628d793bff9c271ccec17df6",
+    "semantic_hash": ""
+  },
+  "backend/services/corporate_wallet_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "749f22397a497a9fd8263658b93914a2",
+    "semantic_hash": ""
+  },
+  "backend/tests/_factories.py": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "955f642f967adc1f124be17733fad9c9",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_status.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "81f77386aca5630f7cfe854e11d39691",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_error_handling.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "d242ec6a63706511c541aeef8c219bca",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_stripe_customer.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "549b29a53277f1db26f3f69025b2b0f3",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_kyb_upload.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "91f7fba8f27b4f8cf6853b733c16b17b",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_fare_split.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "6c1dccdf06ce266fed409ea457b8b0d2",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_payments_pci_guard.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "65e2f057329a348f866b3239532ef380",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_allowance_requests.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "8f515fcda7260475a923e9ee41a4ec09",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_ride_messages.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "751937febe5706140235297e2485c3de",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_webhook.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "cf38accafeabd8da439269814a20f5bc",
+    "semantic_hash": ""
+  },
+  "backend/tests/perf_baseline.py": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "b83226ae301d4b3777340ede21acb497",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_db.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "40783789607fccd854c9a6d02f739190",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_wallet_routes.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "03bba69ea5358de1777f923655d2db47",
+    "semantic_hash": ""
+  },
+  "backend/tests/conftest.py": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "78002a646a32d82c709caadb276929f2",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_admin_routes.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "433e32ac3461fe5a610088d1eaef415e",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_auth_send_otp.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "25b6578ed1efa350e06572483f5e5a57",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_geo_utils.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "9908adefb12f42b14bed6d0e79bf71ab",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_b2b_schema.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "ab60d31f0d4c6778c4655a7c451cff04",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_sanitize_string.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "f30d3d2195587b53b21fa4e1458289d3",
+    "semantic_hash": ""
+  },
+  "backend/tests/verify_db.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "bf5cd8fc0a5d21083f3b434cbb5b574a",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_location_batch.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "499557ec3bd35a86d55ae7da4f1bbef8",
+    "semantic_hash": ""
+  },
+  "backend/tests/__init__.py": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_loyalty.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "030909aadd1680e75236d9fb27942318",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_e2e_members.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "f04fdd220e7cc15cec8ed82f84f55dea",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_membership_db_helpers.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "5680ab6a5945344d3600ecd499167d4e",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_allowance_reset.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "9574e3d43527ade20815d769200b5102",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_ride_accept_flow.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "e732d6fde2156d565c5d2e8cfd021527",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_sms.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "3e5a348b1c504373015a120640bca09c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_claim_ride.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "f59167c8171026b39e147c796f5f2835",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_e2e_foundation.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "5d68d5748eb472a9c4592be6409b8e43",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_low_balance.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "9fa0824aab21b679090fc6ac330e9317",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_membership_schemas.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "90c6892362700b5501423f5ff0649b31",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_wallet.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "5a1360739dafd5532db584e9027353fc",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_schemas.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "042cf4d6d7bb3758156053ba45ef4033",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_documents.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "4ab03d2046a37d18476d3589f2bc8fd5",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_ride_pii.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "d19c81371cfe6b68d12bc3b3372bce0a",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_wallet_view.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "faac35d7550770aa096339143ac68855",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_db_helpers.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "94e6e801bae306d2b9b60eddb93317ae",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_routes_auth.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "992aa72482dd24caa9c3d73d1f91c2be",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_validators.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "a090ce93637a9ec2dfe3f627fb3fc41a",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_autotopup.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "ffcf0ab6c7748e190de318b404899590",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_offer_timeout.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "c7dd458f6ab053108e587511907d88eb",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_wallet_freeze.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "14cf7e4c353a3f2f2bc2667de70dac45",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_rides.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "89a26bc5ca2421d6fa2ae3aff70c6b29",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_quests.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "61bc2a7023a2c37ab2e7296871ceb319",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_rider_routes.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "784aae85907bc4ae1f4c3ec50a2eeff4",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_ride_state_machine.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "fb7294c0fd2c149fc47e394193478f10",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_websocket_auth_ack.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "d2de469375444b9919910e9e4f24472e",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_features.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "c43c1cbc162801828357b120f38de820",
+    "semantic_hash": ""
+  },
+  "backend/tests/perf_post_rides.py": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "b396988ffa491389618dced8d2cd1970",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_auth.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "2fbc5ff1a4fb23fc4af38eb191386511",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_e2e_wallet.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "ff36e6e5cc9b669071abd93536ecc5e3",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_kyb.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "301bb885f6b7c77caae219426434edc9",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_stats.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "387bdda7e427e4888904b910bf886fb9",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_wallet_config.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "4e58bedd3bb54e2e71e0720fb833abd9",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_company_routes.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "9ebf70bef53d8cc9a2c730220018ea9c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_wallet_bootstrap.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "2fa09129fb05946378a86502288299e2",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_drivers.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "7bd8eb8a2efffb73ef0c10435c9fadb2",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/test_corporate_allowance_service.py": {
+    "mtime": 1780622912.6124141,
+    "ast_hash": "c1c366ad8289060d9871be01d6f01189",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/__init__.py": {
+    "mtime": 1780622912.611484,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/test_dispatch_service.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "56aa7434337325249bcf16b80af397d0",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/test_fare_service.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "8c6887a9d09e901c05354d00ecc3eac3",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/test_corporate_membership_service.py": {
+    "mtime": 1780622912.6124141,
+    "ast_hash": "4ebffc8f8462e485c58501b78683b0a6",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/test_corporate_wallet_service.py": {
+    "mtime": 1780622912.6124141,
+    "ast_hash": "923066e6907c99251318b11eac361b16",
+    "semantic_hash": ""
+  },
+  "backend/routes/favorites.py": {
+    "mtime": 1780622912.5810237,
+    "ast_hash": "b6fcf243de4c4e2b59a344cfdb850ec6",
+    "semantic_hash": ""
+  },
+  "backend/routes/auth.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "e5f5e0c9a1999ec83a12e4f5cf3c026a",
+    "semantic_hash": ""
+  },
+  "backend/routes/websocket.py": {
+    "mtime": 1780674269.488494,
+    "ast_hash": "cd569fd0051169229d2a7597429e6204",
+    "semantic_hash": ""
+  },
+  "backend/routes/fare_split.py": {
+    "mtime": 1780622912.5810237,
+    "ast_hash": "c76f24656189a1e9114e335666780264",
+    "semantic_hash": ""
+  },
+  "backend/routes/loyalty.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "293f9319b084d5a9bcba037f44cc0566",
+    "semantic_hash": ""
+  },
+  "backend/routes/corporate_rider.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "cd1894485164abf894bd9626079c0429",
+    "semantic_hash": ""
+  },
+  "backend/routes/fares.py": {
+    "mtime": 1780622912.5810237,
+    "ast_hash": "0641821246f089d10cde31b8db1dd88a",
+    "semantic_hash": ""
+  },
+  "backend/routes/users.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "dd3829563df887d5f9cecd94c819f629",
+    "semantic_hash": ""
+  },
+  "backend/routes/__init__.py": {
+    "mtime": 1780622912.5690236,
+    "ast_hash": "8cfa82f9528ab69af20da281fb226c54",
+    "semantic_hash": ""
+  },
+  "backend/routes/main.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "e541f5c040589736887d85e8f3ed9b77",
+    "semantic_hash": ""
+  },
+  "backend/routes/corporate_wallet.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "f4cb83d11232345e9aa53f7058169fcf",
+    "semantic_hash": ""
+  },
+  "backend/routes/support.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "77af2ad0c967ce954084a933f8e1474d",
+    "semantic_hash": ""
+  },
+  "backend/routes/corporate_accounts.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "8c388e79fa7157027b3000e9d441a8ce",
+    "semantic_hash": ""
+  },
+  "backend/routes/promotions.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "bfabe79cff3ce036d48eefaf253a7be5",
+    "semantic_hash": ""
+  },
+  "backend/routes/notifications.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "c443021feb70c86280160f918b57ab1d",
+    "semantic_hash": ""
+  },
+  "backend/routes/corporate_company.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "29ffeea9d87c210b0fb861a85e5cb7fb",
+    "semantic_hash": ""
+  },
+  "backend/routes/wallet.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "5f620621c3dbf15399b4d77b462204cc",
+    "semantic_hash": ""
+  },
+  "backend/routes/payments.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "574069dc973daefaef10ad4d7b7ea73f",
+    "semantic_hash": ""
+  },
+  "backend/routes/rides.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "507807ed74fd87583e01be81fc2ae171",
+    "semantic_hash": ""
+  },
+  "backend/routes/drivers.py": {
+    "mtime": 1780622912.5810237,
+    "ast_hash": "6ad386f00541ba9dc8fc548821cd03c6",
+    "semantic_hash": ""
+  },
+  "backend/routes/addresses.py": {
+    "mtime": 1780622912.5699844,
+    "ast_hash": "86f261343e10f43d4509ec9b20e1f43a",
+    "semantic_hash": ""
+  },
+  "backend/routes/disputes.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "66971251b7ae58f7d5f841e47be5cb37",
+    "semantic_hash": ""
+  },
+  "backend/routes/settings.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "c2b6d3210a43b25ffa0bda8886e3f443",
+    "semantic_hash": ""
+  },
+  "backend/routes/quests.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "4d0fcbf574f91a7866c319abee8350c3",
+    "semantic_hash": ""
+  },
+  "backend/routes/webhooks.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "96a6b9e28db2d8a0e05e0daa144b628a",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/messaging.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "81b0e351df6fae2e4f44d3c16fc5da29",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/documents.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "985c75b8781e12a0b06d1d49958e0207",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/staff.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "8dfbc557ec1e25a4ba364fd4fb27ec01",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/auth.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "870b746d14fe2dcb183a6a63dfeed3b9",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/maintenance.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "605b5d9ba627d74ef291958461cb5a43",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/users.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "955657cd2f8bfedf69eba821642bbc6d",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/__init__.py": {
+    "mtime": 1780622912.5699844,
+    "ast_hash": "db3b97404304da1971490dbc00efece1",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/faqs.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "77efafe1fe4b6dd37285e8afdf175826",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/monitoring.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "97ae5e95a67c7ba5aead4a933746ef2a",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/subscriptions.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "2baacc0396a60eccc0b172e198405733",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/service_areas.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "3f63e29f7355bbdcb47a72defb55f912",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/support.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "de6018e9038f8da03075ede837c7b8e4",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/promotions.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "a1d20d9764e5286524573bb2674d46f3",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/wallet.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "028d400a35595eac7a529fe978d2af27",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/rides.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "2739fadad2951956e4beb120d9589944",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/analytics.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "ea4a22eeba18c2d1611b546037257b65",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/drivers.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "cab7e7d5f68c7716b7ef8aa58002cddf",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/vehicle_fleet.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "6924f32045c9f0f672b62903c5730233",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/settings.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "087c97a84c03600240ca1179719e2ec4",
+    "semantic_hash": ""
+  },
+  "backend/core/middleware.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "2dcab62bd6eeac8dff5dd7da97a563ce",
+    "semantic_hash": ""
+  },
+  "backend/core/config.py": {
+    "mtime": 1780622912.525735,
+    "ast_hash": "6633cc3a06ff59340de548dd36b6d557",
+    "semantic_hash": ""
+  },
+  "backend/core/lifespan.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "44b26433cc91dd92712cec15fb9f3e97",
+    "semantic_hash": ""
+  },
+  "backend/core/security.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "9edd71151535e5f2c6869c7383785636",
+    "semantic_hash": ""
+  },
+  "backend/scripts/run_migrations.py": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "fda215ea2bcb7ebd5af70983b371a076",
+    "semantic_hash": ""
+  },
+  "backend/scripts/__init__.py": {
+    "mtime": 1780622912.598436,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "backend/scripts/migrate.py": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "d5b15b340efac2b6dcf089164ca411d5",
+    "semantic_hash": ""
+  },
+  "shared/config/index.ts": {
+    "mtime": 1780622913.7122672,
+    "ast_hash": "ea419a0d2f54822d72ca00b0f41879ef",
+    "semantic_hash": ""
+  },
+  "shared/config/firebaseConfig.ts": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "35f53ebd648e7c95e6a474008248c08a",
+    "semantic_hash": ""
+  },
+  "shared/config/spinr.config.ts": {
+    "mtime": 1780622913.7122672,
+    "ast_hash": "3d5529dcd9ee17c07cadedcb4af2fa1e",
+    "semantic_hash": ""
+  },
+  "shared/assets/carImage.ts": {
+    "mtime": 1780622913.7098598,
+    "ast_hash": "d14a794ca62658c6a5d4bd4a0a155aa9",
+    "semantic_hash": ""
+  },
+  "shared/assets/generate-car.js": {
+    "mtime": 1780622913.7098598,
+    "ast_hash": "de93a99f805296bf0880e9a3e660a0c4",
+    "semantic_hash": ""
+  },
+  "shared/validators/index.ts": {
+    "mtime": 1780622913.7165337,
+    "ast_hash": "bf60e0bceb0339e9193e0fa43eb15057",
+    "semantic_hash": ""
+  },
+  "shared/validators/__tests__/validators.test.ts": {
+    "mtime": 1780622913.7165337,
+    "ast_hash": "07ca54cc3f6aa17ed79a3dc4d1fc118d",
+    "semantic_hash": ""
+  },
+  "shared/cache/index.ts": {
+    "mtime": 1780622913.7098598,
+    "ast_hash": "5bd65e6f1c1f61ef8d478ac56a375362",
+    "semantic_hash": ""
+  },
+  "shared/api/upload.ts": {
+    "mtime": 1780622913.7090237,
+    "ast_hash": "5340715021ad353c52ea2a340722f384",
+    "semantic_hash": ""
+  },
+  "shared/api/client.ts": {
+    "mtime": 1780622913.708882,
+    "ast_hash": "2310f1d2980969a869b8195741ddf093",
+    "semantic_hash": ""
+  },
+  "shared/api/cachedClient.ts": {
+    "mtime": 1780622913.708882,
+    "ast_hash": "555b1285ee10036da166c38672201f1a",
+    "semantic_hash": ""
+  },
+  "shared/api/offlineQueue.ts": {
+    "mtime": 1780622913.708882,
+    "ast_hash": "455a2b622c63595a28e7322a5d802a12",
+    "semantic_hash": ""
+  },
+  "shared/utils/logger.ts": {
+    "mtime": 1780622913.7155209,
+    "ast_hash": "25d899175710a44e2ed17eb3d03fa96d",
+    "semantic_hash": ""
+  },
+  "shared/utils/appRating.ts": {
+    "mtime": 1780622913.7155209,
+    "ast_hash": "9548064b95d31306cdb9004a95d576b0",
+    "semantic_hash": ""
+  },
+  "shared/services/errorReporting.ts": {
+    "mtime": 1780622913.7130237,
+    "ast_hash": "bcff86585cf82bec1dad93a9b50563da",
+    "semantic_hash": ""
+  },
+  "shared/services/firebase.ts": {
+    "mtime": 1780622913.7139637,
+    "ast_hash": "56fa5939beb76ba3f51717003a00cf77",
+    "semantic_hash": ""
+  },
+  "shared/store/locationStore.ts": {
+    "mtime": 1780622913.7141778,
+    "ast_hash": "a7cd09002438d3ac9611abf337160f20",
+    "semantic_hash": ""
+  },
+  "shared/store/authStore.ts": {
+    "mtime": 1780622913.7139637,
+    "ast_hash": "1536dbd9eb6b122db3f0ec8ae53855e7",
+    "semantic_hash": ""
+  },
+  "shared/theme/index.ts": {
+    "mtime": 1780622913.714287,
+    "ast_hash": "17dab9c8746e0f2b18f5f94326d4fa4e",
+    "semantic_hash": ""
+  },
+  "shared/theme/ThemeContext.tsx": {
+    "mtime": 1780622913.7141778,
+    "ast_hash": "ba484affbf1bdd2e5b889b56873a4a40",
+    "semantic_hash": ""
+  },
+  "shared/analytics/index.ts": {
+    "mtime": 1780622913.7080553,
+    "ast_hash": "d42088ae4c55653ae343fea177bd26bd",
+    "semantic_hash": ""
+  },
+  "shared/types/expo-linear-gradient.d.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "d78e0c6b1f9fd5b8e39c6590c77ea44d",
+    "semantic_hash": ""
+  },
+  "shared/components/AppMap.tsx": {
+    "mtime": 1780622913.7098598,
+    "ast_hash": "6a5a78c571487f1a5cf92b7db6dedecc",
+    "semantic_hash": ""
+  },
+  "shared/components/SOSButton.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "43bc5511ba762e92a8c2fff1fa7b0817",
+    "semantic_hash": ""
+  },
+  "shared/components/OfflineBanner.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "b005ec7d37a443b02e621aff06f1a15c",
+    "semantic_hash": ""
+  },
+  "shared/components/ErrorBoundary.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "3be9f0a786daa3310f154f41a3d4a706",
+    "semantic_hash": ""
+  },
+  "shared/components/CarMarker.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "265b07330fb939da44a512add3441a49",
+    "semantic_hash": ""
+  },
+  "shared/components/ErrorScreen.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "6a7f92a44da7daaa08127dc8041fe778",
+    "semantic_hash": ""
+  },
+  "shared/components/AppMap.web.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "da1c74747977ca2a0fd87000c9e50d4c",
+    "semantic_hash": ""
+  },
+  "shared/components/CustomAlert.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "f4ecb9e359e68aea9001f742bc717b3f",
+    "semantic_hash": ""
+  },
+  "tests/__init__.py": {
+    "mtime": 1780622913.71673,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "tests/test_rate_limits.py": {
+    "mtime": 1780622913.7170439,
     "ast_hash": "57a2f3900481945309b53b6790b758af",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/tests/hooks/test_pre_commit.sh": {
-    "mtime": 1779512836.5003667,
-    "ast_hash": "d204a3b7184bfffba1ea0e05f9194797",
+  "admin-dashboard/next.config.ts": {
+    "mtime": 1780622912.430921,
+    "ast_hash": "826d62b566b06b8785fae87d09fd1175",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/HANDOFF.json": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "4e2470aa35aac7ddc31db02e2424ef13",
+  "admin-dashboard/vitest.config.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "1f0c3cff4fb1b9b6a23ff921038d67fd",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/config.json": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "8798d8213a91623ddb5ea94f9f7cb43a",
+  "admin-dashboard/playwright.config.ts": {
+    "mtime": 1780622912.4370236,
+    "ast_hash": "a05df95e789039c77af4dc41884afd76",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/graphs/graph.json": {
-    "mtime": 1779512835.1255949,
-    "ast_hash": "add187f48af0bb1abbb45f3edbef2977",
+  "admin-dashboard/sentry.server.config.ts": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "d8457011626f412398f55c07eab0d430",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/graphs/.last-build-snapshot.json": {
-    "mtime": 1779512835.017595,
-    "ast_hash": "4be783f49639526a4bdfe3c506cc28eb",
+  "admin-dashboard/eslint.config.mjs": {
+    "mtime": 1780622912.430921,
+    "ast_hash": "d5525cb3bc78427130b265d1740f25b8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/claude-audit.json": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "e98b2efe1968ea8bbac6e0256ad3a8d4",
+  "admin-dashboard/postcss.config.mjs": {
+    "mtime": 1780622912.4370236,
+    "ast_hash": "239f3ebf717465dc636818a1a619398d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/subprocessors-baseline.json": {
-    "mtime": 1779512835.5373926,
-    "ast_hash": "43a1d08f5c3bb3f4fd2ccb05e794e222",
+  "admin-dashboard/vitest.setup.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "5d8184f1d28fd84dea8f32de71678db0",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/settings.json": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "456a0521c1f1eb5db197735fca9090a5",
+  "admin-dashboard/sentry.client.config.ts": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "8ec3c1f05aa48af34a15a1f97103ea4d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/mcp.example.json": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "3104b5dde5f422f07bbd6740f88878cb",
+  "admin-dashboard/e2e/login.spec.ts": {
+    "mtime": 1780622912.430921,
+    "ast_hash": "408b02158ccd56c536722a9a656a2be8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/launch.json": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "36b5eca93a6c20dd0d24adf81e5fa3af",
+  "admin-dashboard/e2e/auth.setup.ts": {
+    "mtime": 1780622912.430921,
+    "ast_hash": "aac3dc1a8bb7237201f217c53599d628",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/hooks/pre-commit": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "ebcd2cf9c7dd6309305bfafea51276f0",
+  "admin-dashboard/e2e/dashboard.spec.ts": {
+    "mtime": 1780622912.430921,
+    "ast_hash": "a3b4194dbf3f6e2fcbc38712fec6e9c9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/hooks/session-start.sh": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "8bf67ee85a22751869dc37444b0aac17",
+  "admin-dashboard/src/app/layout.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "14f44fddf1334099184f508bd8112949",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/hooks/pre-migration-write.sh": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "58157c39693ba4c3687eb01c258860ec",
+  "admin-dashboard/src/app/page.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "cfd4842cc6996290e7d8ef4b709fcecd",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/hooks/post-python-write.sh": {
-    "mtime": 1779512834.9349425,
-    "ast_hash": "f59e5ac0775df109f990786cf35ffcab",
+  "admin-dashboard/src/app/error.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "7d7f1b32583e4f50600ce37aec08ec0c",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.vscode/settings.json": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "818620337cb4e5f66e8dad9a1d7a5e80",
+  "admin-dashboard/src/app/not-found.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "aee12c16d22d01d27962282429fe2c33",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/SECURITY.md": {
-    "mtime": 1779512835.165595,
-    "ast_hash": "8815dfcade25fc3337de97a9c55a19d1",
+  "admin-dashboard/src/app/track/[rideId]/page.tsx": {
+    "mtime": 1780622912.5005763,
+    "ast_hash": "2124373670ecbcc362668f3edcf33c8d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/SCALING_PLAN.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "599eb33067a6c3bab4322aea90abdb56",
+  "admin-dashboard/src/app/register/driver/page.tsx": {
+    "mtime": 1780622912.4996226,
+    "ast_hash": "4fbaf1b4c1cc55bd15bbe6f2532c90c2",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/INSTRUCTIONS.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "2c4a6aea2b1f90977a039f0f0d4a9448",
+  "admin-dashboard/src/app/dashboard/layout.tsx": {
+    "mtime": 1780622912.4738774,
+    "ast_hash": "8e61268a822b3aae6fcf4d46548b1260",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/TESTING_AND_ENHANCEMENTS.md": {
-    "mtime": 1779512835.165595,
+  "admin-dashboard/src/app/dashboard/page.tsx": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "2e386b6d714ffbd008e7cd9f361d48ba",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/earnings/page.tsx": {
+    "mtime": 1780622912.4697819,
+    "ast_hash": "fdce1c529f40fce3558767415228096d",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/settings/page.tsx": {
+    "mtime": 1780622912.48859,
+    "ast_hash": "17c92487078dea0afaae9ca08b030504",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/page.tsx": {
+    "mtime": 1780622912.4850237,
+    "ast_hash": "f86db91949dbef18d82b9fe8e3d152d3",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/live/[id]/live-map.tsx": {
+    "mtime": 1780622912.4845738,
+    "ast_hash": "4032ef74d3b3f24303a084c03b3a2934",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/live/[id]/page.tsx": {
+    "mtime": 1780622912.4849622,
+    "ast_hash": "a930cfd369bcb9db9449336360852ec0",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "234d4b4bd1953f59e0693b239acbdd67",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-stats-cards.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "1240fe19ca2e0c902bfa150b00f785ba",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-list.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "8c04404e7404c6b770c0d77b78f3aad0",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "42f4af166e601b343ad8019d4813586d",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-flag-form.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "fa4dfce309094a64b4267c7b8b4c5a90",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-complaint-form.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "71d19a7ec7c815b25da82455f6bdf959",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-route-map.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "b05a4f40502c308d8a8602a695ec3419",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-ui-helpers.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "af608b47c42a818373ce4478601b828a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/ride-lost-found.tsx": {
+    "mtime": 1780622912.4810238,
+    "ast_hash": "8994403203e08d08cfa7dfa109c1881f",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx": {
+    "mtime": 1780622912.4570236,
+    "ast_hash": "7923e886cfdf3f78e7c21dc8ed4adfc0",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/notifications/page.tsx": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "64037ee62e42cfd8f57b4092047a7586",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/surge/page.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "5d099dc4e51504db0aa562f9c0b683b9",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/users/page.tsx": {
+    "mtime": 1780622912.496702,
+    "ast_hash": "43328d12e5b1651c7d8dc29eeb525e39",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/corporate-accounts/page.tsx": {
+    "mtime": 1780622912.4610238,
+    "ast_hash": "6270ff9c7e4549926b0dfc5f3efc00e1",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/corporate-accounts/kyb-queue/page.tsx": {
+    "mtime": 1780622912.4610238,
+    "ast_hash": "5d5b09f5e6b01c5d1cef39c10d40848e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/page.tsx": {
+    "mtime": 1780622912.4600475,
+    "ast_hash": "c9eb9caa9f21c6c51a4d6e50eb5caf03",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/allowance-dialog.tsx": {
+    "mtime": 1780622912.459257,
+    "ast_hash": "40001be2d21a196f5aa43caccb2efe5e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/members/page.tsx": {
+    "mtime": 1780622912.4600475,
+    "ast_hash": "16976880f27423daf8fb8ed54baab4b6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/disputes/page.tsx": {
+    "mtime": 1780622912.4610238,
+    "ast_hash": "b05284c2aabdc76202d30ceac668c879",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/staff/page.tsx": {
+    "mtime": 1780622912.4890237,
+    "ast_hash": "c51bee09f7589ea08f3f3c68e3ccc8c9",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/page.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "819fbbb22c76c484dc58461397ca922e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/disputes.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "480e47037c749f5aa30f000c5132e8ca",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/complaints.tsx": {
+    "mtime": 1780622912.4930236,
+    "ast_hash": "8fac0688001d1f3097208ffbf889c26d",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/flags.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "205f3e92567c6f4ef1eecdfeae66a341",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/lost-and-found.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "cdac7311d3da1f4a8f141596fe00b811",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/tickets.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "8ad5b82a2ac42482968e8beac947ce45",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_components/service-area-select.tsx": {
+    "mtime": 1780622912.4930084,
+    "ast_hash": "eb5c7559f5cb3a3fc47aa4824ac655b2",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/vehicle-types/page.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "7f9f6a01846be2cb0a5bb5021816f406",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/page.tsx": {
+    "mtime": 1780622912.4680126,
+    "ast_hash": "fb511ddb4101aaf42fa3d41a4449a1b0",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/driver-notes.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "68ec7d3ec7888a1f4aed3b9b11b3216f",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/driver-charts.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "56c646b2f0b6f2e91422c904c2a21cc6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/driver-stats-cards.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "e7d53b053d396f4e09a115b1adec1951",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/area-stats-table.tsx": {
+    "mtime": 1780622912.4651096,
+    "ast_hash": "c9198f0ca836d96dcdbfc959651f2de4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/driver-action-bar.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "27fc81e9e31836f22db29fda7fedf0ad",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/driver-timeline.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "65ced6d1008d4bd27c27d35ba4938101",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/forecast/page.tsx": {
+    "mtime": 1780622912.4738774,
+    "ast_hash": "a748365e5b075ea2a69e5c9f1303b277",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/service-areas/page.tsx": {
+    "mtime": 1780622912.4850237,
+    "ast_hash": "290789935a88c31b2cfc0263d693db18",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/quests/page.tsx": {
+    "mtime": 1780622912.4797344,
+    "ast_hash": "eb2ea0b97af5638647eff114244a7a58",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/audit-logs/page.tsx": {
+    "mtime": 1780622912.4570236,
+    "ast_hash": "ad01025b0834a131fbed2964f78028d9",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/subscriptions/page.tsx": {
+    "mtime": 1780622912.4890237,
+    "ast_hash": "7bf52167ed3102097486194d686ca3fa",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/promotions/page.tsx": {
+    "mtime": 1780622912.4797344,
+    "ast_hash": "4dfff30ea8fa48b628679c6b69e60767",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/heatmap/page.tsx": {
+    "mtime": 1780622912.4738774,
+    "ast_hash": "37cdb94887b02120f806d565a8fc95bc",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/analytics/page.tsx": {
+    "mtime": 1780622912.4569087,
+    "ast_hash": "e986ab1347941f908221e31020c51974",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/documents/page.tsx": {
+    "mtime": 1780622912.4610238,
+    "ast_hash": "aa7ff33e55ecb530df721206e60c6928",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/alert-feed.tsx": {
+    "mtime": 1780622912.4738774,
+    "ast_hash": "3f2028b2c28354f8a076c8ec3dd5ba5f",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/types.ts": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "b1d8504eb9160a10c51454315143629b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/monitoring-map.tsx": {
+    "mtime": 1780622912.4762542,
+    "ast_hash": "95508cba6aa86cdd1805e1aa7e8772a9",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/ride-panel.tsx": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "5e92ea86a2a16d973a3a85384d3a32f8",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/page.tsx": {
+    "mtime": 1780622912.4762542,
+    "ast_hash": "62f5fd163c5eff79974e16689dc1ae13",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/driver-panel.tsx": {
+    "mtime": 1780622912.4762542,
+    "ast_hash": "99e137249d831d76c7a525efb77b1496",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/toolbar.tsx": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "4b2f28fcbc65c22919801107fcc8fce3",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/login/page.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "4892d0f21fb367b4e30ffb39cb597266",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/hooks/use-monitoring-socket.ts": {
+    "mtime": 1780622912.5081196,
+    "ast_hash": "cfd783265ea4ffb0cf189c388cd8bb63",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/hooks/use-mobile.ts": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "fa5910fcabb30a06b1e810c9dac3324a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/utils.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "dc778c4009748a6e57159e2956c4de05",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/api.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "a35756fbfbc0e1ffc44a536af3fba187",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/export-csv.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "055e35647e504a745fac40ddfd5e637f",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/__tests__/api.test.ts": {
+    "mtime": 1780622912.5088935,
+    "ast_hash": "e6164d3998a8a6679a5a258c76853914",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/__tests__/utils.test.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "9445337e37f58168f9dc8c3563e9cdc2",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/map/maplibre-base.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "995569892971b5c311bab0cb7014041a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/store/authStore.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "53530ee7d5e205e507937df98339bc44",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/setup.ts": {
+    "mtime": 1780622912.4448044,
+    "ast_hash": "30fa13ccc15ab8bdf326d8decb1553fc",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/login.test.tsx": {
+    "mtime": 1780622912.4448044,
+    "ast_hash": "b4f794fa08d4d83d226a2804c01fd7a4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/lib/utils.test.ts": {
+    "mtime": 1780622912.4448044,
+    "ast_hash": "0039006a506e7652f72d251cc117851a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/lib/export-csv.test.ts": {
+    "mtime": 1780622912.4435341,
+    "ast_hash": "44bd4146b5c862731be0344c510c4b5a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/store/authStore.test.ts": {
+    "mtime": 1780622912.4450238,
+    "ast_hash": "01895241394f6bb54b80f0fac85dac0e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/heat-map.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "05965a1ad22f1556a085ffe90c3c370e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/driver-map.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "acf8a197d264e71ccc09ef1e3f71d71a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/sidebar.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "a76563d77dd77707ce38d82f21ecccea",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/geofence-map.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "b843cc9901f061fd96a7c0971168db98",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/theme-provider.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "96f1e695c8498a71db8de5f4ad62e89a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/sheet.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "bb3ca0588bd13d790f9ab6a159f6bdeb",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/dropdown-menu.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "388aafcad8a41631e3ce2efbbbc3d0a4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/select.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "6a0e07cd58ac996abcb87ff5bb702c05",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/input.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "6666f8369b53c79d39be8060dc6c4ce5",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/tooltip.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "17aeef2e263039ea21914a51d71e290f",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/alert-dialog.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "81621b30c6628012c8185d2eef72d692",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/textarea.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "04f9af2a78672f7018b16db2bcec5036",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/tabs.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "6dcceea6a7c4551cba3009b58f1c9e21",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/table.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "531bf830b5f3b399abe3fd453157cdb7",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/sidebar.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "0a3a11eec8c3f49c18d5dcf6fa7ccb03",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/card.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "a6752f4d1da504c7f03196d90cde4b2c",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/toast.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "870993f2ea4c544b4d9a49a2c536e2d6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/toaster.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "cec0538ec0287ee66b3a3955cd92e821",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/separator.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "a27e39c797c6856cf5843b7b84d81cff",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/use-toast.ts": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "5673838018ccf115b53c9230e1a33795",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/avatar.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "03163772efa93ff00e813142e35eaeb6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/badge.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "752d1eea34a44e1becd88c82c5aa1016",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/switch.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "5c8ed3ecdb9e461c52a3d07d50050728",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/dialog.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "d04a6c9cfef3709a491429478b4556e3",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/button.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "c146cd1d6f1e0d54e4a7bb5f15a0834b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/alert.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "d4b3e9e4e501c34b4cdec8f9860f0f35",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/label.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "e7e0c4ad98f3485ecd3c0ca516d0a8bf",
+    "semantic_hash": ""
+  },
+  "agents/orchestrator.py": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "34854372568677ef086027c9a95e39a7",
+    "semantic_hash": ""
+  },
+  "agents/code_reviewer.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "73753939d8e5246f59e5bcd3276e7bb8",
+    "semantic_hash": ""
+  },
+  "agents/registry.py": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "918400348b9eda23e04465b0231d7c9f",
+    "semantic_hash": ""
+  },
+  "agents/documenter.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "bb983f3444926213f45a1dc4927a131a",
+    "semantic_hash": ""
+  },
+  "agents/cli.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "34b609d1a48fc78ff0fbdc1285472ee5",
+    "semantic_hash": ""
+  },
+  "agents/examples.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "0bee432b5135be13d479583bb521ccc3",
+    "semantic_hash": ""
+  },
+  "agents/__init__.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "df5c7cda93ae6eef39e0f9252131a7be",
+    "semantic_hash": ""
+  },
+  "agents/base_agent.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "ba0257c85294da5206598b0ac9040d22",
+    "semantic_hash": ""
+  },
+  "agents/frontend_agent.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "325d2654c5357a4a7d328d6a5d131210",
+    "semantic_hash": ""
+  },
+  "agents/knowledge_base.py": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "7c5e22e3e2e08442c44ecba600a1d3b2",
+    "semantic_hash": ""
+  },
+  "agents/tester.py": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "e3c5405b1cc011db960bf92723237e8c",
+    "semantic_hash": ""
+  },
+  "agents/security_agent.py": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "1d2720f964a3f4c8e502e2aefb1a0f89",
+    "semantic_hash": ""
+  },
+  "agents/backend_agent.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "3a643c1b7ade582778233a1a02a4db5d",
+    "semantic_hash": ""
+  },
+  "agents/deployer.py": {
+    "mtime": 1780622912.5130236,
+    "ast_hash": "aa071c21c5b15148e826b24c09c6b88d",
+    "semantic_hash": ""
+  },
+  "frontend/app.config.ts": {
+    "mtime": 1780622913.203967,
+    "ast_hash": "8a8793b93d1de39c9cea8d27c777f2bf",
+    "semantic_hash": ""
+  },
+  "frontend/test-places.js": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "9594ea443cfcd44acc25b43e3380e4a6",
+    "semantic_hash": ""
+  },
+  "frontend/jest.config.js": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "3699d08d52ac397e56d4d45067509781",
+    "semantic_hash": ""
+  },
+  "frontend/jest.setup.js": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "ae2383489e922d9ad1a18217d4c3055b",
+    "semantic_hash": ""
+  },
+  "frontend/metro.config.js": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "ea33c940558dd5ee461eb3a8c8ba1af5",
+    "semantic_hash": ""
+  },
+  "frontend/eslint.config.js": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "560a864580ad8107fbbf8d6d452c82fe",
+    "semantic_hash": ""
+  },
+  "frontend/babel.config.js": {
+    "mtime": 1780622913.2210238,
+    "ast_hash": "441a2e78a2cb4b522a8c18b3ca198a0e",
+    "semantic_hash": ""
+  },
+  "frontend/test-maps.js": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "035382ca9386112d715f42f65bd94129",
+    "semantic_hash": ""
+  },
+  "frontend/e2e/auth.test.tsx": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "bb5c421353bf68d23ce3bf1e571278e3",
+    "semantic_hash": ""
+  },
+  "frontend/e2e/jest.config.js": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "1014c07225f031764442e190c9f2ff1a",
+    "semantic_hash": ""
+  },
+  "frontend/e2e/init.js": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "0639738366949befda70603b31870dbb",
+    "semantic_hash": ""
+  },
+  "frontend/config/index.ts": {
+    "mtime": 1780622913.2222583,
+    "ast_hash": "10260a0410e6c9d745764a1b5ad728c2",
+    "semantic_hash": ""
+  },
+  "frontend/config/firebaseConfig.ts": {
+    "mtime": 1780622913.221923,
+    "ast_hash": "fb731565b0e3a24652dee9b248bfacc3",
+    "semantic_hash": ""
+  },
+  "frontend/config/supabase.ts": {
+    "mtime": 1780622913.2222583,
+    "ast_hash": "423c3e4ac9ddbf0249344060c2be40fb",
+    "semantic_hash": ""
+  },
+  "frontend/config/spinr.config.ts": {
+    "mtime": 1780622913.2222583,
+    "ast_hash": "c030c0c32fdb9856ef3af6f83d2f460a",
+    "semantic_hash": ""
+  },
+  "frontend/app/otp.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "dca3867c919865698a73f3733c4a5ba7",
+    "semantic_hash": ""
+  },
+  "frontend/app/ride-in-progress.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "523dfdb07cfecb9c14467d1a06200203",
+    "semantic_hash": ""
+  },
+  "frontend/app/driver-arrived.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "ac809532db02c653c00988fafb308d26",
+    "semantic_hash": ""
+  },
+  "frontend/app/rate-ride.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "f9c94adc93c46d813fac00d7850c1994",
+    "semantic_hash": ""
+  },
+  "frontend/app/report-safety.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "88f9458d68eae0aea616c79e4656976b",
+    "semantic_hash": ""
+  },
+  "frontend/app/chat-driver.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "4a3a37c2318cfe7bc97a0e2157d5fb71",
+    "semantic_hash": ""
+  },
+  "frontend/app/payment-confirm.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "6fd22f9c60a6100921a92b723ae80453",
+    "semantic_hash": ""
+  },
+  "frontend/app/_layout.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "f134aeaa8aa5b67441589ededa7d12d9",
+    "semantic_hash": ""
+  },
+  "frontend/app/support.tsx": {
+    "mtime": 1780622913.2090237,
+    "ast_hash": "70919d217ec9ff612f7b2d0bd13f2b99",
+    "semantic_hash": ""
+  },
+  "frontend/app/login.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "04dc8267773f153e772fcab96936ab95",
+    "semantic_hash": ""
+  },
+  "frontend/app/become-driver.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "688d1f1c229be6b6289b113c7b532afd",
+    "semantic_hash": ""
+  },
+  "frontend/app/ride-completed.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "2e526f3f229f8a3eb5f15fa6e2cbf5a9",
+    "semantic_hash": ""
+  },
+  "frontend/app/profile-setup.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "030287ffcbb84b75907615cea9a315de",
+    "semantic_hash": ""
+  },
+  "frontend/app/ride-options.tsx": {
+    "mtime": 1780622913.2090237,
+    "ast_hash": "c54e1adac934543e08d1c9f193a40d5f",
+    "semantic_hash": ""
+  },
+  "frontend/app/driver-arriving.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "29574aa759122c38a3f74b0cae5d677e",
+    "semantic_hash": ""
+  },
+  "frontend/app/ride-status.tsx": {
+    "mtime": 1780622913.2090237,
+    "ast_hash": "39f1f9abbf27588459ee6dd6d65e4c3d",
+    "semantic_hash": ""
+  },
+  "frontend/app/search-destination.tsx": {
+    "mtime": 1780622913.2090237,
+    "ast_hash": "ee63027b9df0827136c202db99c3bca3",
+    "semantic_hash": ""
+  },
+  "frontend/app/index.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "7a09956e142d2dff81bfd3a07d454b01",
+    "semantic_hash": ""
+  },
+  "frontend/app/(tabs)/account.tsx": {
+    "mtime": 1780622913.2046742,
+    "ast_hash": "64b112e6fdacd68d90d2421da5f0b8ed",
+    "semantic_hash": ""
+  },
+  "frontend/app/(tabs)/_layout.tsx": {
+    "mtime": 1780622913.204463,
+    "ast_hash": "83119bc18428a4755b9677d5d3cdf367",
+    "semantic_hash": ""
+  },
+  "frontend/app/(tabs)/activity.tsx": {
+    "mtime": 1780622913.2046742,
+    "ast_hash": "19b74cf3b4b0d4acddcc09245b1f04bf",
+    "semantic_hash": ""
+  },
+  "frontend/app/(tabs)/index.tsx": {
+    "mtime": 1780622913.2050238,
+    "ast_hash": "1c72a01e0372cb461294575d007aeb99",
+    "semantic_hash": ""
+  },
+  "frontend/api/upload.ts": {
+    "mtime": 1780622913.203967,
+    "ast_hash": "313fac4317c28e6410bd3bdce19dfdad",
+    "semantic_hash": ""
+  },
+  "frontend/api/client.ts": {
+    "mtime": 1780622913.2031155,
+    "ast_hash": "58396cdc53ee0f4e2c598c807b1bc52b",
+    "semantic_hash": ""
+  },
+  "frontend/store/documentStore.ts": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "e2e0acb1ce2720af5d890141763fe283",
+    "semantic_hash": ""
+  },
+  "frontend/store/driverStore.ts": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "53911514a04f904af95d453586bf40fd",
+    "semantic_hash": ""
+  },
+  "frontend/store/rideStore.ts": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "a1b98ede9920618e9783f2f801f89119",
+    "semantic_hash": ""
+  },
+  "frontend/store/authStore.ts": {
+    "mtime": 1780622913.2250237,
+    "ast_hash": "e44356b22899217d46261fa15c464b39",
+    "semantic_hash": ""
+  },
+  "frontend/__tests__/store/rideStore.test.ts": {
+    "mtime": 1780622913.2031155,
+    "ast_hash": "989e2f0b95b1474fe80c26f81415e1e6",
+    "semantic_hash": ""
+  },
+  "frontend/__tests__/store/authStore.test.ts": {
+    "mtime": 1780622913.2028084,
+    "ast_hash": "e6a7fe384d8e0eb7efb18536319b05b7",
+    "semantic_hash": ""
+  },
+  "frontend/types/expo-linear-gradient.d.ts": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "d78e0c6b1f9fd5b8e39c6590c77ea44d",
+    "semantic_hash": ""
+  },
+  "frontend/scripts/reset-project.js": {
+    "mtime": 1780622913.2250237,
+    "ast_hash": "55e9a46ae7c35eb0340e956473beaed2",
+    "semantic_hash": ""
+  },
+  "frontend/components/AppMap.tsx": {
+    "mtime": 1780622913.2210238,
+    "ast_hash": "ec5da6d586010f7605492a3473cb2455",
+    "semantic_hash": ""
+  },
+  "frontend/components/AppMap.web.tsx": {
+    "mtime": 1780622913.221923,
+    "ast_hash": "21a9794c39e8856c84b1a56535af59d2",
+    "semantic_hash": ""
+  },
+  "frontend/__mocks__/@shared/cache.js": {
+    "mtime": 1780622913.202335,
+    "ast_hash": "39b30c27c3f7cdde1146ba153933d951",
+    "semantic_hash": ""
+  },
+  "scripts/code_review_helper.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "288a707af28f321e5356e2b8a3541f14",
+    "semantic_hash": ""
+  },
+  "scripts/manage_admin.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "0ef8e7451b9c88044ce2b493ff24d68b",
+    "semantic_hash": ""
+  },
+  "scripts/validate_code_review.py": {
+    "mtime": 1780622913.7072804,
+    "ast_hash": "408c09d694940899d9c7382ba6599194",
+    "semantic_hash": ""
+  },
+  "scripts/run_code_review.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "df48fb0a4a09b48b524e19fe1e98e836",
+    "semantic_hash": ""
+  },
+  "TESTING_AND_ENHANCEMENTS.md": {
+    "mtime": 1780622912.4250238,
     "ast_hash": "6c28613ce521672ca9ec51a8f031f9ce",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/validation_output.txt": {
-    "mtime": 1779512836.5003667,
-    "ast_hash": "51ee370723edbd273f6646ca5f8376aa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/OPEN-ITEMS-TRACKER.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "559d02ee527bae6dd6a5d24ddf701ddc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/render.yaml": {
-    "mtime": 1779512836.3507798,
-    "ast_hash": "d288ff106f4b518d3aaf8348d6253f42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/DRIVER_APP_ANALYSIS.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "ff9592afc766bee0cc604db93488eaea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/README.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "7042196d1288210597db3652019e15ad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/TODO.md": {
-    "mtime": 1779512835.165595,
-    "ast_hash": "8ba2b2ce928226973be849fed599ed10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/CLAUDE.md": {
-    "mtime": 1780075494.328638,
-    "ast_hash": "fd4419f6f487ba3815a2f6c4ac2bc004",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/DEPLOYMENT.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "31ce5daead53dbb0ac889c4dc7fee1ba",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/READINESS_REPORT.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "dff6a4ff3db47f2c96af49a2ad848a80",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/INTEGRATION_COMPLETE.md": {
-    "mtime": 1779512835.1615949,
+  "INTEGRATION_COMPLETE.md": {
+    "mtime": 1780622912.4250238,
     "ast_hash": "e8b8f05a552024c466879c779891c35b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/AUTOCOMPLETE_FIX_GUIDE.md": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "0fc11fdd14845a9d0361078fe6f12e3e",
+  "TODO.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "af2e7a02e2281c41088fa00976d008ad",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/CODE_ANALYSIS_REPORT.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "c1512379c99cd247189257f7712e68de",
+  "READINESS_REPORT.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "dff6a4ff3db47f2c96af49a2ad848a80",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/ANALYSIS_REPORT.md": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "aa97d63a442c96628748ffe43ef1969f",
+  "INSTRUCTIONS.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "2c4a6aea2b1f90977a039f0f0d4a9448",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/ARCHITECTURE.md": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "3e0424d4d47e1978fa25e4bb765da254",
+  "DRIVER_APP_ANALYSIS.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "ff9592afc766bee0cc604db93488eaea",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/DRIVER_BACKEND_AUDIT.md": {
-    "mtime": 1779512835.1615949,
-    "ast_hash": "7006527456782e8d0f3a6463d8dcb041",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/GAP_ANALYSIS.md": {
-    "mtime": 1779512835.1615949,
+  "GAP_ANALYSIS.md": {
+    "mtime": 1780622912.4250238,
     "ast_hash": "063b72dc2b57fe1c66a567cbe84efa1e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/CODE_REVIEW_REPORT.md": {
-    "mtime": 1779512835.1615949,
+  "CLAUDE.md": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "21c428dca92874d894ee5dc81430de93",
+    "semantic_hash": ""
+  },
+  "AUTOCOMPLETE_FIX_GUIDE.md": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "0fc11fdd14845a9d0361078fe6f12e3e",
+    "semantic_hash": ""
+  },
+  "README.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "a7f5d6787e39b064ca3d0b5e43fd700f",
+    "semantic_hash": ""
+  },
+  "validation_output.txt": {
+    "mtime": 1780622913.7170439,
+    "ast_hash": "51ee370723edbd273f6646ca5f8376aa",
+    "semantic_hash": ""
+  },
+  "DEPLOYMENT.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "31ce5daead53dbb0ac889c4dc7fee1ba",
+    "semantic_hash": ""
+  },
+  "CODE_ANALYSIS_REPORT.md": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "c1512379c99cd247189257f7712e68de",
+    "semantic_hash": ""
+  },
+  "CODE_REVIEW_REPORT.md": {
+    "mtime": 1780622912.4250238,
     "ast_hash": "3269c89bb32df082b4604adc55695086",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/plans/heatmap_implementation_plan.md": {
-    "mtime": 1779512836.3507798,
-    "ast_hash": "310e40aaaced509da463df9c1b36f25f",
+  "ANALYSIS_REPORT.md": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "aa97d63a442c96628748ffe43ef1969f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/plans/expo-sdk-54-migration-plan.md": {
-    "mtime": 1779512836.3507798,
-    "ast_hash": "d0672e54ed05f6c2603e94a82fe6daef",
+  "ARCHITECTURE.md": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "3e0424d4d47e1978fa25e4bb765da254",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/plans/expo-sdk-52-downgrade-spec.md": {
-    "mtime": 1779512836.345595,
-    "ast_hash": "f47421e27a8d271faf47dc6863b78b5f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/final_audit.txt": {
-    "mtime": 1779512835.6022294,
+  "driver-app/final_audit.txt": {
+    "mtime": 1780622912.783055,
     "ast_hash": "e3e2b7179c912fa628b3bc2d67c2bd99",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/README.md": {
-    "mtime": 1779512835.5513048,
-    "ast_hash": "e22acbc85bc1f0b21dd2d4fbb55488b7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/audit_report_final.txt": {
-    "mtime": 1779512835.585595,
+  "driver-app/audit_report_final.txt": {
+    "mtime": 1780622912.7730236,
     "ast_hash": "422b204e6c23f1545cd48e226c479501",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/audit_report.txt": {
-    "mtime": 1779512835.585595,
-    "ast_hash": "f848cba92855c5cd002f0665875d43cf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/final_audit_v4.txt": {
-    "mtime": 1779512835.6022294,
+  "driver-app/final_audit_v4.txt": {
+    "mtime": 1780622912.7850237,
     "ast_hash": "14579abc30d2806f4a99dd2d2683632e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/final_audit_v3.txt": {
-    "mtime": 1779512835.6022294,
+  "driver-app/final_audit_v3.txt": {
+    "mtime": 1780622912.7850237,
     "ast_hash": "92cc6c4ca2a8d4ff24df049057686784",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/build-options/README.md": {
-    "mtime": 1779512835.585595,
-    "ast_hash": "812b085224e19ec5f4542b661dda6da8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/build-options/option-b-kotlin-2.1.20/README.md": {
-    "mtime": 1779512835.5923378,
-    "ast_hash": "d3fa03eddd30117f63de8f3fd6780748",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/build-options/option-a-kotlin-2.0.21/README.md": {
-    "mtime": 1779512835.5923378,
-    "ast_hash": "888a8ab97e503fd0194c464614cb4633",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/agents/README.md": {
-    "mtime": 1779512835.277595,
-    "ast_hash": "a0b72b96bb0e559033c76c7075227127",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T03-22-29-638Z.yml": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "6c792a5595288a77b5b525539e7c0f7b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T02-32-32-559Z.yml": {
-    "mtime": 1779512835.153595,
-    "ast_hash": "44c525e1a0c8285ba4c2acee4603152d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T17-01-06-839Z.yml": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "6ae15e48860e9daf06f1a8532e97d67d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T17-29-32-628Z.yml": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "6ae15e48860e9daf06f1a8532e97d67d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T02-32-53-957Z.yml": {
-    "mtime": 1779512835.153595,
-    "ast_hash": "e41f101d185791f7c0ee94a8f1b8eafa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T03-20-56-140Z.yml": {
-    "mtime": 1779512835.153595,
-    "ast_hash": "73490f3075623c776fcf78a4edbc32eb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-03T17-28-58-051Z.yml": {
-    "mtime": 1779512835.153595,
-    "ast_hash": "377645f02d7588ae0455f4c729321c19",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-03T17-26-25-849Z.yml": {
-    "mtime": 1779512835.1455948,
-    "ast_hash": "e693309b31646c3010e1507a0114ce61",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-03T17-27-43-044Z.yml": {
-    "mtime": 1779512835.1523364,
-    "ast_hash": "22f6f4d11e747aabdd3ea99191a1e175",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T16-54-41-581Z.yml": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "6c922f3c28d4602f659f7b245681c6ca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T03-15-59-076Z.yml": {
-    "mtime": 1779512835.153595,
-    "ast_hash": "2780baaa170f695aac291be8c471573d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.playwright-mcp/page-2026-05-04T17-28-05-227Z.yml": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "ba0074c4802039202a1041b538e7e19e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/pull_request_template.md": {
-    "mtime": 1779512834.9415545,
-    "ast_hash": "c615500a3b0d2860d8712d399a3f466d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/labeler.yml": {
-    "mtime": 1779512834.9415545,
-    "ast_hash": "9ceac588bb3e82fd6b362dc0b7e1b9d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/dependabot.yml": {
-    "mtime": 1779512834.9415545,
-    "ast_hash": "7b86d6880178718e0db8b8388eb24d9b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/ISSUE_TEMPLATE/ci_change_request.yml": {
-    "mtime": 1779512834.941267,
-    "ast_hash": "7b4ddafa8f2b591616acc7667ad9ba40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/ISSUE_TEMPLATE/ci_error_report.yml": {
-    "mtime": 1779512834.9415545,
-    "ast_hash": "6bbdd176aa7758d573fbf49048291db5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/security-gates.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "b859dcc54aca144d53fd48c71b11724c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/ci.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "c584f0a6a9fdad636a483e6fe45a54d1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/apply-supabase-schema.yml": {
-    "mtime": 1779512834.9415545,
-    "ast_hash": "73eef86fdfb34cd3edcd39d8e1a49349",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/subprocessor-audit.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "4f7340b27f10f18092b689ed64d96fa0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/migration-check.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "eac0442ece0c5931253590434a413047",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/pip-compile-check.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "97f242040ad322e3558d8c21f71dddce",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/subprocessor-monitor.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "a05e6bdaf3ff7b078afd75d93e9559d7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/deploy-backend.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "4fd268074238ec4b5b9b2188d0f050fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/eas-build.yml": {
-    "mtime": 1780060957.248439,
-    "ast_hash": "2e563701050a2e781757a0fa0c7af765",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/claude-audit.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "5f3d46ae7770a98a742dfef38ccb73ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/claude-review.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "b311615053309000788dafb472320abe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/pr-checks.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "a09d5393609eb9080bd46c8f2cea5115",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/ci-error-audit.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "4e99207a94c963ae68d1483a8b180cda",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/dependabot-auto-merge.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "d944a25f9f5dc4e2ea101d87304edfc6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/mobile-dep-check.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "a4c4e9325592f971f343e9522fd4fd90",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/ci-guardrails.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "18af11f22ee68b41acba4d5c8c6fd4f4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.github/workflows/test-env.yml": {
-    "mtime": 1779512834.9428566,
-    "ast_hash": "cf3765cc2ed571a62ad11202058f7fa1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/README.md": {
-    "mtime": 1779512835.1703293,
-    "ast_hash": "f15aaa42d5d299d091b1171097ea56ad",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/public/robots.txt": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "bea598923a1178595c8e0065c4d3e234",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/tsc_errors.txt": {
-    "mtime": 1779512836.193595,
-    "ast_hash": "9e82d700e437f25667905cdd3da38da9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/README.md": {
-    "mtime": 1779512836.1603162,
-    "ast_hash": "1a436ff3029b0bb9aebb68174f0621d1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/DEPRECATED.md": {
-    "mtime": 1779512836.1603162,
-    "ast_hash": "2d671863289b03f696ff1129cf8357fa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/requirements.txt": {
-    "mtime": 1779512835.341595,
-    "ast_hash": "06370c0bd8422838d33fc3e64c570433",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/SUPABASE_MIGRATION.md": {
-    "mtime": 1779512835.300226,
-    "ast_hash": "461416d448ec683aa4993750380d198e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/README_MIGRATION.md": {
-    "mtime": 1779512835.300226,
-    "ast_hash": "11bb8ca5fbd3f522046c636633c47bce",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/requirements-locked.txt": {
-    "mtime": 1779512835.341595,
-    "ast_hash": "bcac2e0bb25e708de50206e73a5183aa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/requirements-win.txt": {
-    "mtime": 1779512835.341595,
-    "ast_hash": "74800ee8a633aa5b80b5fdb2dd70604e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/SCHEMA.md": {
-    "mtime": 1779512835.300226,
-    "ast_hash": "249420e4bc329c0d598c7d67722dfbe6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/CORPORATE_ACCOUNTS_FIX.md": {
-    "mtime": 1779512835.300226,
-    "ast_hash": "f4be827e06f3b1c5883a7b636d316e27",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/services/README.md": {
-    "mtime": 1779512835.3745186,
-    "ast_hash": "2f11de7079e03d49d8c57876cbb4f58f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/docs/key-rotation.md": {
-    "mtime": 1779512835.3074508,
-    "ast_hash": "952b6e88f61d62b5695766dc800e8564",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/docs/STORAGE_BUCKETS.md": {
-    "mtime": 1779512835.3058493,
-    "ast_hash": "92f0472e4518ecccac9a56d848266091",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/ground-rules.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "dde4f3763e5fc0198a3f9b044bd4b111",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/README.md": {
-    "mtime": 1779512835.2902117,
-    "ast_hash": "adea72f5c25dd28edf9ad75639a8ce28",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/regulatory-matrix.md": {
-    "mtime": 1779512835.2935948,
-    "ast_hash": "00f63a9d6d41cdae159c317a442c89f1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/CHANGELOG.md": {
-    "mtime": 1779512835.2876105,
-    "ast_hash": "7eac445caf1be2116eacfae538f1235e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/modules/admin-panel.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "b1bf1fd37208a904eef1014947d8b130",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/modules/backend-api.md": {
-    "mtime": 1779512835.2935948,
-    "ast_hash": "27662aca5a9ce6ab9c10d102740b2d30",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/modules/rider-app.md": {
-    "mtime": 1779512835.2935948,
-    "ast_hash": "8071f10bfa84b976ba3f00650dc631f4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/modules/driver-app.md": {
-    "mtime": 1779512835.2935948,
-    "ast_hash": "dead2b15cc93140e88cb833a2a15a677",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/templates/remediation-group.md": {
-    "mtime": 1779512835.2982929,
-    "ast_hash": "8a24f7ba65d66f35a28281c6481a8c05",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/templates/run-audit.md": {
-    "mtime": 1779512835.2982929,
-    "ast_hash": "0bb2affb463f857bc38113dc8804b7c4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/templates/audit-output.txt": {
-    "mtime": 1779512835.2935948,
-    "ast_hash": "9996a3c42c504a607a6bd48f0cce2ce9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/02-authentication.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "b5bc734314d9fc2585a92fdcb9579c69",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/20-financial-reconciliation.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "bada290d84ee22c5d34bd2f49911ebf0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/12-compliance-pii-pci.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "07ba995d43bb10325bfdbf481ee9cd21",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/07-state-machine.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "25039c217d86a06e9596480870aefa44",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/16-i18n-localisation.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "19249056aa3f56be755b149cfca0af3c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/15-accessibility-wcag.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "aa798a1b90d6ca2e0afe084723213aa7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/17-observability.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "2db8abe73c718dbbfa4a04074019181c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/09-test-coverage.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "3bd5ca234deb7b10e2ff1a393f5c4a28",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/23-mobile-binary.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "1db43fda23f3c41bec66ff30f9536f54",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/04-input-validation.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "9e9890aa5e25e50a4e062c35d84bba68",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/01-feature-completeness.md": {
-    "mtime": 1779512835.2902117,
-    "ast_hash": "b67a2005da381deae807cbb2d93c7d46",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/11-security-headers-cors.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "2fba20c008f1bcadc34e7697534e8db1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/05-ui-ux-android-ios.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "249f30885bd25a5370517b19de1149c9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/10-error-handling.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "e359343cf380aac414c7e4f7d79d9c21",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/13-notifications-ai-faq.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "7f2968dd7f5fee793183567be346163b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/22-third-party.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "ee2001e38aa83d330da1e7f8ac9afbb0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/06-real-time.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "cffb72b0a1adf460261dc7da544784a8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/19-fraud.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "9dbf2cc355a3f61faf8f628c4a17200d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/21-threat-model.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "8bfd7d5263e05c6df35d5faaa12963ca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/08-payments.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "2fadd149b65aae825a77dd5e4de3c8d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/18-dr-bcp.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "25cf9963c6d29c402265400117223349",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/audit-framework/dimensions/14-performance-scalability.md": {
-    "mtime": 1779512835.2910702,
-    "ast_hash": "8ab8112f042b34c12ec2391124b59ae3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/tsc-errors.txt": {
-    "mtime": 1779512836.4671276,
-    "ast_hash": "9aa1ffd3eb361c3eb9789cb2334a5f1c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/README.md": {
-    "mtime": 1779512836.4263613,
+  "driver-app/README.md": {
+    "mtime": 1780622912.7491193,
     "ast_hash": "e22acbc85bc1f0b21dd2d4fbb55488b7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/build-options/README.md": {
-    "mtime": 1779512836.445595,
-    "ast_hash": "d085a2cc18510e08cc6ac2f1832cfb3b",
+  "driver-app/audit_report.txt": {
+    "mtime": 1780622912.7730236,
+    "ast_hash": "f848cba92855c5cd002f0665875d43cf",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/build-options/option-b-kotlin-2.1.20/README.md": {
-    "mtime": 1779512836.4506917,
-    "ast_hash": "5a268e46edf4fb7c6b5debf2a9b22c36",
+  "rider-app/README.md": {
+    "mtime": 1780622913.6667438,
+    "ast_hash": "e22acbc85bc1f0b21dd2d4fbb55488b7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/build-options/option-a-kotlin-2.0.21/README.md": {
-    "mtime": 1779512836.4506917,
-    "ast_hash": "8ad47cb284a283baa519a465de1ce6e0",
+  "rider-app/tsc-errors.txt": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "9aa1ffd3eb361c3eb9789cb2334a5f1c",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.emergent/emergent.yml": {
-    "mtime": 1779512834.9373403,
-    "ast_hash": "893e99a99512803a7cf2d99544324584",
+  "backend/SUPABASE_MIGRATION.md": {
+    "mtime": 1780622912.525735,
+    "ast_hash": "461416d448ec683aa4993750380d198e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.emergent/summary.txt": {
-    "mtime": 1779512834.9402544,
-    "ast_hash": "183d19b608b420d49b061aa7c3b96685",
+  "backend/requirements.txt": {
+    "mtime": 1780622912.5690236,
+    "ast_hash": "06370c0bd8422838d33fc3e64c570433",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.semgrep/spinr-rules.yml": {
-    "mtime": 1779512835.157595,
-    "ast_hash": "3554ff2f9fe0ef7f7b332274440cbc05",
+  "backend/SCHEMA.md": {
+    "mtime": 1780622912.525735,
+    "ast_hash": "249420e4bc329c0d598c7d67722dfbe6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.kilo/plans/1776144706168-quick-moon.md": {
-    "mtime": 1779512834.950141,
-    "ast_hash": "129e71dc95b4f9c02ea9ec35e626436c",
+  "backend/CORPORATE_ACCOUNTS_FIX.md": {
+    "mtime": 1780622912.525735,
+    "ast_hash": "f4be827e06f3b1c5883a7b636d316e27",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/PROJECT.md": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "c4d7a35b5f3a3bc95258f176bf4fa5df",
+  "backend/README_MIGRATION.md": {
+    "mtime": 1780622912.525735,
+    "ast_hash": "11bb8ca5fbd3f522046c636633c47bce",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/UI-REVIEW.md": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "a72da80e8a3b025d3ca25d516ad320ec",
+  "backend/services/README.md": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "2f11de7079e03d49d8c57876cbb4f58f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/ROADMAP.md": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "66ef8c432e69678e53f8f8521059c84c",
+  "backend/docs/key-rotation.md": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "952b6e88f61d62b5695766dc800e8564",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/STATE.md": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "69facd780c33dc00b19b2a6182f6be52",
+  "plans/expo-sdk-52-downgrade-spec.md": {
+    "mtime": 1780622913.6090238,
+    "ast_hash": "f47421e27a8d271faf47dc6863b78b5f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/REQUIREMENTS.md": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "54f60df862327b3c26a6e9d484f2bf77",
+  "plans/heatmap_implementation_plan.md": {
+    "mtime": 1780622913.6130238,
+    "ast_hash": "310e40aaaced509da463df9c1b36f25f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/.continue-here.md": {
-    "mtime": 1779512834.953745,
-    "ast_hash": "14fc599e614bb4a3ca2ef7cbfbd7e981",
+  "plans/expo-sdk-54-migration-plan.md": {
+    "mtime": 1780622913.6130238,
+    "ast_hash": "d0672e54ed05f6c2603e94a82fe6daef",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.planning/UI-FIX-HANDOFF.md": {
-    "mtime": 1779512834.955109,
-    "ast_hash": "b477db061049563ec96556a06d92af0d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/.continue-here.md": {
-    "mtime": 1779512835.129595,
-    "ast_hash": "963f5bfd0aa7f32d3f288d505663b70e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/MANIFEST.md": {
-    "mtime": 1779512835.1455948,
-    "ast_hash": "70584a2c7c6969b5b3874bfe7097247a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/007-admin-monitoring/README.md": {
-    "mtime": 1779512835.143171,
-    "ast_hash": "61c4411cc2191355544b1c45872dd1e9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/007-admin-monitoring/index.html": {
-    "mtime": 1779512835.144901,
-    "ast_hash": "7163e12473ea325e174a3566d1d1e9bc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/010-rider-sos/index.html": {
-    "mtime": 1779512835.1455948,
-    "ast_hash": "67048aa40995151214b1aeb9f073db62",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/012-driver-nav-arrival/index.html": {
-    "mtime": 1779512835.1455948,
-    "ast_hash": "881b947319327c7b2b2c139bf361522f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/011-driver-sos/index.html": {
-    "mtime": 1779512835.1455948,
-    "ast_hash": "59768f034506dc9f61bbf3b4d3062b20",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/006-rider-active-ride/README.md": {
-    "mtime": 1779512835.141313,
-    "ast_hash": "e8b897ba2ce751db8f2330507fcda1c3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/006-rider-active-ride/index.html": {
-    "mtime": 1779512835.143171,
-    "ast_hash": "e3c0a62231eac93d6169e75ff86ac269",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/001-driver-home/README.md": {
-    "mtime": 1779512835.1351588,
-    "ast_hash": "2bc40db8c908e56257fa9d96cce379e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/001-driver-home/index.html": {
-    "mtime": 1779512835.1356492,
-    "ast_hash": "2775186790fbbacee54a2a9159e3feb8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/004-rider-home/index.html": {
-    "mtime": 1779512835.1356492,
-    "ast_hash": "d3a271f08d6f08e2d33ccb6fd24d63fa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/009-admin-corporate/index.html": {
-    "mtime": 1779512835.144901,
-    "ast_hash": "5e28d31263a4ae9fdd5e427ed87389c3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/005-rider-booking/README.md": {
-    "mtime": 1779512835.137595,
-    "ast_hash": "9929ac6b600c9eaba5175099ba2b9efe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/005-rider-booking/index.html": {
-    "mtime": 1779512835.141313,
-    "ast_hash": "0537e897a1f7024c5834db0b43d799f2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/003-driver-earnings/index.html": {
-    "mtime": 1779512835.1356492,
-    "ast_hash": "f7b028bc921c3c39e2bdd18786bd61d5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/002-driver-offer-active/index.html": {
-    "mtime": 1779512835.1356492,
-    "ast_hash": "a23c94ee21a1dd87ba8360160c3849a5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/sketches/008-admin-drivers/index.html": {
-    "mtime": 1779512835.144901,
-    "ast_hash": "c1d6383d59d59738ec24534066fee7a3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.planning/graphs/GRAPH_REPORT.md": {
-    "mtime": 1779512835.021595,
-    "ast_hash": "4127aa3d960ffa67e80aa4b60095fa1e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/README.md": {
-    "mtime": 1779512834.950141,
-    "ast_hash": "4d7e911e43f7e9d98d836255f03c2cd3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/05_complete_trip.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "4bb751a7f89138b6a7bff05fe7ddd8fc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/03_accept_ride.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "e1de029539d2e4f9be22fe1d6cf55b7b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/04_verify_otp.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "a6faa81af11993cb97c2536a88d8d568",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/01_login.yaml": {
-    "mtime": 1779512834.9513283,
-    "ast_hash": "57ff046c1a5d9453cde2e95279822dc8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/02_go_online.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "3c7946dadfc31bd8e5ac1e0e3b250fea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/06_payout.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "cb4fb4ca57120de86483c989758f074f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/driver/07_in_trip_chat.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "2f9a5afe984cf9f6ed287821bd360ef9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/rider/03_schedule_and_cancel_ride.yaml": {
-    "mtime": 1779512834.953745,
-    "ast_hash": "24f40699642cc322a4234a35a3bb593f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/rider/05_sos_button.yaml": {
-    "mtime": 1779512834.953745,
-    "ast_hash": "6a74aa17c7789d17ca138eba9b381837",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/rider/01_login.yaml": {
-    "mtime": 1779512834.9517412,
-    "ast_hash": "2dcd1f25b639aca9a74050c450f19f3f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/rider/04_mid_trip_chat.yaml": {
-    "mtime": 1779512834.953745,
-    "ast_hash": "8a41b721f1de13090d1302d9f9db4871",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.maestro/rider/02_request_and_cancel_ride.yaml": {
-    "mtime": 1779512834.953745,
-    "ast_hash": "6b59ca3ea26026a20c3cfde788d3d924",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/README.md": {
-    "mtime": 1779512836.3507798,
-    "ast_hash": "cbb469d7db650d13c65b3794886b3ae6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/compliance/2026-04-26-supabase-service-role-key-breach-assessment.md": {
-    "mtime": 1779512836.413595,
-    "ast_hash": "6906b5267ff8557f5b66555fc701b8ef",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/legal/supabase-region-attestation-checklist.md": {
-    "mtime": 1779512836.413595,
-    "ast_hash": "d32eaf27ae23c8690cd3c0756b912485",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/rider-phase-e-P0-issues.md": {
-    "mtime": 1779512836.4215949,
-    "ast_hash": "61b0af85f9be079fd76b51aa6260eef7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/backend-P4-future-features.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "0e4262d2fe1feea455670039cc65635a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-P3-hardening.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "67d21b7c64eea3808194e68f61f7e6c8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P1-before-beta.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "ec766959b2a801f38b695ff7fc8a50f6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/rider-P1-before-beta.md": {
-    "mtime": 1779512836.4215949,
-    "ast_hash": "8e7e6f1d762c8d303d750234362bd99b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/rider-P0-critical-fix-now.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "8916caa7a6904e10a20f11c773f83686",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P2-backend-api.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "a51c6c7516088b7861c0f96fbca4909e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/backend-P3-hardening.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "56c7e91bc8008eed182f11056621656f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P2-before-launch.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "3c2aa2c95774a687a54d4748d9b55215",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/driver-new-issues-2026-04-23.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "d55572e33fbb143872223727822c748e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/rider-P2-before-launch.md": {
-    "mtime": 1779512836.4215949,
-    "ast_hash": "03e7c933686d509d6317d962668a1459",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-PE-P3-hardening.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "39028370c8ec48411171174841a5fdb5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/backend-P1-before-beta.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "6fea1e1bc6fecb92486043408946dc60",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-PE-P2-before-launch.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "a285eba21d49bd9495f3e91b0a487371",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/backend-PE-remediation.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "b3562a474440d9ffb72473533f8c56eb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/backend-P0-critical-fix-now.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "aa3c18e81c50ee315ba3119cb94034e7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-P4-future-features.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "3f6022c4bf620453746729fff5277aa3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-PE-P1-before-beta.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "3c769dd9632e3f8c2926efd8dd2b2760",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P1-backend-api.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "1f02c62e9891a9ddd7adfaf98f764056",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P4-future-features.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "347afabbdaae3fb4d84f9a70705ac064",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-P0-critical-fix-now.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "687e65c95f0571d3d61ca05db74323e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/rider-P3-hardening.md": {
-    "mtime": 1779512836.4215949,
-    "ast_hash": "ba90036b3c2a9612379134f51b069262",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-P1-before-beta.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "a364345b711f0125be24e8ba86d6bfca",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P0-backend-api.md": {
-    "mtime": 1779512836.413595,
-    "ast_hash": "f54d62e5df1a06c9fe04dba6a5e9782e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P0-critical-fix-now.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "2e5d4f5dd1c3ed239e66b879e12db21c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/P3-hardening.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "82d9ff436738b451de0382425d462db8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/admin-P2-before-launch.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "77394307de3778de98695ab1aa4e5423",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/backend-P2-before-launch.md": {
-    "mtime": 1779512836.418195,
-    "ast_hash": "c6ce46f240df7892e07e85ac3e2080c6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/remediation/rider-P4-future-features.md": {
-    "mtime": 1779512836.4215949,
-    "ast_hash": "a6e1dc65f58e34a42e1978a834400f37",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945723237.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "77864c5dcac0d7eb848a6221bd180274",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037652312.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "8c8567defa3f985f8fa62937bc991c64",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036475059.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "7f444095e53926479c7a9950bc0076d4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944892277.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "44f12688cdb7e2bef9f9227156bd9698",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062282109.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "f366d2a49ae34397e36b0a1dac07dc9b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25027031253.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "e7aeff48660dce72499965662b77ac65",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944903538.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "8e71e5fd75b2f72257cd22262bf6613e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036457523.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "a0a1573db114d407437b182127b15d91",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944802287.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "7fbdbd557b8b82e5082bed6d14d16633",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25022896325.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "fd6f3bc10f34ad59f5919178fe8f3f5b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008933209.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "5c8f73a63420ad52ab826bc2ca669970",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035960640.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "045ae46570e616af0c45e9d0beb3c924",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25054248436.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "bcd2551e11e4b888c67e3fa7f223f35e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25059390626.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "0c00ef98a71a86c6bbe50e4637e087dd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-backend-api-v1.txt": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "35e58a39c5b419d80e4161a55241785a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945000682.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "f4ed30a18f903e8273cf78bb74990fdc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-app-remediation-verification-prompt.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "5a4193902d987a2181986a4e344567a6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944958437.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "e16690705e1ffef8ae519cfc39b48b61",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034748381.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "4c9d2298cbff834042690d6e446be844",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062220353.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "2d97b256aae40706787ed9e77f121d85",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944905971.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "d7e53367cfd632c2b5f3b518f3a21698",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25091647538.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "9de374a9cd54082ada110ef2bd274630",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036481034.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "717b53e69561748f0c7766c6e1e2c3e5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036254359.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "7efb5f1f053f8fadea885f7181b5f492",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017481172.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "10adbd0dfab725d69a8a346398e336bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945854209.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "67df38566588af1f23bcb61ad5c8ba10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945288511.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "f02315fe7c7724a943e2b91b529eac99",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25091903200.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "3e9ccea14a74c6bec00b233b4d4f22eb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25029295090.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "29c69995748185318c0c2f37079ef512",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037170424.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "a7772d17f126b8cdcc65772d727ebd8f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062005595.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "b1ef0df41c73570ef649b565b71f9677",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013395931.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "3ba57ac3cef29b407237f0341a178984",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037102267.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "c461460bc19791a04f7c1b73f3c2091f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945839710.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "8dca6571f609bebc9e88c386e69d4ce0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25030997394.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "e3fc99dd42022f829456b79f8e8d6929",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009334434.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "0ce50758c964d4d39ecddc2777e3e85c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036059816.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "17a82d2858a61ead098e4d84b6b3fc1f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945326989.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "f92e05a4e5423e9a37046af9b783df31",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25096896461.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "94785ed5b64f1dfb5d91de4a2e64a1bb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945313499.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "4404361a74512838546206d91621992f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25029672363.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "13cb6d42b253b193ff64e4b45b6441d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25016562595.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "c0ee0fbb9c9d48747ea0aeba7d53c0c5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25094058404.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "d6fa43e3e44a844f2f12071d460e48bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25063703032.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "bb15c2c0b8e8b38972cbd00b43a0e186",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25093261231.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "f095d615d69e3d26ef2ea5b1692d3092",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-P1-verification.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "cf1bc627a1ec034fb547a8c98bb95053",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25032356435.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "7fc22606523cb940130607a945315ea6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25019608314.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "bc8c03491b7ab835a9f816a1f2667f69",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062056630.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "cbeed0d9d6c5eb2b32da125393d5c2d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25019267235.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "7a5339ea4387c9a169b7b8a680d004b2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062241056.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "2fe692921d8b912bd92aef376c669cc3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944884693.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "cd3efa9b77adc7ebc896de76aa716414",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25089410181.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "c19729b9e4f4fd7211804b7f13b80667",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945045257.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "6ee7c256c19e408bf75cc7f1e3944929",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24965538493.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "09565cd737097f2a1e85f89b5468995b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025456862.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "13690da51aa4a635e8b5227c2bc1c3ef",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/task14-performance-scalability.txt": {
-    "mtime": 1779512836.413595,
-    "ast_hash": "8e97cb5b2d56e8afd7c57b4db7206693",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25054104151.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "ee408134c26e07da530c79a602369b56",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025057071.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "ff99621f3cf7486ec0a337a2db99da9c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036903640.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "d1380c0a96086ae5169469dff10896a0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25024905280.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "cf788a08a707172ca52073083b1f5269",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25024884978.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "f7adc3c3d95557201b246ff4af74f853",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25014741319.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "9f79beaac603e5223e22940d3b0c1ed8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P2a-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "44fe6607fa9ae40d65fe033e40d7065d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009007893.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "2da538dcf0e1689e52882e5a25327a10",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25027978965.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "df2b552a55f5f36d54950b730aefe03f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944962059.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "dd66be90d62a5f0901205527a26d6521",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25057106573.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "277baa2b99bd714d176970114e0afea7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944796842.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "2c6c1d5929c28d73643b3ddab1d938c5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036599247.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "e21d929906356ad6a1eed9723f3bed20",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25003815125.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "dccf2917cf8c0cd5cc626de4e3c9ddf9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062044809.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "fbf396087602a5a0a5e744c04b6f118c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037705992.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "8de13d2609b146d5a494f534e566bc35",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025688449.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "5bae05609bae0c5eaf208eeb4b960aae",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24946161474.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "01fbfc9ff7153f48d0f0daebe8317f75",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037187071.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "ae1f51c98e61d353e3104d3bda92d305",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/OPEN-ITEMS-TRACKER.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "9f1cdf8c1a318c49f5973e768bb08047",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945412325.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "46205145db283ed5043441a86a2eb00c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035541495.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "01be9167f5cc3d3c2c29cc98154825fe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036449760.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "42ddd3827005f27cafc72e2db4ca1964",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-backend-api-v1.txt": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "f7144352c4c89866aed300bcefef1180",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035687085.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "0092a962496105edc36c50013aefd00d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017272616.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "44fbaed8611e1f408e67338f047c80d0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-admin-panel-audit-plan-v1.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "178cd7dad44335aa02dada2cf549ca1e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945719900.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "8fa3e47aed4782c6d15a1a7b0efeb60a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013516748.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "affc69e1efc2e1fcfcbd2998b7b86da6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945776272.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "a020c5a65608e6647f098775e4010973",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25091164427.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "e14b9646f1e893029315e50656ba827b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025558590.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "2ccdf0636a4733c65836abaa278a2c16",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945843533.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "2e6271f21ababce6b615bfabc9ba5fb4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25003828400.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "e52b120b21e21699275f8e371eccafa0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945800130.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "d319e53309096e49792e4ae9640ad491",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062030719.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "52b6830ce1771f9a14cf8fa340ee1e16",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25011685612.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "5ff0331d26ac72f5bf8bde4370c346f9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015345354.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "c40f5a253d402c6e618d230499ba52d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944803380.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "d0ad61e4512ba09459c4a92a01fccd93",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/CI_AUDIT_SYSTEM_2026-04-25.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "bdc6dc81948ee5f39e3f6bc980b9dfae",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25016154565.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "f3a09170183fb8fbed5096ff56dad544",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-master-rollup.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "1b1c8d09c1a4135a99c820978ee7ed72",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944790256.md": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "22531d074c0581443dbe994954494712",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25089202600.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "3fb817618fbc7f8a8a181519b184ba15",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035299671.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "cd5ee739821e2f59701da9f7a4bba435",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008922472.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "d3252f586160e3634db156cc73ed682c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-24998584413.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "ad0a9f946b3bd567712054481df0e4bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25093962266.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "ce38bcc634abd09d5d69f0ad4800b867",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25089257284.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "97f7e6a97567f15570070def5148d9eb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945388097.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "5ae679e9c8e795d646e6a47b5a47f147",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036770337.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "0841674b2879d65f1a07f3aa40ab5cff",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945014513.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "4d53e0c5e78c89fdf24ea0e67b83a553",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P4-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "6c0ec879360b8b6ad9bf685388c2fe89",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25096207887.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "260dd234aee8c1448911fe981eb032ed",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-25-admin-panel-audit-v1.txt": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "d5440e371ac7a8a3ff439d830d03652c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25003797266.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "4fa5742c4624462b5947396e716198b1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25028963568.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "9537d1e138d9ab2ed62f9acbd301aca6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25026933870.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "2c7b19a8c970916f6a74673038842841",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034041566.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "06786a4f58cd2ad6087a3e26ae0365e6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25029772653.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "63fc1915dc79fb282f5c22eab73bccb3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009176404.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "7ad67abef3d969edb54b312a46ef288d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036425490.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "34daf6f65c84737d502b9cf4afcd7def",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25012109834.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "f7f0172e12bda3695aaf55faf4870937",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25029533719.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "10e74f37d622ea46ed329851d626c19a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25054261821.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "6b8abbf0a8ed053acc42badc8b002a3a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-admin-panel-v2-phase-e.txt": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "a92fccb71638a3ee1cdde5f1e548fb50",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035122850.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "8b6ef64fd860e48ab1a87cbecaba0a07",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008860654.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "cbd8c343c30f53bde5c815d78fd9b30a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25029110359.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "3aaf48714aa3de03d3edc47b997f880c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25060177825.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "20b0eb21cead88737b0c17bd9649c9ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25003820859.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "a00be0f8cd206a900b2ddb0bfa95e6e0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958618032.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "8acfe83c2fe4ec28f0382dfe00fba032",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945305928.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "b741cb17ff516f072125341f9789e331",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25020753939.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "a23db7ad227cdab19b1d3d3a41323db8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036720056.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "c23123f5a241fe26f3e992010fa4070e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25061992395.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "522593e0e3d2e19f93f3add67bb63561",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25032353444.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "4728162f3a6831837c357a62b6cb8b17",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062238685.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "3780f8c1208f0a6d22b696e2fb7a5e3a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944988838.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "e2f98fb1217c9487947a5869b43a8a40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25116098822.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "5c0ca7bc8f4aac2039014d37bc3b41e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P2b-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "1aaf375caa4539634c87663589b291dd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015033929.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "4e3f2ec2354df1de992fe65d92d0aa14",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944794457.md": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "f90b228c4a1c21d551b9202c3937c495",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25019227487.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "42d671238657ad2ef8c880656f566b89",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009130249.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "cd68dc5c4c14b47872d4442db6178b87",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25027327721.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "0587e39c532ee8357feef8b4e6a6236f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25016848995.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "11e971962caa068eb8413dca9f9c8612",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/rider-app-phase-e-kickoff.md": {
-    "mtime": 1779512836.413595,
-    "ast_hash": "d2db6f78c6f01e9d7483c0961e9ddd82",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25087376829.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "e44e085ea9e1756a9dc7b37c3c7a45d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945999767.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "06c8dae6031b0ac3709ba272a2f140dd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25086842358.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "f8d263f308917100a43e1337681a7fbf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035305831.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "cde4d9ba23294df4f2c518679cba8e5b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P3-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "6fdb1a282c756c5d4d3d032c26fc1b0b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945779040.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "6dc5c00d1a185a71445276ba2c4af682",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25022072198.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "f77fb27ff397474e4fb6cfb8a23e68d2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25061902017.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "4c950453eda813f6ab38262aaaea01de",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25020323023.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "3d640e54408c784c3138d5ae032a3c3c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-remediation-rollup-v2.md": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "637376cc54f886bdbc382fa199e850ba",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945286647.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "11a7364ea340bb250bad8d70d30f57db",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945291289.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "65c3b89608984cca1148334f5d42de37",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-app-remediation-verification-prompt.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "216880b6e44687e66b709108cd334425",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25055987423.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "57149f38ba1f77f66f09f2e16d67157c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034902330.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "7808c3722928725915ed00fed782e3cc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/rider-app-phase-d-kickoff.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "2d3e29b64793be98611dbf2a498cc0dd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25111192377.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "cb4fba280865a1310c137f5d90555397",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945264424.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "d9cb3e4f5bd28740a997f99915656e63",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035462164.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "822eb67229f2f8fe1aee085a66994b25",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25033063543.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "c253b9906f336cabf7047d1efbbe5504",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013428873.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "a2570e12633387b73abe9d328b626652",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034039250.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "d43a5d9ab560dddb419646912766e7b2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P1b-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "bda75de434e742f6ad58ef80a492ea90",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025599985.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "82c1a0ad63fc781b9ceaa27423eb3e56",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015880051.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "f877462f3bcefd2793b484899d3dd6e2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944800572.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "6bb28aa60665412ef602527771994ba2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945353854.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "6725e413137043ebc2398726095522af",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25072739406.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "59ffc3b03a0e89c649133ce9232878cb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25019271412.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "96eb7107039d23a22c1a1808bc182a8d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P1a-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "0d7aa0f64913616a68a64e214b4d3923",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/rider-app-phase-a-kickoff.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "98b549489da18fb26160256c7270c424",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008995057.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "7ac209c6919e2fdd5e727c1dd9b477f8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25088402824.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "7c22e44a3735b6c7a5ca1eca15020b0b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25012245485.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "fae9851a2322e37caa731b5678b9a89f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945017921.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "062f7aa0b34d5aa9e82df77baf225881",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945711198.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "e24401b67c1095b2f7497e7516bdc40d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25090142427.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "ec71f45e156e7c13256fab97554d7ffa",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25065428627.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "a8986f1f681caf8484f4353450496bc5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034751494.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "77cdd3b9da747086fc1fcbaef3072be2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036400930.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "351a6d47548639bc8e6acf9dc885bb4d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25055779655.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "de03599a4ef3570eb865b9c64b59405a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25024936332.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "57dc49f58af65504df32ffeb6648d363",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945319383.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "ab09635b58b12620fb6fe0c28c169991",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25097240814.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "855219af678301b1f6d93b70080af48f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-backend-verification-rollup.md": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "744b0a3e689be9d6c379746eae5af222",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025794058.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "595975df2c9d65a944b8bfa34954db66",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958593840.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "b9c35f4158df0a6a2fe22ac0aff72557",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944794307.md": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "8c57766978a74d7f3a7a34f3648e5852",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036762472.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "84521acd766a54ab39dbb05a566eb6b4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-app-v1-phase-e.txt": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "db342fc1a55d670240e5f3267fa2e48c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009775104.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "0a91594c509b5465dcb33bc4a8e6eddb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-P2-verification.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "17780d33aef954a5a8a8bdaf09022328",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25089781013.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "a72d79865ceffc01234d0b9c01affa4e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017008921.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "436e23f87371e2757a7ab6a5e0474bdd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035203363.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "bd96d66106ee3ad04ce34ae82a4c4364",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034405550.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "d290fe75796395282cbb63c6cbb37512",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/rider-app-phase-b-kickoff.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "6974a376d773dc5f474fec6a3627b36a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036086779.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "7acd0dabfef6f03a34a491882d846177",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034108655.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "541ac54c31c4dc8aabcb32ac17e5a9e4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017234861.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "fb9c7085742559b807f4089b78efff39",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25029778052.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "fb1931401de8e82dbe6ecb684ee9ff21",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036887997.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "0f60e0a9fd8a807d436ab79d588e89e8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-19-rider-app-audit-plan-v1.md": {
-    "mtime": 1779512836.3535707,
-    "ast_hash": "6dde6ef212746478008f8ffb79f30451",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944893971.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "00979886a8b2181e81d747f092dbed7b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24966352255.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "828a097fe0ba30332a151702db939243",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25012047125.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "e003a561a5cc3caea8ebd2707ac030a2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-24971893826.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "0fb6ef963220814d1afcce7467db014b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008990402.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "b64ee9d5eca1a3f90e0a3c545ffa1b3e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009029968.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "d39ab60e82a4a87b1e8bfcb448f7720f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945825838.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "f1a1c8089022696b9099ac1175c6c64d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25012531371.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "7f66bc656b584af8d935c02b621b7806",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034736475.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "96a58537edec8f70fba75ddf9e9521c1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035353620.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "c0a5e0222be3ddd413be25664ce6e08c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008903284.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "f3ff1f1ef11c280c4c4ca4073f04ede4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062252024.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "2ab54591cba7e516632ab05aadb9c518",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-remediation-rollup.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "c88bc414547cf4d47ad2a9b853bb5b15",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-app-v5-phase-e.txt": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "a4e6e9c8dd687fe2cb71303e894f11f3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25028649571.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "ac80c16a7f085a7a1b81854accf8b2dc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062020257.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "6d370acfcacc6f893d142075a7e6fe53",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25019847121.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "23d023243a935e76da04463cc7993840",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036441598.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "443d85cefc7b7d380681f3d1004c83d0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25086838155.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "55dc1d71679c12736a526e411b88a0b4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009060503.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "bf27499f7f2bc6ccb71cca850fcad471",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037024689.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "4ac71c9d904e52b1f2527010175fd263",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25089344363.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "78c46ba9083216cdecb160057a9f9765",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25019835447.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "edd7bc3bf05405fb477926e6a8f76589",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017300131.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "b8e3c01631601c7813853621536c47fd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062276387.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "d18ccf93cb8f92d2fa559db6f3f101d5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036553035.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "34327921f9a3ddd09f92c513689c50c2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25016248234.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "e5d0d3060057f2ae642ccd4f5692f6ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25022063611.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "ee1326f550e7c9924281663b86eea6ab",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015232500.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "fc4b3690fd1b565fbc59a52bf959bde4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008937366.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "0515e75497f240dff6438520b9a6d3f3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945049763.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "52453ae5e67b8eb35142a9bef0936331",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25097160775.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "964535cdfe8488f71a141e1b22beb070",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945707306.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "becd4a3aa7e0f6f2f4d8cf52f9ee2c0b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944888427.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "5a035f47fb1a1dd53f82bad877ac672f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013778603.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "3496e3efae5ec6a6d6269a3cfa9a9356",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25012261186.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "a56c97b5064ae9de5318099a5abc194f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25026902104.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "eaedbe2751cd52c65b37d2908843f61d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944804387.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "4e34b25e0b6aac277e4358c7c4bd5f3a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015062722.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "ef934b69dd031b452bb13996fbb7dab9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25055649436.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "3ab24783a92b8cd83b500bd1ec68c615",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008955935.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "d802e8f152a72b8179d91e74a2dfd8cd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034224363.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "2cc7c9cf948b4e965fbd1fd0d2e732f5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-19-rider-app-v1.txt": {
-    "mtime": 1779512836.3535707,
-    "ast_hash": "ed061826a792f4bf525284e62e6b7504",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015239465.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "a8bb430ceeca6d2d51f4ead33fbc343a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944875975.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "3a70de3a02b86b66e17e7be3bdef5b99",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-24998603407.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "6978b76e29bf2796829149c5489626b7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25028644237.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "b504af79c61c98bc8f87ce649edc2905",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-P0-verification.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "8cf41fe9773a6bf781b35eee31c4c0e1",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035288481.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "a236ac29a134d1f078753107f0de7c15",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017319537.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "d04d7d24c4b870723b62220dd1c2919c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958604152.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "8e22b52c1c8ea0a164585ae4b44be42b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013444196.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "66a3c92b451402817634c96b8f51603d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25070862384.md": {
-    "mtime": 1779512836.4055948,
-    "ast_hash": "1d62b2d06c3f0b56dbfcdb2cb30028d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25024136979.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "767178b3c846027444c32a67523a3e99",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008898670.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "0a2b219e95a9528a1d20bdd332760b40",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958604972.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "49ee9c9b52d6469efb420191be4730bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-rider-P0-verification.md": {
-    "mtime": 1779512836.357595,
-    "ast_hash": "6bd9854a8ba864165b4730609faa1195",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035068637.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "f9db1205234534c3940c6462e5fc36b3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025601861.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "63ed687e5fd4544839fe981381305e85",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958597410.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "41148c4f0a09a30795720de089853f6e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945214553.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "785b726e5dc5359a60225ba92e37fe36",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25111180738.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "2b4ca17f64da9922a11f47327b1a9144",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036401545.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "86d194e7a5873b387f6d7a68812b8e2a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24946163037.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "43c8b1ad98268b97810e9fb393573ddd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25020763995.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "78cefdf0817d05801bbac1014427f671",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945783322.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "889670c0eb48b45af610a030bf44af69",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24952658738.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "2d934f32075c2fa9596056c5c42ac36c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037039765.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "df108b1431d60c32dcde09a2576a624f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958490551.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "36363589ac923da9e38c02be20afba27",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944764704.md": {
-    "mtime": 1779512836.361595,
-    "ast_hash": "32701aef4cc415938c993cdbb739dbe0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25054391658.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "41309e81fe0b74b91495b47ff8e36823",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25008854414.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "3922f58c5493383aa97f003d7463f9e3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25023204788.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "38d0e310241a1f811492cada2471bcb8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-18-driver-app-production-readiness-v4.txt": {
-    "mtime": 1779512836.3520193,
-    "ast_hash": "6db30f00eba06a58353e95d6e51421df",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25027662585.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "5a0ec7931e17e81eb50aa83aeb188537",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/INDEX.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "c231951ed6ddaf33a8eb59c6cb35e2f5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24946014176.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "edfbe202f2f366b091540c7cc97715d6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944968508.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "1edcadc5ab833f7bbc437b0af8e47a80",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25090299692.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "817b1919d853d8458783751e94f19a6c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013490677.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "fbac25bd09afa5a76621df5d8444735c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037713705.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "f39b0fa213a123b802680f2a5f6477b3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944898916.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "e28464231f3699f8db9e2576ba2d1e82",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25003802631.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "36d658a493b102a612e9f18e670a0a28",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24952571275.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "25333e651a7efac183dbd31743d8da42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017000877.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "7dbc865e1f6101d731ea8de69fb409ff",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035306973.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "d5c0232ca04d03c7410e12a35def1e16",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035424557.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "652d29b398cb6ab4072ba35be6398382",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945021308.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "2bf41ff74fd08ecd87edadda102114ba",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034302465.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "de09b110cd5dd0fa9d07aaf58ca4eebe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035607942.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "dd33a771e894ca4515aaa7814a848055",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945229930.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "209e66d793c67f8f239a44b5df94cf67",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25037171455.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "bf0d0f027181711c798d8789f9e035a5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944797087.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "24bf0b11995d36072039811a39332694",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/driver-app-phase-e-kickoff.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "1f8623aff04cb0ce8b5b9b1d2f0b8ac2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25062211688.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "383f74c7b3021b04b6c897783837fd2b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25111927427.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "abf56863a4921f6acd2666e72537e04b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24970132054.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "8593edf85baf48bec8655f64007bb111",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25036326728.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "d462e31927d4c8f3ec2cf5677d816895",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25022947665.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "9cfcbfbd29399e06158b7c0bdef47cbd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009330988.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "1107d071389d8d653c2d8f718a1e2111",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944801843.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "be7774d66cda2f44b4e6289a19a604fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944976594.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "a7e64c686b19fa342814a8af00aae01d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035423763.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "019ebeb47c22531f736c826deca02a56",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945039910.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "4af9597c055db07485e03b60a03fc508",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25031823134.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "96d4fa24439042560d6cf8c561464401",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24958609656.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "2c79d68f87f082c0f0e9ee5157997a39",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945715550.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "29e9bc5340d6bf7434d28ba643e7d539",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25024592786.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "68aec8a41093191df2252a53e0c72ed6",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945772947.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "36f84f0fc34fbfc6b14676b92dd1ecea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25017015169.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "247a3619fa51399140595d2c7d1ab5f9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945768438.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "6bce05aa3a075850335c9fcafc036c5f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25015099453.md": {
-    "mtime": 1779512836.3855948,
-    "ast_hash": "f205bc23af02a1c285db951128900972",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25111189644.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "04405bfbcf7dad156e8d8121142379d4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944799714.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "f2caf95221db38bd2e04529ab77a3616",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944910328.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "8cac78600982e0282c558f2227292095",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944804476.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "8a3c3cd3840dbb9243bd05bb478ab6bd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25098644977.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "21fa3e1fb765ad39171aa57dacf8f65a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944799002.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "4e7a11a36d43a50f9bac6ae08dc53602",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25009659457.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "1a7d946291fb7d2655964d7d8855afba",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24965609677.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "33a32db57644cfca266650c8abf5c543",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-master-rollup-top10.md": {
-    "mtime": 1779512836.373595,
-    "ast_hash": "2a52b89f60afae1a85c9dc0525e89fb9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945726619.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "402abb81f67f13f21f2ae4e290258802",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025016729.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "ef2e5c1f3c86276701cd59930be1e3be",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25058609319.md": {
-    "mtime": 1779512836.4015949,
-    "ast_hash": "e129e18cc620204da34afbf6b49f9d2c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945846322.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "6b388b9282e6b2b85fba506f105f7382",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945796722.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "e394807bf127e170c78a7e81bb377e14",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-P4-verification.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "f86b0daeb3a004680a9651a715548d1b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24945850551.md": {
-    "mtime": 1779512836.3695948,
-    "ast_hash": "8fda4208d6bb40564f01204be9342132",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944882309.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "9eeb091af33c144c9fd9aabfb0b7d5bf",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25033059373.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "a615e5a2fec88f5e7da484c3440d42d7",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25025239030.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "cedfc53ff33e1fa5211aedc282a3fc20",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25027232490.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "95d85626315825eb532375455cc22db5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25013278686.md": {
-    "mtime": 1779512836.377595,
-    "ast_hash": "962be2dbd1a31ea1aec2746010c60f73",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/rider-app-phase-c-kickoff.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "91782663d4854fdfe84a3e02a1a95bff",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944900982.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "2722313a127d12a7fb4ab98fc470ffb4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-29-ci-failure-25096530184.md": {
-    "mtime": 1779512836.409595,
-    "ast_hash": "1eceb895b4b3b3cdefd39df92dca8a45",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25035548099.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "6d3e4760131dbbd47b8f8f74a88184b5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-27-ci-failure-25023188924.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "52ed683b110e22938d83dbe5c8e9f438",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25054526719.md": {
-    "mtime": 1779512836.397595,
-    "ast_hash": "555a258533af6053a53aab176ab0ddf2",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-driver-P3-verification.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "6d5bf1d96ec53f42884a89d00e788487",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-26-ci-failure-24944996988.md": {
-    "mtime": 1779512836.3655949,
-    "ast_hash": "2feea9820e620e05edd336fce42f8428",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25027568531.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "513c55ea86b25f2ea4dbe6d1fec87a14",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25034383045.md": {
-    "mtime": 1779512836.393595,
-    "ast_hash": "87a37967c3497eb14e2ea6b74459d3cc",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-23-backend-api-audit-plan-v1.md": {
-    "mtime": 1779512836.353595,
-    "ast_hash": "20d45202aceb46dadc240ba6d1de2090",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/reports/audits/2026-04-28-ci-failure-25031826780.md": {
-    "mtime": 1779512836.3895948,
-    "ast_hash": "6395e2f9f92a4cac98288235111de528",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/dependency-upgrade-runbook.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "5e7c6cfc6abcf4431dfc6f9838f47cc3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/incident-response.md": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "54499a11cfdfb8c1a283a1495879473b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/dev-setup.md": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "18b46ba712c6e78437a7ba14d1fdc26c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/android-build-strategy.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "d2f4b7436beffd3b3085c5f21b908017",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/data-classification.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "aa4c845d8fc43d1ac0430a2b83c17998",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/vendor-inventory.md": {
-    "mtime": 1779512835.5483928,
-    "ast_hash": "c02960dbd728d86d4bc811051beb9039",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/ci-security-gates.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "a61c4f590a1f74c4d2d2224e2e6d2d77",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/proposed-claude-audit-ci.yml": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "bb4b097ec63c097a19394c27858dfccb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/API_REFERENCE.md": {
-    "mtime": 1779512835.499381,
-    "ast_hash": "8284226da1b5e7afe42bb9f4be12eb90",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/CORPORATE_B2B.md": {
-    "mtime": 1779512835.499381,
+  "docs/CORPORATE_B2B.md": {
+    "mtime": 1780622912.7077994,
     "ast_hash": "ae9fde0297c214353e8138ef9ab82274",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/external-testing.md": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "8694c53d70992f166c776f9260289a21",
+  "docs/ENVIRONMENT_VARIABLES.md": {
+    "mtime": 1780673747.852506,
+    "ast_hash": "a53df78db55d48149af074b73eba7265",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/ACCESSIBILITY.md": {
-    "mtime": 1779512835.493595,
+  "docs/ACCESSIBILITY.md": {
+    "mtime": 1780622912.706926,
     "ast_hash": "dfcf8999e8e0c5665324f9b52bf62dc6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/E2E_TESTING.md": {
-    "mtime": 1779512835.499381,
+  "docs/E2E_TESTING.md": {
+    "mtime": 1780622912.7077994,
     "ast_hash": "13f714fd362d3548748a696c2a473c13",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/accessibility-plan.md": {
-    "mtime": 1779512835.499381,
-    "ast_hash": "b83eb40eb59d68055c801c800f2c6d42",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/dpa-register.md": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "2ccf6f03b1ff3dc5f2560f405097b339",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/MOBILE_SMOKE.md": {
-    "mtime": 1779512835.499381,
-    "ast_hash": "a866c562fa5ae78a19cdaba84cff4e18",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/vendor-register.md": {
-    "mtime": 1779512835.5483928,
-    "ast_hash": "94a6791232d1b728021418e452d0d8a0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/E2E_TEST_GAP_ANALYSIS.md": {
-    "mtime": 1779512835.499381,
-    "ast_hash": "5547d21afb0a1d3aa68af5bf9f3784ed",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/claude-audit-2026-04-22.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "bd4efc605029086f004b4f9bf9aece22",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/ENVIRONMENT_VARIABLES.md": {
-    "mtime": 1779512835.499381,
-    "ast_hash": "83f8496594b6f16ef30715f33cacac8b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/slo.md": {
-    "mtime": 1779512835.5373926,
-    "ast_hash": "4a639e51edcdb869c78d72e302b22822",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/superpowers/plans/2026-04-16-corporate-b2b-plan-1-foundation.md": {
-    "mtime": 1779512835.5394108,
-    "ast_hash": "3c56c8980b42a2da1e939b85df156417",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/superpowers/plans/2026-04-18-corporate-b2b-plan-3-employee-allowances.md": {
-    "mtime": 1779512835.5394108,
-    "ast_hash": "3fdf3c450f8624d77891c1bc8307c67c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/superpowers/plans/2026-04-05-rider-app-ui-richness.md": {
-    "mtime": 1779512835.5384493,
+  "docs/superpowers/plans/2026-04-05-rider-app-ui-richness.md": {
+    "mtime": 1780622912.7397575,
     "ast_hash": "f801cb915e2b9c41cc3da26782d17eef",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/superpowers/plans/2026-04-13-live-monitoring-page.md": {
-    "mtime": 1779512835.5394108,
-    "ast_hash": "78efe99514df0395ff7573e4792b2234",
+  "docs/superpowers/plans/2026-04-16-corporate-b2b-plan-1-foundation.md": {
+    "mtime": 1780622912.7410238,
+    "ast_hash": "3c56c8980b42a2da1e939b85df156417",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/superpowers/plans/2026-04-16-corporate-b2b-plan-2-wallet-stripe.md": {
-    "mtime": 1779512835.5394108,
+  "docs/superpowers/plans/2026-04-16-corporate-b2b-plan-2-wallet-stripe.md": {
+    "mtime": 1780622912.7410238,
     "ast_hash": "53798556d5a8e0f1442e43833c6c4296",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/superpowers/specs/2026-04-05-rider-app-ui-richness-design.md": {
-    "mtime": 1779512835.541595,
+  "docs/superpowers/plans/2026-04-13-live-monitoring-page.md": {
+    "mtime": 1780622912.7404864,
+    "ast_hash": "78efe99514df0395ff7573e4792b2234",
+    "semantic_hash": ""
+  },
+  "docs/superpowers/plans/2026-04-18-corporate-b2b-plan-3-employee-allowances.md": {
+    "mtime": 1780622912.7410238,
+    "ast_hash": "3fdf3c450f8624d77891c1bc8307c67c",
+    "semantic_hash": ""
+  },
+  "docs/superpowers/specs/2026-04-05-rider-app-ui-richness-design.md": {
+    "mtime": 1780622912.7410238,
     "ast_hash": "fa27a5ca1f6af4cdbb33baba4071f5ef",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/superpowers/specs/2026-04-13-live-monitoring-page-design.md": {
-    "mtime": 1779512835.5451398,
-    "ast_hash": "3de4d27948edf13fbc13cae3c9ee7ffe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/superpowers/specs/2026-04-15-corporate-accounts-b2b-design.md": {
-    "mtime": 1779512835.5451398,
+  "docs/superpowers/specs/2026-04-15-corporate-accounts-b2b-design.md": {
+    "mtime": 1780622912.7446282,
     "ast_hash": "911578e1cbfbc9716044a392fe440598",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/threat-model/admin-panel.md": {
-    "mtime": 1779512835.5466428,
-    "ast_hash": "24d3b62592367bd100735c8df825fa63",
+  "docs/superpowers/specs/2026-04-13-live-monitoring-page-design.md": {
+    "mtime": 1780622912.7446282,
+    "ast_hash": "3de4d27948edf13fbc13cae3c9ee7ffe",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/threat-model/backend.md": {
-    "mtime": 1779512835.5483928,
-    "ast_hash": "6466e6d47d16569708b9eecd9395a7f0",
+  "docs/runbooks/api-down.md": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "26894df3eb1fd691ce1fa82c02671622",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/threat-model/rider-app.md": {
-    "mtime": 1779512835.5483928,
-    "ast_hash": "37d323bff1eb5ea197d79cbe32ea24b0",
+  "docs/runbooks/driver-not-receiving-rides.md": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "3ca1ba8dd392025225fc3ab793b57da8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/threat-model/driver-app.md": {
-    "mtime": 1779512835.5483928,
-    "ast_hash": "54826bcc9eaade07a9d208dd76a03507",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/REFERENCE.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "fe844699d1c3830245ac0bbc97f64fc8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/INFRASTRUCTURE.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "3be5d6f68e8d905327c362f057154893",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/AUTH_AND_USERS.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "b7333cf5b074283ea9e35fb67dae29d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/README.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "7decd3988f8596abc12ef0ef94f727b9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/ADMIN_AND_OPS.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "dc4703f693237744bc361ce2a2113fa8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/WALLET_AND_PAYMENTS.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "f003c057ccfe2f91fe6ecd0a6d35be37",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/ARCHITECTURE.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "820661b2c597f16970de84860d6dda31",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/backend/RIDES_AND_DISPATCH.md": {
-    "mtime": 1779512835.519389,
-    "ast_hash": "665db2db6588f4d4ddd774be46b7a757",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/07_SPRINT_4_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "1299c4219f7056c2933d5bf0f034c574",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/02_SPRINT_PLAN.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "66235335ae0280fbd0e66ad3d73664c3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/03_SPRINT_1_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "cc38fa8ec94e77af352ba4aca5311817",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/00_SPINR_FULL_OVERVIEW.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "0374662c03363c2021ca27131434048d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/14_CONTINUOUS_AUDIT_PLAYBOOK.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "ca96d85c6cd46f81ee56f912d6f31f79",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/15_TECH_STACK_AND_FILE_MAPPING.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "9f84ec1ecdb03ba66148f28160af18f3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/17_FIELD_ALIGNMENT_AUDIT.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "a601e4edb905acf26a11897ab0439e1d",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/ADMIN_DASHBOARD_AUDIT_PROMPT.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "c4431d55b2b73f610fb8b78f5929c7f9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/04_SPRINT_2_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "8850a64c60138209f987dfbbe2672a8a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/11_SPRINT_8_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "8403641722c16e370978003af093de78",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/10_SPRINT_7_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "1a11c4f7d50112dc73d19ddcec8f242e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/16_TOOLS_AND_LANGUAGES_BY_MODULE.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "dbbc212d78e6f0ef22435b8d4e2b6924",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/05_SPRINT_3_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "6bad5b7e40bba2f464da65e19f1ea446",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/06_PROJECT_SUMMARY.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "10250bbac5aa3d96b26f4b01546f71fe",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/01_AUDIT_GAPS_REPORT.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "2d5508745f09a448e76ac9e020df869a",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/08_SPRINT_5_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "a643ce027f89e63524e9bccec076ec05",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/09_SPRINT_6_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "980ef7168da6641d1d0d5715aea7510f",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/12_SPRINT_9_COMPLETION.md": {
-    "mtime": 1779512835.5061452,
-    "ast_hash": "fa93d9cc53317255f9cbbd1bccb28657",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/02-auth-rbac.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "75268a5af9aa7e65c48fa4766e836923",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/06-perf-ux-a11y.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "1494dbb1a1881b7b7ffdf21850ac4707",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/04-backend-security.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "3db4306af4eda0f84c806c0d522447a4",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/00-inventory.md": {
-    "mtime": 1779512835.509595,
-    "ast_hash": "8a67058c1843b12593ff4863a8219516",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/05-privacy-logging.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "e31356c690e6b139d8dfd355d70dd66b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/REPORT.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "2598863c8702f29d7d8beb84c7b34565",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/01-sast.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "18e53d2bec3730c994796aee7eb1d25c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/REMEDIATION_PLAN.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "7fd386920c0f3c6e547d4fbd2936781e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/admin-dashboard/03-dast.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "de9a52d0a08420ad832ea91ce78e44fb",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/audit/daily/2026-04-11.md": {
-    "mtime": 1779512835.5143783,
-    "ast_hash": "5c45c5ccb8ab519fc19ff08398113f1c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/runbooks/stripe-reconciliation.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "03d83ff26b2fbeee814a8c6a928c41c9",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/runbooks/data-breach.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "c33e7cb29762d44c5cddba6b65e4a223",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/runbooks/otp-lockout-false-positive.md": {
-    "mtime": 1779512835.529595,
+  "docs/runbooks/otp-lockout-false-positive.md": {
+    "mtime": 1780622912.7330236,
     "ast_hash": "0850fc15f5aba662e4b9f0ffdd935032",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/admin-pwa.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "130d17104341c50c5a4b7603291f4b77",
+  "docs/runbooks/stripe-webhook-failure.md": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "ec58e0c8e5069ac1493b6d188a9c4f63",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/pitr-restore.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "63438c1beb72c911469f0bffd5fad06a",
+  "docs/backend/INFRASTRUCTURE.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "3be5d6f68e8d905327c362f057154893",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/dependency-audit.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "feaa8d43d41ce21481e894b696098661",
+  "docs/backend/ADMIN_AND_OPS.md": {
+    "mtime": 1780622912.7210238,
+    "ast_hash": "dc4703f693237744bc361ce2a2113fa8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/rate-limits.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "22aad802e669783ff87aea6d90bf98f7",
+  "docs/backend/WALLET_AND_PAYMENTS.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "f003c057ccfe2f91fe6ecd0a6d35be37",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/migration-conflict-detection.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "901542cf469c8803a610125047799bf2",
+  "docs/backend/AUTH_AND_USERS.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "b7333cf5b074283ea9e35fb67dae29d3",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/stripe-webhook-failure.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "e7d5a262b733aea027bdcf2fea4b94c3",
+  "docs/backend/README.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "7decd3988f8596abc12ef0ef94f727b9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/api-down.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "e0e4cba775b3effabf6404ea389606e7",
+  "docs/backend/REFERENCE.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "fe844699d1c3830245ac0bbc97f64fc8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/saskatoon-launch.md": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "a9379192d67c5c509bb5c205518824c5",
+  "docs/backend/RIDES_AND_DISPATCH.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "665db2db6588f4d4ddd774be46b7a757",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/admin-rollback.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "73c5a86eeed97c1d2750948dcdfb3548",
+  "docs/backend/ARCHITECTURE.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "820661b2c597f16970de84860d6dda31",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/sos-incident.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "5920e24e63fbd534ed8badbc72b1070a",
+  "docs/audit/02_SPRINT_PLAN.md": {
+    "mtime": 1780622912.7126453,
+    "ast_hash": "66235335ae0280fbd0e66ad3d73664c3",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/redis-down.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "8720b2f3cc00b53f51ccacb40212f435",
+  "docs/audit/06_PROJECT_SUMMARY.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "10250bbac5aa3d96b26f4b01546f71fe",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/supabase-down.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "f7d039fae2d8fc780be4adad5851deb5",
+  "docs/audit/03_SPRINT_1_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "cc38fa8ec94e77af352ba4aca5311817",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/deploy-migration-64-65.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "c2f8f399e759f92afda4291c1cdc3095",
+  "docs/audit/00_SPINR_FULL_OVERVIEW.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "0374662c03363c2021ca27131434048d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/data-retention.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "a2a9e8e9c3620464de53b2345bfee46b",
+  "docs/audit/12_SPRINT_9_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "fa93d9cc53317255f9cbbd1bccb28657",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/MOBILE_SMOKE.md": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "3d050ecc91d84947854f51c4b3ff6f68",
+  "docs/audit/14_CONTINUOUS_AUDIT_PLAYBOOK.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "ca96d85c6cd46f81ee56f912d6f31f79",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/websockets.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "878a1897c8f7d40f40c1233ebf49f780",
+  "docs/audit/16_TOOLS_AND_LANGUAGES_BY_MODULE.md": {
+    "mtime": 1780622912.7170236,
+    "ast_hash": "dbbc212d78e6f0ef22435b8d4e2b6924",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/dependency-update.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "a146003990a7e827f81ac010a2b28730",
+  "docs/audit/04_SPRINT_2_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "8850a64c60138209f987dfbbe2672a8a",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/app-store-review.md": {
-    "mtime": 1780060957.308439,
-    "ast_hash": "eb4b3db13764423869813ad342fe0408",
+  "docs/audit/10_SPRINT_7_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "1a11c4f7d50112dc73d19ddcec8f242e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/docker-image-pinning.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "715b16f98924370595fbe25c57724d57",
+  "docs/audit/15_TECH_STACK_AND_FILE_MAPPING.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "8e91d711ffd9af73d5cb85e560588261",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/error-responses.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "d518f925d3c4a52bc3c4e8cf3f768f3b",
+  "docs/audit/08_SPRINT_5_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "a643ce027f89e63524e9bccec076ec05",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/pii-key-rotation.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "392f40e300ef522198530965cc738d95",
+  "docs/audit/11_SPRINT_8_COMPLETION.md": {
+    "mtime": 1780673747.852506,
+    "ast_hash": "00b5cc55c32af1cebe692c579f444f7e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/security-incident.md": {
-    "mtime": 1779512835.529595,
-    "ast_hash": "d486209499f876bd43ee2dc247a8e2f3",
+  "docs/audit/09_SPRINT_6_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "980ef7168da6641d1d0d5715aea7510f",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/runbooks/driver-not-receiving-rides.md": {
-    "mtime": 1779512835.5273917,
-    "ast_hash": "e3eedc88c9872180c2a6c750d5b117cc",
+  "docs/audit/05_SPRINT_3_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "6bad5b7e40bba2f464da65e19f1ea446",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/adr/002-expo-react-native.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "b8f45afb30cf31c5b3c4444ffbfb1210",
+  "docs/audit/07_SPRINT_4_COMPLETION.md": {
+    "mtime": 1780622912.7130237,
+    "ast_hash": "1299c4219f7056c2933d5bf0f034c574",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/adr/001-supabase-postgres.md": {
-    "mtime": 1779512835.499381,
-    "ast_hash": "3e655c382193d67990cad4fd7a8c0bb3",
+  "docs/audit/01_AUDIT_GAPS_REPORT.md": {
+    "mtime": 1780622912.7126453,
+    "ast_hash": "2d5508745f09a448e76ac9e020df869a",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/adr/README.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "5f636f01e0515634f3e9706664a0fbfe",
+  "docs/audit/daily/2026-04-11.md": {
+    "mtime": 1780622912.7210238,
+    "ast_hash": "5c45c5ccb8ab519fc19ff08398113f1c",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/adr/004-redis-in-process-fallback.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "a20320cc764f1237dd47dc0553d75911",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/adr/003-fastapi-backend.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "7f6bb8cc6bc8512a1e61ee32da2c4567",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/adr/006-railway-deployment.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "de11f60df1090a2410afdbf3eed87757",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/adr/005-jwt-firebase-dual-auth.md": {
-    "mtime": 1779512835.5027134,
-    "ast_hash": "d21bddf135b1efb86dd630b14613e905",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/scoping/P0-5_PHASE_E_RUNBOOK.md": {
-    "mtime": 1779512835.5335948,
-    "ast_hash": "5743b01552d6978a3b876b2e2c16aa63",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/scoping/P0-5_STRIPE_CARD_CHARGE.md": {
-    "mtime": 1779512835.5373926,
-    "ast_hash": "4ad5d262f0bba89356f6e8ac82ed430b",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/testing/ADMIN_DASHBOARD_TESTING.md": {
-    "mtime": 1779512835.5451398,
-    "ast_hash": "410806dbbf39739a18f245469aa55b47",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/testing/FRONTEND_RIDER_TESTING.md": {
-    "mtime": 1779512835.5466428,
-    "ast_hash": "bd09b2b8f385133a16c0155b621237e8",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/testing/BACKEND_TESTING.md": {
-    "mtime": 1779512835.5466428,
-    "ast_hash": "e94f8642ca7d5e481b03357c5ccb3343",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/docs/testing/DRIVER_APP_TESTING.md": {
-    "mtime": 1779512835.5466428,
+  "docs/testing/DRIVER_APP_TESTING.md": {
+    "mtime": 1780622912.7450237,
     "ast_hash": "c7eb25932534123812ffedfe522259eb",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/docs/handoff/P1_NEXT_SESSION_PROMPT.md": {
-    "mtime": 1779512835.521595,
-    "ast_hash": "8c109e8928c6b392e1a64497ea470d79",
+  "docs/testing/ADMIN_DASHBOARD_TESTING.md": {
+    "mtime": 1780622912.7450237,
+    "ast_hash": "410806dbbf39739a18f245469aa55b47",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/P0_ARCHITECTURE_BLUEPRINT.md": {
-    "mtime": 1779512834.9288692,
-    "ast_hash": "12204a2b204e8b4985befeedd72702cf",
+  "docs/testing/BACKEND_TESTING.md": {
+    "mtime": 1780622912.7450237,
+    "ast_hash": "e94f8642ca7d5e481b03357c5ccb3343",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/P3_SESSION_HANDOFF.md": {
-    "mtime": 1779512834.9288692,
-    "ast_hash": "4f16e2f6c428debdd9129dc5809be3bf",
+  "docs/testing/FRONTEND_RIDER_TESTING.md": {
+    "mtime": 1780622912.7450237,
+    "ast_hash": "bd09b2b8f385133a16c0155b621237e8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/README.md": {
-    "mtime": 1779512834.9288692,
-    "ast_hash": "3a8ddd9711527942705e2a08a5c81848",
+  "admin-dashboard/README.md": {
+    "mtime": 1780622912.429842,
+    "ast_hash": "f15aaa42d5d299d091b1171097ea56ad",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/P3_HTTPONLY_DETAILED_DESIGN.md": {
-    "mtime": 1779512834.9288692,
-    "ast_hash": "e7d272008e9aa157d3e7f33cda5bf8ee",
+  "agents/README.md": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "a0b72b96bb0e559033c76c7075227127",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/P0_TASK_BREAKDOWN.md": {
-    "mtime": 1779512834.9288692,
-    "ast_hash": "be53624544b13b3d8518cda791e7db15",
+  "frontend/tsc_errors.txt": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "9e82d700e437f25667905cdd3da38da9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/FRESH_SESSION_START_HERE.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "feff5deee3cb8a2f5295cef998c03844",
+  "frontend/README.md": {
+    "mtime": 1780622913.201249,
+    "ast_hash": "1a436ff3029b0bb9aebb68174f0621d1",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/agents/spinr-migration-reviewer.md": {
-    "mtime": 1779512834.9288692,
-    "ast_hash": "093b001843355140e5d9291b5031800e",
+  "frontend/DEPRECATED.md": {
+    "mtime": 1780622913.201249,
+    "ast_hash": "2d671863289b03f696ff1129cf8357fa",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/agents/spinr-security-auditor.md": {
-    "mtime": 1779512834.930894,
-    "ast_hash": "51110701ada40667617bc67843f632d0",
+  "reports/README.md": {
+    "mtime": 1780622913.6130238,
+    "ast_hash": "cbb469d7db650d13c65b3794886b3ae6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/agents/spinr-money-auditor.md": {
-    "mtime": 1779512834.930894,
-    "ast_hash": "3ac532a8c60287c69cbc575ef18cdb5c",
+  "reports/remediation/P0-critical-fix-now.md": {
+    "mtime": 1780622913.6607738,
+    "ast_hash": "2e5d4f5dd1c3ed239e66b879e12db21c",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/incident.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "2b2a4bc11008f8f86303f5e9bfb39ec3",
+  "reports/remediation/P4-future-features.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "347afabbdaae3fb4d84f9a70705ac064",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/start.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "4e0e56bd7c055087fcec1f8b55abd156",
+  "reports/remediation/P3-hardening.md": {
+    "mtime": 1780622913.6607738,
+    "ast_hash": "82d9ff436738b451de0382425d462db8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/status.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "129e47c4a90e4bbd02aa43de59e681c9",
+  "reports/remediation/P2-before-launch.md": {
+    "mtime": 1780622913.6607738,
+    "ast_hash": "3c2aa2c95774a687a54d4748d9b55215",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/review.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "943d7ff203fd0157df70799b5516b836",
+  "reports/remediation/P1-before-beta.md": {
+    "mtime": 1780622913.6607738,
+    "ast_hash": "ec766959b2a801f38b695ff7fc8a50f6",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/migration-check.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "309713fdddc0586de83edc7612176443",
+  "reports/audits/task14-performance-scalability.txt": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "8e97cb5b2d56e8afd7c57b4db7206693",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/adr.md": {
-    "mtime": 1779512834.930894,
-    "ast_hash": "ed618e023d50280b194e1e3753e83753",
+  "reports/audits/2026-04-18-driver-app-production-readiness-v4.txt": {
+    "mtime": 1780622913.6145463,
+    "ast_hash": "6db30f00eba06a58353e95d6e51421df",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/pr.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "b1cb2199adf561b8420b6c8d64537ed1",
+  "audit-framework/README.md": {
+    "mtime": 1780622912.518087,
+    "ast_hash": "adea72f5c25dd28edf9ad75639a8ce28",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/commit.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "bb741b153e3c6d1b79207739d9253a63",
+  "audit-framework/ground-rules.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "dde4f3763e5fc0198a3f9b044bd4b111",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/plan.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "9fffde147ee6aff8e5f8a9dcd9a9d998",
+  "audit-framework/modules/admin-panel.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "b1bf1fd37208a904eef1014947d8b130",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/commands/fare-audit.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "cad27d2c190c174a9bf997312b767a6f",
+  "audit-framework/modules/driver-app.md": {
+    "mtime": 1780622912.5227118,
+    "ast_hash": "dead2b15cc93140e88cb833a2a15a677",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/context/domain-dispatch.md": {
-    "mtime": 1779512834.9323454,
-    "ast_hash": "9304c9a6f4940c1ae944cf19bd555b72",
+  "audit-framework/modules/rider-app.md": {
+    "mtime": 1780622912.5227118,
+    "ast_hash": "8071f10bfa84b976ba3f00650dc631f4",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/context/domain-safety.md": {
-    "mtime": 1779512834.9349425,
-    "ast_hash": "0d45380267ded857fb9d99175d5d784c",
+  "audit-framework/modules/backend-api.md": {
+    "mtime": 1780622912.5227118,
+    "ast_hash": "27662aca5a9ce6ab9c10d102740b2d30",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/context/sprint-current.md": {
-    "mtime": 1779512834.9349425,
-    "ast_hash": "c0b8779fbc459edd33dd7a59aa83dfd5",
+  "audit-framework/dimensions/11-security-headers-cors.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "2fba20c008f1bcadc34e7697534e8db1",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/context/regulatory-sk.md": {
-    "mtime": 1779512834.9349425,
-    "ast_hash": "27a71446f8569ea494169b05db922090",
+  "audit-framework/dimensions/04-input-validation.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "9e9890aa5e25e50a4e062c35d84bba68",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.claude/context/domain-payments.md": {
-    "mtime": 1780060957.248439,
-    "ast_hash": "3c37b1b9e540c3c0e82861a172ff9ac2",
+  "audit-framework/dimensions/02-authentication.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "b5bc734314d9fc2585a92fdcb9579c69",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/standards/security-standards.md": {
-    "mtime": 1779512834.9242082,
-    "ast_hash": "607e91cf702d9bed3365008690cc3101",
+  "audit-framework/dimensions/07-state-machine.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "25039c217d86a06e9596480870aefa44",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/standards/testing-standards.md": {
-    "mtime": 1779512834.9242082,
-    "ast_hash": "0168abbf4bbc09573a272c8fa4b3a56a",
+  "audit-framework/dimensions/06-real-time.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "cffb72b0a1adf460261dc7da544784a8",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/standards/coding-standards.md": {
-    "mtime": 1779512834.9242082,
-    "ast_hash": "8ee5069902d00ea1ac452b1a5cab3bc4",
+  "audit-framework/dimensions/01-feature-completeness.md": {
+    "mtime": 1780622912.518087,
+    "ast_hash": "b67a2005da381deae807cbb2d93c7d46",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/standards/api-standards.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "ec7eae361afea5441c27e0baeb933b79",
+  "audit-framework/dimensions/14-performance-scalability.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "8ab8112f042b34c12ec2391124b59ae3",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/update-docs.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "7a16a94a048ea29d6e0b63536b07c500",
+  "audit-framework/dimensions/09-test-coverage.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "3bd5ca234deb7b10e2ff1a393f5c4a28",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/code-review.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "658287484d2aed2b8bdb7c7c592e583b",
+  "audit-framework/dimensions/12-compliance-pii-pci.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "07ba995d43bb10325bfdbf481ee9cd21",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/security-audit.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "81ec5930910532b32fc98ce711f2e081",
+  "audit-framework/dimensions/16-i18n-localisation.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "19249056aa3f56be755b149cfca0af3c",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/pre-commit.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "d8d940454fd60b722f1ce462ad741e0f",
+  "audit-framework/dimensions/10-error-handling.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "e359343cf380aac414c7e4f7d79d9c21",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/deploy-backend.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "5037f7c7e12d9db485bd4bf45d1c75ae",
+  "audit-framework/dimensions/13-notifications-ai-faq.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "7f2968dd7f5fee793183567be346163b",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/new-feature.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "ff43d0a34bbb4d24528ee3b200ecbcfd",
+  "audit-framework/dimensions/08-payments.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "2fadd149b65aae825a77dd5e4de3c8d2",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/deploy-frontend.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "02372adb62142061fe661ce8b94d2ce5",
+  "audit-framework/dimensions/05-ui-ux-android-ios.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "249f30885bd25a5370517b19de1149c9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/multi-agent-review.md": {
-    "mtime": 1779512834.9255974,
-    "ast_hash": "6acd2880395f86dc36d7d6df1a363f59",
+  "audit-framework/dimensions/15-accessibility-wcag.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "aa798a1b90d6ca2e0afe084723213aa7",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/workflows/bug-fix.md": {
-    "mtime": 1779512834.9242082,
-    "ast_hash": "ac983f2a888c2a8f66e9e2dc821395db",
+  "audit-framework/templates/remediation-group.md": {
+    "mtime": 1780622912.5240145,
+    "ast_hash": "8a24f7ba65d66f35a28281c6481a8c05",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/devops-engineer.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "e073492715c7119586883249e94b4a25",
+  "audit-framework/templates/audit-output.txt": {
+    "mtime": 1780622912.5227118,
+    "ast_hash": "9996a3c42c504a607a6bd48f0cce2ce9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/documentation-lead.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "977409e2715d6b267c560311e6400b54",
+  "audit-framework/templates/run-audit.md": {
+    "mtime": 1780622912.5240145,
+    "ast_hash": "0bb2affb463f857bc38113dc8804b7c4",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/security-engineer.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "3340005bebeace0ab3c1fa243316d639",
+  "driver-app/assets/images/react-logo@3x.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "8a4d0e5b845044e56e3b2df627d01cfd",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/frontend-developer.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "949da1f6e54d0879e20cc4963be16318",
+  "driver-app/assets/images/icon.png": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "92225e5942757c2f15e32401eb1b1b3d",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/qa-engineer.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "30577ad6ae88c5ab6dcfe689575836b8",
+  "driver-app/assets/images/favicon.png": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "225b422b6a74db10f24efa165dfea5bf",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/tech-lead.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "1fd1cc0cbc07efb5f7e1c484323f1d0c",
+  "driver-app/assets/images/react-logo.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "695d5a1c6f29a689130f3aaa573aec6e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/.agents/roles/backend-developer.md": {
-    "mtime": 1779512834.9194322,
-    "ast_hash": "9b81b91da21e71f3990956e712bbb4f5",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.agents/roles/business-analyst.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "d1c62fbd26ac84647b1786a7a31c3d62",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.agents/roles/manager.md": {
-    "mtime": 1779512834.921179,
-    "ast_hash": "938271021d9b206bcf0ca92160c0d114",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.agents/docs/api-reference.md": {
-    "mtime": 1779512834.9181972,
-    "ast_hash": "4477247ea97bc1b32045f56ab521d846",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.agents/docs/architecture.md": {
-    "mtime": 1779512834.9194322,
-    "ast_hash": "a6bc304bf58b869c3b57fecf40229d65",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.agents/docs/deployment-guide.md": {
-    "mtime": 1779512834.9194322,
-    "ast_hash": "2c51fcf81b6224e833debc8b61f086d3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/.agents/docs/database-schema.md": {
-    "mtime": 1779512834.9194322,
-    "ast_hash": "71a00ece5d03f0cb97abe5ac60643ef0",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/shared/assets/car-top.svg": {
-    "mtime": 1779512836.4861226,
+  "driver-app/assets/images/car-top.svg": {
+    "mtime": 1780622912.7684844,
     "ast_hash": "00d80e3d68e716f0e7bddcd595cc4215",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/shared/assets/car_marker.png": {
-    "mtime": 1779512836.4873166,
-    "ast_hash": "8c87b8b385b57c4e6c9dbd374a7cf4ea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/partial-react-logo.png": {
-    "mtime": 1779512835.581595,
+  "driver-app/assets/images/partial-react-logo.png": {
+    "mtime": 1780622912.7690237,
     "ast_hash": "8f14e478886737f3323a2ac79c833749",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/assets/images/car-top-3d.svg": {
-    "mtime": 1779512835.577595,
+  "driver-app/assets/images/car_marker.png": {
+    "mtime": 1780622912.7684844,
+    "ast_hash": "8c87b8b385b57c4e6c9dbd374a7cf4ea",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/images/car-top-3d.svg": {
+    "mtime": 1780622912.7684844,
     "ast_hash": "5c54f8dfb9fb1c5d865c75796c2d4dea",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/assets/images/react-logo.png": {
-    "mtime": 1779512835.581595,
+  "driver-app/assets/images/react-logo@2x.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "b507e7f2c91ebc8fe24dee79ccb3b600",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/images/adaptive-icon.png": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "d05dc014d48afc0dcbf547a4073598be",
+    "semantic_hash": ""
+  },
+  "rider-app/assets/images/react-logo@3x.png": {
+    "mtime": 1780622913.6810236,
+    "ast_hash": "8a4d0e5b845044e56e3b2df627d01cfd",
+    "semantic_hash": ""
+  },
+  "rider-app/assets/images/icon.png": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "87816012af4683c5e918c9bf25a2610f",
+    "semantic_hash": ""
+  },
+  "rider-app/assets/images/favicon.png": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "225b422b6a74db10f24efa165dfea5bf",
+    "semantic_hash": ""
+  },
+  "rider-app/assets/images/react-logo.png": {
+    "mtime": 1780622913.6810236,
     "ast_hash": "695d5a1c6f29a689130f3aaa573aec6e",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/assets/images/icon.png": {
-    "mtime": 1779512835.581595,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/favicon.png": {
-    "mtime": 1779512835.581595,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/adaptive-icon.png": {
-    "mtime": 1779512835.577595,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/car-top.svg": {
-    "mtime": 1779512835.577595,
+  "rider-app/assets/images/car-top.svg": {
+    "mtime": 1780622913.6810236,
     "ast_hash": "00d80e3d68e716f0e7bddcd595cc4215",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/assets/images/car_marker.png": {
-    "mtime": 1779512835.577595,
-    "ast_hash": "8c87b8b385b57c4e6c9dbd374a7cf4ea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/react-logo@2x.png": {
-    "mtime": 1779512835.581595,
-    "ast_hash": "b507e7f2c91ebc8fe24dee79ccb3b600",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/app-image.png": {
-    "mtime": 1779512835.577595,
-    "ast_hash": "a0a25e90aaa4ff2415839c978ce64783",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/driver-app/assets/images/react-logo@3x.png": {
-    "mtime": 1779512835.585595,
-    "ast_hash": "8a4d0e5b845044e56e3b2df627d01cfd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/public/next.svg": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "8e061864f388b47f33a1c3780831193e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/public/window.svg": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "a2760511c65806022ad20adf74370ff3",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/public/globe.svg": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "2aaafa6a49b6563925fe440891e32717",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/public/vercel.svg": {
-    "mtime": 1779512835.1823084,
-    "ast_hash": "c0af2f507b369b085b35ef4bbe3bcf1e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/admin-dashboard/public/file.svg": {
-    "mtime": 1779512835.177595,
-    "ast_hash": "d09f95206c3fa0bb9bd9fefabfd0ea71",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/assets/images/partial-react-logo.png": {
-    "mtime": 1779512836.177647,
+  "rider-app/assets/images/partial-react-logo.png": {
+    "mtime": 1780622913.6810236,
     "ast_hash": "8f14e478886737f3323a2ac79c833749",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/assets/images/react-logo.png": {
-    "mtime": 1779512836.177647,
-    "ast_hash": "695d5a1c6f29a689130f3aaa573aec6e",
+  "rider-app/assets/images/car-top-3d.svg": {
+    "mtime": 1780622913.6810236,
+    "ast_hash": "5c54f8dfb9fb1c5d865c75796c2d4dea",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/assets/images/icon.png": {
-    "mtime": 1779512836.177647,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/assets/images/favicon.png": {
-    "mtime": 1779512836.177647,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/assets/images/adaptive-icon.png": {
-    "mtime": 1779512836.1745439,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/assets/images/react-logo@2x.png": {
-    "mtime": 1779512836.177647,
+  "rider-app/assets/images/react-logo@2x.png": {
+    "mtime": 1780622913.6810236,
     "ast_hash": "b507e7f2c91ebc8fe24dee79ccb3b600",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/assets/images/app-image.png": {
-    "mtime": 1779512836.177647,
-    "ast_hash": "a0a25e90aaa4ff2415839c978ce64783",
+  "rider-app/assets/images/adaptive-icon.png": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "801d838fbc7a4e2888d087a266c9d5d2",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/frontend/assets/images/splash-image.png": {
-    "mtime": 1779512836.1815948,
-    "ast_hash": "a0a25e90aaa4ff2415839c978ce64783",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/frontend/assets/images/react-logo@3x.png": {
-    "mtime": 1779512836.177647,
-    "ast_hash": "8a4d0e5b845044e56e3b2df627d01cfd",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_233c5166.jpeg": {
-    "mtime": 1779512835.445595,
+  "backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_233c5166.jpeg": {
+    "mtime": 1780622912.6650238,
     "ast_hash": "bde2c87be3bfe256717f53fdbad992f9",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_6c9ab677.jpeg": {
-    "mtime": 1779512835.469595,
+  "backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_6c9ab677.jpeg": {
+    "mtime": 1780622912.6850238,
     "ast_hash": "b1e334b1bce172e9554a105a8e7fd5df",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_90fce351.jpeg": {
-    "mtime": 1779512835.473595,
+  "backend/uploads/profile_a358ee20-f82e-40f4-b6c3-3752889f8908_90fce351.jpeg": {
+    "mtime": 1780622912.6890237,
     "ast_hash": "b3b8fb6cd8b5fb9572c451526d013940",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/assets/images/partial-react-logo.png": {
-    "mtime": 1779512836.445595,
-    "ast_hash": "8f14e478886737f3323a2ac79c833749",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/assets/images/car-top-3d.svg": {
-    "mtime": 1779512836.443784,
-    "ast_hash": "5c54f8dfb9fb1c5d865c75796c2d4dea",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/assets/images/react-logo.png": {
-    "mtime": 1779512836.445595,
-    "ast_hash": "695d5a1c6f29a689130f3aaa573aec6e",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/assets/images/icon.png": {
-    "mtime": 1779512836.445595,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/assets/images/favicon.png": {
-    "mtime": 1779512836.443784,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/assets/images/adaptive-icon.png": {
-    "mtime": 1779512836.4403138,
-    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
-    "semantic_hash": ""
-  },
-  "/home/user/spinrvm/rider-app/assets/images/car-top.svg": {
-    "mtime": 1779512836.443784,
+  "shared/assets/car-top.svg": {
+    "mtime": 1780622913.7090237,
     "ast_hash": "00d80e3d68e716f0e7bddcd595cc4215",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/assets/images/react-logo@2x.png": {
-    "mtime": 1779512836.445595,
-    "ast_hash": "b507e7f2c91ebc8fe24dee79ccb3b600",
+  "shared/assets/car_marker.png": {
+    "mtime": 1780622913.7098598,
+    "ast_hash": "8c87b8b385b57c4e6c9dbd374a7cf4ea",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/assets/images/app-image.png": {
-    "mtime": 1779512836.443784,
-    "ast_hash": "a0a25e90aaa4ff2415839c978ce64783",
+  "admin-dashboard/public/window.svg": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "a2760511c65806022ad20adf74370ff3",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/rider-app/assets/images/react-logo@3x.png": {
-    "mtime": 1779512836.445595,
+  "admin-dashboard/public/globe.svg": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "2aaafa6a49b6563925fe440891e32717",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/public/file.svg": {
+    "mtime": 1780622912.4370236,
+    "ast_hash": "d09f95206c3fa0bb9bd9fefabfd0ea71",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/public/vercel.svg": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "c0af2f507b369b085b35ef4bbe3bcf1e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/public/next.svg": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "8e061864f388b47f33a1c3780831193e",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/react-logo@3x.png": {
+    "mtime": 1780622913.2170236,
     "ast_hash": "8a4d0e5b845044e56e3b2df627d01cfd",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/driver-app/assets/sounds/ride-offer.mp3": {
-    "mtime": 1779512835.585595,
+  "frontend/assets/images/icon.png": {
+    "mtime": 1780622913.2170236,
+    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/favicon.png": {
+    "mtime": 1780622913.2170236,
+    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/react-logo.png": {
+    "mtime": 1780622913.2170236,
+    "ast_hash": "695d5a1c6f29a689130f3aaa573aec6e",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/partial-react-logo.png": {
+    "mtime": 1780622913.2170236,
+    "ast_hash": "8f14e478886737f3323a2ac79c833749",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/splash-image.png": {
+    "mtime": 1780622913.2210238,
+    "ast_hash": "a0a25e90aaa4ff2415839c978ce64783",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/app-image.png": {
+    "mtime": 1780622913.2130237,
+    "ast_hash": "a0a25e90aaa4ff2415839c978ce64783",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/react-logo@2x.png": {
+    "mtime": 1780622913.2170236,
+    "ast_hash": "b507e7f2c91ebc8fe24dee79ccb3b600",
+    "semantic_hash": ""
+  },
+  "frontend/assets/images/adaptive-icon.png": {
+    "mtime": 1780622913.2130237,
+    "ast_hash": "a55a5b0a19757ba9c2be865c451fe63c",
+    "semantic_hash": ""
+  },
+  "railway.json": {
+    "mtime": 1780622913.6130238,
+    "ast_hash": "7f57435666870539fc22772f63c5f66d",
+    "semantic_hash": ""
+  },
+  "package.json": {
+    "mtime": 1780622913.6090238,
+    "ast_hash": "5d362e15898bc7e319cff00a27e527c9",
+    "semantic_hash": ""
+  },
+  "commitlint.config.js": {
+    "mtime": 1780622912.7050238,
+    "ast_hash": "d25424fd0aa2ec88ef4a6bec88209cc0",
+    "semantic_hash": ""
+  },
+  "shared/package.json": {
+    "mtime": 1780622913.7130237,
+    "ast_hash": "e3ef3afb035d4e5eb4ee8d85ed9fdfa8",
+    "semantic_hash": ""
+  },
+  "shared/tsconfig.build.json": {
+    "mtime": 1780622913.714287,
+    "ast_hash": "ca4fccb53f013814929234f4f6bd66ee",
+    "semantic_hash": ""
+  },
+  "shared/tsconfig.json": {
+    "mtime": 1780622913.714287,
+    "ast_hash": "2c5edb08f364b31cefd75adb0e43264b",
+    "semantic_hash": ""
+  },
+  "shared/types/index.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "58c15b467fc58256fb7c0b6534c90dd4",
+    "semantic_hash": ""
+  },
+  "shared/types/api/pagination.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "87442b2fd1b518f4b349602432c922b0",
+    "semantic_hash": ""
+  },
+  "shared/types/api/money.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "4a93a5fa14dca3a118292ea36b269793",
+    "semantic_hash": ""
+  },
+  "shared/types/api/user.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "e1752117f75f10b0e892e0fce4a89b35",
+    "semantic_hash": ""
+  },
+  "shared/types/api/ride.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "5baeceadd921262b136a1fec5c2e6384",
+    "semantic_hash": ""
+  },
+  "shared/types/api/wsEvents.ts": {
+    "mtime": 1780622913.714669,
+    "ast_hash": "217d9c835d88ef3278c1a89d0b72953a",
+    "semantic_hash": ""
+  },
+  "shared/types/api/errors.ts": {
+    "mtime": 1780622913.7144442,
+    "ast_hash": "485a3e8c4365d8b6ce7f949b01335bbc",
+    "semantic_hash": ""
+  },
+  "shared/components/SupportScreen.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "7b4c6ed5da42cadc68d84e3294df096d",
+    "semantic_hash": ""
+  },
+  "shared/components/FormScreen.tsx": {
+    "mtime": 1780622913.7108378,
+    "ast_hash": "123fa1f65dc9b65318302f85b16f46db",
+    "semantic_hash": ""
+  },
+  "shared/hooks/usePlacesAutocomplete.ts": {
+    "mtime": 1780622913.7125325,
+    "ast_hash": "1ef94543f697f7d256dcb8f0781a421c",
+    "semantic_hash": ""
+  },
+  "shared/hooks/queries/index.ts": {
+    "mtime": 1780622913.7125325,
+    "ast_hash": "3f53fd9d72e29edac072bf6c07bca6f1",
+    "semantic_hash": ""
+  },
+  "shared/hooks/queries/driverQueries.ts": {
+    "mtime": 1780622913.7124457,
+    "ast_hash": "370c1b1aab111a5d892a41f4970b234b",
+    "semantic_hash": ""
+  },
+  "shared/hooks/queries/notificationQueries.ts": {
+    "mtime": 1780622913.7125325,
+    "ast_hash": "81eac51a0c16019e5660500d50a4018f",
+    "semantic_hash": ""
+  },
+  "shared/api/places.ts": {
+    "mtime": 1780622913.708882,
+    "ast_hash": "13ee45b153114fb90db4156c7af16cfa",
+    "semantic_hash": ""
+  },
+  "shared/api/queryClient.ts": {
+    "mtime": 1780622913.708882,
+    "ast_hash": "23806d439c3bb3d75b125ff4eca18fde",
+    "semantic_hash": ""
+  },
+  "shared/api/__tests__/client.refresh.test.ts": {
+    "mtime": 1780622913.708882,
+    "ast_hash": "7fbe45f6af02d4594090cec345ac199a",
+    "semantic_hash": ""
+  },
+  "shared/api/__tests__/client.authHeader.test.ts": {
+    "mtime": 1780622913.7083151,
+    "ast_hash": "c086893240b292ee276bdbcfe48f39f1",
+    "semantic_hash": ""
+  },
+  "shared/build-types/peer-deps.d.ts": {
+    "mtime": 1780622913.7098598,
+    "ast_hash": "0ba95d0c0d96adaf21dfa724b5e9716f",
+    "semantic_hash": ""
+  },
+  "shared/utils/responsive.ts": {
+    "mtime": 1780622913.7155209,
+    "ast_hash": "acb55534d85b43108c938d23503a10f8",
+    "semantic_hash": ""
+  },
+  "shared/utils/placesSession.ts": {
+    "mtime": 1780622913.7155209,
+    "ast_hash": "71c39d8108fda9740650f7a19f4389ac",
+    "semantic_hash": ""
+  },
+  "shared/utils/pii.ts": {
+    "mtime": 1780622913.7155209,
+    "ast_hash": "9799a5d0ab496d266c0dfd885264ab3e",
+    "semantic_hash": ""
+  },
+  "shared/utils/__tests__/pii.test.ts": {
+    "mtime": 1780622913.7155209,
+    "ast_hash": "9947fb714c804a724392ad41a9151935",
+    "semantic_hash": ""
+  },
+  "driver-app/expo_52_deps.json": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "06c1d8db25ee6d33f151619319b4133d",
+    "semantic_hash": ""
+  },
+  "driver-app/expo_53_deps.json": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "9b8d77c959817b6fc470660ae4d706c8",
+    "semantic_hash": ""
+  },
+  "driver-app/vercel.json": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "61bd31a2b0ac08f10f13c932b32d6ca1",
+    "semantic_hash": ""
+  },
+  "driver-app/config.ts": {
+    "mtime": 1780622912.7820277,
+    "ast_hash": "4a1da2ebee7c1dd27459cf18a04668e1",
+    "semantic_hash": ""
+  },
+  "driver-app/google-services.json": {
+    "mtime": 1780622912.7850237,
+    "ast_hash": "acb9398a931c04fdd1300bfbe79f9aa9",
+    "semantic_hash": ""
+  },
+  "driver-app/screens_versions.json": {
+    "mtime": 1780622912.7963936,
+    "ast_hash": "5c823bdad1668f0aa71afb6546296b40",
+    "semantic_hash": ""
+  },
+  "driver-app/package.json": {
+    "mtime": 1780622912.7930238,
+    "ast_hash": "fcbca97611a40654c2f99978a7c54842",
+    "semantic_hash": ""
+  },
+  "driver-app/eas.json": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "f7adad9ae17b65907d17bfc32b3923c8",
+    "semantic_hash": ""
+  },
+  "driver-app/expo_52_real_deps.json": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "4951dcfb743835c9df5fd18e719dbf07",
+    "semantic_hash": ""
+  },
+  "driver-app/playwright.config.ts": {
+    "mtime": 1780622912.795122,
+    "ast_hash": "92730e2dc0348a0ebecd3b2019725834",
+    "semantic_hash": ""
+  },
+  "driver-app/tsconfig.json": {
+    "mtime": 1780622912.8010237,
+    "ast_hash": "10ea991732cf3a9543d70f3334cb4bb4",
+    "semantic_hash": ""
+  },
+  "driver-app/components/AlertDialog.tsx": {
+    "mtime": 1780622912.775116,
+    "ast_hash": "2c1bac05ea2d82efad0522edc56cea8e",
+    "semantic_hash": ""
+  },
+  "driver-app/components/ScreenHeader.tsx": {
+    "mtime": 1780622912.7770238,
+    "ast_hash": "660ebef1b0e27a2c071ac01d98fbeebd",
+    "semantic_hash": ""
+  },
+  "driver-app/components/SafeRefreshControl.tsx": {
+    "mtime": 1780622912.7770238,
+    "ast_hash": "223519c324dcf38f20bb64f345b28e88",
+    "semantic_hash": ""
+  },
+  "driver-app/components/activity/ActivityView.tsx": {
+    "mtime": 1780622912.7770238,
+    "ast_hash": "bf3000f62dfc36583d59ce56ffcbae2f",
+    "semantic_hash": ""
+  },
+  "driver-app/store-assets/metadata.json": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "3b8429fd0ce3125fd7a2a64caf02c339",
+    "semantic_hash": ""
+  },
+  "driver-app/hooks/useToast.ts": {
+    "mtime": 1780622912.7890236,
+    "ast_hash": "5830e53ced939424d677a39185b56440",
+    "semantic_hash": ""
+  },
+  "driver-app/hooks/useRideOfferSound.ts": {
+    "mtime": 1780622912.7890236,
+    "ast_hash": "8a10e687740f988373447969383995d1",
+    "semantic_hash": ""
+  },
+  "driver-app/hooks/useAuth.ts": {
+    "mtime": 1780622912.7886426,
+    "ast_hash": "4e419a3b5da53062bc47aeadc446ec1f",
+    "semantic_hash": ""
+  },
+  "driver-app/hooks/__tests__/useDriverDashboard.chat.test.ts": {
+    "mtime": 1780622912.7886426,
+    "ast_hash": "c3e8be64535b8fa43644f7ff4bfc95d4",
+    "semantic_hash": ""
+  },
+  "driver-app/hooks/__tests__/goOnlinePermission.test.ts": {
+    "mtime": 1780622912.7881064,
+    "ast_hash": "6a375875d3103080e171197836b43d72",
+    "semantic_hash": ""
+  },
+  "driver-app/hooks/__tests__/locationBatch.test.ts": {
+    "mtime": 1780622912.7886426,
+    "ast_hash": "4a2789c0948ed3dab4b4e45578b38a1c",
+    "semantic_hash": ""
+  },
+  "driver-app/services/notifeeService.ts": {
+    "mtime": 1780622912.797825,
+    "ast_hash": "9d55a6f9f647583f0f6c6a1c8defd0ff",
+    "semantic_hash": ""
+  },
+  "driver-app/__mocks__/expoWinter.js": {
+    "mtime": 1780622912.7501986,
+    "ast_hash": "64e09ba341e550784c724f369684eda0",
+    "semantic_hash": ""
+  },
+  "driver-app/__mocks__/expo-winter-noop.js": {
+    "mtime": 1780622912.7501986,
+    "ast_hash": "3f347a3031deea0b74235013e6bf27b5",
+    "semantic_hash": ""
+  },
+  "driver-app/__mocks__/expo-winter-runtime.js": {
+    "mtime": 1780622912.7501986,
+    "ast_hash": "1c5c938bef3c07774f1614c30b20c62a",
+    "semantic_hash": ""
+  },
+  "driver-app/app/driver/(tabs)/activity.tsx": {
+    "mtime": 1780622912.75613,
+    "ast_hash": "50ff1bf032e752733c0846c929370bd1",
+    "semantic_hash": ""
+  },
+  "driver-app/app/driver/(tabs)/_layout.tsx": {
+    "mtime": 1780622912.7559319,
+    "ast_hash": "100d3488415ccfae61c19b9b1063a7ff",
+    "semantic_hash": ""
+  },
+  "driver-app/app/driver/(tabs)/index.tsx": {
+    "mtime": 1780622912.75613,
+    "ast_hash": "680aac3f38329f0cbf39b3c6b98f4b7f",
+    "semantic_hash": ""
+  },
+  "driver-app/app/driver/(tabs)/profile.tsx": {
+    "mtime": 1780622912.75613,
+    "ast_hash": "a343456095c45f2aa87053bb6e9eadcd",
+    "semantic_hash": ""
+  },
+  "driver-app/__tests__/store/authStore.initialize.test.ts": {
+    "mtime": 1780622912.752061,
+    "ast_hash": "f20587ea5bef7853eb4e82224a5a246e",
+    "semantic_hash": ""
+  },
+  "driver-app/__tests__/store/driverStore.wav.test.ts": {
+    "mtime": 1780622912.7529967,
+    "ast_hash": "e5df02af226a6a92c79d7c1e44a3e000",
+    "semantic_hash": ""
+  },
+  "driver-app/api/client.ts": {
+    "mtime": 1780622912.7530236,
+    "ast_hash": "332eb10b51e8fca51f82bc3e4e78f182",
+    "semantic_hash": ""
+  },
+  "driver-app/scripts/dedupe-shared-nm.js": {
+    "mtime": 1780622912.7970238,
+    "ast_hash": "a74c92c255724eaf4bd08c91e200b038",
+    "semantic_hash": ""
+  },
+  "driver-app/store/__tests__/documentStore.test.ts": {
+    "mtime": 1780622912.7991686,
+    "ast_hash": "15819e49ad25ec9f9d9f083edffda144",
+    "semantic_hash": ""
+  },
+  "driver-app/store/__tests__/questStore.test.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "acdcaa4f2ae7c01cb75765589f4f5588",
+    "semantic_hash": ""
+  },
+  "driver-app/store/__tests__/driverStore.restart.test.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "820aec92aa1b4b7e0ca1f8ad7b835912",
+    "semantic_hash": ""
+  },
+  "driver-app/store/__tests__/driverStore.chat.test.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "8451b7951c57e8ad8e30a33ff0e2acf8",
+    "semantic_hash": ""
+  },
+  "driver-app/store/__tests__/driverStore.reconnect.test.ts": {
+    "mtime": 1780622912.7996767,
+    "ast_hash": "0e323f71875a494e5d1599b5a54653d2",
+    "semantic_hash": ""
+  },
+  "driver-app/__stubs__/emptyNativeComponent.js": {
+    "mtime": 1780622912.7501986,
+    "ast_hash": "2f3d1a73eac1104259f9bfd70dd740d3",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/alert.ts": {
+    "mtime": 1780622912.790269,
+    "ast_hash": "7947b66bf3f5620b42e41ecd408b38cf",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/complete-trip.spec.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "a77ff43520ec4df426fc68ca2299cb38",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/ride-offer.spec.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "dff8bb2bb0152aa90b95b99abf0df67a",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/fixtures.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "060738bd5d443c8bed1b370306c3b4cd",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/cancellation.spec.ts": {
+    "mtime": 1780622912.7820277,
+    "ast_hash": "02aeb4bb15e47e99fc9854f56e718dd5",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/payout.spec.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "5100a6551c0531f691e608179767b7de",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/verify-otp.spec.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "3a0297c379be51392309c09b53abac83",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/smoke.spec.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "ce16e8413bd31cfabe0ddf093a577021",
+    "semantic_hash": ""
+  },
+  "driver-app/e2e/online-toggle.spec.ts": {
+    "mtime": 1780622912.783055,
+    "ast_hash": "0cc1da04a3ad9eadcdec328816e8748b",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/apiClient.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "b6db9544c58201226b7109c95006535f",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/deviceIntegrity.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "38e9a614668b0f5fe20059d2c62152a0",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/crashlytics.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "7c49848a3d85464cc1c3886138bbae45",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/backgroundLocation.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "ddaec4fbeb1b3037154ddd3adb1c73ea",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/sensorIntegrity.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "a3024b7ab8a25be149a1a3c8ca9738b4",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/locationIntegrity.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "0739482cee427e8b7efcd2bf7523ca9e",
+    "semantic_hash": ""
+  },
+  "driver-app/plugins/withGradleWrapper.js": {
+    "mtime": 1780622912.7963936,
+    "ast_hash": "cd06c3416afeb58b540db031f28984b2",
+    "semantic_hash": ""
+  },
+  "driver-app/plugins/withKspVersion.js": {
+    "mtime": 1780622912.7963936,
+    "ast_hash": "294b659519942c76651bd9eb45cdad94",
+    "semantic_hash": ""
+  },
+  "driver-app/plugins/withNotifeePermissions.js": {
+    "mtime": 1780622912.7963936,
+    "ast_hash": "c4e09a4099ee172a2d0bd70168024569",
+    "semantic_hash": ""
+  },
+  "driver-app/plugins/withForceCompileSdk.js": {
+    "mtime": 1780622912.795122,
+    "ast_hash": "3035bd1fa442ca2fe8e901e0d9865500",
+    "semantic_hash": ""
+  },
+  "driver-app/i18n/fr.json": {
+    "mtime": 1780622912.790269,
+    "ast_hash": "e0e831a0060ab318f33bac166585d31a",
+    "semantic_hash": ""
+  },
+  "driver-app/i18n/en.json": {
+    "mtime": 1780622912.7890236,
+    "ast_hash": "426ea32e8ef7e23cdc3773be3ef5d208",
+    "semantic_hash": ""
+  },
+  "driver-app/i18n/es.json": {
+    "mtime": 1780622912.790269,
+    "ast_hash": "9d0b3916a615463b99d9a209bd2b439f",
+    "semantic_hash": ""
+  },
+  "agents/knowledge/tasks/a40d5f66-6bbf-42d5-89b3-bea02d3fb3bb.json": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "00a99de0b3d0ecd07bbdbe965a25a044",
+    "semantic_hash": ""
+  },
+  "agents/knowledge/tasks/486bac5e-ae47-42df-8abd-321d31c9cd9e.json": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "3ccaa2483652894b5a6efb699bf6b6bc",
+    "semantic_hash": ""
+  },
+  "agents/knowledge/tasks/2eb1f62d-b48d-4bbe-a599-738ae73e4e31.json": {
+    "mtime": 1780622912.51612,
+    "ast_hash": "efd93259bfc805a215e2098b9d05e049",
+    "semantic_hash": ""
+  },
+  "agents/knowledge/tasks/218df452-5459-40a6-a1ed-6ccd139270d7.json": {
+    "mtime": 1780622912.5154452,
+    "ast_hash": "a347133d4d1da8d26e3fe51dd27e641c",
+    "semantic_hash": ""
+  },
+  "agents/knowledge/reviews/977d6de2-21c1-413b-b26f-1fb87c109814.json": {
+    "mtime": 1780622912.5154452,
+    "ast_hash": "343688d164626d7912a3792e706bef74",
+    "semantic_hash": ""
+  },
+  "agents/knowledge/reviews/36e10a57-f590-4e0f-b64e-456d13974f1d.json": {
+    "mtime": 1780622912.515224,
+    "ast_hash": "11a82c38ae6d089117eeb41e7d75d56d",
+    "semantic_hash": ""
+  },
+  ".husky/pre-commit": {
+    "mtime": 1780622912.192809,
+    "ast_hash": "b2d1fffc776e858ae24c812e2adc6f5e",
+    "semantic_hash": ""
+  },
+  ".husky/commit-msg": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "699bed54039a19ca8ff630af76b1a6df",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/components.json": {
+    "mtime": 1780622912.429842,
+    "ast_hash": "9d220183f9dc57492600d841853d7ec6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/vercel.json": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "0bb4f16ffcaaf82cb39eedccf1482ba4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/package.json": {
+    "mtime": 1780622912.4370236,
+    "ast_hash": "f7dd3599e8e9361b8218dbcbb0ccbe48",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/tsconfig.json": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "a82953c22d718fd70b3e62a268dc57e6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/middleware.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "bfe99ae94441830b90b70afd6cf445fa",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/analytics-wrapper.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "11a97ff97f0029e8733ad95733dd3f27",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/auth-initializer.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "ea066264b2032ef15a2b4d320c641e0b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/analytics-provider.tsx": {
+    "mtime": 1780622912.5010238,
+    "ast_hash": "499c212fc5c0dbfc3a9659b115c101f1",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/mfa-enroll-dialog.tsx": {
+    "mtime": 1780622912.5018175,
+    "ast_hash": "034be91ed4238a49bcacfa13d5973f33",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/pagination.tsx": {
+    "mtime": 1780622912.5035226,
+    "ast_hash": "96684761fda78e4f695fa247b538373b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/use-crud-toast.ts": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "2030a221a44357ae279312d9f76a1f41",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/hooks/useAdminLocation.ts": {
+    "mtime": 1780622912.5081196,
+    "ast_hash": "d120c2b0f78875251569890eaec3b557",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/hooks/useRequireModule.ts": {
+    "mtime": 1780622912.5081196,
+    "ast_hash": "79bac263614702a25021f6383f6bce67",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/hooks/usePlacesAutocomplete.ts": {
+    "mtime": 1780622912.5081196,
+    "ast_hash": "f77ea44638a13b9ddb0df91c426d949d",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/403/page.tsx": {
+    "mtime": 1780622912.4462981,
+    "ast_hash": "00df4c5d7d654ff8f1ea3e9aa3fcf727",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/api/admin/auth/logout/route.ts": {
+    "mtime": 1780622912.4470725,
+    "ast_hash": "4aafa07830b16f6c0fcfc14d97d4b7f7",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/api/admin/auth/refresh/route.ts": {
+    "mtime": 1780622912.4481633,
+    "ast_hash": "5d2a566f7adf2212aab7192a34df0f01",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/api/admin/auth/mfa/challenge/route.ts": {
+    "mtime": 1780622912.4481633,
+    "ast_hash": "6e64f857e474b90128b6a9ad6ce665c7",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/api/admin/auth/login/route.ts": {
+    "mtime": 1780622912.4470725,
+    "ast_hash": "e3ac72465620859bd14ee1d57c987a1c",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/api/auth/set-cookie/route.ts": {
+    "mtime": 1780622912.449231,
+    "ast_hash": "45d2dfeacc55937d0257076aada9f6b1",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/loading.tsx": {
+    "mtime": 1780622912.4738774,
+    "ast_hash": "338d880761e267925a7558b35ccb2e42",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/error.tsx": {
+    "mtime": 1780622912.4730237,
+    "ast_hash": "b03bbedf28f8bef489051c44f915c4db",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/users/loading.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "754a26ddd0793570dd139facd960dcc9",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/loading.tsx": {
+    "mtime": 1780622912.4762542,
+    "ast_hash": "305711c728e576d6be3758fe360c3c64",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "f77396d7817b0a121cb0f03f68418c3d",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/earnings/payouts/page.tsx": {
+    "mtime": 1780622912.472141,
+    "ast_hash": "5e96b5d7af268008a90976c2724e5aee",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/earnings/payouts/[id]/page.tsx": {
+    "mtime": 1780622912.472141,
+    "ast_hash": "74560eca3847311ffb74a64303b3388b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/safety/page.tsx": {
+    "mtime": 1780622912.4850237,
+    "ast_hash": "fc998671c234c320eb48373c71070dff",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/settings/loading.tsx": {
+    "mtime": 1780622912.4850237,
+    "ast_hash": "f7c3f2520a655d1e4a14db92ec263506",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/loading.tsx": {
+    "mtime": 1780622912.4680126,
+    "ast_hash": "e9bf3b0d9612bc602093386fb18b0526",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/expiring/loading.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "fef6eb7c6693c9caa4e0a7fc06d144cc",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/expiring/page.tsx": {
+    "mtime": 1780622912.4680126,
+    "ast_hash": "8ee01b45e2758469e545f66293e02645",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/document-reviewer.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "df6ae1c81e7754b9e157b116637fd18b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/queue/loading.tsx": {
+    "mtime": 1780622912.4697819,
+    "ast_hash": "08432c3dd37951bfeb7772174ad98ace",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/queue/page.tsx": {
+    "mtime": 1780622912.4697819,
+    "ast_hash": "8c91a6e603b3164a2dfb7410b8e068d6",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/queue/_components/queue-stats.tsx": {
+    "mtime": 1780622912.4697819,
+    "ast_hash": "93800c6fddb68180093af7a9408fd1da",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/promotions/loading.tsx": {
+    "mtime": 1780622912.4770236,
+    "ast_hash": "528cdf4fff167fc25542674beabbee31",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/corporate-accounts/[id]/policy/page.tsx": {
+    "mtime": 1780622912.4600475,
+    "ast_hash": "b6affa1560cd073bb85afb7112d6329a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/loading.tsx": {
+    "mtime": 1780622912.4849622,
+    "ast_hash": "ff85eb847728e64125071c5a812b6d9c",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/rides/_components/create-ride-modal.tsx": {
+    "mtime": 1780622912.4807668,
+    "ast_hash": "9806579f4b4ba7c4bb67d20f124dea42",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/faqs.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "383db4f689d0d7e1a155e92c46ec88b4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support/_tabs/legal-documents.tsx": {
+    "mtime": 1780622912.494016,
+    "ast_hash": "36e2bbd754366e3c5a28b8ad26bde189",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/faqs/loading.tsx": {
+    "mtime": 1780622912.4730237,
+    "ast_hash": "7bd351fb0a437c0d7f61d356c8579eee",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/faqs/page.tsx": {
+    "mtime": 1780622912.4738774,
+    "ast_hash": "1facecde1dbd2cc61bcb8be688b87bac",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/documents/requirements/page.tsx": {
+    "mtime": 1780622912.463624,
+    "ast_hash": "ddcb1b00fc15a5a2fdaff67db3f205a1",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/analytics/loading.tsx": {
+    "mtime": 1780622912.4564505,
+    "ast_hash": "689c1f7de4da85b45e98db15856da033",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/page.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "c32f5370a7dbfec9b567d8964f973ed1",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/layout.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "2b89aca3fd18af8079583fcc52d5f868",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/page.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "ebc480d774a0832955980a7b7a305cdb",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/layout.tsx": {
+    "mtime": 1780622912.4499297,
+    "ast_hash": "0ae2a987d75c34cc6a087e37408e97c4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/overview/page.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "02f4d6f49e9c0cf93b5a7cf1b76036cd",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/activity/page.tsx": {
+    "mtime": 1780622912.4499297,
+    "ast_hash": "49678bdebdbafa0e1cb20a454de2afbd",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/policy/page.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "5f8cb8bf8a08101a1606842f50345977",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/settings/page.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "abb1553f7f327050e7f971d94965c19e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/billing/page.tsx": {
+    "mtime": 1780622912.4499297,
+    "ast_hash": "358303b159de5362ffdf0b83821bd96a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/allowances/page.tsx": {
+    "mtime": 1780622912.4499297,
+    "ast_hash": "8c508e3192a91c5d109aea786295fb91",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/members/page.tsx": {
+    "mtime": 1780622912.4530237,
+    "ast_hash": "59f8ace8bc9b546ceaeb257c990c995d",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/company-portal/[id]/allowance-requests/page.tsx": {
+    "mtime": 1780622912.4499297,
+    "ast_hash": "70b9bb3db1c2025dd80d72f16747491b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/api/set-cookie.test.ts": {
+    "mtime": 1780622912.4435341,
+    "ast_hash": "6e89a8979a38b2f9bc2b9d919d185872",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/api/admin-auth-refresh.test.ts": {
+    "mtime": 1780622912.4427278,
+    "ast_hash": "603e66bad68fd6579e0ab43ff068f343",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/__tests__/dashboard/pages.smoke.test.tsx": {
+    "mtime": 1780622912.4435341,
+    "ast_hash": "a3fd65db015540b71c0899f2fee02c8e",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/logger.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "52ac7cfec8a70e31a679a0cc6d395721",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/pii.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "c5c9ec1a49b722c6b2800d02b7b77480",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/scripts/test-railway-login.ts": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "cda4c26b3121dfacb48471dbc6ff80e2",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/e2e/auth-fixture.ts": {
+    "mtime": 1780622912.429842,
+    "ast_hash": "e40d23f6ef9e0ba9c94a779ef64ca10f",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/e2e/ride-management.spec.ts": {
+    "mtime": 1780622912.430921,
+    "ast_hash": "5952a66d92e78a64a0b58afa7c09cca4",
+    "semantic_hash": ""
+  },
+  "frontend/vercel.json": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "61bd31a2b0ac08f10f13c932b32d6ca1",
+    "semantic_hash": ""
+  },
+  "frontend/package.json": {
+    "mtime": 1780622913.2250237,
+    "ast_hash": "bd2d83ac0f696b62ccaba1e1331a58d6",
+    "semantic_hash": ""
+  },
+  "frontend/eas.json": {
+    "mtime": 1780622913.2226014,
+    "ast_hash": "db157175390123f4c1bb471193584748",
+    "semantic_hash": ""
+  },
+  "frontend/tsconfig.json": {
+    "mtime": 1780622913.2290237,
+    "ast_hash": "f81cae1f27a5d1365cd00a117a40cdf8",
+    "semantic_hash": ""
+  },
+  "frontend/e2e/.detoxrc.json": {
+    "mtime": 1780622913.2222583,
+    "ast_hash": "ccd716148a144bf8796a8d7aa1d27492",
+    "semantic_hash": ""
+  },
+  "backend/test_batch.json": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "561a8f800522535e0f3e1268737b111d",
+    "semantic_hash": ""
+  },
+  "backend/supabase_schema.sql": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "b15a9447b4416eec58afc0ac7059966d",
+    "semantic_hash": ""
+  },
+  "backend/supabase_rls.sql": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "42b978a3f292716a0e5e1db82f9bbc20",
+    "semantic_hash": ""
+  },
+  "backend/test_batch_dict.json": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "781a07fd315652759a4cba3dda2cb29e",
+    "semantic_hash": ""
+  },
+  "backend/diagnose_driver_ws.py": {
+    "mtime": 1780622912.5293024,
+    "ast_hash": "7455747f5ff0e9cefbdc0d61d4633457",
+    "semantic_hash": ""
+  },
+  "backend/sql/01_postgis_schema.sql": {
+    "mtime": 1780622912.6050236,
+    "ast_hash": "c26505bef4531294e7c5a680619d0c13",
+    "semantic_hash": ""
+  },
+  "backend/sql/04_rides_admin_overhaul.sql": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "a5a1c3540270be12fd2a35f17ebdf685",
+    "semantic_hash": ""
+  },
+  "backend/sql/03_features.sql": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "3b9ec15ca156739324f250630a8cd111",
+    "semantic_hash": ""
+  },
+  "backend/sql/02_add_updated_at.sql": {
+    "mtime": 1780622912.6064022,
+    "ast_hash": "1e49c375b71505913585476622ac0ac6",
+    "semantic_hash": ""
+  },
+  "backend/services/stripe_kyc_sync.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "b2adddd7ea3033d541c1447e8aa7030b",
+    "semantic_hash": ""
+  },
+  "backend/services/cancellation_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "2536a9421e4e5c77de5d037599aefff4",
+    "semantic_hash": ""
+  },
+  "backend/services/payment_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "062ec7af8edba3fa3cc22c28dcce6a2c",
+    "semantic_hash": ""
+  },
+  "backend/services/corporate_policy_service.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "f04d3e35525e6db160fd9f3f1f0c0791",
+    "semantic_hash": ""
+  },
+  "backend/repositories/driver_repo.py": {
+    "mtime": 1780622912.5639248,
+    "ast_hash": "b3da1200089213e249fee4d6bc974c60",
+    "semantic_hash": ""
+  },
+  "backend/repositories/ride_repo.py": {
+    "mtime": 1780622912.5639248,
+    "ast_hash": "2795730c305ffff3bb11385fdf3552ef",
+    "semantic_hash": ""
+  },
+  "backend/repositories/__init__.py": {
+    "mtime": 1780622912.562677,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "backend/repositories/corporate_repo.py": {
+    "mtime": 1780622912.5639248,
+    "ast_hash": "60e053b60c3591d165cd313b67aa89a0",
+    "semantic_hash": ""
+  },
+  "backend/repositories/_base.py": {
+    "mtime": 1780622912.5639248,
+    "ast_hash": "7e040b598b3484415b2c94825b09386d",
+    "semantic_hash": ""
+  },
+  "backend/repositories/wallet_repo.py": {
+    "mtime": 1780622912.5639248,
+    "ast_hash": "aeb5cf414c4703c1f28328429b0abc48",
+    "semantic_hash": ""
+  },
+  "backend/repositories/auth_repo.py": {
+    "mtime": 1780622912.5639248,
+    "ast_hash": "bf5b94fca49b1db57af0072898a4d17c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/13_driver_notes.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "3fd7e833ba9f47eba94f187446fcae4b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/76_push_retry_queue.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "6c10cf852148e190381cba026d45c80d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/18_admin_staff.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "64b4d9d4ebbde9c469402245f5167444",
+    "semantic_hash": ""
+  },
+  "backend/migrations/75_service_area_for_point_rpc.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "8ff8ac47460323d20e0afcf3655ad980",
+    "semantic_hash": ""
+  },
+  "backend/migrations/89_rides_ride_metrics.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "e4ffe29dc12eb9a6d4f8f092aa116676",
+    "semantic_hash": ""
+  },
+  "backend/migrations/54_gps_daily_rollup_fn.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "9c3d187628883cdd02e692a6939a00e4",
+    "semantic_hash": ""
+  },
+  "backend/migrations/10_disputes_table.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "a65ecb317da9905e3a0cfe33a885a004",
+    "semantic_hash": ""
+  },
+  "backend/migrations/54_add_rides_assigned_at.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "a02bb4fd6c3faf3303660d06a0374380",
+    "semantic_hash": ""
+  },
+  "backend/migrations/21_loyalty.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "420e5ecd1f5bb01a1dddf048558afc80",
+    "semantic_hash": ""
+  },
+  "backend/migrations/61_drivers_total_ratings.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "1b6cc4c06f5f586e24080792350a8f99",
+    "semantic_hash": ""
+  },
+  "backend/migrations/56_admin_staff_security_columns.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "33536754c6f2415bb95a3c742387294f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/51_loyalty_unique_and_promo_atomic_increment.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "22a4955ac98ca3c6d2cea127e8f68043",
+    "semantic_hash": ""
+  },
+  "backend/migrations/112_lost_and_found_add_contact_method.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "bfd314e02e1c25d6639aaf66b29a54fe",
+    "semantic_hash": ""
+  },
+  "backend/migrations/53_rides_one_active_per_rider.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "d99d6bc07159fcc6f76a0616d2317531",
+    "semantic_hash": ""
+  },
+  "backend/migrations/81_service_areas_missing_columns.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "0d2becb8266903ab301293c79faf2a82",
+    "semantic_hash": ""
+  },
+  "backend/migrations/28_corporate_wallet_rpc.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "d36d8540b2120cae8f2d6c778626dfbb",
+    "semantic_hash": ""
+  },
+  "backend/migrations/40_rides_ride_code.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "251da8abd01305c9ef4e664398dfb3a8",
+    "semantic_hash": ""
+  },
+  "backend/migrations/106_backfill_surge_enabled.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "7499b2c432f182065d782a6cfcfe4f21",
+    "semantic_hash": ""
+  },
+  "backend/migrations/10b_service_area_driver_matching.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "30f97f65a065e5b57269e830dd0975e3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/95_settings_safety_alert_emails.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "840a4a10d80b118ebe659667fddeb6be",
+    "semantic_hash": ""
+  },
+  "backend/migrations/47_users_profile_image_status.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "4af3a662625e32414eb7be3a7d62561b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/08_complete_schema.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "df3f5c67afca52f64513015e31918cbf",
+    "semantic_hash": ""
+  },
+  "backend/migrations/02_dynamic_documents.sql": {
+    "mtime": 1780622912.5324082,
+    "ast_hash": "e955c46aa7b9a9e474e7d1afc008810d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/15_ride_aggregate_columns.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "79dadd4c5e90425035a3bf219b4e9be6",
+    "semantic_hash": ""
+  },
+  "backend/migrations/84_audit_logs_missing_columns.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "e394abbb40f8570f938471a63fa25d84",
+    "semantic_hash": ""
+  },
+  "backend/migrations/106_settings_dispatch_globals.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "6601221b49170a6de12250b19d70a03a",
+    "semantic_hash": ""
+  },
+  "backend/migrations/05_corporate_accounts.sql": {
+    "mtime": 1780622912.5324082,
+    "ast_hash": "33a3eba7b30533eb711311559afbf10d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/04_stripe_payments.sql": {
+    "mtime": 1780622912.5324082,
+    "ast_hash": "be7b5221224dcfc04b444bbe2d134745",
+    "semantic_hash": ""
+  },
+  "backend/migrations/69b_lost_and_found_concurrent_indexes.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "86db1ef86f67323078cc438a0979fd9f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/16_driver_daily_stats.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "b4888674b80d015267d9d3449e89647d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/97_driver_intent_timestamps.sql": {
+    "mtime": 1780622912.5610237,
+    "ast_hash": "3ae174201d3887d7d239fb822cf05830",
+    "semantic_hash": ""
+  },
+  "backend/migrations/12_driver_lifecycle_status.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "6dc443a6c74af4c2c7b11fd6f749f52b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/80_service_areas_vehicle_pricing.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "39dd88f4dce7f509b979d73645df476b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/56_audit_logs_delete_lockdown.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "48750c6634f7514ca607d01b8078137f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/51_audit_logs_lockdown.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "f9dd10c30529016dc072d74612879f10",
+    "semantic_hash": ""
+  },
+  "backend/migrations/11_driver_needs_review.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "cccc42827ebe729baa45d3457745294c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/50_wallet_atomic_rpcs.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "a69087d23b43a11770a83cc5127acd12",
+    "semantic_hash": ""
+  },
+  "backend/migrations/81_rides_cancellation_fee_columns.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "6de998c04af872e99c457bf7a3b42adc",
+    "semantic_hash": ""
+  },
+  "backend/migrations/111_wallet_pay_for_ride_security_hardening.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "3b9fae7ed6d14d18f399373f22fe4f63",
+    "semantic_hash": ""
+  },
+  "backend/migrations/29_wallet_fks_and_admin_types.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "4ceb5fbce175fc3841585eea99bd4aa3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/48_notifications_tables.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "63a6d4db68e4b879623f2a337ad70680",
+    "semantic_hash": ""
+  },
+  "backend/migrations/55_find_nearby_drivers_suspended_filter.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "39175c19b6063b32cbfd98af9e6ec0fb",
+    "semantic_hash": ""
+  },
+  "backend/migrations/82_rides_discount_columns.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "ed08ed63b0db37af456337b88aa5fdf2",
+    "semantic_hash": ""
+  },
+  "backend/migrations/94_safety_incidents.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "4eec35e589ee8ebd6b19d7d056838f29",
+    "semantic_hash": ""
+  },
+  "backend/migrations/57_purge_pii_retention_regression_fix.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "05904853c70b88d81ed285da89c3dd15",
+    "semantic_hash": ""
+  },
+  "backend/migrations/68_complaints_table.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "0671bf3353bcdee583cb0d084bc5f924",
+    "semantic_hash": ""
+  },
+  "backend/migrations/46_rides_fees_and_taxes.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "ff8a36bf09cb01d7edbe74982183dde9",
+    "semantic_hash": ""
+  },
+  "backend/migrations/107_wallet_pay_idempotent.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "117cd0b6040e1b48a6d2b0f666260909",
+    "semantic_hash": ""
+  },
+  "backend/migrations/72_wav_dispatch_composite_idx.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "3a76935f364f508f4219b3ee5851237c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/98_create_ride_messages.sql": {
+    "mtime": 1780622912.5610237,
+    "ast_hash": "38620693855644b61d0edb494a8aec16",
+    "semantic_hash": ""
+  },
+  "backend/migrations/105_service_areas_timezone.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "c04002bc8a8813353615c7badc2105ab",
+    "semantic_hash": ""
+  },
+  "backend/migrations/101_users_add_is_rider.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "fd5a08834dc8578190356bdae10db052",
+    "semantic_hash": ""
+  },
+  "backend/migrations/37_rides_cancellation_fields.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "5161b0c4d03e303c89292b975c3933c6",
+    "semantic_hash": ""
+  },
+  "backend/migrations/57_audit_logs_schema_standardization.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "537c80c6e601a8a23507ace9fdee1390",
+    "semantic_hash": ""
+  },
+  "backend/migrations/07_promotions_extra_columns.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "2b7c748697f5ee110c76d94db25e547e",
+    "semantic_hash": ""
+  },
+  "backend/migrations/87_rides_payment_exhausted_alert.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "5cd9fc7c8a38b114e3c4ff06b6f69aa1",
+    "semantic_hash": ""
+  },
+  "backend/migrations/80_fix_match_and_claim_driver_type.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "680a722cd8a32712719d9ce7b9c95a7b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/20_quests.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "7f65d018189a6c283839454490ff082f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/44_rides_idempotency_key.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "7cdb224a4b89932d2cc46d29cd588368",
+    "semantic_hash": ""
+  },
+  "backend/migrations/52_fare_split_pay_rpc.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "f4fda241212458eb687692b8e8b07a71",
+    "semantic_hash": ""
+  },
+  "backend/migrations/39_rides_phase_polylines_durations.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "0514f75d3e8eaeeb85a8e672b1e4131e",
+    "semantic_hash": ""
+  },
+  "backend/migrations/91_driver_documents_expiry_date.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "9b1aec3ea1c7669b94df3d6352006b1f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/33_soft_delete_columns.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "a736f647f8b7b47f4d41685c56421865",
+    "semantic_hash": ""
+  },
+  "backend/migrations/24_schema_migrations.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "ba1fa83d9192626b49815afeba871d50",
+    "semantic_hash": ""
+  },
+  "backend/migrations/59_reconciliation_discrepancies.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "136624f6d35f26c64ed43d1c803127c8",
+    "semantic_hash": ""
+  },
+  "backend/migrations/34_rides_performance_indexes.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "7ef6f9f874552df00dfca2bda7a222ba",
+    "semantic_hash": ""
+  },
+  "backend/migrations/65_backfill_driver_insurance_periods.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "39d30eadd103240ce295f3960fcbbace",
+    "semantic_hash": ""
+  },
+  "backend/migrations/113_drivers_add_heading.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "6d149cc9d05c5abb829a44e54f43d79c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/29_corporate_allowance_rpc.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "34ddc222cb5a588496302b5b2855cad3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/08_service_area_subregions.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "4e600254d71fcd78b45a4be1c1ede5ad",
+    "semantic_hash": ""
+  },
+  "backend/migrations/69a_lost_and_found_repair_schema.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "d9234e5d142422ed27356e3654aadb98",
+    "semantic_hash": ""
+  },
+  "backend/migrations/03_corporate_accounts_heatmap.sql": {
+    "mtime": 1780622912.5324082,
+    "ast_hash": "6038f30b3ae76c956b53aa2ebc3c02c0",
+    "semantic_hash": ""
+  },
+  "backend/migrations/96_driver_ride_incentives.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "ba4e843ddfbce0f5201748ffcd8360ee",
+    "semantic_hash": ""
+  },
+  "backend/migrations/06_cloud_messaging.sql": {
+    "mtime": 1780622912.5324082,
+    "ast_hash": "ef78e2a6870438dd38134ab15f2f98ad",
+    "semantic_hash": ""
+  },
+  "backend/migrations/55_drivers_dispatch_partial_index.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "4d4e1ca00238bb8cca3defa94ecff7b1",
+    "semantic_hash": ""
+  },
+  "backend/migrations/110_wallet_pay_for_ride_tip_atomic.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "877e14a859f1377134c0779f84c1fa20",
+    "semantic_hash": ""
+  },
+  "backend/migrations/43_service_areas_surge_source.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "d2e3a1c0c4e614c7096c97843ff8b786",
+    "semantic_hash": ""
+  },
+  "backend/migrations/30_identity_audit.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "2679efdbd9be4eeab4551ffb4a117a83",
+    "semantic_hash": ""
+  },
+  "backend/migrations/28_requirement_key.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "434ef1d26e26ecca1727291aa4a716bd",
+    "semantic_hash": ""
+  },
+  "backend/migrations/103_backfill_incentive_claims.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "a0a752d60fe4539b7fc9617c395b201c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/100_batch_dispatch.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "6c311ba4b52017bc27dda53a0d3e5c66",
+    "semantic_hash": ""
+  },
+  "backend/migrations/77_match_and_claim_driver.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "68b8776875f1ad801b8d712e0175acd5",
+    "semantic_hash": ""
+  },
+  "backend/migrations/78_fix_pii_function_search_path.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "0419ab5a63258807a82e729c405e1c92",
+    "semantic_hash": ""
+  },
+  "backend/migrations/38_rides_cancellation_attribution.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "3c720c9d439a0f661398de869e03dac1",
+    "semantic_hash": ""
+  },
+  "backend/migrations/63_phase3b_field_alignment.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "3233a44e1bdd61b7a46d2689ed73f555",
+    "semantic_hash": ""
+  },
+  "backend/migrations/36_rides_corporate_member_id.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "9b27e03e3d45c67976ec17e0beaa6444",
+    "semantic_hash": ""
+  },
+  "backend/migrations/69_lost_and_found_table.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "b08fb17efd9eaf9f7d42194e38262815",
+    "semantic_hash": ""
+  },
+  "backend/migrations/45_drivers_doc_expiry_warned_at.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "0b15bdb0c227cddfbd25318500cfaf0b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/19_wallet.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "d858fed6e1e222d8b39e88907680c2d3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/22_stripe_events.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "399d6ed190b47799d2fc27c1945d29be",
+    "semantic_hash": ""
+  },
+  "backend/migrations/55_drivers_dispatch_composite_index.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "757f082353f3f26761db5588a382a559",
+    "semantic_hash": ""
+  },
+  "backend/migrations/01_add_driver_user_id.sql": {
+    "mtime": 1780622912.5324082,
+    "ast_hash": "03690ff2b80f642ddb6edd041a76dbdd",
+    "semantic_hash": ""
+  },
+  "backend/migrations/23_profile_image_url.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "d7fab103f46fac3f0e0bb28e349a21c3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/84_drop_service_areas_fee_columns.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "d348a97f2d4a26ac6e64b8b3eab7163f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/93_settings_missing_columns.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "5a59b2387c20f50d5fce2a6f17633bab",
+    "semantic_hash": ""
+  },
+  "backend/migrations/09_subscription_plans.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "fbd7bad29fc8fb589d0a8e35ff24d42e",
+    "semantic_hash": ""
+  },
+  "backend/migrations/85_drivers_add_is_suspended.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "3d915a96f4825c1bb97b15fd62252cee",
+    "semantic_hash": ""
+  },
+  "backend/migrations/109_wallet_pay_missing_ride_guard.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "8a6ff84b84daf9a3488cb3deb0122320",
+    "semantic_hash": ""
+  },
+  "backend/migrations/50_audit_logs_append_only.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "c1ce6d88817d94d5a29df4787a046e04",
+    "semantic_hash": ""
+  },
+  "backend/migrations/64_driver_insurance_periods.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "d643bbe209013dd6539f3b087bfda72c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/96_payouts_instant_reversal.sql": {
+    "mtime": 1780622912.5610237,
+    "ast_hash": "0681b8e6bcd8c0ff051f48ea7bb6e4b3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/60_wav_dispatch.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "9439d4c615c9d100fdd08bc72d9ac319",
+    "semantic_hash": ""
+  },
+  "backend/migrations/92_payouts_instant.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "01486319605881ae19caa28aeb78426f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/66_users_deletion_columns.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "7fb0c50077b22b0d8ee57a8fbefd6fd9",
+    "semantic_hash": ""
+  },
+  "backend/migrations/58_financial_events.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "9a067a38b63fba5baf82ca2ea5a5a548",
+    "semantic_hash": ""
+  },
+  "backend/migrations/92_drivers_stripe_kyc_mirror.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "074aa6210fa9c1a1885c026c64c79fef",
+    "semantic_hash": ""
+  },
+  "backend/migrations/52_admin_staff_mfa.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "bda6a34469016f27379333eeee0d2ec6",
+    "semantic_hash": ""
+  },
+  "backend/migrations/57_fix_retention_purge_audit_insert.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "da4c9e795d19bcc0fb97fdfd020d7b29",
+    "semantic_hash": ""
+  },
+  "backend/migrations/79_add_missing_query_indexes.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "896fbc28c96b6aba551587efd8229bc1",
+    "semantic_hash": ""
+  },
+  "backend/migrations/00_schema_migrations_table.sql": {
+    "mtime": 1780622912.5300512,
+    "ast_hash": "53f6ea41dc1872ecbafccc6fd61958e4",
+    "semantic_hash": ""
+  },
+  "backend/migrations/49_legal_documents.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "0c131377f016c9d36134b792ff5380cb",
+    "semantic_hash": ""
+  },
+  "backend/migrations/17_corporate_accounts_fk.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "397148402e9df6d22972bc9c3a865d6b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/54_dispatch_round_robin_index.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "d4efb8fbabe0ad676e749ed7bbee629b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/41_rides_route_snapshot_url.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "ff05902cab975a3784b4a8dad94f5891",
+    "semantic_hash": ""
+  },
+  "backend/migrations/88_stripe_disputes.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "7ee4a66e1e116c2aaaf9a4ac6ba21a2d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/91_driver_location_history_accuracy_fk.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "38da834b00d5be29b1acd43f64603f37",
+    "semantic_hash": ""
+  },
+  "backend/migrations/48_faqs_audience.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "cfdf6207bc52262ea59c1b1ca3858c8e",
+    "semantic_hash": ""
+  },
+  "backend/migrations/26_rls_coverage_gap.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "6516d4d5dad040ce3f486a9319850593",
+    "semantic_hash": ""
+  },
+  "backend/migrations/27_corporate_b2b_v1.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "ae3691c64d5ef398e591286a077927fd",
+    "semantic_hash": ""
+  },
+  "backend/migrations/90_rides_fare_breakdown_snapshot.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "dd3e093ec3802e3a10bb60d71ad4e98f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/86_promotions_free_ride.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "38f194ef3cf984ece01d6554907a14a4",
+    "semantic_hash": ""
+  },
+  "backend/migrations/52_loyalty_dedup_constraint.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "e5b13f982f60838de7d1d9c2cf4b2a3f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/67_fix_purge_pii_retention_actor_id.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "cf3df9955d068aaa794063849eff32b3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/56_purge_dsar_pending_deletions.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "a9848cbbf17ff22b7612d923a2683574",
+    "semantic_hash": ""
+  },
+  "backend/migrations/104_rides_driver_earnings_snapshot.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "76e8271077d4b780f4bb07080ccde4f4",
+    "semantic_hash": ""
+  },
+  "backend/migrations/71_ride_history_indexes.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "8bb98bdb4bfe164fe898ea9bb986548d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/70_fix_financial_events_rls.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "1943c37c125dff6cc6607968c5a9afc9",
+    "semantic_hash": ""
+  },
+  "backend/migrations/83_promotions_unique_code_per_area.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "4a10a74a01a999f4c9442852bd638694",
+    "semantic_hash": ""
+  },
+  "backend/migrations/31_driver_dedup_and_constraints.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "1d9165a719e89adb2aefd1af291e5908",
+    "semantic_hash": ""
+  },
+  "backend/migrations/50_pii_retention_purge.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "a9ebcd1ebf8a94d14831054cc54c65d2",
+    "semantic_hash": ""
+  },
+  "backend/migrations/62_ride_preferences.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "1a6b5c38e9a8b6e81d837f30ae163a17",
+    "semantic_hash": ""
+  },
+  "backend/migrations/73_fix_document_url_legacy_path.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "ed061659e7ac5e5a6ab1e57190c1192b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/51_audit_logs_remove_user_email.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "c5a9438de5d946bf80b6d68e59aa7b5d",
+    "semantic_hash": ""
+  },
+  "backend/migrations/58_drivers_gst_bn.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "77be78f8b11533ad3b2e6286fee81a4f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/14_driver_activity_log.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "6c333c9497431cba24241bd3109f6ef1",
+    "semantic_hash": ""
+  },
+  "backend/migrations/83_admin_media_assets.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "63c1db80f9782e62e02ddd4bf55c2a4b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/82_promotions_schema_and_service_area.sql": {
+    "mtime": 1780622912.5570238,
+    "ast_hash": "99e038438d45bdb1933fb843868eca25",
+    "semantic_hash": ""
+  },
+  "backend/migrations/51_promo_atomic_increment.sql": {
+    "mtime": 1780622912.5490236,
+    "ast_hash": "2e8100779f0c7a600b1c77e64aece218",
+    "semantic_hash": ""
+  },
+  "backend/migrations/42_drivers_last_status_changed_at.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "c4d13d1ba690e9999c31569b79225260",
+    "semantic_hash": ""
+  },
+  "backend/migrations/100_rides_planned_route_polyline.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "e44ee9ff069fe4aa65858b9ac48e5dc9",
+    "semantic_hash": ""
+  },
+  "backend/migrations/32_encrypt_sensitive_fields.sql": {
+    "mtime": 1780622912.5450237,
+    "ast_hash": "44d7100a2ed15c3206af322175612d6c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/99_cloud_messages_jsonb_columns.sql": {
+    "mtime": 1780622912.5610237,
+    "ast_hash": "7a342cd04a4eae39c27cdd6d8eaaa8ab",
+    "semantic_hash": ""
+  },
+  "backend/migrations/108_wallet_pay_ride_id_text_cast.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "7f71db555534bd0521248477c41c9bb2",
+    "semantic_hash": ""
+  },
+  "backend/migrations/74_correct_total_rides.sql": {
+    "mtime": 1780622912.5530238,
+    "ast_hash": "0d2d91883ad339ce5356e2c19c092c36",
+    "semantic_hash": ""
+  },
+  "backend/scripts/run_migrations.sh": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "e4ad930364059a8e0c3330ee52826ef6",
+    "semantic_hash": ""
+  },
+  "backend/scripts/check_migration.py": {
+    "mtime": 1780622912.5990024,
+    "ast_hash": "0973e59901a7a627220dc8d52d93273c",
+    "semantic_hash": ""
+  },
+  "backend/models/ride_status.py": {
+    "mtime": 1780622912.562677,
+    "ast_hash": "a4bc2ca74a17e7bc42c47239973d2ba1",
+    "semantic_hash": ""
+  },
+  "backend/models/__init__.py": {
+    "mtime": 1780622912.5610237,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_db_executor.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "de20eba796b222d5ccaaf446ee0a0fa8",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p2_chat.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "1152e35cb87346590d4b9c3cbafe49e6",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_drivers_extended.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "0d0d73cf7e2d3c3c1b354e9a916d328c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_broadcast_timeout.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "063152c02cf23145cba3629ef3c4cd37",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_loop_alert.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "8c8b82d6673f778b9867031561e97a56",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_coverage_boost.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "fb9ad555ea385238aaa2e60e8ba4cfca",
+    "semantic_hash": ""
+  },
+  "backend/tests/perf_rides_after.json": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "928d256e1e32687dc5fb47eca15e5453",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_logout_all.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "ffc7f9beae68d13588773eb39de33f2c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_utils_extended.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "cd204cc25d02e74b4ea43af78c2ccc51",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_audit_logs_lockdown.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "939b8be284fc4ee8bc71eef0b1b641a5",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p1_ws_reconnect.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "ece6f6d352116d14677cc10cf29df823",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_analytics_503.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "0904b7e1ed6a36b9c37b1a29be353c43",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_set_driver_available_invariant.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "572be300127f630ee884d1c66e19ef96",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_csrf_middleware.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "5bc1d563742de259ec4ccc3fd643e7c6",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e2e_cancellation.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "784e9ccf1fe8e1403ff54e684426eda0",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e8_duplicate_ride.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "6be7f789b827c183db2ab99eb185d18b",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p2_corporate_decimal.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "e8228e8d44178e666ac290ae5b3a1bc6",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_t4a_annual_job.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "68b5cabe350d79adb6a638169a93896f",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_promo_rate_limit.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "164abcdde05832e2d2d6933ded187ca7",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_route_distance.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "f6b5bd147a933c0e1a6d7b24013e3966",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_cookie_auth.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "900e9b4f750ba5c45da30242a0655036",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p2_promo_wallet_loyalty.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "faff7a2c18db91d44de9c9aff282369f",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_replay_safety_payment_loops.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "e43fd2288afced086fa7280cc71a026d",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p0_ship_blockers.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "2479b08b4c4ff80e923b8dea1c5db6a8",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_payments_stripe_error_specificity.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "6dcecee31c4d30a9dd9a3914fe0e6eac",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_error_response_sanitisation.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "4c04ab049de84431da57c96dbb1accee",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_messaging_fan_out.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "51ac5fd5c4501916ce3bae4121b1b5f5",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p1_multi_stop.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "9f4847f3f0fffb8c353f217d363d74f2",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_websocket_auth.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "0121c4526ae86d55e60a8b632aec157c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_rides_notes_patch.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "33d3ff85fb6c337011ae9bca972c3d73",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_surge_reset_to_auto.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "aeed6ce67dda329164c0d1f136777f34",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p1_security.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "1542da87b6dd34e949633386875daf2c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_appcheck_request_id.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "55fa92ef87ce5eefdb58b9edb7c3b6ea",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_promo_concurrency.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "82f1e465919f804422886e7ed6c0380c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_payment_retry.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "bc99daebf744302a41f31d35bde18e80",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_rides_extended.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "32bdd1e261ebf925aaa5d3d1f535ac90",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_process_payment_card.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "f11cfb4333905b04414faa6edf8ccf71",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_background_location.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "170a150c8398ab26aa698c021ca5b71f",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_security.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "df2c49bae4598db56f39cc6a5a3087ae",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_coverage_rides.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "1d53db54ae48856a41fee9177e4cb88b",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p2_payout_t4a.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "1789b12cf5c0589f83b21c56bf6a0d40",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_coverage_payments.py": {
+    "mtime": 1780622912.6250236,
+    "ast_hash": "a95ba1ca165ed2c94e5ef034e8ea40a4",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_receipt_line_items.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "e43f29909e6139ed6b89d9d808580632",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_vehicle_illustration.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "63e8519e003170b6b1211aed02dc2e1c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p1_auth_hardening.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "643920b1e9ddbad9bbcaecf7d0a31632",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_dsar_export_gather.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "fd2726b1a75997f91c76feb61199a135",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_logout_revocation.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "704cae3fe2319de1ff0571190060fb35",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_webhooks_main.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "a64cd3ba49fc8be8f96ee26d2488b9cc",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_surge_bypass.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "621205e78b3beb5e7d552f6e986f3119",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p0_rating_and_payment.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "54e75e25173e8f771214dacde60376ab",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_business_logic.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "9a005372ec917995ac461f62bdb40cb5",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_payment_sheet.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "1042134b8379bacd460594436976cef4",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_instant_payout.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "0fa0827a998aa412d045e12e0289fb50",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_surge_engine.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "429708d550e48bfa5a09a4916959e625",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_push_notifications.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "6f982479b93a25a486d44836ea6320f8",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e2e_wav_dispatch.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "7d4b33a6f1bd103e8230499ba70a8a5d",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_ws_broadcast.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "faec8d1865d1fc61e9b8a2161cffd789",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e16_surge_boundary.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "0e0909282ace532897ab7a3b9db70d9e",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_b_p0_2.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "00ea5ba3356f8647fde29ad1e6ae1fc9",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_rate_limit_response_shape.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "c23ebbca6b1cc3d772f33c3f6da20604",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_safety_checkin_loop.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "9d72ff4b60f228adb68e73bca8873750",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_ride_history_pagination.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "b3e217a72bccf3caf2016267c1d3ff47",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p1_driver_offline.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "467ef24108fac54d6c0ca6dbf5e23616",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_stripe_card_payment.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "f45a040e60aa75c9c38765ace3638400",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_scheduled_dispatch_cr.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "31e0e9725db8ac7998dac618bc88c081",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_money_decimal.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "47dc3d4f9c0462d4cea1eb8d8dc57cf5",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_websocket_per_user_rate_limit.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "bbd9b5bc06425cde2f2da8c6482049b0",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p2_scheduled_rides.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "6cca9dfde8c861748a2033fef0420004",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_otp_crypto.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "3883511ec1f76e6481e17c189bd40ca7",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p2_sos.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "0e5427e5cf35816992fd0b068dde6530",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_retention_purge.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "d922a390a82de9e176a68e5651dd5714",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_extended.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "97afab9bfb0cd12630301e403be68bdb",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p1_cors.py": {
+    "mtime": 1780622912.6410236,
+    "ast_hash": "44c23294ae914877d5f0b76846204284",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e2e_ride_lifecycle.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "22d12972bd2be78d2a715577727a11f5",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_admin_jwt_modules.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "ef0ad3f7ff3ae00e31764b36b60257c0",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_corporate_ride_payment.py": {
+    "mtime": 1780622912.6210237,
+    "ast_hash": "309c5e31f478fb58b9053672d3b92ef8",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_stuck_ride_sweeper.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "41296fd7926e7e4d0b2d74e74e8aa525",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_maps_proxy.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "0268baa5c62b2fd76e1a11578c44172a",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_money_serialization.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "c48b65d2838368c7ed060de4a9c05ab9",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_insurance_periods.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "9382d8a32256924d6168a9dbbc50598a",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_fares.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "ffe60cf58f8b4475b5483ebae250b32c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_wav_dispatch.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "707cb5becdefd86718b32dfefa784fec",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_schema_contract.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "918ddf766b16bc5297e22559ddea0d26",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_pii_redaction.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "61edf1a6d6a5e4b2b22f000bd1606a75",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_service_areas_public.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "9d5ca2f2d2a8a6ae51bb85975638260b",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e2e_sos_flow.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "b4aea93cb4e64899fd02e21cc5487530",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_stripe_reconcile.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "b0fd91a7d64ceed38f69c9023e945adc",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e4_d10_payment_3ds_quests.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "efa993f26d39ccbe9ec46f65200b2edd",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_document_expiry.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "da388d55c121c8186ab4152a21154b44",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_receipt_email.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "b7c6d1dc89d11a578eadeb9a578727c3",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_monitoring_health.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "87490a6363912c80d19ee5f64d3b7bdc",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_rate_driver.py": {
+    "mtime": 1780622912.6490238,
+    "ast_hash": "df1de3d2bb23f3a90b8c41470fbc3612",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_rbac.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "4f5cdafb2dfb6fd439ec9051935f8a38",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_addresses_favorites_safety_disputes.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "03afcaaab747d123a0a209bb4fd3193c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_stripe_charge.py": {
+    "mtime": 1780622912.6570237,
+    "ast_hash": "a1ad8f2c2330242b84787d738a298e1a",
+    "semantic_hash": ""
+  },
+  "backend/tests/perf_rides_before.json": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "ff624efaeb2ececffb622aebb9b7d1f0",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_db_supabase_helpers.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "ec61103974d3df539045f6ed9e970a06",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_loop_jitter_metrics.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "f48c173a6a47e34ecda33422817363e2",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_p3_wallet_concurrency.py": {
+    "mtime": 1780622912.6450238,
+    "ast_hash": "803e486511c259cf5a067e7d708a05b0",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_a_p0_3_gps_oom.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "faa7bb0f799381db3d6776524c5388ee",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e2e_payment_guard.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "c927e48e85f6563efa652e41298e0c41",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_e2e_rating_regression.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "64b5b05caee2324c330f82236d785195",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_dsar_export.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "ee8c78600ea00570b600aa2f6d4d0bc9",
+    "semantic_hash": ""
+  },
+  "backend/tests/services/test_corporate_policy_service.py": {
+    "mtime": 1780622912.6124141,
+    "ast_hash": "2334033529227ed829b2b1dee688246f",
+    "semantic_hash": ""
+  },
+  "backend/tests/routes/__init__.py": {
+    "mtime": 1780622912.6090279,
+    "ast_hash": "d41d8cd98f00b204e9800998ecf8427e",
+    "semantic_hash": ""
+  },
+  "backend/tests/routes/test_payments.py": {
+    "mtime": 1780622912.611484,
+    "ast_hash": "6a2e87fd500ac3020d396f3be7502920",
+    "semantic_hash": ""
+  },
+  "backend/core/csrf.py": {
+    "mtime": 1780622912.5276701,
+    "ast_hash": "51db9649f2146b54ba599eab487120d9",
+    "semantic_hash": ""
+  },
+  "backend/utils/maps_budget.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "f3292e3411bf1ed8a2b106139f475aeb",
+    "semantic_hash": ""
+  },
+  "backend/utils/stripe_charge.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "d4445c1c30115ccad80b36b2f11fb350",
+    "semantic_hash": ""
+  },
+  "backend/utils/route_validation.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "0422c9ca5fcf4f4954aa30bc3330024a",
+    "semantic_hash": ""
+  },
+  "backend/utils/stripe_config.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "d38ef335346bb9e9be1917106b8f6305",
+    "semantic_hash": ""
+  },
+  "backend/utils/route_snapshot.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "cf6d7b1007707fa9c72880d263567438",
+    "semantic_hash": ""
+  },
+  "backend/utils/location_integrity.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "dc0d91d7b0aa74c4de16fbb7f77289f8",
+    "semantic_hash": ""
+  },
+  "backend/utils/pii.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "68d4eee59bec572ede0928ce4dc9e19d",
+    "semantic_hash": ""
+  },
+  "backend/utils/stripe_reconcile.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "861a5f6e6aa05102ff921abfb603b1e9",
+    "semantic_hash": ""
+  },
+  "backend/utils/metrics.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "c736cac096acae933bfb1c096bdc48aa",
+    "semantic_hash": ""
+  },
+  "backend/utils/deadline.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "a8da50fae6d90c74f8547abcd18d82b7",
+    "semantic_hash": ""
+  },
+  "backend/utils/route_distance.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "4cf37c68533a6564121232608b98e2ed",
+    "semantic_hash": ""
+  },
+  "backend/utils/loop_alert.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "aef314623f2f3788460ed94167e47a9b",
+    "semantic_hash": ""
+  },
+  "backend/utils/driver_presence.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "5f96b25cdf9fd257d7e5969dcd09b478",
+    "semantic_hash": ""
+  },
+  "backend/utils/t4a_pdf.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "181fa96cb77ba1415e26d52f17ac17eb",
+    "semantic_hash": ""
+  },
+  "backend/utils/idempotency.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "c15c4477539cefa82c062a03d1a128ee",
+    "semantic_hash": ""
+  },
+  "backend/utils/datetime_utils.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "bf7fe8293828877e7793354a833117dd",
+    "semantic_hash": ""
+  },
+  "backend/utils/money.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "268ffcab8ec44c13d7fcf131632dd128",
+    "semantic_hash": ""
+  },
+  "backend/utils/log_context.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "f7930dbcf3b157ad0cecada6b9add030",
+    "semantic_hash": ""
+  },
+  "backend/utils/presence_sweeper.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "c88a0c28d6e06e8695bbd61e7c3b981c",
+    "semantic_hash": ""
+  },
+  "backend/utils/error_keys.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "1d2dbb1dcdb36646515f26b02c653190",
+    "semantic_hash": ""
+  },
+  "backend/utils/stuck_ride_sweeper.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "42d549ed81b0a111cf586fde97afe065",
+    "semantic_hash": ""
+  },
+  "backend/utils/driver_online.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "a4e6aba19a7457ec6df915e12c16e8dc",
+    "semantic_hash": ""
+  },
+  "backend/utils/reconciliation.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "1538da964a8e29fe8e239fc4d200b536",
+    "semantic_hash": ""
+  },
+  "backend/utils/insurance_periods.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "b7e5a7ae27ec831e1d61053839ca38be",
+    "semantic_hash": ""
+  },
+  "backend/utils/push_retry.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "16a159b00a23404fde26642d07b4af47",
+    "semantic_hash": ""
+  },
+  "backend/utils/device_attestation.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "d91bc4c46daab48c853143e841f136b5",
+    "semantic_hash": ""
+  },
+  "backend/utils/subprocessor_audit.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "ea5f5f90c5cb490b48e0f557fd785a68",
+    "semantic_hash": ""
+  },
+  "backend/utils/maps_eta.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "342f5d9db4dbde9554ccf956a0fd9935",
+    "semantic_hash": ""
+  },
+  "backend/utils/safety_checkin_loop.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "c0e450c5b98be46b8361c385a25a8c11",
+    "semantic_hash": ""
+  },
+  "backend/utils/loop_monitor.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "9ba4afe8ddf930aa8a4c581694088fc8",
+    "semantic_hash": ""
+  },
+  "backend/utils/retention_purge.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "ad1fc0c5c5fb41839a53dd82052bcc19",
+    "semantic_hash": ""
+  },
+  "backend/utils/cookie_manager.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "3a01afc6f253bc3da07322b2278647d9",
+    "semantic_hash": ""
+  },
+  "backend/utils/receipt_email.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "5c870876e2f2451afd5e61cf431f52f8",
+    "semantic_hash": ""
+  },
+  "backend/utils/ride_code.py": {
+    "mtime": 1780622912.6970236,
+    "ast_hash": "89c4698636dd13b63d2a132b571d020c",
+    "semantic_hash": ""
+  },
+  "backend/utils/t4a_annual_job.py": {
+    "mtime": 1780622912.7010238,
+    "ast_hash": "c8a6a3aa18174712fe7861149c55ced0",
+    "semantic_hash": ""
+  },
+  "backend/utils/audit_logger.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "c97d061b719f3aea2e467b300d3f437c",
+    "semantic_hash": ""
+  },
+  "backend/routes/faqs.py": {
+    "mtime": 1780622912.5810237,
+    "ast_hash": "74de9ccec437bdf3655abed5f542732e",
+    "semantic_hash": ""
+  },
+  "backend/routes/service_areas.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "9335d368b69edf4b09dd2cfe5aae08fb",
+    "semantic_hash": ""
+  },
+  "backend/routes/legal_documents.py": {
+    "mtime": 1780622912.5810237,
+    "ast_hash": "b37474101a472d47331d8fd2540037e7",
+    "semantic_hash": ""
+  },
+  "backend/routes/safety.py": {
+    "mtime": 1780622912.5930238,
+    "ast_hash": "617a012370acb22e0ef76242631db98a",
+    "semantic_hash": ""
+  },
+  "backend/routes/maps_proxy.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "308b679b4379c3cff03d2006354bdbfe",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/incentives.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "e2b9abb95a38c0a287faa9d2657ed3e1",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/legal_documents.py": {
+    "mtime": 1780622912.570479,
+    "ast_hash": "5dda35b2e5e23230c7985afb8c47bb10",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/safety.py": {
+    "mtime": 1780622912.5730238,
+    "ast_hash": "9d15ac6134c24679a2ebe76cf064f140",
+    "semantic_hash": ""
+  },
+  "rider-app/vercel.json": {
+    "mtime": 1780622913.7002835,
+    "ast_hash": "61bd31a2b0ac08f10f13c932b32d6ca1",
+    "semantic_hash": ""
+  },
+  "rider-app/config.ts": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "5c4bae5b1756e6782cef33c1f6fd9152",
+    "semantic_hash": ""
+  },
+  "rider-app/google-services.json": {
+    "mtime": 1780622913.6884718,
+    "ast_hash": "184167dff8205a0290133613b50f10f6",
+    "semantic_hash": ""
+  },
+  "rider-app/package.json": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "af79ad3a7fd80477a2a6fa5d10a1e1e3",
+    "semantic_hash": ""
+  },
+  "rider-app/eas.json": {
+    "mtime": 1780622913.6884718,
+    "ast_hash": "2f864ab7445e68a8acee3518638174f7",
+    "semantic_hash": ""
+  },
+  "rider-app/jest-setup-expo.js": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "aabb97f36641c878470d783161bb32d6",
+    "semantic_hash": ""
+  },
+  "rider-app/tsconfig.json": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "a528cec8b7ac144d967cb6c8a8befdb7",
+    "semantic_hash": ""
+  },
+  "rider-app/components/ConfirmSheet.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "8a64ba56f53a13868bb1f03aaf9ddb08",
+    "semantic_hash": ""
+  },
+  "rider-app/components/Toast.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "e89729066809a987620c8adc9239daf4",
+    "semantic_hash": ""
+  },
+  "rider-app/components/SkeletonBox.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "569b16772766c8f79adc68d63877f7e8",
+    "semantic_hash": ""
+  },
+  "rider-app/components/CustomToggle.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "0eff93aff8de03a02d820937728e75bc",
+    "semantic_hash": ""
+  },
+  "rider-app/components/SchedulePicker.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "7b87d83cdbf06b6d30a7e207503ee68d",
+    "semantic_hash": ""
+  },
+  "rider-app/components/SafeBottomSheet.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "0196324f30b678187f610e237a1d4b34",
+    "semantic_hash": ""
+  },
+  "rider-app/store-assets/metadata.json": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "85063a0fdbd8e650175ac32f8045c813",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/useRideStatusNotification.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "4cdd3f964a29c66401055f2e0263351e",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/useSpinrPaymentSheet.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "8ab9fdf06e3807ff5b9c51c76b7ae80c",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/useScheduledRideReminder.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "24e4639790932f5b6bb1572b62161c3a",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/useAuth.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "450b2e140c137a07beffd341cde8b213",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/useAppResumeKey.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "00bd9d26f4e2bf812f8d79f29094235c",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/__tests__/useRiderSocket.reconnect.test.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "b4305e8ead72f5cbd0507ac3d9e32680",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/__tests__/useScheduledRideReminder.test.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "ff7de18da908f18332c6c3b344225965",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/__tests__/useRiderSocket.chat.test.ts": {
+    "mtime": 1780622913.6890237,
+    "ast_hash": "60169a76b7db9a6a8e601ffdb9512dd4",
+    "semantic_hash": ""
+  },
+  "rider-app/hooks/__tests__/useSpinrPaymentSheet.test.ts": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "676d901a52d8bd6a9cbb12cecca5d91d",
+    "semantic_hash": ""
+  },
+  "rider-app/constants/geo.ts": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "e4106d7aa605f8b5d896b5022b214876",
+    "semantic_hash": ""
+  },
+  "rider-app/constants/rideStatus.ts": {
+    "mtime": 1780622913.688098,
+    "ast_hash": "a07432ec10dbefcde0407a44fc92f63d",
+    "semantic_hash": ""
+  },
+  "rider-app/__mocks__/expoWinter.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "64e09ba341e550784c724f369684eda0",
+    "semantic_hash": ""
+  },
+  "rider-app/__mocks__/expo-winter-stub.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "d73a7de76297a634a5fa6f3afac17286",
+    "semantic_hash": ""
+  },
+  "rider-app/__mocks__/expo-winter-noop.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "3f347a3031deea0b74235013e6bf27b5",
+    "semantic_hash": ""
+  },
+  "rider-app/__mocks__/expo-jest-setup.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "7d23d650767b44dfd60cc27666f1d311",
+    "semantic_hash": ""
+  },
+  "rider-app/__mocks__/expo-winter-runtime.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "1c5c938bef3c07774f1614c30b20c62a",
+    "semantic_hash": ""
+  },
+  "rider-app/__mocks__/@react-native-firebase/crashlytics.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "3681020bfae07368815d75bf8fb75024",
+    "semantic_hash": ""
+  },
+  "rider-app/app/work-allowance-request.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "23f118ee93d399146c0fa31ff1bc9c33",
+    "semantic_hash": ""
+  },
+  "rider-app/app/ride-tracking-webview.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "d3fa62f514c01a083e387feba6ef259f",
+    "semantic_hash": ""
+  },
+  "rider-app/app/confirm-pickup.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "77f4e6fcbafa51929d4d737c229ace08",
+    "semantic_hash": ""
+  },
+  "rider-app/app/accessibility.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "c7c655dcb6cd88d760da067744165fb4",
+    "semantic_hash": ""
+  },
+  "rider-app/app/work-profile.tsx": {
+    "mtime": 1780622913.6770236,
+    "ast_hash": "b631f9384edaa4a87f4637dc660a5671",
+    "semantic_hash": ""
+  },
+  "rider-app/__tests__/errorI18nCoverage.test.ts": {
+    "mtime": 1780622913.6686018,
+    "ast_hash": "5d43a4ac0ba45afa528f7bc1d83f77dc",
+    "semantic_hash": ""
+  },
+  "rider-app/__tests__/auth.integration.ts": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "bcfcd4055257dcb704af5fae01d2e835",
+    "semantic_hash": ""
+  },
+  "rider-app/__tests__/httponly-cookies.e2e.ts": {
+    "mtime": 1780622913.6686018,
+    "ast_hash": "306b5749584efa263da380b11ac6a8fb",
+    "semantic_hash": ""
+  },
+  "rider-app/__tests__/rideStore-wav-gating.test.ts": {
+    "mtime": 1780622913.6686018,
+    "ast_hash": "c2b8a698e63f6f664a4f43438ebf398b",
+    "semantic_hash": ""
+  },
+  "rider-app/store/toastStore.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "5b274a67cb3f00038941cf7ff0ba3430",
+    "semantic_hash": ""
+  },
+  "rider-app/store/workProfileStore.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "c5b460c681bdb60badf4b4bd7f8a7349",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.chat.test.ts": {
+    "mtime": 1780622913.6940405,
+    "ast_hash": "871216dd1e71ed68ac3d847e5b2e593c",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.stops.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "02477f8b34237884b5a3ecc257bd8e12",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.promo.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "626eca0bf53413db75967ac6c5fd8f5c",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.restart.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "23763edc065509d275ab0382bbde1ad2",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.sos.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "156e3e25db69a61f8e93edd81f617bf7",
+    "semantic_hash": ""
+  },
+  "rider-app/store/__tests__/rideStore.wav.test.ts": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "2d9ed63c243105e2f77efb6c97ba9546",
+    "semantic_hash": ""
+  },
+  "rider-app/__stubs__/emptyNativeComponent.js": {
+    "mtime": 1780622913.6672935,
+    "ast_hash": "8d3d47729c7f49e2dda08c5b56386b30",
+    "semantic_hash": ""
+  },
+  "rider-app/lib/alert.ts": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "808a21068a58ed95f37764c9e186ce83",
+    "semantic_hash": ""
+  },
+  "rider-app/e2e/rating-submission.spec.ts": {
+    "mtime": 1780622913.6884718,
+    "ast_hash": "8ad43eca240da629d58cee3544029b4e",
+    "semantic_hash": ""
+  },
+  "rider-app/e2e/cancellation.spec.ts": {
+    "mtime": 1780622913.688098,
+    "ast_hash": "630c4e7f32ae31584b6ca75cd84067b2",
+    "semantic_hash": ""
+  },
+  "rider-app/e2e/payment-completion.spec.ts": {
+    "mtime": 1780622913.6884718,
+    "ast_hash": "385b7ae054251f01d18c1c02edfd5b5e",
+    "semantic_hash": ""
+  },
+  "rider-app/build-options/option-a-kotlin-2.0.21/withStripeAndroidPin.js": {
+    "mtime": 1780622913.6859512,
+    "ast_hash": "af2611e886e7d733537823e23a204ee6",
+    "semantic_hash": ""
+  },
+  "rider-app/utils/apiClient.ts": {
+    "mtime": 1780622913.7002835,
+    "ast_hash": "c80a34b7821ea60f7c01369c5cdd04ae",
+    "semantic_hash": ""
+  },
+  "rider-app/utils/crashlytics.ts": {
+    "mtime": 1780622913.7002835,
+    "ast_hash": "7c49848a3d85464cc1c3886138bbae45",
+    "semantic_hash": ""
+  },
+  "rider-app/utils/fareBreakdown.ts": {
+    "mtime": 1780622913.7002835,
+    "ast_hash": "25f0601e3971e24668c52ebd2c777701",
+    "semantic_hash": ""
+  },
+  "rider-app/utils/attemptRidePayment.ts": {
+    "mtime": 1780622913.7002835,
+    "ast_hash": "9e5aa1642dde3fec2d5574a51ef5b74b",
+    "semantic_hash": ""
+  },
+  "rider-app/utils/__tests__/attemptRidePayment.test.ts": {
+    "mtime": 1780622913.7002835,
+    "ast_hash": "c7322a6fdeb9dc41616146b6844115ed",
+    "semantic_hash": ""
+  },
+  "rider-app/plugins/withGradleWrapper.js": {
+    "mtime": 1780622913.6933837,
+    "ast_hash": "cd06c3416afeb58b540db031f28984b2",
+    "semantic_hash": ""
+  },
+  "rider-app/plugins/withKspVersion.js": {
+    "mtime": 1780622913.6933837,
+    "ast_hash": "294b659519942c76651bd9eb45cdad94",
+    "semantic_hash": ""
+  },
+  "rider-app/plugins/withForceCompileSdk.js": {
+    "mtime": 1780622913.6927516,
+    "ast_hash": "1ab5050a2e844fbf7b5804fff4bef273",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/index.ts": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "8556f2702243542fb405b68c961dc353",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/en-CA.json": {
+    "mtime": 1780622913.6898787,
+    "ast_hash": "f0ef3744fdaaf76c48a66824eea37a45",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/fr.json": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "e68c4163d92047f8c4246b984488ea44",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/fr-CA.json": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "0c2a15749cabf99cfafac9866cdec919",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/en.json": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "702cf38c6a2a2c1e508a4530901ab5fb",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/es.json": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "6eb920fde511108377a78fdc315f5043",
+    "semantic_hash": ""
+  },
+  "rider-app/i18n/zh.json": {
+    "mtime": 1780622913.6916695,
+    "ast_hash": "72b71efc1ebdafefa00f63518ba8e932",
+    "semantic_hash": ""
+  },
+  "rider-app/test-results/.last-run.json": {
+    "mtime": 1780622913.6945474,
+    "ast_hash": "ff6d5dab1dfd50cea584142bc288ce9e",
+    "semantic_hash": ""
+  },
+  "scripts/setup-claude.sh": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "3d97f2276e4799065d8468eef7d1a46f",
+    "semantic_hash": ""
+  },
+  "scripts/apply_supabase_schema.sh": {
+    "mtime": 1780622913.7010438,
+    "ast_hash": "0a5498b56550de56b284b092b8410bc0",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/create_github_issue.py": {
+    "mtime": 1780622913.7049932,
+    "ast_hash": "5309c8ee3d9b413370ed390ea9ab2bf3",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/change_request_generator.py": {
+    "mtime": 1780622913.7049932,
+    "ast_hash": "f19ca92c4722b4fa8c0ba0bda78b0e51",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/error_classifier.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "7a396ec6615e3094ec85c78e97cdeee5",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/__init__.py": {
+    "mtime": 1780622913.7046251,
+    "ast_hash": "3e313de07e493d79708ff5e743fff5bf",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/impact_assessor.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "1740d4604709901abd4bd5f00103110c",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/audit_runner.py": {
+    "mtime": 1780622913.7049932,
+    "ast_hash": "455ff1e34603d6416a88fa27e299d79a",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/report_generator.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "a4037c14136c6479a9b261fb8b667b27",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/fix_recommender.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "d8a3f971c6d1549ba06de24db1738b0a",
+    "semantic_hash": ""
+  },
+  "scripts/ci-audit/fetch_run_data.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "d1b1768e87f7e5f2f66f66335a920305",
+    "semantic_hash": ""
+  },
+  "scripts/smoke/full_stack_smoke.py": {
+    "mtime": 1780622913.7050238,
+    "ast_hash": "7f3680596bf358dc1b93164620df0f74",
+    "semantic_hash": ""
+  },
+  "scripts/smoke/stripe_charge_smoke.py": {
+    "mtime": 1780622913.7072804,
+    "ast_hash": "78f5530a40dd4d2a8aefcad550101d65",
+    "semantic_hash": ""
+  },
+  "tests/test_cross_app_ride_lifecycle.py": {
+    "mtime": 1780622913.7170439,
+    "ast_hash": "e7ae30008a75709d53f6d01b5f2560c0",
+    "semantic_hash": ""
+  },
+  "tests/hooks/test_pre_commit.sh": {
+    "mtime": 1780622913.7170439,
+    "ast_hash": "d204a3b7184bfffba1ea0e05f9194797",
+    "semantic_hash": ""
+  },
+  ".planning/HANDOFF.json": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "4e2470aa35aac7ddc31db02e2424ef13",
+    "semantic_hash": ""
+  },
+  ".planning/config.json": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "8798d8213a91623ddb5ea94f9f7cb43a",
+    "semantic_hash": ""
+  },
+  ".planning/graphs/graph.json": {
+    "mtime": 1780622912.3970237,
+    "ast_hash": "add187f48af0bb1abbb45f3edbef2977",
+    "semantic_hash": ""
+  },
+  ".planning/graphs/.last-build-snapshot.json": {
+    "mtime": 1780622912.2930238,
+    "ast_hash": "4be783f49639526a4bdfe3c506cc28eb",
+    "semantic_hash": ""
+  },
+  "docs/claude-audit.json": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "e98b2efe1968ea8bbac6e0256ad3a8d4",
+    "semantic_hash": ""
+  },
+  "docs/subprocessors-baseline.json": {
+    "mtime": 1780622912.738854,
+    "ast_hash": "43a1d08f5c3bb3f4fd2ccb05e794e222",
+    "semantic_hash": ""
+  },
+  ".claude/settings.json": {
+    "mtime": 1780622912.179687,
+    "ast_hash": "456a0521c1f1eb5db197735fca9090a5",
+    "semantic_hash": ""
+  },
+  ".claude/mcp.example.json": {
+    "mtime": 1780622912.179687,
+    "ast_hash": "3104b5dde5f422f07bbd6740f88878cb",
+    "semantic_hash": ""
+  },
+  ".claude/launch.json": {
+    "mtime": 1780622912.179687,
+    "ast_hash": "36b5eca93a6c20dd0d24adf81e5fa3af",
+    "semantic_hash": ""
+  },
+  ".claude/hooks/pre-commit": {
+    "mtime": 1780622912.179687,
+    "ast_hash": "ebcd2cf9c7dd6309305bfafea51276f0",
+    "semantic_hash": ""
+  },
+  ".claude/hooks/session-start.sh": {
+    "mtime": 1780622912.179687,
+    "ast_hash": "8bf67ee85a22751869dc37444b0aac17",
+    "semantic_hash": ""
+  },
+  ".claude/hooks/pre-migration-write.sh": {
+    "mtime": 1780622912.179687,
+    "ast_hash": "58157c39693ba4c3687eb01c258860ec",
+    "semantic_hash": ""
+  },
+  ".claude/hooks/post-python-write.sh": {
+    "mtime": 1780622912.1780827,
+    "ast_hash": "f59e5ac0775df109f990786cf35ffcab",
+    "semantic_hash": ""
+  },
+  ".vscode/settings.json": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "818620337cb4e5f66e8dad9a1d7a5e80",
+    "semantic_hash": ""
+  },
+  "SECURITY.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "8815dfcade25fc3337de97a9c55a19d1",
+    "semantic_hash": ""
+  },
+  "SCALING_PLAN.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "599eb33067a6c3bab4322aea90abdb56",
+    "semantic_hash": ""
+  },
+  "OPEN-ITEMS-TRACKER.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "559d02ee527bae6dd6a5d24ddf701ddc",
+    "semantic_hash": ""
+  },
+  "render.yaml": {
+    "mtime": 1780622913.6130238,
+    "ast_hash": "d288ff106f4b518d3aaf8348d6253f42",
+    "semantic_hash": ""
+  },
+  "DRIVER_BACKEND_AUDIT.md": {
+    "mtime": 1780622912.4250238,
+    "ast_hash": "7006527456782e8d0f3a6463d8dcb041",
+    "semantic_hash": ""
+  },
+  "driver-app/build-options/README.md": {
+    "mtime": 1780622912.7730236,
+    "ast_hash": "812b085224e19ec5f4542b661dda6da8",
+    "semantic_hash": ""
+  },
+  "driver-app/build-options/option-b-kotlin-2.1.20/README.md": {
+    "mtime": 1780622912.775116,
+    "ast_hash": "d3fa03eddd30117f63de8f3fd6780748",
+    "semantic_hash": ""
+  },
+  "driver-app/build-options/option-a-kotlin-2.0.21/README.md": {
+    "mtime": 1780622912.775116,
+    "ast_hash": "888a8ab97e503fd0194c464614cb4633",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T03-22-29-638Z.yml": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "6c792a5595288a77b5b525539e7c0f7b",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T02-32-32-559Z.yml": {
+    "mtime": 1780622912.4170237,
+    "ast_hash": "44c525e1a0c8285ba4c2acee4603152d",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T17-01-06-839Z.yml": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "6ae15e48860e9daf06f1a8532e97d67d",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T17-29-32-628Z.yml": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "6ae15e48860e9daf06f1a8532e97d67d",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T02-32-53-957Z.yml": {
+    "mtime": 1780622912.4170237,
+    "ast_hash": "e41f101d185791f7c0ee94a8f1b8eafa",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T03-20-56-140Z.yml": {
+    "mtime": 1780622912.4170237,
+    "ast_hash": "73490f3075623c776fcf78a4edbc32eb",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-03T17-28-58-051Z.yml": {
+    "mtime": 1780622912.4170237,
+    "ast_hash": "377645f02d7588ae0455f4c729321c19",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-03T17-26-25-849Z.yml": {
+    "mtime": 1780622912.4130237,
+    "ast_hash": "e693309b31646c3010e1507a0114ce61",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-03T17-27-43-044Z.yml": {
+    "mtime": 1780622912.4147108,
+    "ast_hash": "22f6f4d11e747aabdd3ea99191a1e175",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T16-54-41-581Z.yml": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "6c922f3c28d4602f659f7b245681c6ca",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T03-15-59-076Z.yml": {
+    "mtime": 1780622912.4170237,
+    "ast_hash": "2780baaa170f695aac291be8c471573d",
+    "semantic_hash": ""
+  },
+  ".playwright-mcp/page-2026-05-04T17-28-05-227Z.yml": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "ba0074c4802039202a1041b538e7e19e",
+    "semantic_hash": ""
+  },
+  ".github/pull_request_template.md": {
+    "mtime": 1780622912.1839595,
+    "ast_hash": "c615500a3b0d2860d8712d399a3f466d",
+    "semantic_hash": ""
+  },
+  ".github/labeler.yml": {
+    "mtime": 1780622912.1839595,
+    "ast_hash": "9ceac588bb3e82fd6b362dc0b7e1b9d6",
+    "semantic_hash": ""
+  },
+  ".github/dependabot.yml": {
+    "mtime": 1780622912.1839595,
+    "ast_hash": "7b86d6880178718e0db8b8388eb24d9b",
+    "semantic_hash": ""
+  },
+  ".github/ISSUE_TEMPLATE/ci_change_request.yml": {
+    "mtime": 1780622912.18326,
+    "ast_hash": "7b4ddafa8f2b591616acc7667ad9ba40",
+    "semantic_hash": ""
+  },
+  ".github/ISSUE_TEMPLATE/ci_error_report.yml": {
+    "mtime": 1780622912.1839595,
+    "ast_hash": "6bbdd176aa7758d573fbf49048291db5",
+    "semantic_hash": ""
+  },
+  ".github/workflows/security-gates.yml": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "b859dcc54aca144d53fd48c71b11724c",
+    "semantic_hash": ""
+  },
+  ".github/workflows/ci.yml": {
+    "mtime": 1780673747.852506,
+    "ast_hash": "eed0d270a7c0b593a5e89d27c1b2b5f2",
+    "semantic_hash": ""
+  },
+  ".github/workflows/apply-supabase-schema.yml": {
+    "mtime": 1780622912.1839595,
+    "ast_hash": "73eef86fdfb34cd3edcd39d8e1a49349",
+    "semantic_hash": ""
+  },
+  ".github/workflows/subprocessor-audit.yml": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "4f7340b27f10f18092b689ed64d96fa0",
+    "semantic_hash": ""
+  },
+  ".github/workflows/migration-check.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "eac0442ece0c5931253590434a413047",
+    "semantic_hash": ""
+  },
+  ".github/workflows/pip-compile-check.yml": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "97f242040ad322e3558d8c21f71dddce",
+    "semantic_hash": ""
+  },
+  ".github/workflows/subprocessor-monitor.yml": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "a05e6bdaf3ff7b078afd75d93e9559d7",
+    "semantic_hash": ""
+  },
+  ".github/workflows/deploy-backend.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "4fd268074238ec4b5b9b2188d0f050fb",
+    "semantic_hash": ""
+  },
+  ".github/workflows/eas-build.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "8add5f3fba9aad673c4186100000862e",
+    "semantic_hash": ""
+  },
+  ".github/workflows/claude-audit.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "5f3d46ae7770a98a742dfef38ccb73ab",
+    "semantic_hash": ""
+  },
+  ".github/workflows/claude-review.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "b311615053309000788dafb472320abe",
+    "semantic_hash": ""
+  },
+  ".github/workflows/pr-checks.yml": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "a09d5393609eb9080bd46c8f2cea5115",
+    "semantic_hash": ""
+  },
+  ".github/workflows/ci-error-audit.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "4e99207a94c963ae68d1483a8b180cda",
+    "semantic_hash": ""
+  },
+  ".github/workflows/dependabot-auto-merge.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "d944a25f9f5dc4e2ea101d87304edfc6",
+    "semantic_hash": ""
+  },
+  ".github/workflows/mobile-dep-check.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "a4c4e9325592f971f343e9522fd4fd90",
+    "semantic_hash": ""
+  },
+  ".github/workflows/ci-guardrails.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "18af11f22ee68b41acba4d5c8c6fd4f4",
+    "semantic_hash": ""
+  },
+  ".github/workflows/test-env.yml": {
+    "mtime": 1780622912.1890237,
+    "ast_hash": "cf3765cc2ed571a62ad11202058f7fa1",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/public/robots.txt": {
+    "mtime": 1780622912.4410393,
+    "ast_hash": "bea598923a1178595c8e0065c4d3e234",
+    "semantic_hash": ""
+  },
+  "backend/requirements-locked.txt": {
+    "mtime": 1780622912.5650237,
+    "ast_hash": "bcac2e0bb25e708de50206e73a5183aa",
+    "semantic_hash": ""
+  },
+  "backend/requirements-win.txt": {
+    "mtime": 1780622912.5650237,
+    "ast_hash": "74800ee8a633aa5b80b5fdb2dd70604e",
+    "semantic_hash": ""
+  },
+  "backend/docs/STORAGE_BUCKETS.md": {
+    "mtime": 1780622912.5293024,
+    "ast_hash": "92f0472e4518ecccac9a56d848266091",
+    "semantic_hash": ""
+  },
+  "audit-framework/regulatory-matrix.md": {
+    "mtime": 1780622912.5227118,
+    "ast_hash": "00f63a9d6d41cdae159c317a442c89f1",
+    "semantic_hash": ""
+  },
+  "audit-framework/CHANGELOG.md": {
+    "mtime": 1780622912.5170238,
+    "ast_hash": "7eac445caf1be2116eacfae538f1235e",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/20-financial-reconciliation.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "bada290d84ee22c5d34bd2f49911ebf0",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/17-observability.md": {
+    "mtime": 1780622912.5185637,
+    "ast_hash": "2db8abe73c718dbbfa4a04074019181c",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/23-mobile-binary.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "1db43fda23f3c41bec66ff30f9536f54",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/22-third-party.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "ee2001e38aa83d330da1e7f8ac9afbb0",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/19-fraud.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "9dbf2cc355a3f61faf8f628c4a17200d",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/21-threat-model.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "8bfd7d5263e05c6df35d5faaa12963ca",
+    "semantic_hash": ""
+  },
+  "audit-framework/dimensions/18-dr-bcp.md": {
+    "mtime": 1780622912.5210238,
+    "ast_hash": "25cf9963c6d29c402265400117223349",
+    "semantic_hash": ""
+  },
+  "rider-app/build-options/README.md": {
+    "mtime": 1780622913.6850238,
+    "ast_hash": "d085a2cc18510e08cc6ac2f1832cfb3b",
+    "semantic_hash": ""
+  },
+  "rider-app/build-options/option-b-kotlin-2.1.20/README.md": {
+    "mtime": 1780622913.6859512,
+    "ast_hash": "5a268e46edf4fb7c6b5debf2a9b22c36",
+    "semantic_hash": ""
+  },
+  "rider-app/build-options/option-a-kotlin-2.0.21/README.md": {
+    "mtime": 1780622913.6859512,
+    "ast_hash": "8ad47cb284a283baa519a465de1ce6e0",
+    "semantic_hash": ""
+  },
+  ".emergent/emergent.yml": {
+    "mtime": 1780622912.1810238,
+    "ast_hash": "893e99a99512803a7cf2d99544324584",
+    "semantic_hash": ""
+  },
+  ".emergent/summary.txt": {
+    "mtime": 1780622912.1822479,
+    "ast_hash": "183d19b608b420d49b061aa7c3b96685",
+    "semantic_hash": ""
+  },
+  ".semgrep/spinr-rules.yml": {
+    "mtime": 1780622912.4210236,
+    "ast_hash": "3554ff2f9fe0ef7f7b332274440cbc05",
+    "semantic_hash": ""
+  },
+  ".kilo/plans/1776144706168-quick-moon.md": {
+    "mtime": 1780622912.193172,
+    "ast_hash": "129e71dc95b4f9c02ea9ec35e626436c",
+    "semantic_hash": ""
+  },
+  ".planning/PROJECT.md": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "c4d7a35b5f3a3bc95258f176bf4fa5df",
+    "semantic_hash": ""
+  },
+  ".planning/UI-REVIEW.md": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "a72da80e8a3b025d3ca25d516ad320ec",
+    "semantic_hash": ""
+  },
+  ".planning/ROADMAP.md": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "66ef8c432e69678e53f8f8521059c84c",
+    "semantic_hash": ""
+  },
+  ".planning/STATE.md": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "69facd780c33dc00b19b2a6182f6be52",
+    "semantic_hash": ""
+  },
+  ".planning/REQUIREMENTS.md": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "54f60df862327b3c26a6e9d484f2bf77",
+    "semantic_hash": ""
+  },
+  ".planning/.continue-here.md": {
+    "mtime": 1780622912.1970236,
+    "ast_hash": "14fc599e614bb4a3ca2ef7cbfbd7e981",
+    "semantic_hash": ""
+  },
+  ".planning/UI-FIX-HANDOFF.md": {
+    "mtime": 1780622912.1982384,
+    "ast_hash": "b477db061049563ec96556a06d92af0d",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/.continue-here.md": {
+    "mtime": 1780622912.3970237,
+    "ast_hash": "963f5bfd0aa7f32d3f288d505663b70e",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/MANIFEST.md": {
+    "mtime": 1780622912.4130237,
+    "ast_hash": "70584a2c7c6969b5b3874bfe7097247a",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/007-admin-monitoring/README.md": {
+    "mtime": 1780622912.4073067,
+    "ast_hash": "61c4411cc2191355544b1c45872dd1e9",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/007-admin-monitoring/index.html": {
+    "mtime": 1780622912.4083276,
+    "ast_hash": "7163e12473ea325e174a3566d1d1e9bc",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/010-rider-sos/index.html": {
+    "mtime": 1780622912.4090238,
+    "ast_hash": "67048aa40995151214b1aeb9f073db62",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/012-driver-nav-arrival/index.html": {
+    "mtime": 1780622912.4130237,
+    "ast_hash": "881b947319327c7b2b2c139bf361522f",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/011-driver-sos/index.html": {
+    "mtime": 1780622912.4090238,
+    "ast_hash": "59768f034506dc9f61bbf3b4d3062b20",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/006-rider-active-ride/README.md": {
+    "mtime": 1780622912.4060776,
+    "ast_hash": "e8b897ba2ce751db8f2330507fcda1c3",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/006-rider-active-ride/index.html": {
+    "mtime": 1780622912.4073067,
+    "ast_hash": "e3c0a62231eac93d6169e75ff86ac269",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/001-driver-home/README.md": {
+    "mtime": 1780622912.4006827,
+    "ast_hash": "2bc40db8c908e56257fa9d96cce379e1",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/001-driver-home/index.html": {
+    "mtime": 1780622912.4012146,
+    "ast_hash": "2775186790fbbacee54a2a9159e3feb8",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/004-rider-home/index.html": {
+    "mtime": 1780622912.4050238,
+    "ast_hash": "d3a271f08d6f08e2d33ccb6fd24d63fa",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/009-admin-corporate/index.html": {
+    "mtime": 1780622912.4090238,
+    "ast_hash": "5e28d31263a4ae9fdd5e427ed87389c3",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/005-rider-booking/README.md": {
+    "mtime": 1780622912.4050238,
+    "ast_hash": "9929ac6b600c9eaba5175099ba2b9efe",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/005-rider-booking/index.html": {
+    "mtime": 1780622912.4060776,
+    "ast_hash": "0537e897a1f7024c5834db0b43d799f2",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/003-driver-earnings/index.html": {
+    "mtime": 1780622912.4012146,
+    "ast_hash": "f7b028bc921c3c39e2bdd18786bd61d5",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/002-driver-offer-active/index.html": {
+    "mtime": 1780622912.4012146,
+    "ast_hash": "a23c94ee21a1dd87ba8360160c3849a5",
+    "semantic_hash": ""
+  },
+  ".planning/sketches/008-admin-drivers/index.html": {
+    "mtime": 1780622912.4090238,
+    "ast_hash": "c1d6383d59d59738ec24534066fee7a3",
+    "semantic_hash": ""
+  },
+  ".planning/graphs/GRAPH_REPORT.md": {
+    "mtime": 1780622912.2970238,
+    "ast_hash": "4127aa3d960ffa67e80aa4b60095fa1e",
+    "semantic_hash": ""
+  },
+  ".maestro/README.md": {
+    "mtime": 1780622912.193172,
+    "ast_hash": "4d7e911e43f7e9d98d836255f03c2cd3",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/05_complete_trip.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "4bb751a7f89138b6a7bff05fe7ddd8fc",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/03_accept_ride.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "e1de029539d2e4f9be22fe1d6cf55b7b",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/04_verify_otp.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "a6faa81af11993cb97c2536a88d8d568",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/01_login.yaml": {
+    "mtime": 1780622912.194232,
+    "ast_hash": "57ff046c1a5d9453cde2e95279822dc8",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/02_go_online.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "3c7946dadfc31bd8e5ac1e0e3b250fea",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/06_payout.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "cb4fb4ca57120de86483c989758f074f",
+    "semantic_hash": ""
+  },
+  ".maestro/driver/07_in_trip_chat.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "2f9a5afe984cf9f6ed287821bd360ef9",
+    "semantic_hash": ""
+  },
+  ".maestro/rider/03_schedule_and_cancel_ride.yaml": {
+    "mtime": 1780622912.1966083,
+    "ast_hash": "24f40699642cc322a4234a35a3bb593f",
+    "semantic_hash": ""
+  },
+  ".maestro/rider/05_sos_button.yaml": {
+    "mtime": 1780622912.1966083,
+    "ast_hash": "6a74aa17c7789d17ca138eba9b381837",
+    "semantic_hash": ""
+  },
+  ".maestro/rider/01_login.yaml": {
+    "mtime": 1780622912.1946266,
+    "ast_hash": "2dcd1f25b639aca9a74050c450f19f3f",
+    "semantic_hash": ""
+  },
+  ".maestro/rider/04_mid_trip_chat.yaml": {
+    "mtime": 1780622912.1966083,
+    "ast_hash": "8a41b721f1de13090d1302d9f9db4871",
+    "semantic_hash": ""
+  },
+  ".maestro/rider/02_request_and_cancel_ride.yaml": {
+    "mtime": 1780622912.1966083,
+    "ast_hash": "6b59ca3ea26026a20c3cfde788d3d924",
+    "semantic_hash": ""
+  },
+  "reports/compliance/2026-04-26-supabase-service-role-key-breach-assessment.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "6906b5267ff8557f5b66555fc701b8ef",
+    "semantic_hash": ""
+  },
+  "reports/legal/supabase-region-attestation-checklist.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "d32eaf27ae23c8690cd3c0756b912485",
+    "semantic_hash": ""
+  },
+  "reports/remediation/rider-phase-e-P0-issues.md": {
+    "mtime": 1780622913.6650238,
+    "ast_hash": "61b0af85f9be079fd76b51aa6260eef7",
+    "semantic_hash": ""
+  },
+  "reports/remediation/backend-P4-future-features.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "0e4262d2fe1feea455670039cc65635a",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-P3-hardening.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "67d21b7c64eea3808194e68f61f7e6c8",
+    "semantic_hash": ""
+  },
+  "reports/remediation/rider-P1-before-beta.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "8e7e6f1d762c8d303d750234362bd99b",
+    "semantic_hash": ""
+  },
+  "reports/remediation/rider-P0-critical-fix-now.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "8916caa7a6904e10a20f11c773f83686",
+    "semantic_hash": ""
+  },
+  "reports/remediation/P2-backend-api.md": {
+    "mtime": 1780622913.6607738,
+    "ast_hash": "a51c6c7516088b7861c0f96fbca4909e",
+    "semantic_hash": ""
+  },
+  "reports/remediation/backend-P3-hardening.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "56c7e91bc8008eed182f11056621656f",
+    "semantic_hash": ""
+  },
+  "reports/remediation/driver-new-issues-2026-04-23.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "d55572e33fbb143872223727822c748e",
+    "semantic_hash": ""
+  },
+  "reports/remediation/rider-P2-before-launch.md": {
+    "mtime": 1780622913.6650238,
+    "ast_hash": "03e7c933686d509d6317d962668a1459",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-PE-P3-hardening.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "39028370c8ec48411171174841a5fdb5",
+    "semantic_hash": ""
+  },
+  "reports/remediation/backend-P1-before-beta.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "6fea1e1bc6fecb92486043408946dc60",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-PE-P2-before-launch.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "a285eba21d49bd9495f3e91b0a487371",
+    "semantic_hash": ""
+  },
+  "reports/remediation/backend-PE-remediation.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "b3562a474440d9ffb72473533f8c56eb",
+    "semantic_hash": ""
+  },
+  "reports/remediation/backend-P0-critical-fix-now.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "aa3c18e81c50ee315ba3119cb94034e7",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-P4-future-features.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "3f6022c4bf620453746729fff5277aa3",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-PE-P1-before-beta.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "3c769dd9632e3f8c2926efd8dd2b2760",
+    "semantic_hash": ""
+  },
+  "reports/remediation/P1-backend-api.md": {
+    "mtime": 1780622913.6607738,
+    "ast_hash": "1f02c62e9891a9ddd7adfaf98f764056",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-P0-critical-fix-now.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "687e65c95f0571d3d61ca05db74323e4",
+    "semantic_hash": ""
+  },
+  "reports/remediation/rider-P3-hardening.md": {
+    "mtime": 1780622913.6650238,
+    "ast_hash": "ba90036b3c2a9612379134f51b069262",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-P1-before-beta.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "a364345b711f0125be24e8ba86d6bfca",
+    "semantic_hash": ""
+  },
+  "reports/remediation/P0-backend-api.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "f54d62e5df1a06c9fe04dba6a5e9782e",
+    "semantic_hash": ""
+  },
+  "reports/remediation/admin-P2-before-launch.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "77394307de3778de98695ab1aa4e5423",
+    "semantic_hash": ""
+  },
+  "reports/remediation/backend-P2-before-launch.md": {
+    "mtime": 1780622913.6610236,
+    "ast_hash": "c6ce46f240df7892e07e85ac3e2080c6",
+    "semantic_hash": ""
+  },
+  "reports/remediation/rider-P4-future-features.md": {
+    "mtime": 1780622913.6650238,
+    "ast_hash": "a6e1dc65f58e34a42e1978a834400f37",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945723237.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "77864c5dcac0d7eb848a6221bd180274",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037652312.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "8c8567defa3f985f8fa62937bc991c64",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036475059.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "7f444095e53926479c7a9950bc0076d4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944892277.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "44f12688cdb7e2bef9f9227156bd9698",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062282109.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "f366d2a49ae34397e36b0a1dac07dc9b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25027031253.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "e7aeff48660dce72499965662b77ac65",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944903538.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "8e71e5fd75b2f72257cd22262bf6613e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036457523.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "a0a1573db114d407437b182127b15d91",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944802287.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "7fbdbd557b8b82e5082bed6d14d16633",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25022896325.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "fd6f3bc10f34ad59f5919178fe8f3f5b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008933209.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "5c8f73a63420ad52ab826bc2ca669970",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035960640.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "045ae46570e616af0c45e9d0beb3c924",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25054248436.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "bcd2551e11e4b888c67e3fa7f223f35e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25059390626.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "0c00ef98a71a86c6bbe50e4637e087dd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-backend-api-v1.txt": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "35e58a39c5b419d80e4161a55241785a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945000682.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "f4ed30a18f903e8273cf78bb74990fdc",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-app-remediation-verification-prompt.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "5a4193902d987a2181986a4e344567a6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944958437.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "e16690705e1ffef8ae519cfc39b48b61",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034748381.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "4c9d2298cbff834042690d6e446be844",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062220353.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "2d97b256aae40706787ed9e77f121d85",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944905971.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "d7e53367cfd632c2b5f3b518f3a21698",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25091647538.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "9de374a9cd54082ada110ef2bd274630",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036481034.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "717b53e69561748f0c7766c6e1e2c3e5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036254359.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "7efb5f1f053f8fadea885f7181b5f492",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017481172.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "10adbd0dfab725d69a8a346398e336bd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945854209.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "67df38566588af1f23bcb61ad5c8ba10",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945288511.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "f02315fe7c7724a943e2b91b529eac99",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25091903200.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "3e9ccea14a74c6bec00b233b4d4f22eb",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25029295090.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "29c69995748185318c0c2f37079ef512",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037170424.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "a7772d17f126b8cdcc65772d727ebd8f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062005595.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "b1ef0df41c73570ef649b565b71f9677",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013395931.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "3ba57ac3cef29b407237f0341a178984",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037102267.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "c461460bc19791a04f7c1b73f3c2091f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945839710.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "8dca6571f609bebc9e88c386e69d4ce0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25030997394.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "e3fc99dd42022f829456b79f8e8d6929",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009334434.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "0ce50758c964d4d39ecddc2777e3e85c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036059816.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "17a82d2858a61ead098e4d84b6b3fc1f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945326989.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "f92e05a4e5423e9a37046af9b783df31",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25096896461.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "94785ed5b64f1dfb5d91de4a2e64a1bb",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945313499.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "4404361a74512838546206d91621992f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25029672363.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "13cb6d42b253b193ff64e4b45b6441d2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25016562595.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "c0ee0fbb9c9d48747ea0aeba7d53c0c5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25094058404.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "d6fa43e3e44a844f2f12071d460e48bd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25063703032.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "bb15c2c0b8e8b38972cbd00b43a0e186",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25093261231.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "f095d615d69e3d26ef2ea5b1692d3092",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-P1-verification.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "cf1bc627a1ec034fb547a8c98bb95053",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25032356435.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "7fc22606523cb940130607a945315ea6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25019608314.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "bc8c03491b7ab835a9f816a1f2667f69",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062056630.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "cbeed0d9d6c5eb2b32da125393d5c2d2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25019267235.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "7a5339ea4387c9a169b7b8a680d004b2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062241056.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "2fe692921d8b912bd92aef376c669cc3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944884693.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "cd3efa9b77adc7ebc896de76aa716414",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25089410181.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "c19729b9e4f4fd7211804b7f13b80667",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945045257.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "6ee7c256c19e408bf75cc7f1e3944929",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24965538493.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "09565cd737097f2a1e85f89b5468995b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025456862.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "13690da51aa4a635e8b5227c2bc1c3ef",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25054104151.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "ee408134c26e07da530c79a602369b56",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025057071.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "ff99621f3cf7486ec0a337a2db99da9c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036903640.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "d1380c0a96086ae5169469dff10896a0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25024905280.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "cf788a08a707172ca52073083b1f5269",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25024884978.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "f7adc3c3d95557201b246ff4af74f853",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25014741319.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "9f79beaac603e5223e22940d3b0c1ed8",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P2a-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "44fe6607fa9ae40d65fe033e40d7065d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009007893.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "2da538dcf0e1689e52882e5a25327a10",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25027978965.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "df2b552a55f5f36d54950b730aefe03f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944962059.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "dd66be90d62a5f0901205527a26d6521",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25057106573.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "277baa2b99bd714d176970114e0afea7",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944796842.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "2c6c1d5929c28d73643b3ddab1d938c5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036599247.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "e21d929906356ad6a1eed9723f3bed20",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25003815125.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "dccf2917cf8c0cd5cc626de4e3c9ddf9",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062044809.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "fbf396087602a5a0a5e744c04b6f118c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037705992.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "8de13d2609b146d5a494f534e566bc35",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025688449.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "5bae05609bae0c5eaf208eeb4b960aae",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24946161474.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "01fbfc9ff7153f48d0f0daebe8317f75",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037187071.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "ae1f51c98e61d353e3104d3bda92d305",
+    "semantic_hash": ""
+  },
+  "reports/audits/OPEN-ITEMS-TRACKER.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "9f1cdf8c1a318c49f5973e768bb08047",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945412325.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "46205145db283ed5043441a86a2eb00c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035541495.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "01be9167f5cc3d3c2c29cc98154825fe",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036449760.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "42ddd3827005f27cafc72e2db4ca1964",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-backend-api-v1.txt": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "f7144352c4c89866aed300bcefef1180",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035687085.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "0092a962496105edc36c50013aefd00d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017272616.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "44fbaed8611e1f408e67338f047c80d0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-admin-panel-audit-plan-v1.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "178cd7dad44335aa02dada2cf549ca1e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945719900.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "8fa3e47aed4782c6d15a1a7b0efeb60a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013516748.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "affc69e1efc2e1fcfcbd2998b7b86da6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945776272.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "a020c5a65608e6647f098775e4010973",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25091164427.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "e14b9646f1e893029315e50656ba827b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025558590.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "2ccdf0636a4733c65836abaa278a2c16",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945843533.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "2e6271f21ababce6b615bfabc9ba5fb4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25003828400.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "e52b120b21e21699275f8e371eccafa0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945800130.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "d319e53309096e49792e4ae9640ad491",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062030719.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "52b6830ce1771f9a14cf8fa340ee1e16",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25011685612.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "5ff0331d26ac72f5bf8bde4370c346f9",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015345354.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "c40f5a253d402c6e618d230499ba52d6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944803380.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "d0ad61e4512ba09459c4a92a01fccd93",
+    "semantic_hash": ""
+  },
+  "reports/audits/CI_AUDIT_SYSTEM_2026-04-25.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "bdc6dc81948ee5f39e3f6bc980b9dfae",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25016154565.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "f3a09170183fb8fbed5096ff56dad544",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-master-rollup.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "1b1c8d09c1a4135a99c820978ee7ed72",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944790256.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "22531d074c0581443dbe994954494712",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25089202600.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "3fb817618fbc7f8a8a181519b184ba15",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035299671.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "cd5ee739821e2f59701da9f7a4bba435",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008922472.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "d3252f586160e3634db156cc73ed682c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-24998584413.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "ad0a9f946b3bd567712054481df0e4bd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25093962266.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "ce38bcc634abd09d5d69f0ad4800b867",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25089257284.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "97f7e6a97567f15570070def5148d9eb",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945388097.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "5ae679e9c8e795d646e6a47b5a47f147",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036770337.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "0841674b2879d65f1a07f3aa40ab5cff",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945014513.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "4d53e0c5e78c89fdf24ea0e67b83a553",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P4-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "6c0ec879360b8b6ad9bf685388c2fe89",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25096207887.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "260dd234aee8c1448911fe981eb032ed",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-25-admin-panel-audit-v1.txt": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "d5440e371ac7a8a3ff439d830d03652c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25003797266.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "4fa5742c4624462b5947396e716198b1",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25028963568.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "9537d1e138d9ab2ed62f9acbd301aca6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25026933870.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "2c7b19a8c970916f6a74673038842841",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034041566.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "06786a4f58cd2ad6087a3e26ae0365e6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25029772653.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "63fc1915dc79fb282f5c22eab73bccb3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009176404.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "7ad67abef3d969edb54b312a46ef288d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036425490.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "34daf6f65c84737d502b9cf4afcd7def",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25012109834.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "f7f0172e12bda3695aaf55faf4870937",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25029533719.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "10e74f37d622ea46ed329851d626c19a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25054261821.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "6b8abbf0a8ed053acc42badc8b002a3a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-admin-panel-v2-phase-e.txt": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "a92fccb71638a3ee1cdde5f1e548fb50",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035122850.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "8b6ef64fd860e48ab1a87cbecaba0a07",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008860654.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "cbd8c343c30f53bde5c815d78fd9b30a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25029110359.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "3aaf48714aa3de03d3edc47b997f880c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25060177825.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "20b0eb21cead88737b0c17bd9649c9ab",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25003820859.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "a00be0f8cd206a900b2ddb0bfa95e6e0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958618032.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "8acfe83c2fe4ec28f0382dfe00fba032",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945305928.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "b741cb17ff516f072125341f9789e331",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25020753939.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "a23db7ad227cdab19b1d3d3a41323db8",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036720056.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "c23123f5a241fe26f3e992010fa4070e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25061992395.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "522593e0e3d2e19f93f3add67bb63561",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25032353444.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "4728162f3a6831837c357a62b6cb8b17",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062238685.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "3780f8c1208f0a6d22b696e2fb7a5e3a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944988838.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "e2f98fb1217c9487947a5869b43a8a40",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25116098822.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "5c0ca7bc8f4aac2039014d37bc3b41e4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P2b-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "1aaf375caa4539634c87663589b291dd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015033929.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "4e3f2ec2354df1de992fe65d92d0aa14",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944794457.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "f90b228c4a1c21d551b9202c3937c495",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25019227487.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "42d671238657ad2ef8c880656f566b89",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009130249.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "cd68dc5c4c14b47872d4442db6178b87",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25027327721.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "0587e39c532ee8357feef8b4e6a6236f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25016848995.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "11e971962caa068eb8413dca9f9c8612",
+    "semantic_hash": ""
+  },
+  "reports/audits/rider-app-phase-e-kickoff.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "d2db6f78c6f01e9d7483c0961e9ddd82",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25087376829.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "e44e085ea9e1756a9dc7b37c3c7a45d6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945999767.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "06c8dae6031b0ac3709ba272a2f140dd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25086842358.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "f8d263f308917100a43e1337681a7fbf",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035305831.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "cde4d9ba23294df4f2c518679cba8e5b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P3-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "6fdb1a282c756c5d4d3d032c26fc1b0b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945779040.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "6dc5c00d1a185a71445276ba2c4af682",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25022072198.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "f77fb27ff397474e4fb6cfb8a23e68d2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25061902017.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "4c950453eda813f6ab38262aaaea01de",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25020323023.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "3d640e54408c784c3138d5ae032a3c3c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-remediation-rollup-v2.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "637376cc54f886bdbc382fa199e850ba",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945286647.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "11a7364ea340bb250bad8d70d30f57db",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945291289.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "65c3b89608984cca1148334f5d42de37",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-app-remediation-verification-prompt.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "216880b6e44687e66b709108cd334425",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25055987423.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "57149f38ba1f77f66f09f2e16d67157c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034902330.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "7808c3722928725915ed00fed782e3cc",
+    "semantic_hash": ""
+  },
+  "reports/audits/rider-app-phase-d-kickoff.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "2d3e29b64793be98611dbf2a498cc0dd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25111192377.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "cb4fba280865a1310c137f5d90555397",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945264424.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "d9cb3e4f5bd28740a997f99915656e63",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035462164.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "822eb67229f2f8fe1aee085a66994b25",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25033063543.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "c253b9906f336cabf7047d1efbbe5504",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013428873.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "a2570e12633387b73abe9d328b626652",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034039250.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "d43a5d9ab560dddb419646912766e7b2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P1b-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "bda75de434e742f6ad58ef80a492ea90",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025599985.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "82c1a0ad63fc781b9ceaa27423eb3e56",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015880051.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "f877462f3bcefd2793b484899d3dd6e2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944800572.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "6bb28aa60665412ef602527771994ba2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945353854.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "6725e413137043ebc2398726095522af",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25072739406.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "59ffc3b03a0e89c649133ce9232878cb",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25019271412.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "96eb7107039d23a22c1a1808bc182a8d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P1a-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "0d7aa0f64913616a68a64e214b4d3923",
+    "semantic_hash": ""
+  },
+  "reports/audits/rider-app-phase-a-kickoff.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "98b549489da18fb26160256c7270c424",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008995057.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "7ac209c6919e2fdd5e727c1dd9b477f8",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25088402824.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "7c22e44a3735b6c7a5ca1eca15020b0b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25012245485.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "fae9851a2322e37caa731b5678b9a89f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945017921.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "062f7aa0b34d5aa9e82df77baf225881",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945711198.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "e24401b67c1095b2f7497e7516bdc40d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25090142427.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "ec71f45e156e7c13256fab97554d7ffa",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25065428627.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "a8986f1f681caf8484f4353450496bc5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034751494.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "77cdd3b9da747086fc1fcbaef3072be2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036400930.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "351a6d47548639bc8e6acf9dc885bb4d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25055779655.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "de03599a4ef3570eb865b9c64b59405a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25024936332.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "57dc49f58af65504df32ffeb6648d363",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945319383.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "ab09635b58b12620fb6fe0c28c169991",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25097240814.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "855219af678301b1f6d93b70080af48f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-backend-verification-rollup.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "744b0a3e689be9d6c379746eae5af222",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025794058.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "595975df2c9d65a944b8bfa34954db66",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958593840.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "b9c35f4158df0a6a2fe22ac0aff72557",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944794307.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "8c57766978a74d7f3a7a34f3648e5852",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036762472.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "84521acd766a54ab39dbb05a566eb6b4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-app-v1-phase-e.txt": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "db342fc1a55d670240e5f3267fa2e48c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009775104.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "0a91594c509b5465dcb33bc4a8e6eddb",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-P2-verification.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "17780d33aef954a5a8a8bdaf09022328",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25089781013.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "a72d79865ceffc01234d0b9c01affa4e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017008921.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "436e23f87371e2757a7ab6a5e0474bdd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035203363.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "bd96d66106ee3ad04ce34ae82a4c4364",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034405550.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "d290fe75796395282cbb63c6cbb37512",
+    "semantic_hash": ""
+  },
+  "reports/audits/rider-app-phase-b-kickoff.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "6974a376d773dc5f474fec6a3627b36a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036086779.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "7acd0dabfef6f03a34a491882d846177",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034108655.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "541ac54c31c4dc8aabcb32ac17e5a9e4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017234861.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "fb9c7085742559b807f4089b78efff39",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25029778052.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "fb1931401de8e82dbe6ecb684ee9ff21",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036887997.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "0f60e0a9fd8a807d436ab79d588e89e8",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-19-rider-app-audit-plan-v1.md": {
+    "mtime": 1780622913.6159859,
+    "ast_hash": "6dde6ef212746478008f8ffb79f30451",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944893971.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "00979886a8b2181e81d747f092dbed7b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24966352255.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "828a097fe0ba30332a151702db939243",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25012047125.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "e003a561a5cc3caea8ebd2707ac030a2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-24971893826.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "0fb6ef963220814d1afcce7467db014b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008990402.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "b64ee9d5eca1a3f90e0a3c545ffa1b3e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009029968.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "d39ab60e82a4a87b1e8bfcb448f7720f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945825838.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "f1a1c8089022696b9099ac1175c6c64d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25012531371.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "7f66bc656b584af8d935c02b621b7806",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034736475.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "96a58537edec8f70fba75ddf9e9521c1",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035353620.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "c0a5e0222be3ddd413be25664ce6e08c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008903284.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "f3ff1f1ef11c280c4c4ca4073f04ede4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062252024.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "2ab54591cba7e516632ab05aadb9c518",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-remediation-rollup.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "c88bc414547cf4d47ad2a9b853bb5b15",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-app-v5-phase-e.txt": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "a4e6e9c8dd687fe2cb71303e894f11f3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25028649571.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "ac80c16a7f085a7a1b81854accf8b2dc",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062020257.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "6d370acfcacc6f893d142075a7e6fe53",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25019847121.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "23d023243a935e76da04463cc7993840",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036441598.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "443d85cefc7b7d380681f3d1004c83d0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25086838155.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "55dc1d71679c12736a526e411b88a0b4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009060503.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "bf27499f7f2bc6ccb71cca850fcad471",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037024689.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "4ac71c9d904e52b1f2527010175fd263",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25089344363.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "78c46ba9083216cdecb160057a9f9765",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25019835447.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "edd7bc3bf05405fb477926e6a8f76589",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017300131.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "b8e3c01631601c7813853621536c47fd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062276387.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "d18ccf93cb8f92d2fa559db6f3f101d5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036553035.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "34327921f9a3ddd09f92c513689c50c2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25016248234.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "e5d0d3060057f2ae642ccd4f5692f6ab",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25022063611.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "ee1326f550e7c9924281663b86eea6ab",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015232500.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "fc4b3690fd1b565fbc59a52bf959bde4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008937366.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "0515e75497f240dff6438520b9a6d3f3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945049763.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "52453ae5e67b8eb35142a9bef0936331",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25097160775.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "964535cdfe8488f71a141e1b22beb070",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945707306.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "becd4a3aa7e0f6f2f4d8cf52f9ee2c0b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944888427.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "5a035f47fb1a1dd53f82bad877ac672f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013778603.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "3496e3efae5ec6a6d6269a3cfa9a9356",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25012261186.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "a56c97b5064ae9de5318099a5abc194f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25026902104.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "eaedbe2751cd52c65b37d2908843f61d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944804387.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "4e34b25e0b6aac277e4358c7c4bd5f3a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015062722.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "ef934b69dd031b452bb13996fbb7dab9",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25055649436.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "3ab24783a92b8cd83b500bd1ec68c615",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008955935.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "d802e8f152a72b8179d91e74a2dfd8cd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034224363.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "2cc7c9cf948b4e965fbd1fd0d2e732f5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-19-rider-app-v1.txt": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "ed061826a792f4bf525284e62e6b7504",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015239465.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "a8bb430ceeca6d2d51f4ead33fbc343a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944875975.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "3a70de3a02b86b66e17e7be3bdef5b99",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-24998603407.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "6978b76e29bf2796829149c5489626b7",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25028644237.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "b504af79c61c98bc8f87ce649edc2905",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-P0-verification.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "8cf41fe9773a6bf781b35eee31c4c0e1",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035288481.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "a236ac29a134d1f078753107f0de7c15",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017319537.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "d04d7d24c4b870723b62220dd1c2919c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958604152.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "8e22b52c1c8ea0a164585ae4b44be42b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013444196.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "66a3c92b451402817634c96b8f51603d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25070862384.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "1d62b2d06c3f0b56dbfcdb2cb30028d3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25024136979.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "767178b3c846027444c32a67523a3e99",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008898670.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "0a2b219e95a9528a1d20bdd332760b40",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958604972.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "49ee9c9b52d6469efb420191be4730bd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-rider-P0-verification.md": {
+    "mtime": 1780622913.6210237,
+    "ast_hash": "6bd9854a8ba864165b4730609faa1195",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035068637.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "f9db1205234534c3940c6462e5fc36b3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025601861.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "63ed687e5fd4544839fe981381305e85",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958597410.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "41148c4f0a09a30795720de089853f6e",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945214553.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "785b726e5dc5359a60225ba92e37fe36",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25111180738.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "2b4ca17f64da9922a11f47327b1a9144",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036401545.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "86d194e7a5873b387f6d7a68812b8e2a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24946163037.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "43c8b1ad98268b97810e9fb393573ddd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25020763995.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "78cefdf0817d05801bbac1014427f671",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945783322.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "889670c0eb48b45af610a030bf44af69",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24952658738.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "2d934f32075c2fa9596056c5c42ac36c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037039765.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "df108b1431d60c32dcde09a2576a624f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958490551.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "36363589ac923da9e38c02be20afba27",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944764704.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "32701aef4cc415938c993cdbb739dbe0",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25054391658.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "41309e81fe0b74b91495b47ff8e36823",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25008854414.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "3922f58c5493383aa97f003d7463f9e3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25023204788.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "38d0e310241a1f811492cada2471bcb8",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25027662585.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "5a0ec7931e17e81eb50aa83aeb188537",
+    "semantic_hash": ""
+  },
+  "reports/audits/INDEX.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "c231951ed6ddaf33a8eb59c6cb35e2f5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24946014176.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "edfbe202f2f366b091540c7cc97715d6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944968508.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "1edcadc5ab833f7bbc437b0af8e47a80",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25090299692.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "817b1919d853d8458783751e94f19a6c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013490677.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "fbac25bd09afa5a76621df5d8444735c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037713705.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "f39b0fa213a123b802680f2a5f6477b3",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944898916.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "e28464231f3699f8db9e2576ba2d1e82",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25003802631.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "36d658a493b102a612e9f18e670a0a28",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24952571275.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "25333e651a7efac183dbd31743d8da42",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017000877.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "7dbc865e1f6101d731ea8de69fb409ff",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035306973.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "d5c0232ca04d03c7410e12a35def1e16",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035424557.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "652d29b398cb6ab4072ba35be6398382",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945021308.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "2bf41ff74fd08ecd87edadda102114ba",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034302465.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "de09b110cd5dd0fa9d07aaf58ca4eebe",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035607942.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "dd33a771e894ca4515aaa7814a848055",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945229930.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "209e66d793c67f8f239a44b5df94cf67",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25037171455.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "bf0d0f027181711c798d8789f9e035a5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944797087.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "24bf0b11995d36072039811a39332694",
+    "semantic_hash": ""
+  },
+  "reports/audits/driver-app-phase-e-kickoff.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "83c85ddd2eb11e120bebe10765335514",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25062211688.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "383f74c7b3021b04b6c897783837fd2b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25111927427.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "abf56863a4921f6acd2666e72537e04b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24970132054.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "8593edf85baf48bec8655f64007bb111",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25036326728.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "d462e31927d4c8f3ec2cf5677d816895",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25022947665.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "9cfcbfbd29399e06158b7c0bdef47cbd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009330988.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "1107d071389d8d653c2d8f718a1e2111",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944801843.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "be7774d66cda2f44b4e6289a19a604fb",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944976594.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "a7e64c686b19fa342814a8af00aae01d",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035423763.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "019ebeb47c22531f736c826deca02a56",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945039910.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "4af9597c055db07485e03b60a03fc508",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25031823134.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "96d4fa24439042560d6cf8c561464401",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24958609656.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "2c79d68f87f082c0f0e9ee5157997a39",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945715550.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "29e9bc5340d6bf7434d28ba643e7d539",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25024592786.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "68aec8a41093191df2252a53e0c72ed6",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945772947.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "36f84f0fc34fbfc6b14676b92dd1ecea",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25017015169.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "247a3619fa51399140595d2c7d1ab5f9",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945768438.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "6bce05aa3a075850335c9fcafc036c5f",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25015099453.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "f205bc23af02a1c285db951128900972",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25111189644.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "04405bfbcf7dad156e8d8121142379d4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944799714.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "f2caf95221db38bd2e04529ab77a3616",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944910328.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "8cac78600982e0282c558f2227292095",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944804476.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "8a3c3cd3840dbb9243bd05bb478ab6bd",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25098644977.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "21fa3e1fb765ad39171aa57dacf8f65a",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944799002.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "4e7a11a36d43a50f9bac6ae08dc53602",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25009659457.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "1a7d946291fb7d2655964d7d8855afba",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24965609677.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "33a32db57644cfca266650c8abf5c543",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-master-rollup-top10.md": {
+    "mtime": 1780622913.6330237,
+    "ast_hash": "2a52b89f60afae1a85c9dc0525e89fb9",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945726619.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "402abb81f67f13f21f2ae4e290258802",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025016729.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "ef2e5c1f3c86276701cd59930be1e3be",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25058609319.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "e129e18cc620204da34afbf6b49f9d2c",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945846322.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "6b388b9282e6b2b85fba506f105f7382",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945796722.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "e394807bf127e170c78a7e81bb377e14",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-P4-verification.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "f86b0daeb3a004680a9651a715548d1b",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24945850551.md": {
+    "mtime": 1780622913.6290238,
+    "ast_hash": "8fda4208d6bb40564f01204be9342132",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944882309.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "9eeb091af33c144c9fd9aabfb0b7d5bf",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25033059373.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "a615e5a2fec88f5e7da484c3440d42d7",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25025239030.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "cedfc53ff33e1fa5211aedc282a3fc20",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25027232490.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "95d85626315825eb532375455cc22db5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25013278686.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "962be2dbd1a31ea1aec2746010c60f73",
+    "semantic_hash": ""
+  },
+  "reports/audits/rider-app-phase-c-kickoff.md": {
+    "mtime": 1780622913.6570237,
+    "ast_hash": "91782663d4854fdfe84a3e02a1a95bff",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944900982.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "2722313a127d12a7fb4ab98fc470ffb4",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-29-ci-failure-25096530184.md": {
+    "mtime": 1780622913.6530237,
+    "ast_hash": "1eceb895b4b3b3cdefd39df92dca8a45",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25035548099.md": {
+    "mtime": 1780622913.6450236,
+    "ast_hash": "6d3e4760131dbbd47b8f8f74a88184b5",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-27-ci-failure-25023188924.md": {
+    "mtime": 1780622913.6370237,
+    "ast_hash": "52ed683b110e22938d83dbe5c8e9f438",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25054526719.md": {
+    "mtime": 1780622913.6490238,
+    "ast_hash": "555a258533af6053a53aab176ab0ddf2",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-driver-P3-verification.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "6d5bf1d96ec53f42884a89d00e788487",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-26-ci-failure-24944996988.md": {
+    "mtime": 1780622913.6250236,
+    "ast_hash": "2feea9820e620e05edd336fce42f8428",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25027568531.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "513c55ea86b25f2ea4dbe6d1fec87a14",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25034383045.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "87a37967c3497eb14e2ea6b74459d3cc",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-23-backend-api-audit-plan-v1.md": {
+    "mtime": 1780622913.6170237,
+    "ast_hash": "20d45202aceb46dadc240ba6d1de2090",
+    "semantic_hash": ""
+  },
+  "reports/audits/2026-04-28-ci-failure-25031826780.md": {
+    "mtime": 1780622913.6410236,
+    "ast_hash": "6395e2f9f92a4cac98288235111de528",
+    "semantic_hash": ""
+  },
+  "docs/dependency-upgrade-runbook.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "5e7c6cfc6abcf4431dfc6f9838f47cc3",
+    "semantic_hash": ""
+  },
+  "docs/incident-response.md": {
+    "mtime": 1780622912.7290237,
+    "ast_hash": "54499a11cfdfb8c1a283a1495879473b",
+    "semantic_hash": ""
+  },
+  "docs/dev-setup.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "18b46ba712c6e78437a7ba14d1fdc26c",
+    "semantic_hash": ""
+  },
+  "docs/android-build-strategy.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "d2f4b7436beffd3b3085c5f21b908017",
+    "semantic_hash": ""
+  },
+  "docs/data-classification.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "aa4c845d8fc43d1ac0430a2b83c17998",
+    "semantic_hash": ""
+  },
+  "docs/vendor-inventory.md": {
+    "mtime": 1780622912.7471194,
+    "ast_hash": "6ccaa36262e81f07c737583d6eb6dc11",
+    "semantic_hash": ""
+  },
+  "docs/ci-security-gates.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "a61c4f590a1f74c4d2d2224e2e6d2d77",
+    "semantic_hash": ""
+  },
+  "docs/proposed-claude-audit-ci.yml": {
+    "mtime": 1780622912.7290237,
+    "ast_hash": "bb4b097ec63c097a19394c27858dfccb",
+    "semantic_hash": ""
+  },
+  "docs/API_REFERENCE.md": {
+    "mtime": 1780673747.852506,
+    "ast_hash": "2030b0c59e688ea0ef89ebd9da7ba9ec",
+    "semantic_hash": ""
+  },
+  "docs/external-testing.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "657c70d99fbec06cb5145d980167c5bf",
+    "semantic_hash": ""
+  },
+  "docs/accessibility-plan.md": {
+    "mtime": 1780622912.7090237,
+    "ast_hash": "b83eb40eb59d68055c801c800f2c6d42",
+    "semantic_hash": ""
+  },
+  "docs/dpa-register.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "2ccf6f03b1ff3dc5f2560f405097b339",
+    "semantic_hash": ""
+  },
+  "docs/MOBILE_SMOKE.md": {
+    "mtime": 1780622912.7077994,
+    "ast_hash": "a866c562fa5ae78a19cdaba84cff4e18",
+    "semantic_hash": ""
+  },
+  "docs/vendor-register.md": {
+    "mtime": 1780622912.7471194,
+    "ast_hash": "94a6791232d1b728021418e452d0d8a0",
+    "semantic_hash": ""
+  },
+  "docs/E2E_TEST_GAP_ANALYSIS.md": {
+    "mtime": 1780622912.7077994,
+    "ast_hash": "5547d21afb0a1d3aa68af5bf9f3784ed",
+    "semantic_hash": ""
+  },
+  "docs/claude-audit-2026-04-22.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "bd4efc605029086f004b4f9bf9aece22",
+    "semantic_hash": ""
+  },
+  "docs/slo.md": {
+    "mtime": 1780622912.738854,
+    "ast_hash": "4a639e51edcdb869c78d72e302b22822",
+    "semantic_hash": ""
+  },
+  "docs/threat-model/admin-panel.md": {
+    "mtime": 1780622912.7450237,
+    "ast_hash": "24d3b62592367bd100735c8df825fa63",
+    "semantic_hash": ""
+  },
+  "docs/threat-model/backend.md": {
+    "mtime": 1780622912.7471194,
+    "ast_hash": "6466e6d47d16569708b9eecd9395a7f0",
+    "semantic_hash": ""
+  },
+  "docs/threat-model/rider-app.md": {
+    "mtime": 1780622912.7471194,
+    "ast_hash": "37d323bff1eb5ea197d79cbe32ea24b0",
+    "semantic_hash": ""
+  },
+  "docs/threat-model/driver-app.md": {
+    "mtime": 1780622912.7471194,
+    "ast_hash": "54826bcc9eaade07a9d208dd76a03507",
+    "semantic_hash": ""
+  },
+  "docs/audit/17_FIELD_ALIGNMENT_AUDIT.md": {
+    "mtime": 1780622912.7170236,
+    "ast_hash": "a601e4edb905acf26a11897ab0439e1d",
+    "semantic_hash": ""
+  },
+  "docs/audit/ADMIN_DASHBOARD_AUDIT_PROMPT.md": {
+    "mtime": 1780622912.7170236,
+    "ast_hash": "c4431d55b2b73f610fb8b78f5929c7f9",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/02-auth-rbac.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "75268a5af9aa7e65c48fa4766e836923",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/06-perf-ux-a11y.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "1494dbb1a1881b7b7ffdf21850ac4707",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/04-backend-security.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "3db4306af4eda0f84c806c0d522447a4",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/00-inventory.md": {
+    "mtime": 1780622912.7170236,
+    "ast_hash": "8a67058c1843b12593ff4863a8219516",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/05-privacy-logging.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "e31356c690e6b139d8dfd355d70dd66b",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/REPORT.md": {
+    "mtime": 1780622912.7210238,
+    "ast_hash": "2598863c8702f29d7d8beb84c7b34565",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/01-sast.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "18e53d2bec3730c994796aee7eb1d25c",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/REMEDIATION_PLAN.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "7fd386920c0f3c6e547d4fbd2936781e",
+    "semantic_hash": ""
+  },
+  "docs/audit/admin-dashboard/03-dast.md": {
+    "mtime": 1780622912.7197535,
+    "ast_hash": "de9a52d0a08420ad832ea91ce78e44fb",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/stripe-reconciliation.md": {
+    "mtime": 1780622912.7370236,
+    "ast_hash": "03d83ff26b2fbeee814a8c6a928c41c9",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/data-breach.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "c33e7cb29762d44c5cddba6b65e4a223",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/admin-pwa.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "130d17104341c50c5a4b7603291f4b77",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/pitr-restore.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "63438c1beb72c911469f0bffd5fad06a",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/dependency-audit.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "feaa8d43d41ce21481e894b696098661",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/rate-limits.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "22aad802e669783ff87aea6d90bf98f7",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/migration-conflict-detection.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "901542cf469c8803a610125047799bf2",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/saskatoon-launch.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "a9379192d67c5c509bb5c205518824c5",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/admin-rollback.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "73c5a86eeed97c1d2750948dcdfb3548",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/sos-incident.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "5920e24e63fbd534ed8badbc72b1070a",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/redis-down.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "8720b2f3cc00b53f51ccacb40212f435",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/supabase-down.md": {
+    "mtime": 1780622912.7370236,
+    "ast_hash": "f7d039fae2d8fc780be4adad5851deb5",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/deploy-migration-64-65.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "c2f8f399e759f92afda4291c1cdc3095",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/data-retention.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "a2a9e8e9c3620464de53b2345bfee46b",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/MOBILE_SMOKE.md": {
+    "mtime": 1780622912.7290237,
+    "ast_hash": "3d050ecc91d84947854f51c4b3ff6f68",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/websockets.md": {
+    "mtime": 1780622912.7370236,
+    "ast_hash": "878a1897c8f7d40f40c1233ebf49f780",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/dependency-update.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "a146003990a7e827f81ac010a2b28730",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/app-store-review.md": {
+    "mtime": 1780622912.7308173,
+    "ast_hash": "eb4b3db13764423869813ad342fe0408",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/docker-image-pinning.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "715b16f98924370595fbe25c57724d57",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/error-responses.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "d518f925d3c4a52bc3c4e8cf3f768f3b",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/pii-key-rotation.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "392f40e300ef522198530965cc738d95",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/security-incident.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "d486209499f876bd43ee2dc247a8e2f3",
+    "semantic_hash": ""
+  },
+  "docs/adr/002-expo-react-native.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "b8f45afb30cf31c5b3c4444ffbfb1210",
+    "semantic_hash": ""
+  },
+  "docs/adr/001-supabase-postgres.md": {
+    "mtime": 1780622912.7090237,
+    "ast_hash": "3e655c382193d67990cad4fd7a8c0bb3",
+    "semantic_hash": ""
+  },
+  "docs/adr/README.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "9f6b38f330719bdc1cffaa0ad51cea00",
+    "semantic_hash": ""
+  },
+  "docs/adr/004-redis-in-process-fallback.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "a20320cc764f1237dd47dc0553d75911",
+    "semantic_hash": ""
+  },
+  "docs/adr/003-fastapi-backend.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "7f6bb8cc6bc8512a1e61ee32da2c4567",
+    "semantic_hash": ""
+  },
+  "docs/adr/006-railway-deployment.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "de11f60df1090a2410afdbf3eed87757",
+    "semantic_hash": ""
+  },
+  "docs/adr/005-jwt-firebase-dual-auth.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "d21bddf135b1efb86dd630b14613e905",
+    "semantic_hash": ""
+  },
+  "docs/scoping/P0-5_PHASE_E_RUNBOOK.md": {
+    "mtime": 1780622912.7370236,
+    "ast_hash": "8914df50a9e0504972bb4c60aa99a7fa",
+    "semantic_hash": ""
+  },
+  "docs/scoping/P0-5_STRIPE_CARD_CHARGE.md": {
+    "mtime": 1780622912.738854,
+    "ast_hash": "4ad5d262f0bba89356f6e8ac82ed430b",
+    "semantic_hash": ""
+  },
+  "docs/handoff/P1_NEXT_SESSION_PROMPT.md": {
+    "mtime": 1780622912.7290237,
+    "ast_hash": "8c109e8928c6b392e1a64497ea470d79",
+    "semantic_hash": ""
+  },
+  ".claude/P0_ARCHITECTURE_BLUEPRINT.md": {
+    "mtime": 1780622912.1721997,
+    "ast_hash": "12204a2b204e8b4985befeedd72702cf",
+    "semantic_hash": ""
+  },
+  ".claude/P3_SESSION_HANDOFF.md": {
+    "mtime": 1780622912.1730237,
+    "ast_hash": "4f16e2f6c428debdd9129dc5809be3bf",
+    "semantic_hash": ""
+  },
+  ".claude/README.md": {
+    "mtime": 1780622912.1730237,
+    "ast_hash": "3a8ddd9711527942705e2a08a5c81848",
+    "semantic_hash": ""
+  },
+  ".claude/P3_HTTPONLY_DETAILED_DESIGN.md": {
+    "mtime": 1780622912.1721997,
+    "ast_hash": "e7d272008e9aa157d3e7f33cda5bf8ee",
+    "semantic_hash": ""
+  },
+  ".claude/P0_TASK_BREAKDOWN.md": {
+    "mtime": 1780673747.852506,
+    "ast_hash": "b384b104d7ea6fc6f7c2f8f0d088fdbd",
+    "semantic_hash": ""
+  },
+  ".claude/FRESH_SESSION_START_HERE.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "feff5deee3cb8a2f5295cef998c03844",
+    "semantic_hash": ""
+  },
+  ".claude/agents/spinr-migration-reviewer.md": {
+    "mtime": 1780622912.1730237,
+    "ast_hash": "093b001843355140e5d9291b5031800e",
+    "semantic_hash": ""
+  },
+  ".claude/agents/spinr-security-auditor.md": {
+    "mtime": 1780622912.1747718,
+    "ast_hash": "51110701ada40667617bc67843f632d0",
+    "semantic_hash": ""
+  },
+  ".claude/agents/spinr-money-auditor.md": {
+    "mtime": 1780622912.1747718,
+    "ast_hash": "3ac532a8c60287c69cbc575ef18cdb5c",
+    "semantic_hash": ""
+  },
+  ".claude/commands/incident.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "2b2a4bc11008f8f86303f5e9bfb39ec3",
+    "semantic_hash": ""
+  },
+  ".claude/commands/start.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "4e0e56bd7c055087fcec1f8b55abd156",
+    "semantic_hash": ""
+  },
+  ".claude/commands/status.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "129e47c4a90e4bbd02aa43de59e681c9",
+    "semantic_hash": ""
+  },
+  ".claude/commands/review.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "943d7ff203fd0157df70799b5516b836",
+    "semantic_hash": ""
+  },
+  ".claude/commands/migration-check.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "309713fdddc0586de83edc7612176443",
+    "semantic_hash": ""
+  },
+  ".claude/commands/adr.md": {
+    "mtime": 1780622912.1747718,
+    "ast_hash": "ed618e023d50280b194e1e3753e83753",
+    "semantic_hash": ""
+  },
+  ".claude/commands/pr.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "b1cb2199adf561b8420b6c8d64537ed1",
+    "semantic_hash": ""
+  },
+  ".claude/commands/commit.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "bb741b153e3c6d1b79207739d9253a63",
+    "semantic_hash": ""
+  },
+  ".claude/commands/plan.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "9fffde147ee6aff8e5f8a9dcd9a9d998",
+    "semantic_hash": ""
+  },
+  ".claude/commands/fare-audit.md": {
+    "mtime": 1780622912.175762,
+    "ast_hash": "cad27d2c190c174a9bf997312b767a6f",
+    "semantic_hash": ""
+  },
+  ".claude/context/domain-dispatch.md": {
+    "mtime": 1780622912.1770236,
+    "ast_hash": "9304c9a6f4940c1ae944cf19bd555b72",
+    "semantic_hash": ""
+  },
+  ".claude/context/domain-safety.md": {
+    "mtime": 1780622912.1780827,
+    "ast_hash": "0d45380267ded857fb9d99175d5d784c",
+    "semantic_hash": ""
+  },
+  ".claude/context/sprint-current.md": {
+    "mtime": 1780622912.1780827,
+    "ast_hash": "c0b8779fbc459edd33dd7a59aa83dfd5",
+    "semantic_hash": ""
+  },
+  ".claude/context/regulatory-sk.md": {
+    "mtime": 1780622912.1780827,
+    "ast_hash": "27a71446f8569ea494169b05db922090",
+    "semantic_hash": ""
+  },
+  ".claude/context/domain-payments.md": {
+    "mtime": 1780622912.1780827,
+    "ast_hash": "3c37b1b9e540c3c0e82861a172ff9ac2",
+    "semantic_hash": ""
+  },
+  ".agents/standards/security-standards.md": {
+    "mtime": 1780622912.1679766,
+    "ast_hash": "607e91cf702d9bed3365008690cc3101",
+    "semantic_hash": ""
+  },
+  ".agents/standards/testing-standards.md": {
+    "mtime": 1780622912.1679766,
+    "ast_hash": "0168abbf4bbc09573a272c8fa4b3a56a",
+    "semantic_hash": ""
+  },
+  ".agents/standards/coding-standards.md": {
+    "mtime": 1780622912.1679766,
+    "ast_hash": "8ee5069902d00ea1ac452b1a5cab3bc4",
+    "semantic_hash": ""
+  },
+  ".agents/standards/api-standards.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "ec7eae361afea5441c27e0baeb933b79",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/update-docs.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "7a16a94a048ea29d6e0b63536b07c500",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/code-review.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "658287484d2aed2b8bdb7c7c592e583b",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/security-audit.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "81ec5930910532b32fc98ce711f2e081",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/pre-commit.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "d8d940454fd60b722f1ce462ad741e0f",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/deploy-backend.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "5037f7c7e12d9db485bd4bf45d1c75ae",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/new-feature.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "ff43d0a34bbb4d24528ee3b200ecbcfd",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/deploy-frontend.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "02372adb62142061fe661ce8b94d2ce5",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/multi-agent-review.md": {
+    "mtime": 1780622912.1690385,
+    "ast_hash": "6acd2880395f86dc36d7d6df1a363f59",
+    "semantic_hash": ""
+  },
+  ".agents/workflows/bug-fix.md": {
+    "mtime": 1780622912.1679766,
+    "ast_hash": "ac983f2a888c2a8f66e9e2dc821395db",
+    "semantic_hash": ""
+  },
+  ".agents/roles/devops-engineer.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "e073492715c7119586883249e94b4a25",
+    "semantic_hash": ""
+  },
+  ".agents/roles/documentation-lead.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "977409e2715d6b267c560311e6400b54",
+    "semantic_hash": ""
+  },
+  ".agents/roles/security-engineer.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "3340005bebeace0ab3c1fa243316d639",
+    "semantic_hash": ""
+  },
+  ".agents/roles/frontend-developer.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "949da1f6e54d0879e20cc4963be16318",
+    "semantic_hash": ""
+  },
+  ".agents/roles/qa-engineer.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "30577ad6ae88c5ab6dcfe689575836b8",
+    "semantic_hash": ""
+  },
+  ".agents/roles/tech-lead.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "1fd1cc0cbc07efb5f7e1c484323f1d0c",
+    "semantic_hash": ""
+  },
+  ".agents/roles/backend-developer.md": {
+    "mtime": 1780622912.1641579,
+    "ast_hash": "9b81b91da21e71f3990956e712bbb4f5",
+    "semantic_hash": ""
+  },
+  ".agents/roles/business-analyst.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "d1c62fbd26ac84647b1786a7a31c3d62",
+    "semantic_hash": ""
+  },
+  ".agents/roles/manager.md": {
+    "mtime": 1780622912.165225,
+    "ast_hash": "938271021d9b206bcf0ca92160c0d114",
+    "semantic_hash": ""
+  },
+  ".agents/docs/api-reference.md": {
+    "mtime": 1780622912.1631029,
+    "ast_hash": "4477247ea97bc1b32045f56ab521d846",
+    "semantic_hash": ""
+  },
+  ".agents/docs/architecture.md": {
+    "mtime": 1780622912.1641579,
+    "ast_hash": "a6bc304bf58b869c3b57fecf40229d65",
+    "semantic_hash": ""
+  },
+  ".agents/docs/deployment-guide.md": {
+    "mtime": 1780622912.1641579,
+    "ast_hash": "2c51fcf81b6224e833debc8b61f086d3",
+    "semantic_hash": ""
+  },
+  ".agents/docs/database-schema.md": {
+    "mtime": 1780622912.1641579,
+    "ast_hash": "71a00ece5d03f0cb97abe5ac60643ef0",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/sounds/ride-offer.mp3": {
+    "mtime": 1780622912.7690237,
     "ast_hash": "8b14ed6b49ef71583f7fb82a100c9ed1",
     "semantic_hash": ""
   },
-  "/home/user/spinrvm/backend/migrations/114_rides_scheduled_dispatch_flags.sql": {
-    "mtime": 1780075319.9566276,
+  "backend/migrations/114_rides_scheduled_dispatch_flags.sql": {
+    "mtime": 1780622912.5370238,
     "ast_hash": "d19de5146740e363dd4264cc21c5b093",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/driver-offers/page.tsx": {
+    "mtime": 1780622912.463624,
+    "ast_hash": "e59ac3d3615afb0ee164e96037f1159b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/drivers/_components/driver-activity.tsx": {
+    "mtime": 1780622912.465691,
+    "ast_hash": "17ad33411ac2a6022c66ff9aadda76b4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support-tickets/_components/zoho-config-card.tsx": {
+    "mtime": 1780622912.4905949,
+    "ast_hash": "d47f02d5ee69ba36ab483836d0d6faa4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support-tickets/page.tsx": {
+    "mtime": 1780622912.4905949,
+    "ast_hash": "33ad310308bb3de0cca94c1f6ef015f4",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support-tickets/tickets/[id]/page.tsx": {
+    "mtime": 1780622912.4916687,
+    "ast_hash": "a0814bfeef2886a2751f5fcc13d8b18c",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support-tickets/tickets/page.tsx": {
+    "mtime": 1780622912.4916687,
+    "ast_hash": "b9854733918c7938147d7c4de7d2906a",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/support-tickets/trends/page.tsx": {
+    "mtime": 1780622912.4916687,
+    "ast_hash": "52c03d56759ebe4490512737030d3813",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/dashboard/venues/page.tsx": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "1cbae0a7ca164ae447a08c35fb293140",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/components/ui/rich-text-editor.tsx": {
+    "mtime": 1780622912.5050237,
+    "ast_hash": "4a767b71f6a4534f7511b7da6e475960",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/lib/track-host.ts": {
+    "mtime": 1780622912.5093117,
+    "ast_hash": "bd375dfc54518b0172915d5c1afded25",
+    "semantic_hash": ""
+  },
+  "backend/migrations/110_drivers_device_attestation.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "c65ca7883a8ad1ac86ae0e4f0caa96c4",
+    "semantic_hash": ""
+  },
+  "backend/migrations/110_settings_resend_email.sql": {
+    "mtime": 1780622912.5330238,
+    "ast_hash": "9ee1e9fd4ca1f6281ec4a53e1e02df5c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/114_lost_and_found_add_item_category.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "250a480a03384957a92d1bc59f50fc9e",
+    "semantic_hash": ""
+  },
+  "backend/migrations/114_ride_history_stable_cursor_index.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "083a538e22efa9620ec6c7e2e2592dd3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/115_lost_and_found_chat.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "1c9f18983c05f262466aef6b0a35b181",
+    "semantic_hash": ""
+  },
+  "backend/migrations/116_lost_and_found_rider_user_id.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "288388446a9bc50cf4a7c0d0555b313f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/117_push_retry_target_app.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "27b00b3a2bfb432a2e5da9fe7c029d4a",
+    "semantic_hash": ""
+  },
+  "backend/migrations/117_ride_routes.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "d74b3d021edb73319c2a042784e9f08c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/118_route_quality_received_at.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "ea390a7d8a5713f16846ee898bcf14d3",
+    "semantic_hash": ""
+  },
+  "backend/migrations/119_route_tracking_perf_indexes.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "83b6f865c362b6b163281b64de60e13f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/120_ensure_emergency_contacts_and_gps_column.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "4d99341b7747950a895dca57a8ef560c",
+    "semantic_hash": ""
+  },
+  "backend/migrations/121_zoho_desk_integration.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "4d3a82eb6533de42cd9b3066014d8169",
+    "semantic_hash": ""
+  },
+  "backend/migrations/122_zoho_desk_default_from_email.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "de55b1a63e5c20fe12f044b15b7de59e",
+    "semantic_hash": ""
+  },
+  "backend/migrations/123_zoho_desk_tickets_mirror.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "e5c3652b165e48d67c0bb1a6bc0492e0",
+    "semantic_hash": ""
+  },
+  "backend/migrations/124_zoho_desk_sync_cursor.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "69d670e8fb902a6a844b728f842b9eb0",
+    "semantic_hash": ""
+  },
+  "backend/migrations/125_lost_and_found_zoho_ticket.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "893fb1c207309b10a578a078358afdcb",
+    "semantic_hash": ""
+  },
+  "backend/migrations/126_disputes_zoho_ticket.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "d22db827831661ef74877b9be96e922f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/127_zoho_desk_mirror_backfilled.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "40f80f4ada8d258b210480eda9c10f7f",
+    "semantic_hash": ""
+  },
+  "backend/migrations/128_support_entities_zoho_ticket.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "71f696d1a42a33a52e7adebfdd640564",
+    "semantic_hash": ""
+  },
+  "backend/migrations/129_ride_routes_pickup_road_polyline.sql": {
+    "mtime": 1780622912.5370238,
+    "ast_hash": "93325217517391e04bd50cb2f9e05f06",
+    "semantic_hash": ""
+  },
+  "backend/migrations/130_ride_offers_offered_at_index.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "06a66cce6620bb06f37ef22f69be5dca",
+    "semantic_hash": ""
+  },
+  "backend/migrations/131_ride_offers_preempted_status.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "6cc9d388ad90e16dddb961986af4e02b",
+    "semantic_hash": ""
+  },
+  "backend/migrations/132_zoho_desk_auto_sync_toggle.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "f2cacda4dbb4408eeae5be4de0535a06",
+    "semantic_hash": ""
+  },
+  "backend/migrations/133_rides_pickup_nav_coords.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "1f8934857a6cf906db7f479a909278a0",
+    "semantic_hash": ""
+  },
+  "backend/migrations/134_venues_pickup_points.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "a0d0ad4a835c82a4f408e71e52f3ee54",
+    "semantic_hash": ""
+  },
+  "backend/migrations/135_seed_pickup_venues.sql": {
+    "mtime": 1780622912.5410237,
+    "ast_hash": "3dbf06ce40f8761dd5de938ecfb8fa5d",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/support_tickets.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "d830c011d2850ca8f12363b2c73cb298",
+    "semantic_hash": ""
+  },
+  "backend/routes/admin/venues.py": {
+    "mtime": 1780622912.5770237,
+    "ast_hash": "072dd57485bf7bd5c68cedad74cc8717",
+    "semantic_hash": ""
+  },
+  "backend/routes/lost_and_found.py": {
+    "mtime": 1780622912.5850236,
+    "ast_hash": "c72926e0f5de3d79e3fd91bcc2510310",
+    "semantic_hash": ""
+  },
+  "backend/services/zoho_desk_db.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "51ee1e812d5edc85b64de1c5e653670d",
+    "semantic_hash": ""
+  },
+  "backend/services/zoho_desk_integration.py": {
+    "mtime": 1780622912.6013942,
+    "ast_hash": "c885e294ee85e2d901a1f2e0ab0e6412",
+    "semantic_hash": ""
+  },
+  "backend/services/zoho_desk_service.py": {
+    "mtime": 1780622912.6050236,
+    "ast_hash": "8ea63416c3414aaec150a4aac211eda8",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_admin_drivers_expiring.py": {
+    "mtime": 1780622912.6130238,
+    "ast_hash": "58ef0d06f67611e1a531ab5cabd97580",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_breadcrumb_persistence.py": {
+    "mtime": 1780622912.6170237,
+    "ast_hash": "eaf4d6670e4fd12319f18ebbb57b78f7",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_driver_activity.py": {
+    "mtime": 1780622912.6290238,
+    "ast_hash": "9509ebed7552a2a0ed3e777f7f87d4ed",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_driver_location_redis_resilience.py": {
+    "mtime": 1780674353.708492,
+    "ast_hash": "0ccdb234bf77eab0d4aca6d9a18f17ae",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_estimate_ghost_driver_filter.py": {
+    "mtime": 1780622912.6330237,
+    "ast_hash": "751bb4e2346cff0190089121e0979256",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_live_route.py": {
+    "mtime": 1780622912.6370237,
+    "ast_hash": "97392bd488ec79802faad0d52e4a685c",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_route_distance_osrm.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "04bd5ec6c999813905a8b79d6d0b9f0f",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_route_validation_osrm.py": {
+    "mtime": 1780622912.6530237,
+    "ast_hash": "f34d1ff150b705e03dd153452edd61e7",
+    "semantic_hash": ""
+  },
+  "backend/tests/test_zoho_desk.py": {
+    "mtime": 1780622912.6610236,
+    "ast_hash": "b060b590f50766ca821aece0abd7bef9",
+    "semantic_hash": ""
+  },
+  "backend/utils/breadcrumbs.py": {
+    "mtime": 1780622912.691878,
+    "ast_hash": "7c43b6bd04a305258d1bfa6f1d14a717",
+    "semantic_hash": ""
+  },
+  "backend/utils/driver_activity.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "7f5760b081a58b0530b7e031cb2d2a2a",
+    "semantic_hash": ""
+  },
+  "backend/utils/google_places_new.py": {
+    "mtime": 1780622912.6930237,
+    "ast_hash": "e52f4331ce1960cf85f8f5c6553d371a",
+    "semantic_hash": ""
+  },
+  "backend/utils/zoho_desk_sync.py": {
+    "mtime": 1780622912.7050238,
+    "ast_hash": "d2e6268ed59d11ee0a6ee1c869c7844e",
+    "semantic_hash": ""
+  },
+  "deploy/osrm/railway.json": {
+    "mtime": 1780622912.706926,
+    "ast_hash": "45f51763fe266fdd4bcf8c77c7666ce3",
+    "semantic_hash": ""
+  },
+  "deploy/osrm/smoke-test.sh": {
+    "mtime": 1780622912.706926,
+    "ast_hash": "568a781c0b7e4f92cdab75e44718c276",
+    "semantic_hash": ""
+  },
+  "driver-app/__tests__/components/ActivityView.test.tsx": {
+    "mtime": 1780622912.752061,
+    "ast_hash": "60c2557f331ccee92e587ce66cb44d91",
+    "semantic_hash": ""
+  },
+  "driver-app/app/driver/lost-and-found-chat.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "ea901f4e7a73c773c7aa95ebea5c375a",
+    "semantic_hash": ""
+  },
+  "driver-app/app/driver/lost-and-found.tsx": {
+    "mtime": 1780622912.7570238,
+    "ast_hash": "c28ba7caff40d9bcb33d04630236ce90",
+    "semantic_hash": ""
+  },
+  "driver-app/components/BrandSplash.tsx": {
+    "mtime": 1780673747.8565059,
+    "ast_hash": "56417e6416392df0f9bf0b58e751bb4e",
+    "semantic_hash": ""
+  },
+  "driver-app/components/CancelReasonSheet.tsx": {
+    "mtime": 1780622912.7764652,
+    "ast_hash": "ed0a891903dccef456141980144715fc",
+    "semantic_hash": ""
+  },
+  "driver-app/index.js": {
+    "mtime": 1780622912.790269,
+    "ast_hash": "2927db520b94d117bea617bc59564d1d",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/__tests__/carMapCamera.test.ts": {
+    "mtime": 1780622912.791748,
+    "ast_hash": "c7a923c0ec8c0087e41e07df9881a6da",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/__tests__/carRoute.test.ts": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "05fe13f57d38c0a2d3daaa4454776739",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/__tests__/carScreen.test.ts": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "58154334a8d354e8cf0319ea46aa2a10",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/__tests__/register.test.ts": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "7133306ec4187296d8921e10e4c5116c",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/carMapCamera.ts": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "59d94d97455375331c93ea14731e758b",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/carRoute.ts": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "060432cd5b6f4fedca03ed2b35033739",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/carScreen.ts": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "a6e747652e5ca14d8da113b5b3cb37e8",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/carSurface.tsx": {
+    "mtime": 1780622912.792219,
+    "ast_hash": "776ec05ce8feaf72dcec28eab6337d15",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/register.ts": {
+    "mtime": 1780622912.7930238,
+    "ast_hash": "494c7bed60dcc8fd7c25b5e387e7a454",
+    "semantic_hash": ""
+  },
+  "driver-app/lib/androidAuto/useCarLocation.ts": {
+    "mtime": 1780622912.7930238,
+    "ast_hash": "e199a0576aeada7932def79fa9fd728b",
+    "semantic_hash": ""
+  },
+  "driver-app/utils/__tests__/backgroundLocation.test.ts": {
+    "mtime": 1780622912.8032808,
+    "ast_hash": "8d26ffd562bd76e0170f74d050e46693",
+    "semantic_hash": ""
+  },
+  "rider-app/app/lost-and-found-chat.tsx": {
+    "mtime": 1780622913.6696367,
+    "ast_hash": "a6806275a895b6901bdb554bf42f2d0d",
+    "semantic_hash": ""
+  },
+  "rider-app/app/lost-and-found.tsx": {
+    "mtime": 1780622913.6730237,
+    "ast_hash": "9d6a16996737885536d08ff507d625b3",
+    "semantic_hash": ""
+  },
+  "rider-app/components/BrandSplash.tsx": {
+    "mtime": 1780673747.8605058,
+    "ast_hash": "56417e6416392df0f9bf0b58e751bb4e",
+    "semantic_hash": ""
+  },
+  "rider-app/components/CancelReasonSheet.tsx": {
+    "mtime": 1780622913.6866083,
+    "ast_hash": "c917a816d79321e2fc407008a7dddc16",
+    "semantic_hash": ""
+  },
+  "scripts/brand/gen_brand_assets.py": {
+    "mtime": 1780622913.7046251,
+    "ast_hash": "0a65710c076404edc902bb687bf7971c",
+    "semantic_hash": ""
+  },
+  ".github/workflows/bootstrap-fly.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "c7696c68cf9aa5f6e476ba56f5c05374",
+    "semantic_hash": ""
+  },
+  ".github/workflows/deploy-fly.yml": {
+    "mtime": 1780622912.1850238,
+    "ast_hash": "1cc1b9bd8c398ad5b21209e85115209d",
+    "semantic_hash": ""
+  },
+  "deploy/osrm/README.md": {
+    "mtime": 1780622912.706926,
+    "ast_hash": "6f5261fb853ea0cbc47f934724b4a1c5",
+    "semantic_hash": ""
+  },
+  "docs/adr/007-fly-primary-railway-standby.md": {
+    "mtime": 1780622912.7102206,
+    "ast_hash": "d0d293b25854c71e7ee235688609ae11",
+    "semantic_hash": ""
+  },
+  "docs/carplay-android-auto.md": {
+    "mtime": 1780622912.7229278,
+    "ast_hash": "dc6e6845c280aa6228d6f1a0cc9b9375",
+    "semantic_hash": ""
+  },
+  "docs/compliance/sgi-quarterly.md": {
+    "mtime": 1780622912.7250237,
+    "ast_hash": "d06b6fe4fe783708e0ea16b1a9924861",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/railway-fly-cloudflare.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "3e45cd49cfa414fcc80cdd706b310cea",
+    "semantic_hash": ""
+  },
+  "docs/runbooks/railway-fly-failover.md": {
+    "mtime": 1780622912.7330236,
+    "ast_hash": "87d7575c796b4c80f5ed4252df7a0e6b",
+    "semantic_hash": ""
+  },
+  "admin-dashboard/src/app/icon.svg": {
+    "mtime": 1780622912.4970238,
+    "ast_hash": "fe40cdf84c1b29fbfe3239fc0b58b4c4",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/images/spinr-logo.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "82c11604714f9bbea4c749bff4f2fca2",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/images/splash-mark.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "873f57f22d7e50288009501e9fd3439f",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/images/zoom_in.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "5a8a4f6e926893fe0ecc279a08991157",
+    "semantic_hash": ""
+  },
+  "driver-app/assets/images/zoom_out.png": {
+    "mtime": 1780622912.7690237,
+    "ast_hash": "0ca5242d00259450ddbbd3c0883c2efa",
+    "semantic_hash": ""
+  },
+  "rider-app/assets/images/spinr-logo.png": {
+    "mtime": 1780622913.6810236,
+    "ast_hash": "82c11604714f9bbea4c749bff4f2fca2",
+    "semantic_hash": ""
+  },
+  "rider-app/assets/images/splash-mark.png": {
+    "mtime": 1780622913.6810236,
+    "ast_hash": "873f57f22d7e50288009501e9fd3439f",
     "semantic_hash": ""
   }
 }


### PR DESCRIPTION
The driver WS location handler wrote the ephemeral 60s Redis location
cache (manager.update_driver_location) BEFORE the authoritative
drivers-table write. redis_set re-raises when REDIS_URL is set but
Redis is unreachable, so a Redis blip raised in the cache write and
skipped the durable lat/lng persistence. An online driver was then
left with no position and the admin live-monitoring map drew no car
marker (online count survives via presence, which swallows its own
Redis errors).

- socket_manager.update_driver_location: treat the cache as
  best-effort (warning log, no raise) per the degraded-but-recovered
  convention; it's a 60s ephemeral key, not authoritative state.
- websocket.py: persist to the drivers table first, then warm the
  cache, so coordinates land even if Redis is degraded.
- regression test asserting the cache write swallows a Redis failure.

https://claude.ai/code/session_018gXqdHtFovTPa9xDFjt3RH

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
