### PR TITLE
fix(driver): surface location permission/GPS failure on dashboard

### DIFF
--- a/backend/routes/fares.py
+++ b/backend/routes/fares.py
@@ -80,22 +80,40 @@ async def invalidate_fare_cache() -> int:
 async def get_vehicle_types(service_area_id: Optional[str] = None):
     """Return active vehicle types, optionally filtered to those configured for a service area.
 
-    When ``service_area_id`` is provided, only vehicle types that have an
-    active fare_config row for that area are returned. This prevents
-    drivers from picking a vehicle type that has no fare set up for their
-    area (which would fail at ride creation).
+    When ``service_area_id`` is provided, only vehicle types with pricing
+    configured for that area are returned. This prevents drivers from
+    picking a vehicle type that has no fare set up for their area (which
+    would fail at ride creation).
+
+    Pricing-source precedence mirrors ``build_fares_for_area``:
+    ``service_areas.vehicle_pricing`` JSONB (what the Service Areas admin
+    editor writes, keyed by vehicle type NAME) is authoritative; legacy
+    ``fare_configs`` rows (keyed by vehicle_type_id) apply only when the
+    area has no vehicle_pricing. Filtering on fare_configs alone returned
+    an empty list for every area configured through the admin UI.
     """
     types = await db_supabase.get_rows("vehicle_types", {"is_active": True}, limit=100)
 
     if service_area_id:
-        configs = await db_supabase.get_rows(
-            "fare_configs",
-            {"service_area_id": service_area_id, "is_active": True},
-            columns="vehicle_type_id",
-            limit=100,
+        areas = await db_supabase.get_rows("service_areas", {"id": service_area_id}, limit=1)
+        vp_raw = (areas[0] if areas else {}).get("vehicle_pricing") or []
+        allowed_names = (
+            {row["vehicle_type"] for row in vp_raw if isinstance(row, dict) and row.get("vehicle_type")}
+            if isinstance(vp_raw, list)
+            else set()
         )
-        allowed_ids = {c["vehicle_type_id"] for c in (configs or []) if c.get("vehicle_type_id")}
-        types = [vt for vt in (types or []) if vt.get("id") in allowed_ids]
+
+        if allowed_names:
+            types = [vt for vt in (types or []) if vt.get("name") in allowed_names]
+        else:
+            configs = await db_supabase.get_rows(
+                "fare_configs",
+                {"service_area_id": service_area_id, "is_active": True},
+                columns="vehicle_type_id",
+                limit=100,
+            )
+            allowed_ids = {c["vehicle_type_id"] for c in (configs or []) if c.get("vehicle_type_id")}
+            types = [vt for vt in (types or []) if vt.get("id") in allowed_ids]
 
     for vt in types or []:
         if isinstance(vt, dict) and vt.get("illustration_url") and not vt.get("image_url"):

--- a/backend/tests/test_fares.py
+++ b/backend/tests/test_fares.py
@@ -87,6 +87,10 @@ async def test_build_fares_for_area_returns_only_configured_vehicle_types():
         {"id": "vt_lux", "name": "Luxury", "is_active": True},
     ]
 
+    # Stale legacy fare_configs rows that would re-expose Luxury if the
+    # fallback were (incorrectly) consulted despite vehicle_pricing existing.
+    stale_legacy_fares = [{"vehicle_type_id": "vt_lux", "base_fare": 5.00, "is_active": True}]
+
     with patch("backend.routes.fares.db_supabase.get_rows", new_callable=AsyncMock) as mock_get_rows:
         mock_get_rows.return_value = stale_legacy_fares
         fares = await build_fares_for_area(matched_area, vehicle_types)
@@ -96,3 +100,67 @@ async def test_build_fares_for_area_returns_only_configured_vehicle_types():
     fares_by_id = {fare["vehicle_type"]["id"]: fare for fare in fares}
     assert fares_by_id["vt_sedan"]["base_fare"] == "4.25"
     assert fares_by_id["vt_xl"]["base_fare"] == "6.00"
