### PR TITLE
fix(admin/rides): change export default window from 2 days to 24 hours

### DIFF
--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -210,11 +210,11 @@ async def admin_export_filtered_rides(
 ):
     """Return all rides matching the active filters for CSV export (no pagination, max 10k rows).
 
-    When no date range is provided, defaults to the last 2 days to avoid
+    When no date range is provided, defaults to the last 24 hours to avoid
     accidentally dumping the entire rides table.
     """
     if not date_from and not date_to:
-        date_from = (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%d")
+        date_from = (datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%S+00:00")
     filters = await _build_rides_filters(status, is_scheduled, search, date_from, date_to, service_area_id)
 
     if sort_by and sort_by in _VALID_SORT_COLUMNS:


### PR DESCRIPTION
When no date range filter is set, the export endpoint now returns rides
from the last 24 hours (rolling window) instead of since midnight two
days ago. The full ISO timestamp with UTC offset is used so the filter
is precise rather than snapping to day boundaries.

https://claude.ai/code/session_01Ay6aMHYQYLrqn3NHA7aW8K