### PR TITLE
fix(rides): draw only the travelled trip leg on route snapshots

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -3685,10 +3685,12 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                     for p in sampled
                 ]
 
-            # Combined polyline for the static map snapshot (route_snapshot_url)
+            # Trip-leg polyline for the static map snapshot (route_snapshot_url)
             # ONLY — kept in-memory, not persisted to rides (geometry now lives in
-            # ride_routes). [[lat, lng, phase], ...].
-            trip_points = [b for b in all_breadcrumbs if b.get("tracking_phase") in phases_to_split]
+            # ride_routes). [[lat, lng, phase], ...]. The navigating_to_pickup leg
+            # is excluded: the receipt map shows the travelled pickup→dropoff
+            # route only (drawing both legs read as two routes on the snapshot).
+            trip_points = [b for b in all_breadcrumbs if b.get("tracking_phase") == "trip_in_progress"]
             if trip_points:
                 MAX_POINTS = 200
                 step = max(1, len(trip_points) // MAX_POINTS)
@@ -4040,16 +4042,22 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
     # embed a permanent image URL. Only regenerate if we have enough GPS
     # data to produce a meaningful route — otherwise preserve the planned-
     # route snapshot from creation (which used the Google Directions polyline).
-    # Threshold mirrors the distance-calculation guard: < 5 trip_in_progress
-    # points means the breadcrumb trail is essentially a straight line and
-    # the planned-route image will be more accurate than the GPS trace.
+    # A road-snapped trip geometry (sanity-gated above) always qualifies; a raw
+    # breadcrumb trail needs >= 10 trip_in_progress points, mirroring the
+    # renderer's own sparsity guard. Below that the Static Maps API draws
+    # straight chords between the few points — the "straight line P→D next to
+    # the real path" snapshot artifact — and the planned-route image from
+    # creation is more accurate than the GPS trace.
     trip_points_for_snapshot = sum(
         1
         for b in (all_breadcrumbs if "all_breadcrumbs" in locals() else [])
         if b.get("tracking_phase") == "trip_in_progress"
     )
-    has_gps_trail = trip_points_for_snapshot >= 5
+    has_gps_trail = bool(road_polyline) or trip_points_for_snapshot >= 10
     if has_gps_trail:
+        # Prefer the road-snapped trip polyline: it follows the road network
+        # even where raw GPS was sparse. phase_polylines is dropped in that
+        # case so the renderer can't pick the raw trail over it.
         asyncio.create_task(
             _generate_and_store_ride_snapshot(
                 ride_id=ride_id,
@@ -4057,8 +4065,8 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
                 pickup_lng=ride.get("pickup_lng"),
                 dropoff_lat=ride.get("dropoff_lat"),
                 dropoff_lng=ride.get("dropoff_lng"),
-                phase_polylines=phase_polylines,
-                route_polyline=route_polyline,
+                phase_polylines=None if road_polyline else phase_polylines,
+                route_polyline=road_polyline or route_polyline,
             )
         )
     else:

--- a/backend/tests/test_utils_extended.py
+++ b/backend/tests/test_utils_extended.py
@@ -1471,6 +1471,110 @@ class TestCoercePolyline:
 
 
 # ===========================================================================
+# utils/route_snapshot.py — render_ride_snapshot_google trail selection
+# ===========================================================================
+
+
+class TestSnapshotTrailSelection:
+    """The receipt snapshot must draw the travelled trip leg only — never the
+    navigating_to_pickup leg, and never straight chords from a sparse trip
+    trail (the 'two lines on the snapshot' regression)."""
+
+    def _patch_static_maps(self, monkeypatch, captured: list):
+        from backend.utils import route_snapshot
+
+        class _FakeResp:
+            status_code = 200
+            headers = {"content-type": "image/png"}
+            content = b"\x89PNG"
+
+        class _FakeClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url):
+                captured.append(url)
+                return _FakeResp()
+
+        monkeypatch.setattr(route_snapshot.httpx, "AsyncClient", _FakeClient)
+
+    def _render(self, monkeypatch, **kwargs):
+        import asyncio
+
+        from backend.utils.route_snapshot import render_ride_snapshot_google
+
+        captured: list = []
+        self._patch_static_maps(monkeypatch, captured)
+        png = asyncio.run(
+            render_ride_snapshot_google(
+                api_key="test-key",
+                pickup_lat=50.45,
+                pickup_lng=-104.61,
+                dropoff_lat=50.41,
+                dropoff_lng=-104.63,
+                **kwargs,
+            )
+        )
+        assert png == b"\x89PNG"
+        assert len(captured) == 1
+        return captured[0]
+
+    @staticmethod
+    def _trip_trail(n):
+        return [[50.45 + i * 0.001, -104.61 - i * 0.001, "2026-06-11T10:00:00Z"] for i in range(n)]
+
+    @staticmethod
+    def _pickup_trail(n):
+        return [[50.48 + i * 0.001, -104.58 - i * 0.001, "2026-06-11T09:50:00Z"] for i in range(n)]
+
+    def test_dense_trip_trail_drawn_without_pickup_leg(self, monkeypatch):
+        url = self._render(
+            monkeypatch,
+            phase_polylines={
+                "navigating_to_pickup": self._pickup_trail(20),
+                "trip_in_progress": self._trip_trail(20),
+            },
+        )
+        assert "path=" in url
+        assert "50.45,-104.61" in url  # trip leg start
+        assert "50.48,-104.58" not in url  # pickup approach leg excluded
+
+    def test_sparse_trip_trail_falls_back_to_route_polyline(self, monkeypatch):
+        # A dense pickup leg must NOT carry a sparse trip leg over the
+        # 10-point threshold — that combination drew the pickup approach as
+        # the "actual path" plus straight chords pickup→dropoff.
+        url = self._render(
+            monkeypatch,
+            phase_polylines={
+                "navigating_to_pickup": self._pickup_trail(50),
+                "trip_in_progress": self._trip_trail(4),
+            },
+            route_polyline=[[50.44, -104.62], [50.43, -104.625], [50.42, -104.628]],
+        )
+        assert "50.44,-104.62" in url  # route_polyline fallback used
+        assert "50.48,-104.58" not in url  # pickup leg still excluded
+
+    def test_no_phase_trails_uses_route_polyline(self, monkeypatch):
+        url = self._render(
+            monkeypatch,
+            route_polyline=[[50.45, -104.61], [50.41, -104.63]],
+        )
+        assert "path=" in url
+        assert "50.45,-104.61" in url
+
+    def test_no_trail_at_all_renders_markers_only(self, monkeypatch):
+        url = self._render(monkeypatch)
+        assert "path=" not in url
+        assert "markers=color:green" in url and "markers=color:red" in url
+
+
+# ===========================================================================
 # utils/subprocessor_audit.py — _fetch_page and _sha256 coverage
 # ===========================================================================
 