+
+
+def _vehicle_types_db(area_row, fare_config_rows):
+    """get_rows side-effect for the /vehicle-types endpoint tests."""
+    all_types = [
+        {"id": "vt_economy", "name": "Economy", "is_active": True},
+        {"id": "vt_xl", "name": "XL", "is_active": True},
+        {"id": "vt_van", "name": "Van", "is_active": True},
+        {"id": "vt_premium", "name": "Premium", "is_active": True},
+    ]
+
+    async def _get_rows(table, filters=None, **kw):
+        if table == "vehicle_types":
+            return all_types
+        if table == "service_areas":
+            return [area_row] if area_row else []
+        if table == "fare_configs":
+            return fare_config_rows
+        raise AssertionError(f"unexpected table {table}")
+
+    return _get_rows
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_get_vehicle_types_honours_vehicle_pricing_jsonb():
+    """Regression: areas configured via the admin Vehicle Pricing editor write
+    service_areas.vehicle_pricing JSONB, not fare_configs rows. The area filter
+    must honour that (it previously returned [] for every such area, leaving
+    the driver app's vehicle type picker empty)."""
+    from backend.routes.fares import get_vehicle_types
+
+    area = {
+        "id": "area_regina",
+        "vehicle_pricing": [
+            {"vehicle_type": "Economy", "base_fare": 2.0},
+            {"vehicle_type": "XL", "base_fare": 2.0},
+            {"vehicle_type": "Van", "base_fare": 2.0},
+        ],
+    }
+    with patch(
+        "backend.routes.fares.db_supabase.get_rows",
+        side_effect=_vehicle_types_db(area, fare_config_rows=[]),
+    ):
+        types = await get_vehicle_types(service_area_id="area_regina")
+
+    assert [vt["name"] for vt in types] == ["Economy", "XL", "Van"]
+
+
+@pytest.mark.unit
+@pytest.mark.anyio
+async def test_get_vehicle_types_falls_back_to_fare_configs_when_no_jsonb():
+    """Areas without vehicle_pricing JSONB still filter via legacy fare_configs."""
+    from backend.routes.fares import get_vehicle_types
+
+    area = {"id": "area_legacy", "vehicle_pricing": []}
+    legacy = [{"vehicle_type_id": "vt_premium"}]
+    with patch(
+        "backend.routes.fares.db_supabase.get_rows",
+        side_effect=_vehicle_types_db(area, fare_config_rows=legacy),
+    ):
+        types = await get_vehicle_types(service_area_id="area_legacy")
+
+    assert [vt["name"] for vt in types] == ["Premium"]

