### PR TITLE
fix(surge): honor per-area toggle in admin surge endpoint + status read

### DIFF
--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -587,7 +587,35 @@ async def admin_delete_service_area(area_id: str, admin: dict = Depends(get_admi
 
 @router.put("/service-areas/{area_id}/surge")
 async def admin_update_surge_pricing(area_id: str, surge: SurgePricingRequest, admin: dict = Depends(get_admin_user)):
-    """Update surge pricing for a service area."""
+    """Update surge pricing for a service area.
+
+    ``is_active`` is the per-area surge master toggle:
+      * is_active=True  → enable surge and price at ``multiplier``
+      * is_active=False → disable surge; the area reverts to 1.0× and every
+        fare path / the surge engine ignores any parked multiplier.
+
+    The authoritative write is to the ``service_areas`` row (surge_enabled /
+    surge_active / surge_multiplier) — the columns every fare builder and the
+    surge engine gate on. A ``surge_pricing`` row is also written for history.
+    """
+    # Authoritative surge state — mirror the toggle onto the columns the fare
+    # builders (fare_service.py, routes/fares.py, features.py) and the surge
+    # engine actually read. Without this the call only logged a history row and
+    # left every ride priced at 1.0× regardless of the requested surge.
+    if surge.is_active:
+        area_update: Dict[str, Any] = {
+            "surge_enabled": True,
+            "surge_active": surge.multiplier > 1.0,
+            "surge_multiplier": surge.multiplier,
+        }
+    else:
+        area_update = {
+            "surge_enabled": False,
+            "surge_active": False,
+            "surge_multiplier": 1.0,
+        }
+    await db_supabase.update_one("service_areas", {"id": area_id}, area_update)
+
     surge_doc = {
         "id": str(uuid.uuid4()),
         "service_area_id": area_id,

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -402,6 +402,61 @@ class TestServiceAreaValidation:
         assert captured["surge_active"] is False
         assert captured["surge_multiplier"] == 1.0
 
+    def test_surge_endpoint_enables_service_area_columns(self, client):
+        """PUT .../surge with is_active=True writes the surge columns fares read.
+
+        Regression: the endpoint used to only log a surge_pricing history row,
+        so the requested surge never reached the service_areas columns that the
+        fare paths gate on — every ride stayed at 1.0× despite a 'success'.
+        """
+        captured: dict = {}
+
+        async def _capture(table, filt, payload):
+            if table == "service_areas":
+                captured.update(payload)
+
+        with (
+            patch("db_supabase.get_rows", new=AsyncMock(return_value=[{"id": "area-1"}])),
+            patch("db_supabase.update_one", new=AsyncMock(side_effect=_capture)),
+            patch("db_supabase.insert_one", new=AsyncMock()),
+            patch("routes.admin.service_areas.invalidate_fare_cache", new=AsyncMock()),
+            patch("routes.admin.service_areas.log_admin_action", new=AsyncMock()),
+        ):
+            resp = client.put(
+                "/api/admin/service-areas/area-1/surge",
+                json={"multiplier": 1.75, "is_active": True},
+            )
+
+        assert resp.status_code == 200
+        assert captured["surge_enabled"] is True
+        assert captured["surge_active"] is True
+        assert captured["surge_multiplier"] == 1.75
+
+    def test_surge_endpoint_disables_and_resets_when_inactive(self, client):
+        """PUT .../surge with is_active=False disables surge and resets to 1.0×."""
+        captured: dict = {}
+
+        async def _capture(table, filt, payload):
+            if table == "service_areas":
+                captured.update(payload)
+
+        with (
+            patch("db_supabase.get_rows", new=AsyncMock(return_value=[{"id": "area-1"}])),
+            patch("db_supabase.update_one", new=AsyncMock(side_effect=_capture)),
+            patch("db_supabase.insert_one", new=AsyncMock()),
+            patch("routes.admin.service_areas.invalidate_fare_cache", new=AsyncMock()),
+            patch("routes.admin.service_areas.log_admin_action", new=AsyncMock()),
+        ):
+            resp = client.put(
+                "/api/admin/service-areas/area-1/surge",
+                json={"multiplier": 2.0, "is_active": False},
+            )
+
+        assert resp.status_code == 200
+        assert captured["surge_enabled"] is False
+        assert captured["surge_active"] is False
+        assert captured["surge_multiplier"] == 1.0
+
     def test_disabling_above_cap_surge_needs_no_justification(self, client):
         """Switching off a parked >2.5x surge must not require a justification.
 

--- a/backend/tests/test_surge_engine.py
+++ b/backend/tests/test_surge_engine.py
@@ -518,3 +518,55 @@ def test_manual_override_value_above_auto_cap_is_valid() -> None:
     # The engine itself never calls ratio_to_multiplier on manual areas,
     # so the value is not clipped — just round-trip as-is.
     assert admin_stored_value == 3.0
+
+
+# ── get_surge_status: per-area toggle gating ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_surge_status_gates_on_surge_enabled():
+    """get_surge_status reports EFFECTIVE surge.
+
+    A parked multiplier on a surge-disabled area must read as 1.0× / inactive
+    (same gate the fare paths apply), and surge_enabled is surfaced so the
+    admin dashboard can show the toggle state.
+    """
+    areas = [
+        {
+            "id": "a1",
+            "name": "Disabled",
+            "surge_enabled": False,
+            "surge_active": True,
+            "surge_multiplier": 2.0,
+            "is_active": True,
+        },
+        {
+            "id": "a2",
+            "name": "Enabled",
+            "surge_enabled": True,
+            "surge_active": True,
+            "surge_multiplier": 1.75,
+            "is_active": True,
+        },
+    ]
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=areas)
+
+    with (
+        patch("utils.surge_engine.db", db_mock),
+        patch("utils.surge_engine._count_demand_in_area", AsyncMock(return_value=0)),
+        patch("utils.surge_engine._count_supply_in_area", AsyncMock(return_value=5)),
+    ):
+        from utils.surge_engine import get_surge_status
+
+        statuses = await get_surge_status()
+
+    by_id = {s["area_id"]: s for s in statuses}
+    # Disabled area: toggle state exposed; surge gated to 1.0× / inactive.
+    assert by_id["a1"]["surge_enabled"] is False
+    assert by_id["a1"]["surge_active"] is False
+    assert by_id["a1"]["multiplier"] == 1.0
+    # Enabled + active area: the real multiplier surfaces.
+    assert by_id["a2"]["surge_enabled"] is True
+    assert by_id["a2"]["surge_active"] is True
+    assert by_id["a2"]["multiplier"] == 1.75

--- a/backend/utils/surge_engine.py
+++ b/backend/utils/surge_engine.py
@@ -243,13 +243,24 @@ async def get_surge_status() -> List[Dict[str, Any]]:
         supply = await _count_supply_in_area(area)
         ratio = round(demand / max(supply, 1), 2)
 
+        # Per-area surge master toggle. Report the EFFECTIVE surge the fare
+        # paths would apply: when surge_enabled is off, surge never applies, so
+        # a parked multiplier / stale surge_active flag must read as 1.0× /
+        # inactive here too — otherwise the admin status view advertises surge
+        # that booking never charges. surge_enabled is surfaced so the dashboard
+        # can show the toggle state directly.
+        surge_enabled = bool(area.get("surge_enabled", False))
+        surge_active = surge_enabled and bool(area.get("surge_active", False))
+        multiplier = area.get("surge_multiplier", 1.0) if surge_active else 1.0
+
         statuses.append(
             {
                 "area_id": area["id"],
                 "name": area.get("name", ""),
                 "city": area.get("city", ""),
-                "multiplier": area.get("surge_multiplier", 1.0),
-                "surge_active": area.get("surge_active", False),
+                "surge_enabled": surge_enabled,
+                "multiplier": multiplier,
+                "surge_active": surge_active,
                 "source": area.get("surge_source", "auto"),
                 "demand_count": demand,
                 "supply_count": supply,


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Admin surge endpoint and admin surge-status read now honor the per-area `surge_enabled` toggle, so surge set via `PUT /api/admin/service-areas/{id}/surge` actually reaches pricing and disabled areas never advertise surge.
- **Type** [required]: `fix`
- **Linked issue** [required]: none — found during a requested fare/surge toggle audit; no tracking issue exists.
- **Risk** [required]: `low`
- **User-visible change** [required]: `admins` — the surge endpoint now actually applies/clears surge; the surge-status view reports effective surge plus the toggle state.
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `single-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `additive` — `GET /api/admin/surge/status` response gains `surge_enabled`; `multiplier`/`surge_active` now report effective (toggle-gated) values instead of raw row values.
- **Background job change** [required]: `none` — only the `get_surge_status` read helper in `surge_engine.py` changed; the recalculation loop is untouched.
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — no schema or data change; reverting restores the prior (broken) endpoint behavior only.
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: `service_areas.surge_enabled` exists and is backfilled (migrations 81 + 106, already merged).
- **Not changing but considered** (optional): no 404 on unknown `area_id` in the surge endpoint (pre-existing), `features.py` v1 surge endpoint's missing fare-cache invalidation, and the unused `updateSurge` wrapper in `admin-dashboard/src/lib/api.ts` — all noted for follow-up.

## Tier 3 — Compliance flags

- `[x]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — gates which surge multiplier reaches fare pricing; arithmetic unchanged, request model still caps this endpoint at 2.5×.
- `[ ]` **PIPEDA-relevant** — no PII fields, logs, or analytics payloads touched.
- `[ ]` **SK Transportation Act** — surge cap behavior unchanged (2.5× cap predates this PR).
- `[ ]` **Auth / RLS** — no auth logic touched; endpoint keeps `Depends(get_admin_user)`.
- `[ ]` **Safety** — not applicable.
- `[ ]` **Third-party SDK added** — none.
- `[ ]` **Breaking change to `shared/`** — none.

## Tier 4 — Verification

- **Unit tests** [required]: `added` — 3 (surge endpoint enable path, disable path, status-read gating).
- **Integration tests** [required]: `not-applicable` — handler/helper logic fully covered by unit tests with mocked DB; no schema change.
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video**: `not-applicable` — no UI files touched.
- **Perf numbers**: `not-applicable` — no SLA-critical path touched (admin-only endpoint plus admin status read; rider-facing fare calc unchanged).

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev — pending: authoring sandbox has no network; logic is mock-tested and makes no schema change.
- [ ] Tested with rider + driver + admin accounts — N/A: single-surface backend change.
- [ ] Verified the rollback command actually works — N/A: `risk:low`, plain `git revert`.
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` — N/A: no convention changed; behavior now matches what those docs already describe.
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics.

---

## Details

Audit of fare calculation and the per-area surge toggle (`service_areas.surge_enabled`) confirmed the gate is already enforced in every fare-affecting path (`fare_service.py`, `routes/fares.py`, `features.py`, `routes/rides.py` estimate/create, public `service_areas.py`, surge engine loop). Two surge-adjacent admin gaps did not honor it — fixed here:

1. **`PUT /api/admin/service-areas/{id}/surge`** (`routes/admin/service_areas.py`) wrote only a `surge_pricing` history row and never touched the `service_areas` columns fares read — a surge set through it returned success but never reached pricing, and it could not honor the toggle. It now writes the authoritative columns with toggle semantics: `is_active=true` enables surge at the chosen multiplier; `is_active=false` disables and resets to 1.0×. History write kept; fare cache invalidated after the authoritative write.

2. **`get_surge_status`** (`utils/surge_engine.py`, backs `GET /api/admin/surge/status`) reported the raw multiplier and `surge_active` without applying the `surge_enabled` gate, so a disabled area with a parked multiplier advertised surge that booking never charges. It now reports effective values (1.0× / inactive when disabled) and surfaces `surge_enabled` for the dashboard.

Behavior guarantee: toggle **off** → every fare path prices at 1.0×, the surge engine skips the area, status/public reads report no surge. Toggle **on** → the selected multiplier applies (auto cap 2.5×; above-cap manual override still requires written justification via the audited endpoint).

https://claude.ai/code/session_01PCTQvkuZnEGuu7yj2U2Gn7

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
