### PR TITLE
fix(ci): decouple Python CVE audit from backend test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,11 @@ jobs:
   # Deploy Backend
   deploy-backend:
     runs-on: ubuntu-latest
-    needs: [backend-test]
+    # python-dependency-audit gates the deploy (not the tests): before the
+    # audit was split into its own job, a pip-audit failure inside
+    # backend-test blocked this deploy transitively — keep that release
+    # blocker intact now that tests report independently.
+    needs: [backend-test, python-dependency-audit]
     if: github.ref == 'refs/heads/main'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,6 @@ jobs:
           # separate bare `pip install pytest-mock` needed.
           pip install --require-hashes -r requirements-locked.txt
 
-      - name: Python dependency CVE scan
-        run: |
-          pip install pip-audit
-          pip-audit -r backend/requirements-locked.txt
-
       - name: Install ruff
         run: pip install ruff==0.15.12
 
@@ -94,6 +89,30 @@ jobs:
           file: ./backend/coverage.xml
           flags: backend
           name: backend-coverage
+
+  # Python dependency CVE audit.
+  # Runs as its own job — NOT as a step inside backend-test — because a newly
+  # published advisory against a pinned dependency must never gate the test
+  # suite: between 2026-05-23 and 2026-06-12 an in-step pip-audit failure
+  # silently skipped "Run backend tests" on every run of main and every PR.
+  # The audit stays a loud, first-class failure (wired into notify-failure)
+  # but tests, lint, and coverage report independently of it.
+  python-dependency-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Python dependency CVE scan
+        run: |
+          pip install pip-audit
+          pip-audit -r backend/requirements-locked.txt
 
   # Frontend (Rider App) Tests
   # DISABLED: frontend/ was deprecated 2026-04-14 (Decision D-003/D-004).
@@ -649,7 +668,7 @@ jobs:
   # Notify on failure
   notify-failure:
     runs-on: ubuntu-latest
-    needs: [backend-test, rider-app-test, driver-app-test, admin-test]
+    needs: [backend-test, rider-app-test, driver-app-test, admin-test, python-dependency-audit]
     if: failure()
 
     steps:
@@ -667,4 +686,4 @@ jobs:
         if: always()
         run: |
           echo "::warning::One or more CI jobs failed. Configure SLACK_WEBHOOK in repo secrets for Slack alerts."
-          echo "Failed needs: backend-test, rider-app-test, driver-app-test, or admin-test"
+          echo "Failed needs: backend-test, rider-app-test, driver-app-test, admin-test, or python-dependency-audit"

--- a/backend/tests/test_ws_health.py
+++ b/backend/tests/test_ws_health.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 # Stub heavy deps before any backend import (mirrors test_p3_ws_broadcast).
 _STUBS = ["loguru", "logging_utils", "fastapi", "fastapi.websockets"]
 for _m in _STUBS:


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Move the pip-audit CVE scan out of the `backend-test` job into a standalone `python-dependency-audit` job so a published dependency advisory can no longer silently skip the backend test suite; fix the missing `import pytest` (surfaced by this PR's first real test run) that aborted suite collection.
- **Type** [required]: `fix`
- **Linked issue** [required]: none — found during a live investigation (scheduled-ride dispatch triage) in a Claude session; no tracking issue existed.
- **Risk** [required]: `low` — CI workflow + one test-file import; no runtime behaviour change.
- **User-visible change** [required]: `none`
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[x]` infra  `[x]` CI
- **Blast radius** [required]: `multi-surface` — one workflow file plus one backend test file (test-only; no production code).
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none` — (GitHub Actions job, not a backend asyncio loop)
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe` — revert restores the scan as an in-job step; no state, data, or deploy coordination involved.
- **Dependencies / coordination** [required]: none to merge this — but a follow-up PR must bump the 5 vulnerable pins (aiohttp 3.13.5, urllib3 2.6.3, idna 3.13, pyjwt 2.12.1, starlette 1.0.0) in `requirements-locked.txt` so the new audit job goes green; hash regeneration needs PyPI access. Until then, `deploy-backend` in ci.yml stays gated on the audit (same as before this PR).
- **Assumptions** [required]: a dependency-advisory failure should be a loud, independent signal — not a gate that disables test execution. Audit alerting parity is kept via `notify-failure.needs`; deploy gating parity via `deploy-backend.needs` (per Codex review).
- **Not changing but considered** (optional): bumping the vulnerable pins in this PR — rejected because `--require-hashes` lockfile regeneration wasn't possible from the sandbox, and it would bundle a second logical change.

## Tier 3 — Compliance flags

- `[ ]` **Money-touching** — not applicable
- `[ ]` **PIPEDA-relevant** — not applicable
- `[ ]` **SK Transportation Act** — not applicable
- `[ ]` **Auth / RLS** — not applicable
- `[ ]` **Safety** — not applicable
- `[ ]` **Third-party SDK added** — none (pip-audit was already installed by the old step)
- `[ ]` **Breaking change to `shared/`** — not applicable

## Tier 4 — Verification

- **Unit tests** [required]: `updated` — restored suite collection: `tests/test_ws_health.py` used `@pytest.mark.anyio` without `import pytest`, a collection error that aborted pytest before any test ran (2,788 collected, 0 executed). One-line import added.
- **Integration tests** [required]: `not-applicable` — this PR's own CI run is the integration test: it is the first run since 2026-05-23 in which "Run backend tests" actually executes.
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video**: not applicable — no UI files touched.
- **Perf numbers**: not applicable — no SLA-critical runtime path touched.

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev — N/A, no backend production code change
- [ ] Tested with rider + driver + admin accounts — N/A, CI + test-only
- [ ] Verified the rollback command actually works — N/A, risk is low; plain `git revert`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` — N/A, no convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

---

### Context for reviewers

Between at least **2026-05-23 and 2026-06-12**, every `ci.yml` run on `main` (and every PR) skipped the entire backend pytest suite: the in-job pip-audit step failed on 12 published advisories against 5 pinned packages, and the test step sat behind it with no `continue-on-error`. Coverage still uploaded, so the gap was easy to miss. Verified by probing 22 runs across the window — `Python dependency CVE scan: failure` → `Run backend tests: skipped` in every one.

The first real test run on this PR immediately proved the point: a missing `import pytest` in `tests/test_ws_health.py` (merged unnoticed during the blackout) aborted collection of all 2,788 tests. Fixed in `055a372`. Deploy gating on the audit was restored in `caafd85` (Codex review finding).

**Expect this PR's checks to be partially red for pre-existing reasons:** the `python-dependency-audit` job will fail until the pins are bumped (follow-up), and the rider-app, admin-dashboard, driver-app TypeScript, and security-gates jobs are already failing on `main`. The signal to review here is `backend-test` — it now actually runs pytest.

https://claude.ai/code/session_01BkEPqtyxysMeew95qdLj7w

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
