### PR TITLE
feat(obs): expose WS fan-out status + per-replica connection counts

### DIFF
--- a/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx
@@ -9,10 +9,12 @@ import {
     Database,
     Gauge,
     HardDrive,
+    Radio,
     RefreshCw,
     Server,
     ShieldAlert,
     Trash2,
+    WifiOff,
     Zap,
 } from "lucide-react";
 
@@ -36,9 +38,11 @@ import {
     flushRedisPrefix,
     getInfrastructureStats,
     getRedisHealth,
+    getWebsocketHealth,
     type InfrastructureStats,
     type RedisHealthResponse,
     type RedisPrefixCount,
+    type WebsocketHealth,
 } from "@/lib/api";
 
 // Poll interval for the lightweight (O(1)) stats call. The SCAN-based
@@ -90,6 +94,7 @@ export default function RedisMonitoringPage() {
 
     const [redis, setRedis] = useState<RedisHealthResponse | null>(null);
     const [infra, setInfra] = useState<InfrastructureStats | null>(null);
+    const [ws, setWs] = useState<WebsocketHealth | null>(null);
     const [loading, setLoading] = useState(true);
     const [scanRefreshing, setScanRefreshing] = useState(false);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -117,10 +122,20 @@ export default function RedisMonitoringPage() {
         }
     }, []);
 