--- a/backend/utils/route_snapshot.py
+++ b/backend/utils/route_snapshot.py
@@ -51,16 +51,21 @@ async def render_ride_snapshot_google(
     # Build path from phase_polylines or route_polyline
     trail_points: list[str] = []
 
-    pickup_trail = _extract_trail((phase_polylines or {}).get("navigating_to_pickup"))
     trip_trail = _extract_trail((phase_polylines or {}).get("trip_in_progress"))
 
-    # Require at least 10 combined phase-trail points before trusting them.
-    # Fewer than that means GPS coverage was too sparse and the Static Maps API
-    # draws straight segments between the handful of points — the reported
-    # "double line" artifact.  Fall through to route_polyline in that case.
-    _phase_points = pickup_trail + trip_trail
-    if len(_phase_points) >= 10:
-        trail_points = _phase_points
+    # The snapshot shows the travelled pickup→dropoff route ONLY. The
+    # navigating_to_pickup leg is deliberately excluded: drawn alongside the
+    # trip leg it reads as a second route on the receipt map (admin tooling
+    # replays per-phase trails from ride_routes instead).
+    #
+    # Require at least 10 trip-leg points before trusting the raw trail —
+    # gated on the trip leg ALONE, not the combined phase count: a dense
+    # pickup leg used to carry a sparse trip leg over the threshold, and the
+    # Static Maps API then drew straight chords between the few trip points
+    # (the reported "straight line between P and D" next to the real path).
+    # Fall through to route_polyline in that case.
+    if len(trip_trail) >= 10:
+        trail_points = trip_trail
     elif route_polyline:
         for pt in route_polyline:
             try:
@@ -174,12 +179,12 @@ def render_ride_snapshot(
 
     import io
 
-    pickup_trail = _coerce_polyline((phase_polylines or {}).get("navigating_to_pickup"))
+    # Trip leg only — see render_ride_snapshot_google for why the
+    # navigating_to_pickup leg is excluded from the snapshot.
     trip_trail = _coerce_polyline((phase_polylines or {}).get("trip_in_progress"))
-    has_phase_trails = bool(pickup_trail) or bool(trip_trail)
 
     legacy_trail: list[tuple[float, float]] = []
-    if not has_phase_trails and route_polyline:
+    if not trip_trail and route_polyline:
         for pt in route_polyline:
             try:
                 lat = float(pt[0])
@@ -196,8 +201,6 @@ def render_ride_snapshot(
         m.add_marker(CircleMarker((dropoff_lng, dropoff_lat), "#ffffff", 14))
         m.add_marker(CircleMarker((dropoff_lng, dropoff_lat), "#ef4444", 10))
 
-        if pickup_trail:
-            m.add_line(Line(pickup_trail, "#f59e0b", 4))
         if trip_trail:
             m.add_line(Line(trip_trail, "#3b82f6", 4))
         if legacy_trail:


### PR DESCRIPTION
The completed-ride snapshot drew the navigating_to_pickup leg and the
trip leg as one concatenated path, and its >=10-point sparsity guard
counted both phases combined. A dense pickup-approach leg could carry a
sparse trip leg over the threshold, so Static Maps drew the approach leg
as a road-following path plus long straight chords between the few trip
points — the 'straight line between pickup and dropoff next to the
actual path' artifact on receipts.

The renderer now draws the trip_in_progress trail only, gates the
sparsity check on that leg alone, and falls back to route_polyline when
it is too sparse. The OSM fallback renderer likewise no longer draws the
pickup leg. Admin tooling still gets per-phase trails from ride_routes.

https://claude.ai/code/session_01Lf4u55v38JqvurJYGDQZmn