### PR TITLE
monitoring: robust WebSocket hook with URL normalization, auth ack, reconnection jitter, and UI error display

### DIFF
--- a/admin-dashboard/src/app/dashboard/monitoring/page.tsx
+++ b/admin-dashboard/src/app/dashboard/monitoring/page.tsx
@@ -229,7 +229,11 @@ export default function MonitoringPage() {
     }
   }, [applyDriver, applyRide, followMode, pushAlert, refreshCounts, selected]);
 
-  const { status: wsStatus, requestSnapshots } = useMonitoringSocket({ token, onEvent: handleWsEvent });
+  const {
+    status: wsStatus,
+    requestSnapshots,
+    lastError: wsError,
+  } = useMonitoringSocket({ token, onEvent: handleWsEvent });
 
   // ── Initial data load + polling ─────────────────────────────────────
   const loadData = useCallback(async () => {
@@ -508,7 +512,7 @@ export default function MonitoringPage() {
         <div className="flex items-center gap-2 bg-yellow-50 border-b border-yellow-200 px-4 py-2 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:border-yellow-800 dark:text-yellow-300">
           <span className="font-medium">Live data paused</span>
           <span className="text-yellow-700 dark:text-yellow-400">
-            — map and ride list may be stale ({wsStatus === "connecting" ? "reconnecting…" : "connection lost"})
+            — map and ride list may be stale ({wsStatus === "connecting" ? "reconnecting…" : wsError || "connection lost"})
           </span>
         </div>
       )}

--- a/admin-dashboard/src/hooks/use-monitoring-socket.test.tsx
+++ b/admin-dashboard/src/hooks/use-monitoring-socket.test.tsx
@@ -1,0 +1,144 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMonitoringSocket } from "./use-monitoring-socket";
+
+class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    static instances: MockWebSocket[] = [];
+
+    readyState = MockWebSocket.CONNECTING;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: (() => void) | null = null;
+    onclose: (() => void) | null = null;
+    sent: string[] = [];
+
+    constructor(public url: string) {
+        MockWebSocket.instances.push(this);
+    }
+
+    send(message: string) {
+        this.sent.push(message);
+    }
+
+    close() {
+        this.readyState = MockWebSocket.CLOSED;
+        this.onclose?.();
+    }
+
+    open() {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.();
+    }
+
+    receive(data: Record<string, unknown>) {
+        this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+    }
+}
+
+describe("useMonitoringSocket", () => {
+    const originalEnv = { ...process.env };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        process.env.NEXT_PUBLIC_WS_URL = "";
+        process.env.NEXT_PUBLIC_API_URL = "";
+        MockWebSocket.instances = [];
+        vi.spyOn(Math, "random").mockReturnValue(0.5);
+        vi.stubGlobal("WebSocket", MockWebSocket);
+        vi.stubGlobal("crypto", { randomUUID: () => "admin-client-id" });
+    });
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+    });
+
+    it("builds the admin websocket URL from NEXT_PUBLIC_API_URL when a WS URL is not set", () => {
+        process.env.NEXT_PUBLIC_API_URL = "https://spinr-backend-production.up.railway.app";
+        const onEvent = vi.fn();
+
+        renderHook(() => useMonitoringSocket({ token: "token", onEvent }));
+
+        expect(MockWebSocket.instances[0].url).toBe(
+            "wss://spinr-backend-production.up.railway.app/ws/admin/admin-client-id",
+        );
+    });
+
+    it("normalizes a pasted full /ws/admin URL from NEXT_PUBLIC_WS_URL", () => {
+        process.env.NEXT_PUBLIC_WS_URL =
+            "wss://spinr-backend-production.up.railway.app/ws/admin/some-old-id";
+        const onEvent = vi.fn();
+
+        renderHook(() => useMonitoringSocket({ token: "token", onEvent }));
+
+        expect(MockWebSocket.instances[0].url).toBe(
+            "wss://spinr-backend-production.up.railway.app/ws/admin/admin-client-id",
+        );
+    });
+
+    it("does not schedule a reconnect when React intentionally closes a stale socket", () => {
+        const onEvent = vi.fn();
+        const { rerender } = renderHook(
+            ({ token }) => useMonitoringSocket({ token, onEvent }),
+            { initialProps: { token: "old-token" } },
+        );
+
+        expect(MockWebSocket.instances).toHaveLength(1);
+
+        rerender({ token: "new-token" });
+
+        expect(MockWebSocket.instances).toHaveLength(2);
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("reconnects after the current live socket closes unexpectedly", () => {
+        const onEvent = vi.fn();
+        renderHook(() => useMonitoringSocket({ token: "token", onEvent }));
+
+        expect(MockWebSocket.instances).toHaveLength(1);
+
+        act(() => {
+            MockWebSocket.instances[0].close();
+        });
+
+        expect(vi.getTimerCount()).toBe(1);
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+
+        expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("does not reconnect forever after a fatal auth error", () => {
+        const onEvent = vi.fn();
+        const { result } = renderHook(() => useMonitoringSocket({ token: "bad-token", onEvent }));
+
+        expect(MockWebSocket.instances).toHaveLength(1);
+
+        act(() => {
+            MockWebSocket.instances[0].open();
+            MockWebSocket.instances[0].receive({
+                type: "error",
+                message: "invalid_token_or_user_not_found",
+            });
+        });
+
+        expect(result.current.status).toBe("error");
+        expect(vi.getTimerCount()).toBe(0);
+
+        act(() => {
+            vi.advanceTimersByTime(30_000);
+        });
+
+        expect(MockWebSocket.instances).toHaveLength(1);
+    });
+});

--- a/admin-dashboard/src/hooks/use-monitoring-socket.ts
+++ b/admin-dashboard/src/hooks/use-monitoring-socket.ts
@@ -22,17 +22,84 @@ const KNOWN_EVENT_TYPES = [
     "rides_snapshot",
 ];
 
+const FATAL_ERROR_MESSAGES = new Set([
+    "authentication_required",
+    "invalid_token_or_user_not_found",
+    "admin_access_required",
+    "session_revoked",
+    "token_revoked",
+    "ERR_TOKEN_AUDIENCE",
+    "firebase_audience_not_configured",
+]);
+
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const AUTH_ACK_TIMEOUT_MS = 15_000;
+
+function normalizeWsBaseUrl(rawBaseUrl: string): string {
+    const trimmed = rawBaseUrl.trim().replace(/\/+$/, "");
+    if (!trimmed) return "";
+
+    try {
+        const url = new URL(trimmed);
+        if (url.protocol === "https:") url.protocol = "wss:";
+        if (url.protocol === "http:") url.protocol = "ws:";
+        // Operators sometimes paste a full /ws/admin/... URL into the Vercel
+        // env var. The hook appends the connection-specific path itself, so
+        // keep only the backend origin in that case. Non-/ws path prefixes are
+        // preserved for deployments mounted behind a subpath.
+        if (url.pathname === "/" || url.pathname.startsWith("/ws")) {
+            url.pathname = "";
+        } else {
+            url.pathname = url.pathname.replace(/\/+$/, "");
+        }
+        url.search = "";
+        url.hash = "";
+        return url.toString().replace(/\/+$/, "");
+    } catch {
+        return trimmed;
+    }
+}
+
+function reconnectDelayWithJitter(retryCount: number): number {
+    const exponentialDelay = Math.min(
+        BASE_RECONNECT_DELAY_MS * 2 ** retryCount,
+        MAX_RECONNECT_DELAY_MS,
+    );
+    // Spread reconnects across a fleet of admin tabs so a backend restart does
+    // not create a synchronized reconnect stampede.
+    const jitterMultiplier = 0.8 + Math.random() * 0.4;
+    return Math.round(exponentialDelay * jitterMultiplier);
+}
+
 export function useMonitoringSocket({ token, onEvent }: UseMonitoringSocketOptions) {
     const [status, setStatus] = useState<ConnectionStatus>("disconnected");
+    const [lastError, setLastError] = useState<string | null>(null);
     const wsRef = useRef<WebSocket | null>(null);
     const retryCountRef = useRef(0);
     const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const authAckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const shouldReconnectRef = useRef(true);
     const onEventRef = useRef(onEvent);
     onEventRef.current = onEvent;
 
     const clientId = useRef(
         typeof crypto !== "undefined" ? crypto.randomUUID() : Math.random().toString(36).slice(2)
     );
+
+    const clearRetryTimer = useCallback(() => {
+        if (retryTimerRef.current) {
+            clearTimeout(retryTimerRef.current);
+            retryTimerRef.current = null;
+        }
+    }, []);
+
+    const clearAuthAckTimer = useCallback(() => {
+        if (authAckTimerRef.current) {
+            clearTimeout(authAckTimerRef.current);
+            authAckTimerRef.current = null;
+        }
+    }, []);
 
     const send = useCallback((msg: Record<string, unknown>) => {
         if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -46,8 +113,21 @@ export function useMonitoringSocket({ token, onEvent }: UseMonitoringSocketOptio
     }, [send]);
 
     const connect = useCallback(() => {
-        if (!token) return;
-        if (wsRef.current?.readyState === WebSocket.OPEN) return;
+        if (!token) {
+            setStatus("disconnected");
+            setLastError(
+                "Waiting for an admin access token. If this does not clear, refresh or sign in again.",
+            );
+            return;
+        }
+        clearRetryTimer();
+        shouldReconnectRef.current = true;
+        if (
+            wsRef.current?.readyState === WebSocket.OPEN ||
+            wsRef.current?.readyState === WebSocket.CONNECTING
+        ) {
+            return;
+        }
 
         const fallbackScheme =
             typeof window !== "undefined" && window.location.protocol === "https:"
@@ -55,25 +135,49 @@ export function useMonitoringSocket({ token, onEvent }: UseMonitoringSocketOptio
                 : "ws";
         const fallbackHost =
             typeof window !== "undefined" ? window.location.host : "";
-        const wsBase =
+        const wsBase = normalizeWsBaseUrl(
             process.env.NEXT_PUBLIC_WS_URL ||
-            (fallbackHost ? `${fallbackScheme}://${fallbackHost}` : "");
+            process.env.NEXT_PUBLIC_API_URL ||
+            (fallbackHost ? `${fallbackScheme}://${fallbackHost}` : ""),
+        );
+        if (!wsBase) {
+            setStatus("error");
+            setLastError(
+                "WebSocket URL is not configured. Set NEXT_PUBLIC_WS_URL or NEXT_PUBLIC_API_URL and redeploy.",
+            );
+            return;
+        }
         const url = `${wsBase}/ws/admin/${clientId.current}`;
 
         setStatus("connecting");
+        setLastError(null);
         const ws = new WebSocket(url);
         wsRef.current = ws;
 
         ws.onopen = () => {
             ws.send(JSON.stringify({ type: "auth", token }));
             setStatus("connecting");
+            clearAuthAckTimer();
+            authAckTimerRef.current = setTimeout(() => {
+                if (wsRef.current === ws && ws.readyState === WebSocket.OPEN) {
+                    setLastError(
+                        "WebSocket opened but auth_success was not received. Check the admin token and backend /ws/admin auth logs.",
+                    );
+                    ws.close();
+                }
+            }, AUTH_ACK_TIMEOUT_MS);
         };
 
         ws.onmessage = (event) => {
             try {
-                const data = JSON.parse(event.data) as { type: string } & Record<string, unknown>;
+                const data = JSON.parse(event.data) as { type: string; message?: string } & Record<
+                    string,
+                    unknown
+                >;
                 if (data.type === "auth_success") {
+                    clearAuthAckTimer();
                     setStatus("connected");
+                    setLastError(null);
                     retryCountRef.current = 0;
                     requestSnapshots();
                     return;
@@ -83,7 +187,17 @@ export function useMonitoringSocket({ token, onEvent }: UseMonitoringSocketOptio
                     return;
                 }
                 if (data.type === "error") {
+                    clearAuthAckTimer();
                     setStatus("error");
+                    setLastError(
+                        data.message
+                            ? `Backend WebSocket auth error: ${data.message}`
+                            : "Backend WebSocket returned an error.",
+                    );
+                    if (data.message && FATAL_ERROR_MESSAGES.has(data.message)) {
+                        shouldReconnectRef.current = false;
+                        ws.close();
+                    }
                     return;
                 }
                 if (KNOWN_EVENT_TYPES.includes(data.type)) {
@@ -94,23 +208,49 @@ export function useMonitoringSocket({ token, onEvent }: UseMonitoringSocketOptio
             }
         };
 
-        ws.onerror = () => setStatus("error");
-
-        ws.onclose = () => {
-            setStatus("disconnected");
-            const delay = Math.min(1000 * 2 ** retryCountRef.current, 30_000);
-            retryCountRef.current += 1;
-            retryTimerRef.current = setTimeout(connect, delay);
+        ws.onerror = () => {
+            setStatus("error");
+            setLastError(
+                "WebSocket transport error. In Chrome, a failed WebSocket may show Status N/A; check whether the handshake reached the backend.",
+            );
         };
-    }, [token, requestSnapshots]);
+
+        ws.onclose = (event) => {
+            clearAuthAckTimer();
+            const isCurrentSocket = wsRef.current === ws;
+            if (isCurrentSocket) {
+                wsRef.current = null;
+                if (!shouldReconnectRef.current || !token) {
+                    setStatus("error");
+                    return;
+                }
+                setStatus("disconnected");
+                const code = typeof event?.code === "number" ? event.code : null;
+                const reason =
+                    typeof event?.reason === "string" && event.reason ? ` (${event.reason})` : "";
+                setLastError(
+                    code
+                        ? `WebSocket closed with code ${code}${reason}; reconnecting…`
+                        : "WebSocket closed; reconnecting…",
+                );
+                const delay = reconnectDelayWithJitter(retryCountRef.current);
+                retryCountRef.current += 1;
+                retryTimerRef.current = setTimeout(connect, delay);
+            }
+        };
+    }, [token, clearAuthAckTimer, clearRetryTimer, requestSnapshots]);
 
     useEffect(() => {
         connect();
         return () => {
-            retryTimerRef.current && clearTimeout(retryTimerRef.current);
-            wsRef.current?.close();
+            shouldReconnectRef.current = false;
+            clearRetryTimer();
+            clearAuthAckTimer();
+            const ws = wsRef.current;
+            wsRef.current = null;
+            ws?.close();
         };
-    }, [connect]);
+    }, [connect, clearAuthAckTimer, clearRetryTimer]);
 
-    return { status, send, requestSnapshots };
+    return { status, send, requestSnapshots, lastError };
 }


### PR DESCRIPTION
### Motivation

- Improve resilience of the admin monitoring live feed by making the WebSocket connection more robust to transport and auth issues.  
- Surface backend/auth errors to operators in the monitoring UI so stale/live status is clearer.  
- Add unit tests to prevent regressions around URL construction, reconnect behavior, and fatal auth handling.

### Description

- Replace `use-monitoring-socket` internals to add `lastError` state, an auth-ack timeout, and fatal error detection to stop reconnection on unrecoverable auth failures.  
- Add URL normalization via `normalizeWsBaseUrl` and build the fallback using `NEXT_PUBLIC_WS_URL` or `NEXT_PUBLIC_API_URL` so pasted full `/ws/admin/...` values and non-root paths are handled.  
- Implement exponential backoff with jitter using `reconnectDelayWithJitter`, clear/cleanup timers on unmount, and prevent reconnect storms across admin tabs.  
- Surface `lastError` as `wsError` from `useMonitoringSocket` into the monitoring page and show the backend error message in the stale-data banner, and add `use-monitoring-socket.test.tsx` to cover URL building, reconnects, and fatal auth behavior.

### Testing

- Added unit tests in `src/hooks/use-monitoring-socket.test.tsx` exercising URL construction, normalization, reconnect scheduling, and stopping on fatal auth errors.  
- Ran the `use-monitoring-socket` test suite with Vitest and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232c8acc188330abe2147005af484c)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