--- a/driver-app/app/become-driver.tsx
+++ b/driver-app/app/become-driver.tsx
@@ -221,7 +221,18 @@ export default function BecomeDriverScreen() {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
-      setVehicleTypes(data);
+      let types = Array.isArray(data) ? data : [];
+      // A service area with no fare configs filters out every type
+      // (backend returns 200 + []). Fall back to the unfiltered active
+      // list so onboarding isn't blocked by missing fare configuration.
+      if (types.length === 0) {
+        const fallback = await fetch(`${SpinrConfig.backendUrl}/api/v1/vehicle-types`);
+        if (fallback.ok) {
+          const fallbackData = await fallback.json();
+          if (Array.isArray(fallbackData)) types = fallbackData;
+        }
+      }
+      setVehicleTypes(types);
     } catch (e: any) {
       console.log('Error fetching vehicle types:', e);
       Alert.alert('Connection Error', 'Failed to load vehicle types. Please check your internet connection.');

--- a/driver-app/app/driver/(tabs)/index.tsx
+++ b/driver-app/app/driver/(tabs)/index.tsx
@@ -97,6 +97,7 @@ function DriverDashboard() {
     isOnline,
     connectionState,
     location,
+    locationStatus,
     otpInput,
     setOtpInput,
     toggleOnline,
@@ -625,6 +626,36 @@ function DriverDashboard() {
   };
 
   if (!location?.coords) {
+    // Permission denied or the GPS fix failed: an infinite spinner here gave
+    // the driver no way out (and nothing reaches the backend, so no logs).
+    if (locationStatus === 'denied' || locationStatus === 'unavailable') {
+      const denied = locationStatus === 'denied';
+      return (
+        <View style={[styles.container, { justifyContent: 'center', alignItems: 'center', paddingHorizontal: 32 }]}>
+          <Ionicons name={denied ? 'location-outline' : 'navigate-outline'} size={48} color={colors.primary} />
+          <Text style={styles.locationFallbackTitle}>
+            {t(denied ? 'home.locationDeniedTitle' : 'home.locationUnavailableTitle')}
+          </Text>
+          <Text style={styles.locationFallbackBody}>
+            {t(denied ? 'home.locationDeniedBody' : 'home.locationUnavailableBody')}
+          </Text>
+          {denied && (
+            <TouchableOpacity style={styles.locationFallbackBtn} onPress={() => Linking.openSettings()} activeOpacity={0.8}>
+              <Text style={styles.locationFallbackBtnText}>{t('home.openSettings')}</Text>
+            </TouchableOpacity>
+          )}
+          <TouchableOpacity
+            style={[styles.locationFallbackBtn, denied && styles.locationFallbackBtnSecondary]}
+            onPress={() => refreshLocation(true)}
+            activeOpacity={0.8}
+          >
+            <Text style={[styles.locationFallbackBtnText, denied && styles.locationFallbackBtnTextSecondary]}>
+              {t('home.retryLocation')}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
     return (
       <View style={[styles.container, { justifyContent: 'center', alignItems: 'center' }]}>
         <ActivityIndicator size="large" color={colors.primary} />
@@ -969,6 +1000,40 @@ function createStyles(colors: ThemeColors) {
       color: '#fff',
       fontSize: 12,
       fontWeight: '600',
+    },
+    locationFallbackTitle: {
+      color: colors.text,
+      marginTop: 16,
+      fontSize: 17,
+      fontWeight: '700',
+      textAlign: 'center',
+    },
+    locationFallbackBody: {
+      color: colors.textDim,
+      marginTop: 8,
+      fontSize: 14,
+      lineHeight: 20,
+      textAlign: 'center',
+    },
+    locationFallbackBtn: {
+      marginTop: 16,
+      backgroundColor: colors.primary,
+      borderRadius: 12,
+      paddingVertical: 12,
+      paddingHorizontal: 32,
+    },
+    locationFallbackBtnSecondary: {
+      backgroundColor: 'transparent',
+      borderWidth: 1,
+      borderColor: colors.border,
+    },
+    locationFallbackBtnText: {
+      color: '#fff',
+      fontSize: 15,
+      fontWeight: '600',
+    },
+    locationFallbackBtnTextSecondary: {
+      color: colors.text,
     },
     markerContainer: {
       alignItems: 'center',

--- a/driver-app/app/vehicle-info.tsx
+++ b/driver-app/app/vehicle-info.tsx
@@ -57,6 +57,7 @@ export default function VehicleInfoScreen() {
 
     const [vehicleTypeName, setVehicleTypeName] = useState('');
     const [vehicleTypes, setVehicleTypes] = useState<VehicleType[]>([]);
+    const [vehicleTypesStatus, setVehicleTypesStatus] = useState<'loading' | 'error' | 'loaded'>('loading');
     const [showVehicleTypePicker, setShowVehicleTypePicker] = useState(false);
 
     useEffect(() => {
@@ -75,17 +76,30 @@ export default function VehicleInfoScreen() {
     }, [driver]);
 
     const fetchVehicleTypes = async () => {
+        setVehicleTypesStatus('loading');
         try {
             const areaId = driver?.service_area_id;
-            const url = areaId ? `/vehicle-types?service_area_id=${areaId}` : '/vehicle-types';
-            const response = await api.get<VehicleType[]>(url);
-            setVehicleTypes(response.data);
+            let types: VehicleType[] = [];
+            if (areaId) {
+                const response = await api.get<VehicleType[]>(`/vehicle-types?service_area_id=${areaId}`);
+                types = response.data || [];
+            }
+            // A service area with no fare configs filters out every type
+            // (backend returns 200 + []). The driver still needs to classify
+            // their vehicle, so fall back to the unfiltered active list.
+            if (types.length === 0) {
+                const response = await api.get<VehicleType[]>('/vehicle-types');
+                types = response.data || [];
+            }
+            setVehicleTypes(types);
+            setVehicleTypesStatus('loaded');
             if (driver?.vehicle_type_id) {
-                const found = response.data.find((t: any) => t.id === driver.vehicle_type_id);
+                const found = types.find((t: any) => t.id === driver.vehicle_type_id);
                 if (found) setVehicleTypeName(found.name);
             }
-        } catch (error) {
-            console.log('Failed to fetch vehicle types');
+        } catch (error: any) {
+            setVehicleTypesStatus('error');
+            showToast('error', 'Error', error?.response?.data?.detail || 'Failed to load vehicle types. Check your connection and try again.');
         }
     };
 
@@ -387,6 +401,25 @@ export default function VehicleInfoScreen() {
                                     )}
                                 </TouchableOpacity>
                             )}
+                            ListEmptyComponent={
+                                <View style={styles.vehicleTypeEmpty}>
+                                    {vehicleTypesStatus === 'loading' ? (
+                                        <ActivityIndicator color={colors.primary} />
+                                    ) : (
+                                        <>
+                                            <Ionicons name="car-outline" size={36} color={colors.textDim} />
+                                            <Text style={styles.vehicleTypeEmptyText}>
+                                                {vehicleTypesStatus === 'error'
+                                                    ? "Couldn't load vehicle types. Check your connection and try again."
+                                                    : 'No vehicle types are available yet. Please contact support.'}
+                                            </Text>
+                                            <TouchableOpacity style={styles.vehicleTypeRetryBtn} onPress={fetchVehicleTypes} activeOpacity={0.8}>
+                                                <Text style={styles.vehicleTypeRetryText}>Try Again</Text>
+                                            </TouchableOpacity>
+                                        </>
+                                    )}
+                                </View>
+                            }
                         />
                     </View>
                 </View>
@@ -633,5 +666,9 @@ function createStyles(colors: ThemeColors) {
         vehicleTypeInfo: { flex: 1 },
         vehicleTypeOptionName: { fontSize: 16, fontWeight: '700', color: colors.text },
         vehicleTypeOptionDesc: { fontSize: 13, color: colors.textDim, marginTop: 2 },
+        vehicleTypeEmpty: { paddingVertical: 36, paddingHorizontal: 24, alignItems: 'center', gap: 12 },
+        vehicleTypeEmptyText: { fontSize: 14, color: colors.textDim, textAlign: 'center', lineHeight: 20 },
+        vehicleTypeRetryBtn: { backgroundColor: colors.primary, borderRadius: 10, paddingVertical: 10, paddingHorizontal: 28 },
+        vehicleTypeRetryText: { color: '#fff', fontSize: 14, fontWeight: '600' },
     });
 }

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -372,6 +372,15 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       return null;
     }
 
+    // Permission can be granted while device-wide location services are
+    // off (Android quick-settings toggle) — getCurrentPositionAsync would
+    // just throw, so detect it up front.
+    const servicesOn = await Location.hasServicesEnabledAsync().catch(() => true);
+    if (!servicesOn) {
+      setLocationStatus(locationRef.current ? 'ok' : 'unavailable');
+      return null;
+    }
+
     if (useCache) {
       try {
         const lastKnown = await Location.getLastKnownPositionAsync();
@@ -380,7 +389,13 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     }
 
     try {
-      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+      // getCurrentPositionAsync has no timeout and can hang indefinitely
+      // waiting for a fix (indoors, weak GPS) — race it so the driver
+      // never sits on the spinner forever.
+      const loc = await Promise.race([
+        Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced }),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('location fix timeout')), 15000)),
+      ]);
       setLocation(loc);
       locationRef.current = loc;
       setLocationStatus('ok');