+    const fetchWs = useCallback(async () => {
+        try {
+            const res = await getWebsocketHealth();
+            setWs(res);
+        } catch (err: any) {
+            // non-fatal — leave previous state
+            console.error("[monitoring] ws health fetch failed", err);
+        }
+    }, []);
+
     // Initial load
     useEffect(() => {
-        Promise.all([fetchRedis(), fetchInfra()]).finally(() => setLoading(false));
-    }, [fetchRedis, fetchInfra]);
+        Promise.all([fetchRedis(), fetchInfra(), fetchWs()]).finally(() => setLoading(false));
+    }, [fetchRedis, fetchInfra, fetchWs]);
 
     // Stats polling (O(1) — safe on an interval)
     useEffect(() => {
@@ -133,10 +148,15 @@ export default function RedisMonitoringPage() {
         return () => clearInterval(id);
     }, [fetchInfra]);
 
+    useEffect(() => {
+        const id = setInterval(fetchWs, INFRA_POLL_MS);
+        return () => clearInterval(id);
+    }, [fetchWs]);
+
     const handleManualRefresh = async () => {
         setScanRefreshing(true);
         try {
-            await Promise.all([fetchRedis(), fetchInfra()]);
+            await Promise.all([fetchRedis(), fetchInfra(), fetchWs()]);
             toast({ title: "Refreshed", description: "Redis + infra stats updated" });
         } finally {
             setScanRefreshing(false);
@@ -334,6 +354,75 @@ export default function RedisMonitoringPage() {
                     </CardContent>
                 </Card>
             </div>
+
+            {/* WebSocket fan-out degraded banner — the live-map failure mode */}
+            {ws && ws.fanout.configured && !ws.fanout.active && (
+                <Card className="border-red-500/50">
+                    <CardContent className="pt-6 flex items-start gap-2 text-red-600 dark:text-red-400">
+                        <WifiOff className="mt-0.5 h-5 w-5 shrink-0" />
+                        <div>
+                            <p className="font-medium">
+                                WebSocket fan-out is LOCAL-ONLY on this replica — live monitoring is degraded.
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                                The cross-replica pub/sub channel <code>{ws.fanout.channel}</code> is not
+                                connected{ws.fanout.last_error ? <> (<code>{ws.fanout.last_error}</code>)</> : null},
+                                so the admin map only sees clients on the same worker. Fix Redis connectivity
+                                (see the connectivity probe above) and restart the backend — pub/sub does not
+                                self-heal after a boot-time failure.
+                            </p>
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* WebSocket health */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <Radio className="h-5 w-5" />
+                        WebSocket Health
+                    </CardTitle>
+                    <p className="text-xs text-muted-foreground">
+                        Cross-replica fan-out status and live socket counts for the replica that
+                        served this request. Counts are <strong>per-replica</strong>, not fleet-wide
+                        {ws?.workers_hint ? <> (this backend runs {ws.workers_hint} uvicorn workers)</> : null}.
+                    </p>
+                </CardHeader>
+                <CardContent>
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-5">
+                        {/* Fan-out status */}
+                        <div className="rounded-md border bg-muted/30 px-3 py-2 lg:col-span-1">
+                            <p className="text-xs text-muted-foreground">Fan-out</p>
+                            {!ws ? (
+                                <p className="font-semibold">–</p>
+                            ) : ws.fanout.active ? (
+                                <Badge variant="default" className="mt-1 gap-1">
+                                    <CheckCircle2 className="h-3 w-3" /> Live
+                                </Badge>
+                            ) : ws.fanout.configured ? (
+                                <Badge variant="destructive" className="mt-1 gap-1">
+                                    <WifiOff className="h-3 w-3" /> Local-only
+                                </Badge>
+                            ) : (
+                                <Badge variant="secondary" className="mt-1 gap-1">
+                                    <CircleSlash className="h-3 w-3" /> Single-machine
+                                </Badge>
+                            )}
+                        </div>
+                        <InfraStat label="Total sockets" value={formatNumber(ws?.connections.total)} />
+                        <InfraStat label="Admins" value={formatNumber(ws?.connections.admins)} />
+                        <InfraStat label="Drivers" value={formatNumber(ws?.connections.drivers)} />
+                        <InfraStat label="Riders" value={formatNumber(ws?.connections.riders)} />
+                    </div>
+                    <p className="mt-3 text-xs text-muted-foreground">
+                        Channel <code>{ws?.fanout.channel ?? "–"}</code>
+                        {ws?.fanout.backend_scheme ? <> · backend <code>{ws.fanout.backend_scheme}://</code></> : null}
+                        {ws?.replica_hostname ? <> · replica <code>{ws.replica_hostname}</code></> : null}
+                        {ws?.fanout.last_error ? <> · last error <code>{ws.fanout.last_error}</code></> : null}
+                    </p>
+                </CardContent>
+            </Card>
 
             {/* Prefix breakdown */}
             <Card>

--- a/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx
@@ -37,9 +37,11 @@ import { useToast } from "@/components/ui/use-toast";
 import {
     flushRedisPrefix,
     getInfrastructureStats,
+    getRedisConnectivity,
     getRedisHealth,
     getWebsocketHealth,
     type InfrastructureStats,
+    type RedisConnectivityProbe,
     type RedisHealthResponse,
     type RedisPrefixCount,
     type WebsocketHealth,
@@ -81,6 +83,32 @@ function memoryColor(percent: number | null | undefined): string {
     return "bg-emerald-500";
 }
 
+function connectivityBadge(status: "ok" | "degraded" | "error" | "unset") {
+    if (status === "ok")
+        return (
+            <Badge variant="default" className="gap-1">
+                <CheckCircle2 className="h-3 w-3" /> OK
+            </Badge>
+        );
+    if (status === "degraded")
+        return (
+            <Badge variant="secondary" className="gap-1">
+                <AlertTriangle className="h-3 w-3" /> Pub/sub broken
+            </Badge>
+        );
+    if (status === "error")
+        return (
+            <Badge variant="destructive" className="gap-1">
+                <ShieldAlert className="h-3 w-3" /> Error
+            </Badge>
+        );
+    return (
+        <Badge variant="secondary" className="gap-1">
+            <CircleSlash className="h-3 w-3" /> Unset
+        </Badge>
+    );
+}
+
 function circuitBadgeVariant(
     state: "closed" | "open" | "half_open",
 ): { variant: "default" | "destructive" | "secondary"; label: string; icon: React.ElementType } {
@@ -95,6 +123,7 @@ export default function RedisMonitoringPage() {
     const [redis, setRedis] = useState<RedisHealthResponse | null>(null);
     const [infra, setInfra] = useState<InfrastructureStats | null>(null);
     const [ws, setWs] = useState<WebsocketHealth | null>(null);
+    const [connectivity, setConnectivity] = useState<RedisConnectivityProbe[] | null>(null);
     const [loading, setLoading] = useState(true);
     const [scanRefreshing, setScanRefreshing] = useState(false);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -132,10 +161,23 @@ export default function RedisMonitoringPage() {
         }
     }, []);
 
+    // Expensive (PING + pub/sub round-trip per URL) — load + manual refresh
+    // only, never on the poll loop, to avoid burning Redis/Upstash quota.
+    const fetchConnectivity = useCallback(async () => {
+        try {
+            const res = await getRedisConnectivity();
+            setConnectivity(res.connectivity);
+        } catch (err: any) {
+            console.error("[monitoring] connectivity probe failed", err);
+        }
+    }, []);
+
     // Initial load
     useEffect(() => {
-        Promise.all([fetchRedis(), fetchInfra(), fetchWs()]).finally(() => setLoading(false));
-    }, [fetchRedis, fetchInfra, fetchWs]);
+        Promise.all([fetchRedis(), fetchInfra(), fetchWs(), fetchConnectivity()]).finally(() =>
+            setLoading(false),
+        );
+    }, [fetchRedis, fetchInfra, fetchWs, fetchConnectivity]);
 
     // Stats polling (O(1) — safe on an interval)
     useEffect(() => {
@@ -156,7 +198,7 @@ export default function RedisMonitoringPage() {
     const handleManualRefresh = async () => {
         setScanRefreshing(true);
         try {
-            await Promise.all([fetchRedis(), fetchInfra(), fetchWs()]);
+            await Promise.all([fetchRedis(), fetchInfra(), fetchWs(), fetchConnectivity()]);
             toast({ title: "Refreshed", description: "Redis + infra stats updated" });
         } finally {
             setScanRefreshing(false);
@@ -354,6 +396,60 @@ export default function RedisMonitoringPage() {
                     </CardContent>
                 </Card>
             </div>
+
+            {/* Redis connectivity (PING + pub/sub round-trip) — off the poll loop */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                        <Activity className="h-5 w-5" />
+                        Redis Connectivity
+                    </CardTitle>
+                    <p className="text-xs text-muted-foreground">
+                        Live PING + pub/sub round-trip per configured URL — the only check that
+                        distinguishes &quot;up&quot; from &quot;up but pub/sub broken&quot;. Runs on
+                        load and manual refresh only (it costs connection quota), so use Refresh to
+                        re-probe.
+                    </p>
+                </CardHeader>
+                <CardContent>
+                    {!connectivity ? (
+                        <p className="py-4 text-center text-sm text-muted-foreground">
+                            Probing…
+                        </p>
+                    ) : (
+                        <div className="flex flex-col gap-2">
+                            {connectivity.map((p) => (
+                                <div
+                                    key={p.label}
+                                    className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-muted/30 px-3 py-2"
+                                >
+                                    <div className="min-w-0">
+                                        <div className="flex items-center gap-2">
+                                            <code className="text-xs font-medium">{p.label}</code>
+                                            {p.same_as ? (
+                                                <span className="text-xs text-muted-foreground">
+                                                    (same as {p.same_as})
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                        <p className="truncate text-xs text-muted-foreground">
+                                            {p.endpoint ?? "not configured"}
+                                            {p.ping_ms != null ? ` · ping ${p.ping_ms}ms` : ""}
+                                            {p.pubsub ? ` · pub/sub ${p.pubsub.ok ? "ok" : "FAILED"}` : ""}
+                                        </p>
+                                        {(p.error || p.warning || p.pubsub?.error) && (
+                                            <p className="text-xs text-red-600 dark:text-red-400">
+                                                {p.error || p.pubsub?.error || p.warning}
+                                            </p>
+                                        )}
+                                    </div>
+                                    {connectivityBadge(p.status)}
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
 
             {/* WebSocket fan-out degraded banner — the live-map failure mode */}
             {ws && ws.fanout.configured && !ws.fanout.active && (

--- a/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/redis/page.tsx
@@ -384,9 +384,14 @@ export default function RedisMonitoringPage() {
                         WebSocket Health
                     </CardTitle>
                     <p className="text-xs text-muted-foreground">
-                        Cross-replica fan-out status and live socket counts for the replica that
-                        served this request. Counts are <strong>per-replica</strong>, not fleet-wide
-                        {ws?.workers_hint ? <> (this backend runs {ws.workers_hint} uvicorn workers)</> : null}.
+                        Cross-replica fan-out status and live socket counts for the uvicorn worker
+                        that served this request. Counts are <strong>per-worker</strong>, not
+                        host-wide
+                        {ws?.workers_hint ? (
+                            <> — this backend runs {ws.workers_hint} workers, so the host total is
+                            spread across them and each refresh may hit a different one</>
+                        ) : null}
+                        .
                     </p>
                 </CardHeader>
                 <CardContent>
@@ -418,7 +423,8 @@ export default function RedisMonitoringPage() {
                     <p className="mt-3 text-xs text-muted-foreground">
                         Channel <code>{ws?.fanout.channel ?? "–"}</code>
                         {ws?.fanout.backend_scheme ? <> · backend <code>{ws.fanout.backend_scheme}://</code></> : null}
-                        {ws?.replica_hostname ? <> · replica <code>{ws.replica_hostname}</code></> : null}
+                        {ws?.replica_hostname ? <> · host <code>{ws.replica_hostname}</code></> : null}
+                        {ws?.worker_pid ? <> · worker pid <code>{ws.worker_pid}</code></> : null}
                         {ws?.fanout.last_error ? <> · last error <code>{ws.fanout.last_error}</code></> : null}
                     </p>
                 </CardContent>

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2264,6 +2264,23 @@ export type InfrastructureStats = {
 export const getRedisHealth = () =>
     request<RedisHealthResponse>("/api/admin/monitoring/redis");
 
+export type WebsocketHealth = {
+    fanout: {
+        active: boolean;
+        channel: string;
+        backend_scheme: string;
+        configured: boolean;
+        last_error: string | null;
+    };
+    connections: { total: number; admins: number; drivers: number; riders: number };
+    replica_hostname: string;
+    workers_hint: number | null;
+    per_replica: boolean;
+};
+
+export const getWebsocketHealth = () =>
+    request<WebsocketHealth>("/api/admin/monitoring/websockets");
+
 export const getInfrastructureStats = () =>
     request<InfrastructureStats>("/api/admin/monitoring/infrastructure");
 

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2282,6 +2282,30 @@ export type WebsocketHealth = {
 export const getWebsocketHealth = () =>
     request<WebsocketHealth>("/api/admin/monitoring/websockets");
 
+export type RedisConnectivityProbe = {
+    label: string;
+    configured: boolean;
+    status: "ok" | "degraded" | "error" | "unset";
+    endpoint?: string;
+    scheme?: string;
+    host?: string;
+    port?: number | null;
+    tls?: boolean;
+    ping_ms?: number;
+    pubsub?: { ok: boolean; error?: string };
+    error?: string;
+    warning?: string;
+    same_as?: string;
+};
+
+// Separate from getRedisHealth on purpose: this opens Redis clients and runs a
+// pub/sub round-trip per URL, so it's called only on load + manual refresh,
+// never on the 10s poll loop.
+export const getRedisConnectivity = () =>
+    request<{ connectivity: RedisConnectivityProbe[] }>(
+        "/api/admin/monitoring/redis/connectivity",
+    );
+
 export const getInfrastructureStats = () =>
     request<InfrastructureStats>("/api/admin/monitoring/infrastructure");
 

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2274,8 +2274,9 @@ export type WebsocketHealth = {
     };
     connections: { total: number; admins: number; drivers: number; riders: number };
     replica_hostname: string;
+    worker_pid: number;
     workers_hint: number | null;
-    per_replica: boolean;
+    per_worker: boolean;
 };
 
 export const getWebsocketHealth = () =>

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -391,21 +391,33 @@ async def lifespan(app: FastAPI):
         # Connectivity diagnosis — probe every Redis URL (PING + pub/sub
         # round-trip) and print a password-free banner so operators can tell
         # "down" from "up but pub/sub broken" from "wrong URL kind" straight
-        # from the Fly logs. Best-effort; never blocks boot.
-        try:
-            from utils.redis_diag import diagnose_redis, log_diagnosis
+        # from the Fly logs. Run it in the BACKGROUND: diagnose_redis awaits a
+        # pub/sub round-trip serially across three URLs, so a diagnostic-only
+        # Redis stall would otherwise add tens of seconds to boot and risk
+        # tripping the deploy health check. Best-effort; never blocks boot.
+        app.state.redis_diagnosis = None
 
-            _diag = await diagnose_redis(
-                {
-                    "REDIS_URL": settings.REDIS_URL,
-                    "RATE_LIMIT_REDIS_URL": settings.RATE_LIMIT_REDIS_URL,
-                    "WS_REDIS_URL (effective)": ws_redis_url,
-                }
-            )
-            log_diagnosis(_diag)
-            app.state.redis_diagnosis = _diag
-        except Exception as _diag_err:
-            logger.warning(f"Redis diagnosis failed: {_diag_err}")
+        async def _run_redis_diagnosis() -> None:
+            try:
+                from utils.redis_diag import diagnose_redis, log_diagnosis
+
+                _diag = await asyncio.wait_for(
+                    diagnose_redis(
+                        {
+                            "REDIS_URL": settings.REDIS_URL,
+                            "RATE_LIMIT_REDIS_URL": settings.RATE_LIMIT_REDIS_URL,
+                            "WS_REDIS_URL (effective)": ws_redis_url,
+                        }
+                    ),
+                    timeout=20.0,
+                )
+                log_diagnosis(_diag)
+                app.state.redis_diagnosis = _diag
+            except Exception as _diag_err:
+                logger.warning(f"Redis diagnosis failed: {_diag_err}")
+
+        # Keep a reference so the task isn't garbage-collected mid-flight.
+        app.state.redis_diag_task = asyncio.create_task(_run_redis_diagnosis(), name="redis_startup_diagnosis")
 
         if not ws_started and settings.ENV.lower() == "production":
             # Production without distributed WS is a correctness

--- a/backend/routes/admin/monitoring.py
+++ b/backend/routes/admin/monitoring.py
@@ -390,6 +390,44 @@ async def flush_redis_prefix(
     }
 
 
+@router.get("/websockets")
+async def get_websocket_health(
+    current_admin: dict = Depends(get_admin_user),
+) -> Dict[str, Any]:
+    """WebSocket health for the backend replica that served this request.
+
+    Two parts:
+      - ``fanout``: cross-replica pub/sub status (``ws_pubsub.status()``).
+        When ``active`` is False the admin live-monitoring map only sees
+        clients connected to the *same* uvicorn worker — the exact failure
+        behind a frozen map when Redis is unreachable. ``last_error`` says
+        why (e.g. ``connect: TimeoutError``).
+      - ``connections``: active socket counts on THIS replica, bucketed by
+        client type. With multiple uvicorn workers each process holds its
+        own registry, so these are per-replica, not fleet-wide
+        (``workers_hint`` surfaces the configured worker count).
+    """
+    import platform
+
+    try:
+        from ...socket_manager import manager
+        from ...utils.ws_pubsub import pubsub
+    except ImportError:
+        from socket_manager import manager  # type: ignore
+        from utils.ws_pubsub import pubsub  # type: ignore
+
+    workers_env = os.environ.get("UVICORN_WORKERS")
+    workers_hint = int(workers_env) if workers_env and workers_env.isdigit() else None
+
+    return {
+        "fanout": pubsub.status(),
+        "connections": manager.connection_stats(),
+        "replica_hostname": platform.node(),
+        "workers_hint": workers_hint,
+        "per_replica": True,
+    }
+
+
 # ── Infrastructure utilization ────────────────────────────────────────
 #
 # Process-level resource usage for the backend replica answering this

--- a/backend/routes/admin/monitoring.py
+++ b/backend/routes/admin/monitoring.py
@@ -315,10 +315,29 @@ async def get_redis_health(
     ]
     prefixes_with_meta.sort(key=lambda x: x["count"], reverse=True)
 
-    # Live connectivity probe — PING + pub/sub round-trip on every configured
-    # Redis URL. This is what tells you "Redis up but pub/sub broken" (the
-    # failure mode that breaks cross-replica admin live-monitoring on Upstash),
-    # which get_redis_stats's INFO snapshot can't see. Best-effort.
+    return {
+        "stats": stats,
+        "prefix_counts": prefixes_with_meta,
+        "flushable_prefixes": sorted(_FLUSHABLE_PREFIXES),
+    }
+
+
+@router.get("/redis/connectivity")
+async def get_redis_connectivity(
+    current_admin: dict = Depends(get_admin_user),
+) -> Dict[str, Any]:
+    """Live connectivity probe — PING + pub/sub round-trip on every configured
+    Redis URL. This is what tells you "Redis up but pub/sub broken" (the
+    failure mode that breaks cross-replica admin live-monitoring on Upstash),
+    which get_redis_stats's INFO snapshot can't see.
+
+    Deliberately a SEPARATE endpoint from `/redis`: each probe opens Redis
+    clients and runs SUBSCRIBE/PUBLISH/receive per URL, which costs
+    connection/request quota (and can hang when pub/sub is slow — exactly the
+    Upstash failure being debugged). The dashboard polls `/redis` every ~10s
+    but only calls this on page load + manual refresh, so the expensive probe
+    is never on the poll loop. Best-effort.
+    """
     connectivity: List[Dict[str, Any]] = []
     try:
         try:
@@ -340,12 +359,7 @@ async def get_redis_health(
     except Exception as exc:
         connectivity = [{"label": "probe", "status": "error", "error": str(exc)}]
 
-    return {
-        "stats": stats,
-        "prefix_counts": prefixes_with_meta,
-        "flushable_prefixes": sorted(_FLUSHABLE_PREFIXES),
-        "connectivity": connectivity,
-    }
+    return {"connectivity": connectivity}
 
 
 class FlushPrefixRequest(BaseModel):

--- a/backend/routes/admin/monitoring.py
+++ b/backend/routes/admin/monitoring.py
@@ -402,10 +402,12 @@ async def get_websocket_health(
         clients connected to the *same* uvicorn worker — the exact failure
         behind a frozen map when Redis is unreachable. ``last_error`` says
         why (e.g. ``connect: TimeoutError``).
-      - ``connections``: active socket counts on THIS replica, bucketed by
-        client type. With multiple uvicorn workers each process holds its
-        own registry, so these are per-replica, not fleet-wide
-        (``workers_hint`` surfaces the configured worker count).
+      - ``connections``: active socket counts for the uvicorn worker that
+        answered this request, bucketed by client type. Each worker process
+        holds its own in-process registry, so these are **per-worker**, not
+        per-host — with ``workers_hint`` workers on a host the true host
+        total is spread across that many processes, and a given request only
+        sees one. ``worker_pid`` identifies which process answered.
     """
     import platform
 
@@ -423,8 +425,9 @@ async def get_websocket_health(
         "fanout": pubsub.status(),
         "connections": manager.connection_stats(),
         "replica_hostname": platform.node(),
+        "worker_pid": os.getpid(),
         "workers_hint": workers_hint,
-        "per_replica": True,
+        "per_worker": True,
     }
 
 

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -96,6 +96,25 @@ class ConnectionManager:
         if not self._has_sockets_for_user(user_id):
             self._user_msg_timestamps.pop(user_id, None)
 
+    def connection_stats(self) -> Dict[str, int]:
+        """Count active sockets on THIS replica, bucketed by client type.
+
+        Keys are ``{client_type}_{user_id}`` (see routes/websocket.py), so we
+        bucket on the prefix. With multiple uvicorn workers each process holds
+        its own ``active_connections`` dict, so these counts are per-replica,
+        not fleet-wide — the admin WS-health card labels them that way.
+        """
+        counts = {"total": 0, "admins": 0, "drivers": 0, "riders": 0}
+        for key in self.active_connections:
+            counts["total"] += 1
+            if key.startswith("admin_"):
+                counts["admins"] += 1
+            elif key.startswith("driver_"):
+                counts["drivers"] += 1
+            elif key.startswith("rider_"):
+                counts["riders"] += 1
+        return counts
+
     def note_user_message(
         self,
         user_id: str,

--- a/backend/tests/test_ws_health.py
+++ b/backend/tests/test_ws_health.py
@@ -1,0 +1,80 @@
+"""Unit tests for the admin WebSocket-health primitives.
+
+Covers the two helpers behind GET /api/admin/monitoring/websockets:
+  - ConnectionManager.connection_stats(): per-replica socket counts bucketed
+    by client type.
+  - _WSPubSub.status(): cross-replica fan-out health snapshot, including the
+    "configured but not connected" degraded state (Redis unreachable) that
+    leaves the admin live map local-only — and the guarantee that the
+    snapshot never leaks the password-bearing Redis URL.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+# Stub heavy deps before any backend import (mirrors test_p3_ws_broadcast).
+_STUBS = ["loguru", "logging_utils", "fastapi", "fastapi.websockets"]
+for _m in _STUBS:
+    if _m not in sys.modules:
+        sys.modules[_m] = MagicMock()
+sys.modules["loguru"].logger = MagicMock()
+sys.modules["fastapi"].WebSocket = MagicMock()
+sys.modules["logging_utils"].diag_logger = MagicMock()
+
+from backend.socket_manager import ConnectionManager  # noqa: E402
+from backend.utils.ws_pubsub import CHANNEL, _WSPubSub  # noqa: E402
+
+# ── connection_stats ──────────────────────────────────────────────────────
+
+
+def test_connection_stats_empty():
+    mgr = ConnectionManager()
+    assert mgr.connection_stats() == {"total": 0, "admins": 0, "drivers": 0, "riders": 0}
+
+
+def test_connection_stats_buckets_by_client_type():
+    mgr = ConnectionManager()
+    # Keys are {client_type}_{user_id} exactly as routes/websocket.py builds them.
+    for key in ("admin_a1", "admin_a2", "driver_d1", "rider_r1", "rider_r2", "rider_r3"):
+        mgr.active_connections[key] = MagicMock()
+
+    stats = mgr.connection_stats()
+    assert stats == {"total": 6, "admins": 2, "drivers": 1, "riders": 3}
+
+
+def test_connection_stats_counts_unknown_prefix_in_total_only():
+    mgr = ConnectionManager()
+    mgr.active_connections["weird_key"] = MagicMock()
+    stats = mgr.connection_stats()
+    assert stats["total"] == 1
+    assert stats["admins"] == stats["drivers"] == stats["riders"] == 0
+
+
+# ── _WSPubSub.status ──────────────────────────────────────────────────────
+
+
+def test_status_unconfigured_single_machine():
+    ps = _WSPubSub()
+    s = ps.status()
+    assert s["active"] is False
+    assert s["configured"] is False
+    assert s["channel"] == CHANNEL
+    assert s["backend_scheme"] == ""
+    assert s["last_error"] is None
+
+
+def test_status_configured_but_disconnected_reports_reason():
+    ps = _WSPubSub()
+    # Simulate a failed connect: URL was set, error recorded, no live task.
+    ps._url = "rediss://default:secretpassword@redis.example.com:6379"
+    ps._last_error = "connect: TimeoutError"
+
+    s = ps.status()
+    assert s["active"] is False
+    assert s["configured"] is True
+    assert s["backend_scheme"] == "rediss"
+    assert s["last_error"] == "connect: TimeoutError"
+    # The snapshot must never leak the password-bearing URL.
+    assert "secretpassword" not in str(s)

--- a/backend/tests/test_ws_health.py
+++ b/backend/tests/test_ws_health.py
@@ -78,3 +78,49 @@ def test_status_configured_but_disconnected_reports_reason():
     assert s["last_error"] == "connect: TimeoutError"
     # The snapshot must never leak the password-bearing URL.
     assert "secretpassword" not in str(s)
+
+
+def test_active_requires_live_subscription():
+    """Regression for the Codex finding: after a failed reconnect drops the
+    subscription, `_pubsub` is None but the consumer task keeps looping in
+    backoff. `active` must be False (degraded), not True ("Live")."""
+    ps = _WSPubSub()
+    ps._redis = MagicMock()
+    task = MagicMock()
+    task.done.return_value = False
+    ps._task = task
+
+    ps._pubsub = None  # reconnect closed the subscription, consumer still looping
+    assert ps.active is False
+
+    ps._pubsub = MagicMock()  # resubscribed
+    assert ps.active is True
+
+
+@pytest.mark.anyio
+async def test_start_reports_configured_when_connect_fails(monkeypatch):
+    """Regression for the Codex finding: a configured-but-unreachable Redis
+    must report configured=True (so the degraded banner shows), not be
+    mislabelled single-machine because `_url` was only set on success."""
+
+    async def _bad_ping():
+        raise OSError("redis unreachable")
+
+    bad_client = MagicMock()
+    bad_client.ping = _bad_ping
+
+    fake_asyncio = MagicMock()
+    fake_asyncio.from_url = MagicMock(return_value=bad_client)
+    monkeypatch.setitem(sys.modules, "redis", MagicMock())
+    monkeypatch.setitem(sys.modules, "redis.asyncio", fake_asyncio)
+
+    ps = _WSPubSub()
+    ok = await ps.start(MagicMock(), "rediss://default:secretpassword@redis.example.com:6379")
+
+    assert ok is False
+    s = ps.status()
+    assert s["configured"] is True
+    assert s["active"] is False
+    assert s["backend_scheme"] == "rediss"
+    assert s["last_error"].startswith("connect:")
+    assert "secretpassword" not in str(s)

--- a/backend/utils/ws_pubsub.py
+++ b/backend/utils/ws_pubsub.py
@@ -63,11 +63,35 @@ class _WSPubSub:
         self._task: Optional[asyncio.Task] = None
         self._manager: Any = None
         self._url: str = ""
+        # Last connect/subscribe failure reason, surfaced to the admin
+        # WS-health card so "fan-out is local-only" comes with a why.
+        # Never holds the URL (which carries the password).
+        self._last_error: Optional[str] = None
 
     @property
     def active(self) -> bool:
         """True iff we have a live Redis connection and a running consumer."""
         return self._redis is not None and self._task is not None and not self._task.done()
+
+    def status(self) -> dict:
+        """Snapshot of cross-replica fan-out health on THIS replica.
+
+        ``active`` True means this process holds a live Redis subscription and
+        a running consumer, so broadcasts published by *other* replicas reach
+        the admin sockets connected here. False means local-only delivery —
+        the admin live map only sees clients on this same worker, which is the
+        failure mode when Redis is unreachable. ``configured`` distinguishes
+        "no Redis URL set (single-machine by design)" from "URL set but the
+        connection failed" (see ``last_error``).
+        """
+        scheme = self._url.split("://", 1)[0] if self._url else ""
+        return {
+            "active": self.active,
+            "channel": CHANNEL,
+            "backend_scheme": scheme,
+            "configured": bool(self._url),
+            "last_error": self._last_error,
+        }
 
     async def start(self, manager: Any, redis_url: str) -> bool:
         """Connect to Redis, subscribe to the channel, spawn the consumer.
@@ -92,6 +116,7 @@ class _WSPubSub:
             await client.ping()
         except Exception as e:
             # Never log the URL; it contains the password.
+            self._last_error = f"connect: {type(e).__name__}"
             logger.error(f"WS pub/sub: could not connect to Redis ({type(e).__name__}) — falling back to local-only")
             return False
 
@@ -103,11 +128,13 @@ class _WSPubSub:
             self._pubsub = client.pubsub()
             await self._pubsub.subscribe(CHANNEL)
         except Exception as e:
+            self._last_error = f"subscribe: {type(e).__name__}"
             logger.error(f"WS pub/sub: subscribe failed: {e}")
             await self._safe_close_pubsub()
             await self._safe_close_redis()
             return False
 
+        self._last_error = None
         self._task = asyncio.create_task(self._consumer(), name="ws_pubsub_consumer")
         scheme = redis_url.split("://", 1)[0]
         logger.info(f"WS pub/sub started (backend={scheme}://…, channel={CHANNEL})")

--- a/backend/utils/ws_pubsub.py
+++ b/backend/utils/ws_pubsub.py
@@ -70,8 +70,17 @@ class _WSPubSub:
 
     @property
     def active(self) -> bool:
-        """True iff we have a live Redis connection and a running consumer."""
-        return self._redis is not None and self._task is not None and not self._task.done()
+        """True iff we have a live Redis connection, a live subscription, and
+        a running consumer.
+
+        ``_pubsub`` is included deliberately: after a runtime Redis drop a
+        failed ``_reconnect()`` nulls ``_pubsub`` but leaves the consumer task
+        looping in backoff, so checking only ``_redis``/``_task`` would report
+        "Live" while this replica is no longer subscribed to the fan-out
+        channel. Tying ``active`` to the subscription keeps the health endpoint
+        honest during a reconnect-failure window.
+        """
+        return self._redis is not None and self._pubsub is not None and self._task is not None and not self._task.done()
 
     def status(self) -> dict:
         """Snapshot of cross-replica fan-out health on THIS replica.
@@ -111,6 +120,13 @@ class _WSPubSub:
             logger.warning("WS pub/sub: redis package not installed; single-machine mode")
             return False
 
+        # Record that fan-out is *configured* before we attempt the connection,
+        # so status() reports configured=True (and the right scheme) even when
+        # the connect/subscribe below fails. Otherwise a Redis-unreachable
+        # backend would mislabel itself "single-machine" and suppress the
+        # degraded banner — the exact state we built this to surface.
+        self._url = redis_url
+
         try:
             client = redis_asyncio.from_url(redis_url, decode_responses=True)
             await client.ping()
@@ -122,7 +138,6 @@ class _WSPubSub:
 
         self._redis = client
         self._manager = manager
-        self._url = redis_url
 
         try:
             self._pubsub = client.pubsub()


### PR DESCRIPTION
Add the building blocks for an admin WebSocket-health view:
- ConnectionManager.connection_stats(): active socket counts on this
  replica, bucketed by client type (admins/drivers/riders).
- _WSPubSub.status(): cross-replica fan-out health (active, channel,
  configured, last_error). 'active=False' is exactly the state behind a
  frozen admin live map when Redis is unreachable. last_error is set on
  connect/subscribe failure and never holds the password-bearing URL.

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
