### PR TITLE
fix(driver-app): show PENDING REVIEW in profile summary when doc awaiting review

### DIFF
--- a/driver-app/app/driver/(tabs)/profile.tsx
+++ b/driver-app/app/driver/(tabs)/profile.tsx
@@ -465,35 +465,33 @@ export default function ProfileScreen() {
                 const isExpiringSoon = expiresIn !== null && expiresIn > 0 && expiresIn < 30;
 
                 const badgeColor =
-                    isExpired ? '#EF4444' :
-                    isExpiringSoon ? '#F59E0B' :
-                    isValid ? '#10B981' :
-                    docStatus === 'approved' ? '#10B981' :
                     docStatus === 'pending' ? '#F59E0B' :
                     docStatus === 'rejected' ? '#EF4444' :
+                    isExpired ? '#EF4444' :
+                    isExpiringSoon ? '#F59E0B' :
+                    (isValid || docStatus === 'approved') ? '#10B981' :
                     '#EF4444'; // upload required
 
                 const badgeLabel =
-                    isExpired ? 'EXPIRED' :
-                    isExpiringSoon ? `Exp in ${expiresIn}d` :
-                    isValid ? 'VALID' :
-                    docStatus === 'approved' ? 'APPROVED' :
                     docStatus === 'pending' ? 'PENDING REVIEW' :
                     docStatus === 'rejected' ? 'REJECTED' :
+                    isExpired ? 'EXPIRED' :
+                    isExpiringSoon ? `Exp in ${expiresIn}d` :
+                    (isValid || docStatus === 'approved') ? 'VALID' :
                     'UPLOAD REQUIRED';
 
                 const iconColor =
-                    isExpired ? '#EF4444' :
-                    (isValid || docStatus === 'approved') ? '#10B981' :
                     docStatus === 'pending' ? '#F59E0B' :
                     docStatus === 'rejected' ? '#EF4444' :
+                    isExpired ? '#EF4444' :
+                    (isValid || docStatus === 'approved') ? '#10B981' :
                     colors.textDim;
 
                 const iconBg =
-                    isExpired ? 'rgba(239, 68, 68, 0.1)' :
-                    (isValid || docStatus === 'approved') ? 'rgba(16, 185, 129, 0.1)' :
                     docStatus === 'pending' ? 'rgba(245, 158, 11, 0.1)' :
                     docStatus === 'rejected' ? 'rgba(239, 68, 68, 0.1)' :
+                    isExpired ? 'rgba(239, 68, 68, 0.1)' :
+                    (isValid || docStatus === 'approved') ? 'rgba(16, 185, 129, 0.1)' :
                     '#F9FAFB';
 
                 return (


### PR DESCRIPTION
Documents with a future expiry date were showing VALID in the profile
summary even when their status was still pending admin review. The badge,
colour, and icon logic now check docStatus === 'pending' / 'rejected' first,
so the review state always wins over the expiry-based labels.

https://claude.ai/code/session_01YUNN8TwHrKMp1p1papEmFM

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
