### PR TITLE
fix(migrate): honor PG_CONNECTION_STRING / DATABASE_URL in the migrat…

### DIFF
--- a/backend/scripts/migrate.py
+++ b/backend/scripts/migrate.py
@@ -13,6 +13,12 @@ Environment variables required:
     SUPABASE_SERVICE_ROLE_KEY — Supabase service role key (not anon key)
 
 Optional:
+    PG_CONNECTION_STRING / DATABASE_URL — full Postgres DSN. When set, it is used
+        verbatim and the direct db.<ref>.supabase.co host is NOT derived. That
+        direct host is IPv6-only on current Supabase projects and fails to resolve
+        on many IPv4-only networks; point this at the Session pooler instead
+        (user postgres.<ref> @ aws-N-<region>.pooler.supabase.com:5432). Takes
+        precedence over SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY.
     MIGRATIONS_DIR — path to migration files (default: backend/migrations)
 """
 
@@ -58,6 +64,24 @@ def get_db_connection():
         sys.exit(1)
 
     load_dotenv()
+
+    # Direct DSN override. When PG_CONNECTION_STRING (or DATABASE_URL) is set we
+    # use it verbatim and skip deriving the `db.<ref>.supabase.co` host — that
+    # host is IPv6-only on current Supabase projects and fails to resolve on many
+    # IPv4-only networks. Point this at the Session pooler
+    # (user postgres.<ref> @ aws-N-<region>.pooler.supabase.com:5432) for IPv4.
+    # The value contains a password, so it is never logged.
+    pg_dsn = os.environ.get("PG_CONNECTION_STRING") or os.environ.get("DATABASE_URL")
+    if pg_dsn:
+        try:
+            conn = psycopg2.connect(pg_dsn)
+            conn.autocommit = False
+            logger.info("Connected via PG_CONNECTION_STRING/DATABASE_URL override.")
+            return conn
+        except Exception as e:
+            logger.error(f"Database connection failed: {e}")
+            sys.exit(1)
+
     supabase_url = os.environ.get("SUPABASE_URL", "").rstrip("/")
     service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
 


### PR DESCRIPTION
…ion runner

scripts/migrate.py derived the database host as db.<ref>.supabase.co from SUPABASE_URL and connected as user=postgres. On current Supabase projects that direct host is IPv6-only, so it fails to resolve on IPv4-only networks ("could not translate host name ... Name or service not known"), and there is no way to point the runner at the Session pooler (which needs a tenant-qualified user postgres.<ref> and a different host).

Honor a full DSN via PG_CONNECTION_STRING (or DATABASE_URL) — the same var backend/SUPABASE_MIGRATION.md already references — taking precedence over the derived host. This unblocks running migrations against a ca-central-1 project through the IPv4 Session pooler. The DSN holds a password and is never logged.

https://claude.ai/code/session_01L2o8T6SUa2F7Pe5JpwzjZT

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