@@ -390,8 +405,17 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       } catch {}
       return loc;
     } catch {
-      // A lastKnown fix may already be rendering the map — only flag
-      // unavailable when there is nothing to show at all.
+      // Fix failed or timed out — a coarse last-known position still lets
+      // the map render; watchPositionAsync corrects it once a fix lands.
+      try {
+        const lastKnown = await Location.getLastKnownPositionAsync();
+        if (lastKnown) {
+          setLocation(lastKnown);
+          locationRef.current = lastKnown;
+          setLocationStatus('ok');
+          return lastKnown;
+        }
+      } catch {}
       setLocationStatus(locationRef.current ? 'ok' : 'unavailable');
       return null;
     }

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -61,11 +61,14 @@ const _toFiniteCoord = (v: unknown): number | null => {
   return n;
 };
 
+export type LocationStatus = 'pending' | 'denied' | 'unavailable' | 'ok';
+
 interface UseDriverDashboardReturn {
   // State
   isOnline: boolean;
   connectionState: ConnectionState;
   location: Location.LocationObject | null;
+  locationStatus: LocationStatus;
   otpInput: string;
   setOtpInput: (value: string) => void;
   wsError: string | null;
@@ -207,6 +210,10 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
   const [isOnline, setIsOnline] = useState(driverData?.is_online || false);
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
   const [location, setLocation] = useState<Location.LocationObject | null>(null);
+  // Why a separate status: `location` stays null when permission is denied or
+  // the GPS fix fails, and the dashboard used to spin on "Getting your
+  // location..." forever with no way to tell those cases apart.
+  const [locationStatus, setLocationStatus] = useState<LocationStatus>('pending');
   const [otpInput, setOtpInput] = useState('');
 
   // Clear OTP input when ride state changes away from arrived_at_pickup
@@ -343,6 +350,7 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
   // AppState refresh the map would still point at home until
   // watchPositionAsync starts after Go Online).
   const refreshLocation = useCallback(async (useCache: boolean) => {
+    setLocationStatus(prev => (prev === 'ok' ? prev : 'pending'));
     if (useCache) {
       try {
         const AsyncStorage = require('@react-native-async-storage/async-storage').default;
@@ -359,7 +367,10 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       const res = await Location.requestForegroundPermissionsAsync();
       status = res.status;
     }
-    if (status !== 'granted') return null;
+    if (status !== 'granted') {
+      setLocationStatus('denied');
+      return null;
+    }
 
     if (useCache) {
       try {
@@ -372,12 +383,16 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
       setLocation(loc);
       locationRef.current = loc;
+      setLocationStatus('ok');
       try {
         const AsyncStorage = require('@react-native-async-storage/async-storage').default;
         AsyncStorage.setItem('spinr_driver_last_location', JSON.stringify({ lat: loc.coords.latitude, lng: loc.coords.longitude }));
       } catch {}
       return loc;
     } catch {
+      // A lastKnown fix may already be rendering the map — only flag
+      // unavailable when there is nothing to show at all.
+      setLocationStatus(locationRef.current ? 'ok' : 'unavailable');
       return null;
     }
   }, []);
@@ -1373,6 +1388,7 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     isOnline,
     connectionState,
     location,
+    locationStatus,
     otpInput,
     setOtpInput,
     wsError,

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -368,16 +368,25 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       status = res.status;
     }
     if (status !== 'granted') {
+      // The dashboard gates on location, not status — a fix restored from
+      // the AsyncStorage cache above would keep a stale map rendered over
+      // this blocking error, and locationRef would leak the stale position
+      // to the backend on WS reconnect. Clear both.
+      setLocation(null);
+      locationRef.current = null;
       setLocationStatus('denied');
       return null;
     }
 
     // Permission can be granted while device-wide location services are
     // off (Android quick-settings toggle) — getCurrentPositionAsync would
-    // just throw, so detect it up front.
+    // just throw, so detect it up front. No fix will ever arrive in this
+    // state, so a stale cached map would be misleading: clear it too.
     const servicesOn = await Location.hasServicesEnabledAsync().catch(() => true);
     if (!servicesOn) {
-      setLocationStatus(locationRef.current ? 'ok' : 'unavailable');
+      setLocation(null);
+      locationRef.current = null;
+      setLocationStatus('unavailable');
       return null;
     }
 
@@ -416,7 +425,18 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
           return lastKnown;
         }
       } catch {}
