### PR TITLE
fix(sentry): send startup capture so Fly.io Setup Incomplete banner clears

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -380,6 +380,7 @@ if sentry_dsn:
 
     logger.add(_loguru_sentry_sink, level="ERROR")
     logger.info("Sentry SDK initialized for error monitoring")
+    sentry_sdk.capture_message("Sentry connected – spinr-backend startup", level="info")
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
Fly.io's Sentry extension requires at least one event to reach Sentry
before it marks setup as complete. Emit an info-level capture_message on
every boot so the first deploy after SENTRY_DSN is set clears the banner
immediately.

https://claude.ai/code/session_013TfSLLHJfTTdhz6MyVt43N