### PR TITLE
fix(rider): AI button white-screen crash + gate Account AI entry on config

### DIFF
--- a/rider-app/app/(tabs)/account.tsx
+++ b/rider-app/app/(tabs)/account.tsx
@@ -23,6 +23,7 @@ import { showToast } from '../../store/toastStore';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
 import { useWorkProfileStore } from '../../store/workProfileStore';
+import { useAiChatStore } from '../../store/aiChatStore';
 
 const BLURHASH_PLACEHOLDER = 'LGF5]+Yk^6#M@-5c,1J5@[or[Q6.';
 
@@ -33,6 +34,20 @@ export default function AccountScreen() {
   const { profiles, workModeEnabled } = useWorkProfileStore();
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
+  const aiEnabled = useAiChatStore((s) => s.enabled);
+  const loadAiConfig = useAiChatStore((s) => s.loadConfig);
+
+  useEffect(() => {
+    loadAiConfig();
+  }, [loadAiConfig]);
+
+  const handleAiPress = () => {
+    if (aiEnabled) {
+      router.push('/ai-assistant' as any);
+    } else {
+      showToast('Coming Soon', 'AI Ride Booking is coming soon!', 'info');
+    }
+  };
 
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
@@ -354,7 +369,7 @@ export default function AccountScreen() {
             <View style={styles.card}>
               <MenuRow styles={styles} colors={colors} icon="bag-handle" iconColor="#F97316" iconBg="rgba(249, 115, 22, 0.1)" label="Lost & Found" onPress={() => router.push('/lost-and-found' as any)} />
               <View style={styles.cardDivider} />
-              <MenuRow styles={styles} colors={colors} icon="sparkles" iconColor="#8B5CF6" iconBg="rgba(139, 92, 246, 0.1)" label="AI Assistant" onPress={() => router.push('/ai-assistant' as any)} />
+              <MenuRow styles={styles} colors={colors} icon="sparkles" iconColor="#8B5CF6" iconBg="rgba(139, 92, 246, 0.1)" label="AI Assistant" onPress={handleAiPress} />
               <View style={styles.cardDivider} />
               <MenuRow styles={styles} colors={colors} icon="help-circle" iconColor="#2563EB" iconBg="rgba(37, 99, 235, 0.1)" label="Help Center" onPress={() => router.push('/support' as any)} />
               <View style={styles.cardDivider} />

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -273,6 +273,14 @@ export default function HomeScreen() {
     router.push('/search-destination' as any);
   };
 
+  const handleAiPress = () => {
+    if (aiEnabled) {
+      router.push('/ai-assistant' as any);
+    } else {
+      showToast('Coming Soon', 'AI Ride Booking is coming soon!', 'info');
+    }
+  };
+
   const handleQuickAction = (_type: string) => {
     router.push('/search-destination' as any);
   };
@@ -473,6 +481,7 @@ export default function HomeScreen() {
             showPromo={showPromo}
             setShowPromo={setShowPromo}
             handleSearchPress={handleSearchPress}
+            handleAiPress={handleAiPress}
             handleQuickAction={handleQuickAction}
           />
         </View>
@@ -501,6 +510,7 @@ export default function HomeScreen() {
               showPromo={showPromo}
               setShowPromo={setShowPromo}
               handleSearchPress={handleSearchPress}
+              handleAiPress={handleAiPress}
               handleQuickAction={handleQuickAction}
             />
           </BottomSheetScrollView>
@@ -511,11 +521,11 @@ export default function HomeScreen() {
 }
 
 function BottomSheetContent({
-  colors, styles, showPromo, setShowPromo, handleSearchPress, handleQuickAction,
+  colors, styles, showPromo, setShowPromo, handleSearchPress, handleAiPress, handleQuickAction,
 }: {
   colors: ThemeColors; styles: any;
   showPromo: boolean; setShowPromo: (v: boolean) => void;
-  handleSearchPress: () => void; handleQuickAction: (type: string) => void;
+  handleSearchPress: () => void; handleAiPress: () => void; handleQuickAction: (type: string) => void;
 }) {
   return (
     <>
@@ -531,13 +541,7 @@ function BottomSheetContent({
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.aiButton}
-          onPress={() => {
-            if (aiEnabled) {
-              router.push('/ai-assistant' as any);
-            } else {
-              showToast('Coming Soon', 'AI Ride Booking is coming soon!', 'info');
-            }
-          }}
+          onPress={handleAiPress}
           activeOpacity={0.8}
           accessibilityLabel="AI assistant"
           accessibilityRole="button"

--- a/rider-app/app/ai-assistant.tsx
+++ b/rider-app/app/ai-assistant.tsx
@@ -73,7 +73,7 @@ function RideStatusBanner({ colors, styles }: { colors: ThemeColors; styles: Ret
 
   const handleShare = async () => {
     try {
-      const res = await api.get(`/rides/${currentRide.id}/share`);
+      const res = await api.get<{ share_url?: string }>(`/rides/${currentRide.id}/share`);
       const url = res.data?.share_url;
       if (url) await Share.share({ message: `Follow my Spinr trip live: ${url}` });
     } catch (error) {

--- a/rider-app/hooks/__tests__/useSpinrPaymentSheet.test.ts
+++ b/rider-app/hooks/__tests__/useSpinrPaymentSheet.test.ts
@@ -56,7 +56,7 @@ describe('useSpinrPaymentSheet', () => {
       outcome = await result.current.presentSheet({ rideId: 'ride-1', amount: 15.5 });
     });
     expect(outcome!.ok).toBe(true);
-    expect(mockApi.post).toHaveBeenCalledWith('/payments/payment-sheet', { amount: 15.5, ride_id: 'ride-1' });
+    expect(mockApi.post).toHaveBeenCalledWith('/payments/payment-sheet', { amount: 15.5, ride_id: 'ride-1', tip_amount: 0 });
   });
 
   it('includes tipAmount in the total sent to the backend', async () => {

--- a/rider-app/store/__tests__/aiChatStore.test.ts
+++ b/rider-app/store/__tests__/aiChatStore.test.ts
@@ -135,7 +135,7 @@ describe('sendMessage', () => {
 
 describe('config + history', () => {
   it('loadConfig gates the entry points', async () => {
-    mockApi.get.mockResolvedValueOnce({ data: { enabled: true, disclaimer: 'AI can be wrong.' } });
+    mockApi.get.mockResolvedValueOnce({ data: { enabled: true, disclaimer: 'AI can be wrong.' }, status: 200 });
     await useAiChatStore.getState().loadConfig();
     expect(useAiChatStore.getState().enabled).toBe(true);
     expect(useAiChatStore.getState().disclaimer).toBe('AI can be wrong.');
@@ -154,6 +154,7 @@ describe('config + history', () => {
           { id: 'm2', role: 'assistant', content: 'hello!', created_at: '2026-06-01T00:00:01Z' },
         ],
       },
+      status: 200,
     });
     await useAiChatStore.getState().loadHistory();
     const { messages, conversationId } = useAiChatStore.getState();

--- a/rider-app/store/__tests__/rideStore.restart.test.ts
+++ b/rider-app/store/__tests__/rideStore.restart.test.ts
@@ -24,6 +24,8 @@ jest.mock('@shared/api/client', () => ({
     patch: jest.fn(),
     delete: jest.fn(),
   },
+  hasAuthToken: jest.fn(() => true),
+  SpinrApiError: class SpinrApiError extends Error {},
 }));
 
 jest.mock('@shared/store/authStore', () => ({

--- a/rider-app/store/__tests__/rideStore.test.ts
+++ b/rider-app/store/__tests__/rideStore.test.ts
@@ -21,7 +21,12 @@ jest.mock('@shared/api/client', () => {
     patch: jest.fn(),
     delete: jest.fn(),
   };
-  return { __esModule: true, default: mockClient };
+  return {
+    __esModule: true,
+    default: mockClient,
+    hasAuthToken: jest.fn(() => true),
+    SpinrApiError: class SpinrApiError extends Error {},
+  };
 });
 
 // Mock the auth store (imported transitively via @shared/store/authStore)
@@ -297,7 +302,13 @@ describe('rideStore — double-booking prevention', () => {
       currentRide: makeRide('searching') as any,
     });
 
-    // The store guard throws before the API is ever called, so no mock is needed.
+    // The guard revalidates against the server before throwing, so
+    // GET /rides/active must confirm the ride is still live.
+    const mockApi = require('@shared/api/client').default;
+    mockApi.get.mockResolvedValueOnce({
+      data: { active: true, ride: makeRide('searching') },
+      status: 200,
+    });
     await expect(
       act(async () => { await useRideStore.getState().createRide('card'); })
     ).rejects.toThrow('A ride is already active');
@@ -315,11 +326,11 @@ describe('rideStore — cancel after driver_arrived', () => {
     err.response = { status: 400, data: { detail: 'Cancellation fee applies after driver has arrived' } };
     mockApi.post.mockRejectedValueOnce(err);
 
+    // cancelRide records the error in state and rethrows so callers can react
     await act(async () => {
-      await useRideStore.getState().cancelRide();
+      await expect(useRideStore.getState().cancelRide()).rejects.toThrow('Cancellation fee applies');
     });
 
-    // cancelRide swallows the error into state — verify error was recorded
     expect(useRideStore.getState().error).toBeTruthy();
     // Ride is NOT cleared on error — rider stays on the screen
     expect(useRideStore.getState().currentRide).not.toBeNull();
@@ -394,9 +405,9 @@ describe('rideStore — cancelRide after driver_arrived', () => {
     err.response = { status: 400, data: { detail: 'Cancellation fee applies' } };
     mockApi.post.mockRejectedValueOnce(err);
 
-    // cancelRide does not rethrow — it sets error state
+    // cancelRide sets error state and rethrows for the caller to handle
     await act(async () => {
-      await useRideStore.getState().cancelRide();
+      await expect(useRideStore.getState().cancelRide()).rejects.toThrow();
     });
 
     const state = useRideStore.getState();

--- a/rider-app/store/__tests__/walletStore.test.ts
+++ b/rider-app/store/__tests__/walletStore.test.ts
@@ -47,7 +47,9 @@ describe('walletStore', () => {
       isLoading: false,
       error: null,
     });
-    jest.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so unconsumed mockResolvedValueOnce
+    // values can never leak between tests.
+    jest.resetAllMocks();
   });
 
   // ---------------------------------------------------------------------------
@@ -75,15 +77,24 @@ describe('walletStore', () => {
 
   // ---------------------------------------------------------------------------
   describe('topUp', () => {
-    it('updates wallet balance after top-up', async () => {
+    it('returns PaymentSheet params and leaves the balance untouched', async () => {
+      // topUp only creates the Stripe PaymentIntent; the balance updates
+      // after the PaymentSheet flow completes and fetchWallet refetches.
       useWalletStore.setState({ wallet: makeWallet({ balance: '50.00' }) });
-      mockApi.post.mockResolvedValueOnce({ data: { balance: 70.0 }, status: 200 });
-      mockApi.get.mockResolvedValueOnce({ data: makeWallet({ balance: '70.00' }), status: 200 });
+      const sheetParams = {
+        paymentIntent: 'pi_secret',
+        ephemeralKey: 'ek_test',
+        customer: 'cus_1',
+        publishableKey: 'pk_test',
+      };
+      mockApi.post.mockResolvedValueOnce({ data: sheetParams, status: 200 });
 
-      await useWalletStore.getState().topUp(20.0);
+      const result = await useWalletStore.getState().topUp(20.0);
 
       expect(mockApi.post).toHaveBeenCalledWith('/wallet/top-up', { amount: 20.0 });
-      expect(useWalletStore.getState().wallet?.balance).toBe('70.00');
+      expect(result).toEqual(sheetParams);
+      expect(useWalletStore.getState().wallet?.balance).toBe('50.00');
+      expect(useWalletStore.getState().isLoading).toBe(false);
     });
 
     it('throws and sets error when top-up fails', async () => {

--- a/rider-app/store/aiChatStore.ts
+++ b/rider-app/store/aiChatStore.ts
@@ -73,7 +73,7 @@ export const useAiChatStore = create<AiChatState>((set, get) => ({
 
   loadConfig: async () => {
     try {
-      const res = await api.get('/ai/config');
+      const res = await api.get<{ enabled?: boolean; disclaimer?: string }>('/ai/config');
       set({ enabled: !!res.data?.enabled, disclaimer: res.data?.disclaimer ?? '' });
     } catch {
       // Config failure just hides the entry points; nothing to surface.
@@ -85,7 +85,9 @@ export const useAiChatStore = create<AiChatState>((set, get) => ({
     try {
       const stored = await AsyncStorage.getItem(CONVERSATION_KEY);
       if (!stored) return;
-      const res = await api.get(`/ai/conversations/${stored}/messages`);
+      const res = await api.get<{
+        messages?: { id: string; role: 'user' | 'assistant'; content: string; created_at: string }[];
+      }>(`/ai/conversations/${stored}/messages`);
       const messages: AiChatMessage[] = (res.data?.messages ?? []).map(
         (m: { id: string; role: 'user' | 'assistant'; content: string; created_at: string }) => ({
           id: m.id,

--- a/rider-app/utils/__tests__/aiChat.test.ts
+++ b/rider-app/utils/__tests__/aiChat.test.ts
@@ -77,7 +77,7 @@ function streamResponse(chunks: string[], init: { ok?: boolean; status?: number;
 
 describe('streamChat', () => {
   it('POSTs with auth + stream body and delivers events in order', async () => {
-    const fetchImpl = jest.fn(async () => streamResponse([FRAME]));
+    const fetchImpl = jest.fn(async (_url: string, _init: any) => streamResponse([FRAME]));
     const events: AiSseEvent[] = [];
     await streamChat({
       message: 'where is my driver?',
@@ -121,7 +121,7 @@ describe('streamChat', () => {
 
   it('passes the abort signal to the transport', async () => {
     const controller = new AbortController();
-    const fetchImpl = jest.fn(async () => streamResponse([]));
+    const fetchImpl = jest.fn(async (_url: string, _init: any) => streamResponse([]));
     await streamChat({
       message: 'hi',
       conversationId: null,

--- a/shared/components/SupportScreen.tsx
+++ b/shared/components/SupportScreen.tsx
@@ -63,7 +63,7 @@ async function askAssistant(
   message: string,
   conversationId: string | null,
 ): Promise<{ reply: string; conversationId: string | null }> {
-  const res = await api.post('/ai/chat', {
+  const res = await api.post<{ reply?: string; conversation_id?: string | null }>('/ai/chat', {
     message,
     conversation_id: conversationId,
     stream: false,


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Fix the white-screen crash when tapping the AI button on the home screen, gate the Account screen's "AI Assistant" row on the server-side AI config (shows a "Coming Soon" toast when disabled), and clear the pre-existing typecheck/test failures that blocked the `rider-app-test` gate.
- **Type**: `fix`
- **Linked issue**: `none` — user-reported white screen (logcat showed `ReactHost: Tried to access onWindowFocusChange while context is not ready` after the React instance died)
- **Risk**: `low` — small handler changes in rider-app screens plus type annotations and test realignment; no API, schema, or store-logic changes
- **User-visible change**: `riders` — tapping the AI button no longer white-screens the app; when AI is disabled, both entry points show a "Coming Soon" toast instead of opening a dead screen
- **Scope contract**: `[x]` This PR matches its stated type — the AI entry-point fix plus the pre-existing CI-gate failures on the same surface (rider-app tsc + jest), no product-logic changes

## Tier 2 — Impact

- **Surfaces touched**: `[x]` rider-app (one type-only annotation in `shared/components/SupportScreen.tsx`)
- **Blast radius**: `isolated`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: reads the existing `/ai/config` `enabled` flag (no new flag)
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe`
- **Dependencies / coordination**: `none`
- **Assumptions**: `none`

## Tier 3 — Compliance flags

None apply.

## Tier 4 — Verification

- **Unit tests**: full rider-app suite green — 224/224 across 21 suites; `tsc --noEmit` clean (was 15 pre-existing errors)
- **Integration tests**: `not-applicable`
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: `not-applicable`
- **Perf numbers**: `not-applicable`

**Pre-merge checklist**:

- [x] Crash verified via typecheck (pre-fix: `Cannot find name 'aiEnabled'` / `'router'` at the AI button handler; post-fix: clean)
- [x] No PII or sensitive data introduced

## Changes

### `rider-app/app/(tabs)/index.tsx` — the crash fix
The home screen's "AI" sparkle button lives in `BottomSheetContent`, a standalone top-level component, but its `onPress` closed over `aiEnabled` and `router` — variables that only exist inside `HomeScreen` (introduced in 53eef8b). The home screen rendered fine because the bad references sit inside the tap-handler closure, but tapping the button threw `ReferenceError: Property 'aiEnabled' doesn't exist`, which in release builds tears down the whole React instance → white screen.

- Hoisted the handler into `HomeScreen` as `handleAiPress()` (same pattern as `handleSearchPress`)
- Passed it as a prop to both `BottomSheetContent` call sites (tablet side panel + phone bottom sheet)

### `rider-app/app/(tabs)/account.tsx` — entry-point gating
The Account screen's "AI Assistant" row pushed to `/ai-assistant` unconditionally, bypassing the `enabled` flag from `/ai/config`.

- Added the same `handleAiPress()` gate: enabled → open the assistant; disabled → "Coming Soon" toast
- Loads the AI config on mount so the flag is fresh on direct entry

### Pre-existing `rider-app-test` gate failures (also red on `main`)
The job's `tsc --noEmit` and jest steps were failing before this PR; fixed here so the gate can pass:

- **Typing** (`ai-assistant.tsx`, `aiChatStore.ts`, `SupportScreen.tsx`, AI test files): typed the `/ai/config`, `/ai/conversations/{id}/messages`, `/rides/{id}/share`, and `/ai/chat` responses; satisfied the api/fetch mock signatures in the AI tests
- **Stale tests** (`rideStore`, `rideStore.restart`, `walletStore`, `useSpinrPaymentSheet`): mock factories now export `hasAuthToken`/`SpinrApiError` (the store imports them; their absence broke `hydrateActiveRide` and `cancelRide` tests); the double-booking test mocks the `GET /rides/active` revalidation the guard performs; `cancelRide` tests follow the set-error-and-rethrow contract; `walletStore.topUp` test matches the Stripe PaymentSheet contract (and the suite uses `resetAllMocks` so one-shot mock queues can't leak between tests); the payment-sheet POST expectation includes `tip_amount: 0`

https://claude.ai/code/session_013KBFYXPmzhRnaUw4cP3sXU

## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]` N/A — no visual changes; behavior fix only
- **Accessibility** — labels, contrast, screen reader: N/A — existing accessibility labels unchanged
- **Dark mode verified** (if theme-aware): N/A — no styling changes
- **i18n / localization strings added** (if user-visible copy): N/A — reuses the existing "Coming Soon" toast copy
- **Tested on smallest supported device width**: N/A — no layout changes

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