-      setLocationStatus(locationRef.current ? 'ok' : 'unavailable');
+      if (locationRef.current) {
+        // A real fix from this session (lastKnown/watcher) is still on the
+        // map — keep it; the watcher corrects it once a fresh fix lands.
+        setLocationStatus('ok');
+      } else {
+        // Only the AsyncStorage-cached coordinate (if any) is showing.
+        // It never reached locationRef so it can't be sent to dispatch,
+        // but it would silently mask this failure — clear it so the
+        // retry UI appears instead of a stale map.
+        setLocation(null);
+        setLocationStatus('unavailable');
+      }
       return null;
     }
   }, []);

--- a/driver-app/i18n/en.json
+++ b/driver-app/i18n/en.json
@@ -35,6 +35,12 @@
         "noRideRequests": "No ride requests",
         "waitingForRequests": "Waiting for ride requests...",
         "gettingLocation": "Getting your location...",
+        "locationDeniedTitle": "Location permission needed",
+        "locationDeniedBody": "Spinr needs your location to show the map and receive ride requests. Enable location access in your device settings.",
+        "locationUnavailableTitle": "Couldn't get your location",
+        "locationUnavailableBody": "Check that GPS is turned on, then try again.",
+        "openSettings": "Open Settings",
+        "retryLocation": "Try Again",
         "go": "GO",
         "stop": "STOP"
     },

