### PR TITLE
fix(db): add route_validation column + ride_offers cancelled status

### DIFF
--- a/backend/migrations/142_rides_route_validation_column.sql
+++ b/backend/migrations/142_rides_route_validation_column.sql
@@ -1,0 +1,17 @@
+-- 142_rides_route_validation_column.sql
+-- Adds route_validation JSONB column to rides.
+-- backend/routes/drivers.py stores the post-trip OSRM/Google Roads verdict here
+-- (provider, total_points, snapped_points, deviation_pct, avg_deviation_m,
+--  max_deviation_m, verdict). Without this column every completed ride with
+-- ≥5 breadcrumbs produced a PGRST204 schema-cache error and lost the fraud signal.
+--
+-- Forward-compatible: nullable column, no NOT NULL / default change to existing rows.
+--
+-- Rollback:
+--   ALTER TABLE rides DROP COLUMN IF EXISTS route_validation;
+
+ALTER TABLE rides ADD COLUMN IF NOT EXISTS route_validation JSONB;
+
+COMMENT ON COLUMN rides.route_validation IS
+  'Post-trip road-network match result (provider, verdict, deviation_pct, etc.) '
+  'written by the route_validation background task after ride completion.';

--- a/backend/migrations/143_ride_offers_cancelled_status.sql
+++ b/backend/migrations/143_ride_offers_cancelled_status.sql
@@ -1,0 +1,21 @@
+-- 143_ride_offers_cancelled_status.sql
+-- Adds 'cancelled' to the ride_offers status check constraint.
+-- When a rider cancels a ride that is in batch dispatch, rides.py marks any
+-- pending offers as 'cancelled' so drivers are notified and freed. The
+-- constraint introduced in migration 100 (and widened by 131) did not include
+-- this value, causing a 23514 check-constraint violation on every such cancel.
+--
+-- Forward-compatible: widens the allowed set only. Old backend code that never
+-- writes 'cancelled' still satisfies the new constraint.
+--
+-- Rollback:
+--   1. UPDATE ride_offers SET status = 'expired' WHERE status = 'cancelled';
+--   2. ALTER TABLE ride_offers DROP CONSTRAINT ride_offers_status_check;
+--      ALTER TABLE ride_offers ADD CONSTRAINT ride_offers_status_check
+--        CHECK (status IN ('pending','accepted','declined','expired','preempted'));
+
+ALTER TABLE ride_offers DROP CONSTRAINT IF EXISTS ride_offers_status_check;
+
+ALTER TABLE ride_offers
+    ADD CONSTRAINT ride_offers_status_check
+    CHECK (status IN ('pending', 'accepted', 'declined', 'expired', 'preempted', 'cancelled'));

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -409,7 +409,7 @@ async def _validate_ride_route(ride_id: str, breadcrumbs: list, driver_id: str) 
         try:
             await db_supabase.update_one("rides", {"id": ride_id}, {"route_validation": result})
         except Exception as db_exc:
-            logger.warning(f"[route_validation] failed to store results on ride {ride_id}: {db_exc}")
+            logger.error(f"[route_validation] failed to store results on ride {ride_id}: {db_exc}", exc_info=True)
 
         if result["verdict"] in ("suspicious", "likely_spoofed"):
             logger.warning(

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3955,7 +3955,7 @@ async def cancel_ride_rider(
                 except Exception as _e:
                     logger.warning(f"[CANCEL] failed to notify batch-offer driver {_offer_did}: {_e}")
     except Exception as _batch_exc:
-        logger.warning(f"[CANCEL] batch offer cleanup failed for ride {ride_id}: {_batch_exc}")
+        logger.error(f"[CANCEL] batch offer cleanup failed for ride {ride_id}: {_batch_exc}", exc_info=True)
 
     # Notify the rider's own connection — broadcast_ride_status only fans
     # out to the rider when rider_id is passed, but an explicit message


### PR DESCRIPTION
Migration 142: adds rides.route_validation JSONB so post-trip OSRM/Roads
fraud-detection results can be persisted (was crashing with PGRST204 on
every completed ride with ≥5 breadcrumbs).

Migration 143: widens ride_offers_status_check to include 'cancelled'.
When a rider cancels during batch dispatch, rides.py marks pending offers
as 'cancelled'; the missing value caused a 23514 constraint violation,
leaving drivers stuck on stale offer panels and not freed for new rides.

Also escalates two logger.warning → logger.error on these DB write paths
per CLAUDE.md conventions (DB errors must surface to Sentry).

https://claude.ai/code/session_018ziU356JsCAS7nFKig4imM

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