--- a/driver-app/i18n/es.json
+++ b/driver-app/i18n/es.json
@@ -35,6 +35,12 @@
         "noRideRequests": "Sin solicitudes de viaje",
         "waitingForRequests": "Esperando solicitudes de viaje...",
         "gettingLocation": "Obteniendo tu ubicación...",
+        "locationDeniedTitle": "Se necesita permiso de ubicación",
+        "locationDeniedBody": "Spinr necesita tu ubicación para mostrar el mapa y recibir solicitudes de viaje. Activa el acceso a la ubicación en los ajustes de tu dispositivo.",
+        "locationUnavailableTitle": "No pudimos obtener tu ubicación",
+        "locationUnavailableBody": "Comprueba que el GPS esté activado e inténtalo de nuevo.",
+        "openSettings": "Abrir ajustes",
+        "retryLocation": "Reintentar",
         "go": "IR",
         "stop": "PARAR"
     },

--- a/driver-app/i18n/fr.json
+++ b/driver-app/i18n/fr.json
@@ -35,6 +35,12 @@
         "noRideRequests": "Aucune demande de course",
         "waitingForRequests": "En attente de demandes de course...",
         "gettingLocation": "Localisation en cours...",
+        "locationDeniedTitle": "Autorisation de localisation requise",
+        "locationDeniedBody": "Spinr a besoin de votre position pour afficher la carte et recevoir des demandes de course. Activez l'accès à la localisation dans les réglages de votre appareil.",
+        "locationUnavailableTitle": "Impossible d'obtenir votre position",
+        "locationUnavailableBody": "Vérifiez que le GPS est activé, puis réessayez.",
+        "openSettings": "Ouvrir les réglages",
+        "retryLocation": "Réessayer",
         "go": "GO",
         "stop": "STOP"
     },


### PR DESCRIPTION
The dashboard gated rendering on location.coords and showed an infinite
'Getting your location...' spinner when permission was denied or the GPS
fix failed — both errors were swallowed in refreshLocation, and nothing
reaches the backend, so logs stay clean while the driver is stuck.

Track a locationStatus (pending/denied/unavailable/ok) in
useDriverDashboard and render an actionable fallback with Open Settings
and Try Again instead of spinning forever.

https://claude.ai/code/session_017UZVFuQ4omn7ozmahXVL7Z

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
