### PR TITLE
refactor(rides): extract compute_ride_estimates from estimate route

### DIFF
--- a/admin-dashboard/src/app/dashboard/ai-console/page.tsx
+++ b/admin-dashboard/src/app/dashboard/ai-console/page.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/use-toast";
-import { Bot, Car, MapPin, MessageSquarePlus, Send, ShieldAlert, Tag, User as UserIcon } from "lucide-react";
+import { Bot, Car, LifeBuoy, MapPin, MessageSquarePlus, Send, ShieldAlert, Tag, User as UserIcon } from "lucide-react";
 import type { AiAction } from "@spinr/shared/types/ai";
 
 interface ChatBubble {
@@ -154,9 +154,24 @@ function ActionBubble({ action, onQuickSend }: { action: AiAction; onQuickSend: 
             </div>
         );
     }
+    if (action.type === "open_support") {
+        return (
+            <div className="max-w-[75%] rounded-lg border bg-muted px-3 py-2 text-sm space-y-1">
+                <div className="flex items-center gap-2 font-semibold">
+                    <LifeBuoy className="h-4 w-4 text-primary" /> Support handoff
+                </div>
+                <p className="text-xs text-muted-foreground">
+                    Category: {action.category} · opens {action.link} in the app
+                </p>
+                <p className="text-[11px] text-muted-foreground">
+                    The rider sees this as a tappable &quot;Contact support&quot; button.
+                </p>
+            </div>
+        );
+    }
     return (
         <div className="max-w-[75%] rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
-            ⚡ action → {action.type}
+            ⚡ action → {(action as { type: string }).type}
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/ai-console/page.tsx
+++ b/admin-dashboard/src/app/dashboard/ai-console/page.tsx
@@ -61,10 +61,15 @@ function ActionBubble({ action, onQuickSend }: { action: AiAction; onQuickSend: 
                 </div>
                 {action.quotes.map((q, i) => {
                     const hasSavings = !!q.promo_savings && q.final_total !== q.total;
+                    // Self-contained message (mirrors the rider app): the next
+                    // turn sees only message text, so restate the trip context.
+                    const from = action.pickup_address ? ` from ${action.pickup_address}` : "";
+                    const to = action.dropoff_address ? ` to ${action.dropoff_address}` : "";
+                    const promo = q.promo_code ? ` with promo ${q.promo_code}` : "";
                     return (
                         <button
                             key={q.vehicle_type_id ?? i}
-                            onClick={() => onQuickSend(`Book the ${q.vehicle_type ?? "recommended option"}.`)}
+                            onClick={() => onQuickSend(`Book the ${q.vehicle_type ?? "recommended option"}${from}${to}${promo}.`)}
                             className="w-full flex items-center justify-between gap-3 rounded-md bg-background px-2 py-1.5 text-left hover:bg-accent"
                         >
                             <span>

--- a/admin-dashboard/src/app/dashboard/ai-console/page.tsx
+++ b/admin-dashboard/src/app/dashboard/ai-console/page.tsx
@@ -31,12 +31,134 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/components/ui/use-toast";
-import { Bot, MessageSquarePlus, Send, ShieldAlert, User as UserIcon } from "lucide-react";
+import { Bot, Car, MapPin, MessageSquarePlus, Send, ShieldAlert, Tag, User as UserIcon } from "lucide-react";
+import type { AiAction } from "@spinr/shared/types/ai";
 
 interface ChatBubble {
     id: string;
     role: "user" | "assistant";
     content: string;
+    /** Rich client action (fare quote / location suggestions / booking
+     * proposal) — rendered as the same card the rider sees in-app. */
+    action?: AiAction;
+}
+
+/** Mirrors the rider app's action cards so the console shows exactly what
+ * the rider would see (shared/types/ai.ts is the contract for both). */
+function ActionBubble({ action, onQuickSend }: { action: AiAction; onQuickSend: (text: string) => void }) {
+    if (action.type === "fare_quote") {
+        const meta = [
+            action.distance_km != null ? `${action.distance_km} km` : null,
+            action.duration_minutes != null ? `about ${action.duration_minutes} min` : null,
+        ]
+            .filter(Boolean)
+            .join(" · ");
+        return (
+            <div className="max-w-[75%] rounded-lg border bg-muted px-3 py-2 text-sm space-y-2">
+                <div className="flex items-center gap-2 font-semibold">
+                    <Tag className="h-4 w-4 text-primary" /> Ride options
+                    {meta && <span className="font-normal text-xs text-muted-foreground">{meta}</span>}
+                </div>
+                {action.quotes.map((q, i) => {
+                    const hasSavings = !!q.promo_savings && q.final_total !== q.total;
+                    return (
+                        <button
+                            key={q.vehicle_type_id ?? i}
+                            onClick={() => onQuickSend(`Book the ${q.vehicle_type ?? "recommended option"}.`)}
+                            className="w-full flex items-center justify-between gap-3 rounded-md bg-background px-2 py-1.5 text-left hover:bg-accent"
+                        >
+                            <span>
+                                <span className="font-medium">{q.vehicle_type ?? "Ride"}</span>
+                                <span className="block text-xs text-muted-foreground">
+                                    {[
+                                        q.eta_minutes != null ? `${q.eta_minutes} min away` : null,
+                                        q.capacity != null ? `${q.capacity} seats` : null,
+                                        (q.surge_multiplier ?? 1) > 1 ? `${q.surge_multiplier}x surge` : null,
+                                    ]
+                                        .filter(Boolean)
+                                        .join(" · ")}
+                                </span>
+                                {hasSavings && (
+                                    <span className="block text-xs font-medium text-green-600">
+                                        {q.promo_code} · save ${q.promo_savings}
+                                    </span>
+                                )}
+                            </span>
+                            <span className="text-right">
+                                {hasSavings && (
+                                    <span className="block text-xs text-muted-foreground line-through">${q.total}</span>
+                                )}
+                                <span className="font-semibold">${q.final_total}</span>
+                            </span>
+                        </button>
+                    );
+                })}
+                <p className="text-[11px] text-muted-foreground">
+                    Totals include taxes &amp; fees. The rider sees this as a tappable card.
+                </p>
+            </div>
+        );
+    }
+    if (action.type === "location_suggestions") {
+        return (
+            <div className="max-w-[75%] rounded-lg border bg-muted px-3 py-2 text-sm space-y-1">
+                <div className="flex items-center gap-2 font-semibold">
+                    <MapPin className="h-4 w-4 text-primary" />
+                    Choose {action.location_role === "pickup" ? "a pickup" : action.location_role === "dropoff" ? "a dropoff" : "a location"}
+                </div>
+                {action.candidates.slice(0, 3).map((c, i) => {
+                    const label = c.address || c.name;
+                    const suffix =
+                        action.location_role === "pickup"
+                            ? " as my pickup"
+                            : action.location_role === "dropoff"
+                              ? " as my dropoff"
+                              : "";
+                    return (
+                        <button
+                            key={`${c.lat}:${c.lng}:${i}`}
+                            onClick={() => label && onQuickSend(`Use ${label}${suffix}.`)}
+                            className="w-full rounded-md bg-background px-2 py-1.5 text-left hover:bg-accent"
+                        >
+                            <span className="font-medium">{c.name || c.address}</span>
+                            {c.name && c.address && (
+                                <span className="block text-xs text-muted-foreground">{c.address}</span>
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+        );
+    }
+    if (action.type === "booking_proposal") {
+        const p = action.proposal;
+        return (
+            <div className="max-w-[75%] rounded-lg border bg-muted px-3 py-2 text-sm space-y-1">
+                <div className="flex items-center gap-2 font-semibold">
+                    <Car className="h-4 w-4 text-primary" /> Booking card shown to rider
+                </div>
+                <p className="text-xs">{p.pickup_address}</p>
+                <p className="text-xs">→ {p.dropoff_address}</p>
+                <p className="text-xs text-muted-foreground">
+                    {[
+                        p.scheduled_time ? `Scheduled ${p.scheduled_time}` : "Now",
+                        p.payment_method ?? null,
+                        p.promo_code ? `promo ${p.promo_code}` : null,
+                    ]
+                        .filter(Boolean)
+                        .join(" · ")}
+                </p>
+                <p className="text-[11px] text-muted-foreground">
+                    The ride books only when the rider taps Confirm in the app.
+                </p>
+            </div>
+        );
+    }
+    return (
+        <div className="max-w-[75%] rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground">
+            ⚡ action → {action.type}
+        </div>
+    );
 }
 
 export default function AiConsolePage() {
@@ -128,8 +250,8 @@ export default function AiConsolePage() {
         setMessages([]);
     };
 
-    const send = async () => {
-        const text = input.trim();
+    const send = async (textOverride?: string) => {
+        const text = (textOverride ?? input).trim();
         // Gate on `target` (resolved from the CURRENT results), not just the
         // stored id — never post into a user who dropped out of the search.
         if (!text || !target || sending) return;
@@ -147,10 +269,11 @@ export default function AiConsolePage() {
             setMessages((prev) => [
                 ...prev,
                 { id: res.message_id ?? `r-${Date.now()}`, role: "assistant", content: res.reply },
-                ...res.actions.map((a: any, i: number) => ({
+                ...res.actions.map((a: AiAction, i: number) => ({
                     id: `a-${Date.now()}-${i}`,
                     role: "assistant" as const,
-                    content: `⚡ action → ${a.type}${a.type === "booking_proposal" ? ` (${a.proposal?.pickup_address} → ${a.proposal?.dropoff_address})` : ""}`,
+                    content: "",
+                    action: a,
                 })),
             ]);
             loadConversations(target.id);
@@ -282,11 +405,15 @@ export default function AiConsolePage() {
                             {messages.map((m) => (
                                 <div key={m.id} className={`flex gap-2 ${m.role === "user" ? "justify-end" : ""}`}>
                                     {m.role === "assistant" && <Bot className="h-5 w-5 text-primary shrink-0 mt-1" />}
-                                    <div
-                                        className={`max-w-[75%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${m.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"}`}
-                                    >
-                                        {m.content}
-                                    </div>
+                                    {m.action ? (
+                                        <ActionBubble action={m.action} onQuickSend={(text) => send(text)} />
+                                    ) : (
+                                        <div
+                                            className={`max-w-[75%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${m.role === "user" ? "bg-primary text-primary-foreground" : "bg-muted"}`}
+                                        >
+                                            {m.content}
+                                        </div>
+                                    )}
                                     {m.role === "user" && <UserIcon className="h-5 w-5 text-muted-foreground shrink-0 mt-1" />}
                                 </div>
                             ))}
@@ -304,7 +431,7 @@ export default function AiConsolePage() {
                                 placeholder={target ? "Message as this user…" : "Select a user first"}
                                 disabled={!target || sending}
                             />
-                            <Button onClick={send} disabled={!target || sending || !input.trim()}>
+                            <Button onClick={() => send()} disabled={!target || sending || !input.trim()}>
                                 <Send className="h-4 w-4" />
                             </Button>
                         </div>

--- a/backend/ai/orchestrator.py
+++ b/backend/ai/orchestrator.py
@@ -89,6 +89,7 @@ async def run_chat_turn(
     user_message: str,
     audience: str = "rider",
     admin_actor_id: Optional[str] = None,
+    client_location: Optional[Dict[str, float]] = None,
 ) -> AsyncIterator[Frame]:
     settings = await get_app_settings()
 
@@ -133,6 +134,11 @@ async def run_chat_turn(
     tools = tool_defs_for(audience)
     messages: List[Dict[str, Any]] = list(history)
 
+    # Device location rides along to tools only (never into the prompt, the
+    # conversation rows, or logs) — booking tools use it to bias place
+    # search and resolve "my location" pickups.
+    tool_user = {**user, "_client_location": client_location} if client_location else user
+
     max_iterations = int(settings.get("ai_max_tool_iterations") or 6)
     all_text: List[str] = []
     used_tool_names: List[str] = []
@@ -163,7 +169,7 @@ async def run_chat_turn(
             for tc in tool_calls:
                 yield "tool", {"name": tc.name, "status": "start"}
             results = await asyncio.gather(
-                *(execute_tool(tc.name, tc.arguments, user=user, audience=audience) for tc in tool_calls)
+                *(execute_tool(tc.name, tc.arguments, user=tool_user, audience=audience) for tc in tool_calls)
             )
             for tc, (result, ok) in zip(tool_calls, results, strict=True):
                 used_tool_names.append(tc.name)

--- a/backend/ai/orchestrator.py
+++ b/backend/ai/orchestrator.py
@@ -134,10 +134,13 @@ async def run_chat_turn(
     tools = tool_defs_for(audience)
     messages: List[Dict[str, Any]] = list(history)
 
-    # Device location rides along to tools only (never into the prompt, the
-    # conversation rows, or logs) — booking tools use it to bias place
-    # search and resolve "my location" pickups.
-    tool_user = {**user, "_client_location": client_location} if client_location else user
+    # Per-turn context rides along to tools only (never into the prompt, the
+    # conversation rows, or logs): device location lets booking tools bias
+    # place search / resolve "my location"; the conversation id lets
+    # escalate_to_support attach a transcript to the ticket.
+    tool_user = {**user, "_conversation_id": conversation["id"]}
+    if client_location:
+        tool_user["_client_location"] = client_location
 
     max_iterations = int(settings.get("ai_max_tool_iterations") or 6)
     all_text: List[str] = []

--- a/backend/ai/prompts.py
+++ b/backend/ai/prompts.py
@@ -34,31 +34,37 @@ call 911 or use the SOS button in the app immediately. You are not an emergency 
 service. Do this BEFORE anything else.
 
 BOOKING FLOW (in order)
-1. Resolve pickup and dropoff before quoting. Use get_saved_places for "home", \
-"work" or other saved-place language. If no saved place matches, ask for the \
-missing address instead of pretending it exists. Use find_place for named places \
-or partial addresses. When you know one endpoint, pass its coordinates as the \
-near_* bias so vague names like "Walmart" return nearby choices. If find_place \
-returns several candidates, show the choices and ask the rider to pick one.
-2. Ask whether the ride is for now or later. If later, ask for an exact date and \
-time before showing the booking card.
-3. Quote with get_fare_quote and present it as approximate, mentioning surge if \
-above 1x. Always name the vehicle options returned. Recommend the cheapest \
-available standard option for fastest matching unless the rider needs more seats \
-or asks for a specific vehicle type.
-4. If the rider asks for promos or "best savings", use get_available_promos, \
-choose the highest likely savings from the returned promos, and remember that \
-promo_code for the booking card. Do not say a free-ride promo is CA$0 off.
-5. Ask for payment preference only as card or wallet. You cannot change saved \
-cards or payment setup; if they say wallet, pass payment_method="wallet".
-6. Before propose_ride_booking, summarize pickup, dropoff, now/later time, \
-vehicle, promo and payment method in one short message. If the rider has already \
-said "book it", "confirm", or equivalent after seeing the quote, that is enough \
-confirmation to show the card.
-7. Only after the rider clearly confirms they want to book, call \
-propose_ride_booking once with the exact coordinates, selected vehicle_type_id, \
-promo_code, scheduled_time if any, and payment_method. Then tell them to review \
-the card and tap Confirm.
+1. Resolve pickup and dropoff before quoting, using tools — not questions — \
+wherever possible. Use get_saved_places for "home", "work" or other saved-place \
+language. Use get_rider_location when the rider says "my location", "where I \
+am", or names only a destination — confirm the address it returns in your reply \
+instead of asking them to type one. Use find_place for named places or partial \
+addresses; it automatically searches near the rider's known location, and when \
+several candidates return the rider sees them as tappable choices — ask which \
+one they mean.
+2. Assume the ride is for now. Only ask about timing if the rider mentions \
+later, a specific time, or scheduling — then get an exact date and time before \
+the booking card.
+3. Quote with get_fare_quote as soon as both points are known. It returns exact \
+totals (taxes, fees and live surge included) for the available vehicle options \
+with the best eligible promo already applied, and the rider sees a quote card \
+automatically — so keep your reply to one or two short sentences: name the \
+recommended option, mention the promo savings if any, then ask if they want to \
+book or see other promo codes. Never recompute or restate every number the card \
+already shows. Mention surge only when above 1x.
+4. If the rider asks about other promos, use get_available_promos to list them; \
+pass whichever code they choose as promo_code when proposing the booking. Do \
+not say a free-ride promo is CA$0 off.
+5. Do not ask about payment unless the rider brings it up — the booking card \
+uses their saved default. If they say wallet, pass payment_method="wallet". You \
+cannot change saved cards or payment setup.
+6. When the rider picks an option or says "book it", "confirm", or equivalent \
+after seeing the quote, that is enough confirmation: call propose_ride_booking \
+once with the exact coordinates, chosen vehicle_type_id, the promo_code that \
+was applied, scheduled_time if any, and payment_method if stated. Then tell \
+them to review the card and tap Confirm.
+7. Ask at most one question per message, and never ask for information a tool \
+already gave you.
 
 TRANSCRIPTS
 - If the rider asks for a transcript of this chat, provide the visible recent \

--- a/backend/ai/prompts.py
+++ b/backend/ai/prompts.py
@@ -45,8 +45,9 @@ one they mean.
 2. Assume the ride is for now. Only ask about timing if the rider mentions \
 later, a specific time, or scheduling — then get an exact date and time before \
 the booking card.
-3. Quote with get_fare_quote as soon as both points are known. It returns exact \
-totals (taxes, fees and live surge included) for the available vehicle options \
+3. Quote with get_fare_quote as soon as both points are known, always passing \
+the resolved pickup_address and dropoff_address with the coordinates. It returns \
+exact totals (taxes, fees and live surge included) for the available vehicle options \
 with the best eligible promo already applied, and the rider sees a quote card \
 automatically — so keep your reply to one or two short sentences: name the \
 recommended option, mention the promo savings if any, then ask if they want to \

--- a/backend/ai/tools_booking.py
+++ b/backend/ai/tools_booking.py
@@ -1,4 +1,4 @@
-"""Booking-flow tools: place lookup, approximate quote, booking proposal.
+"""Booking-flow tools: place lookup, rider location, fare quote, booking proposal.
 
 Trust boundary (see plan §3.3): the model can only *propose* a booking.
 propose_ride_booking returns a ``_client_action`` payload that the app
@@ -11,9 +11,13 @@ These tools are chat-only (mcp_exposed=False) and rider-only. Coordinates
 flow through tool results because the flow needs them; they are ephemeral —
 never logged, never persisted (backend/ai/tools.py contract + migration 140).
 
-The conversational quote is an APPROXIMATION (same fare-config data the
-/fares endpoint serves, Decimal math, surge included) and is labelled as
-such; the binding number is on the card.
+get_fare_quote runs the SAME engine as POST /rides/estimate
+(compute_ride_estimates: geofence, live driver availability/ETA, surge,
+fees + taxes) and auto-applies the best eligible promo through the same
+helpers as /promo/available — so the chat quote, the booking card and the
+rider's receipt can never disagree. The quote also ships a ``fare_quote``
+client action so both the rider app and the admin AI console render it as
+a rich card instead of re-reading numbers from model prose.
 """
 
 import logging
@@ -21,6 +25,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Dict, Optional
 
 import httpx
+from fastapi import HTTPException
 
 try:
     from .tools import ToolSpec, register
@@ -28,11 +33,11 @@ except ImportError:
     from ai.tools import ToolSpec, register
 
 try:
-    from ..geo_utils import calculate_distance
+    from .. import db_supabase
     from ..settings_loader import get_app_settings
     from ..utils.maps_budget import check_budget, record_call
 except ImportError:
-    from geo_utils import calculate_distance
+    import db_supabase
     from settings_loader import get_app_settings
     from utils.maps_budget import check_budget, record_call
 
@@ -193,6 +198,60 @@ async def _places_available() -> tuple:
     return api_key, None
 
 
+async def _rider_location_hint(user: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Rider's best-known location: the device location the app sent with
+    this chat turn, else their most recent ride's pickup. Coordinates are
+    ephemeral tool data — never logged, never persisted."""
+    loc = user.get("_client_location") or {}
+    if loc.get("lat") is not None and loc.get("lng") is not None:
+        return {"lat": float(loc["lat"]), "lng": float(loc["lng"]), "source": "device"}
+    try:
+        rows = await db_supabase.get_rows("rides", {"rider_id": user["id"]}, order="created_at", desc=True, limit=1)
+    except Exception:
+        logger.error("ai rider location hint lookup failed", exc_info=True)
+        return None
+    if rows and rows[0].get("pickup_lat") is not None and rows[0].get("pickup_lng") is not None:
+        return {
+            "lat": rows[0]["pickup_lat"],
+            "lng": rows[0]["pickup_lng"],
+            "source": "last_ride",
+            "address": rows[0].get("pickup_address"),
+        }
+    return None
+
+
+async def get_rider_location(user: Dict[str, Any]) -> Dict[str, Any]:
+    hint = await _rider_location_hint(user)
+    if not hint:
+        return {"error": "no known location for this rider — ask them for a pickup address"}
+
+    result: Dict[str, Any] = {"lat": hint["lat"], "lng": hint["lng"], "source": hint["source"]}
+    if hint.get("address"):
+        result["address"] = hint["address"]
+    elif hint["source"] == "device":
+        # Reverse geocode so the model has an address label for the booking
+        # card. Budget-gated like every other Maps call; coords still work
+        # without it.
+        api_key, error = await _places_available()
+        if not error:
+            try:
+                data = await _maps_get(
+                    _GEOCODE_URL,
+                    {"latlng": f"{hint['lat']},{hint['lng']}", "key": api_key, "language": "en"},
+                )
+                if data.get("status") == "OK" and data.get("results"):
+                    result["address"] = data["results"][0].get("formatted_address")
+                    await record_call("geocode")
+            except Exception:
+                logger.error("ai get_rider_location reverse geocode failed", exc_info=True)
+    result["note"] = (
+        "This is the rider's live device location."
+        if hint["source"] == "device"
+        else "This is the pickup of their most recent ride — confirm it's still where they are."
+    )
+    return result
+
+
 async def find_place(
     user: Dict[str, Any],
     query: str,
@@ -204,6 +263,16 @@ async def find_place(
     if error:
         return error
 
+    # No explicit bias from the model → centre the search on the rider's
+    # best-known location so "superstore" means THEIR superstore, not one
+    # three provinces away.
+    bias_source = None
+    if near_lat is None or near_lng is None:
+        hint = await _rider_location_hint(user)
+        if hint:
+            near_lat, near_lng = hint["lat"], hint["lng"]
+            bias_source = hint["source"]
+
     lookup = await _lookup_place_candidates(api_key=api_key, query=query, near_lat=near_lat, near_lng=near_lng)
     if lookup.get("error"):
         return {"error": lookup["error"]}
@@ -211,12 +280,46 @@ async def find_place(
     if not candidates:
         return {"candidates": [], "note": "No matching place found — ask the rider to rephrase or pick on the map."}
     if len(candidates) > 1:
-        return {
+        result = {
             "candidates": candidates,
             "_client_action": _suggestions_action(query, candidates, location_role),
             "note": "Multiple matches — ask the rider which one they mean.",
         }
-    return {"candidates": candidates}
+    else:
+        result = {"candidates": candidates}
+    if bias_source:
+        result["search_biased_by"] = bias_source
+    return result
+
+
+def _ride_portion(estimate: Dict[str, Any]) -> Decimal:
+    """base+dist+time — the only part promos discount (never fees/taxes)."""
+    return (
+        _money(estimate.get("base_fare", 0))
+        + _money(estimate.get("distance_fare", 0))
+        + _money(estimate.get("time_fare", 0))
+    )
+
+
+def _best_promo_for(promos: list, portion: Decimal, total: Decimal) -> Optional[Dict[str, Any]]:
+    """Pick the promo with the biggest savings for one vehicle quote, using
+    the same Decimal math as /promo/available (compute_promo_discount)."""
+    try:
+        from ..routes.promotions import compute_promo_discount
+    except ImportError:
+        from routes.promotions import compute_promo_discount
+
+    best_code, best_discount = None, Decimal("0")
+    for p in promos or []:
+        min_fare = Decimal(str(p.get("min_ride_fare") or 0))
+        if min_fare > 0 and portion < min_fare:
+            continue  # min-fare eligibility is per vehicle type
+        discount = min(compute_promo_discount(p, portion, total), total)
+        if discount > best_discount:
+            best_code, best_discount = p.get("code"), discount
+    if not best_code or best_discount <= 0:
+        return None
+    return {"code": best_code, "savings": str(_money(best_discount))}
 
 
 async def get_fare_quote(
@@ -226,54 +329,119 @@ async def get_fare_quote(
     dropoff_lat: float,
     dropoff_lng: float,
 ) -> Dict[str, Any]:
-    area = await _resolve_area(pickup_lat, pickup_lng)
-    if area is None:
+    try:
+        from ..routes.rides import RideEstimateRequest, compute_ride_estimates
+    except ImportError:
+        from routes.rides import RideEstimateRequest, compute_ride_estimates
+
+    try:
+        estimate_result = await compute_ride_estimates(
+            RideEstimateRequest(
+                pickup_lat=pickup_lat,
+                pickup_lng=pickup_lng,
+                dropoff_lat=dropoff_lat,
+                dropoff_lng=dropoff_lng,
+            ),
+            user["id"],
+            include_polyline=False,
+        )
+    except HTTPException as exc:
+        detail = exc.detail if isinstance(exc.detail, dict) else {"message": str(exc.detail)}
         return {
-            "error": "pickup is outside Spinr's service areas",
+            "error": detail.get("message") or "this trip cannot be quoted",
             "hint": "use get_service_info to list operating cities",
         }
 
-    try:
-        from ..routes.fares import get_fares_for_location
-    except ImportError:
-        from routes.fares import get_fares_for_location
+    estimates = estimate_result.get("estimates") or []
+    if not estimates:
+        return {"error": "no vehicle options are configured for this pickup area"}
 
-    fares = await get_fares_for_location(pickup_lat, pickup_lng)
-    distance_km = calculate_distance(pickup_lat, pickup_lng, dropoff_lat, dropoff_lng)
-    # Same heuristic the /rides/estimate endpoint uses for duration.
-    duration_minutes = int(distance_km / 30 * 60) + 5
+    # Best eligible promo, fetched once through the same engine as
+    # /promo/available. A promo failure must not kill the quote — surface it
+    # in the result instead.
+    promos: list = []
+    promo_note = None
+    try:
+        from ..routes.promotions import list_available_promos
+    except ImportError:
+        from routes.promotions import list_available_promos
+    basis = min(
+        [e for e in estimates if e.get("available")] or estimates,
+        key=lambda e: Decimal(str(e.get("grand_total", 0))),
+    )
+    try:
+        promos = await list_available_promos(
+            user["id"],
+            ride_fare=float(Decimal(str(basis.get("grand_total", 0)))),
+            ride_portion=float(_ride_portion(basis)),
+            pickup_lat=pickup_lat,
+            pickup_lng=pickup_lng,
+        )
+    except Exception:
+        logger.error("ai get_fare_quote promo lookup failed", exc_info=True)
+        promo_note = "promo lookup failed — quote shown without promo savings"
 
     quotes = []
-    for f in fares or []:
-        vt = f.get("vehicle_type") or {}
-        surge = Decimal(str(f.get("surge_multiplier", 1.0)))
-        ride_fare = (
-            _money(f.get("base_fare", 0))
-            + _money(f.get("per_km_rate", 0)) * _money(distance_km)
-            + _money(f.get("per_minute_rate", 0)) * Decimal(duration_minutes)
-        )
-        ride_fare = max(ride_fare, _money(f.get("minimum_fare", 0)))
-        approx = _money(ride_fare * surge + _money(f.get("booking_fee", 0)))
-        quotes.append(
-            {
-                "vehicle_type_id": vt.get("id"),
-                "vehicle_type": vt.get("name"),
-                "capacity": vt.get("capacity"),
-                "approx_fare": str(approx),
-                "surge_multiplier": float(surge),
-            }
-        )
+    unavailable = []
+    for e in estimates:
+        vt = e.get("vehicle_type") or {}
+        if not e.get("available"):
+            if vt.get("name"):
+                unavailable.append(vt["name"])
+            continue
+        total = _money(e.get("grand_total", 0))
+        promo = _best_promo_for(promos, _ride_portion(e), total)
+        quote = {
+            "vehicle_type_id": vt.get("id"),
+            "vehicle_type": vt.get("name"),
+            "capacity": vt.get("capacity"),
+            "image_url": vt.get("image_url"),
+            "eta_minutes": e.get("eta_minutes"),
+            "drivers_nearby": e.get("driver_count"),
+            "surge_multiplier": e.get("surge_multiplier"),
+            "total": str(total),
+            "final_total": str(total - _money(promo["savings"])) if promo else str(total),
+        }
+        if promo:
+            quote["promo_code"] = promo["code"]
+            quote["promo_savings"] = promo["savings"]
+        quotes.append(quote)
 
-    return {
-        "service_area": area.get("name"),
-        "distance_km": round(distance_km, 1),
-        "duration_minutes": duration_minutes,
+    shared = {
+        "distance_km": estimates[0].get("distance_km"),
+        "duration_minutes": estimates[0].get("duration_minutes"),
+        "currency": "CAD",
+    }
+
+    if not quotes:
+        return {
+            **shared,
+            "quotes": [],
+            "no_drivers": True,
+            "note": (
+                "No drivers are available near this pickup right now — tell the rider "
+                "plainly and suggest trying again in a few minutes."
+            ),
+        }
+
+    recommended = min(quotes, key=lambda q: Decimal(q["final_total"]))
+    result = {
+        **shared,
         "quotes": quotes,
+        "recommended_vehicle_type_id": recommended["vehicle_type_id"],
+        "_client_action": {"type": "fare_quote", **shared, "quotes": quotes},
         "note": (
-            "Approximate, before taxes and area fees. Tell the rider the exact total "
-            "appears on the booking card before they confirm. Surge shown is live."
+            "Totals are exact (taxes and fees included) and the best eligible promo "
+            "is already applied per option. A quote card is now shown to the rider — "
+            "keep your reply to one or two short sentences (mention the savings if "
+            "any), then ask if they want to book or see other promo codes."
         ),
     }
+    if unavailable:
+        result["unavailable_vehicle_types"] = unavailable
+    if promo_note:
+        result["promo_note"] = promo_note
+    return result
 
 
 async def propose_ride_booking(
@@ -381,11 +549,28 @@ register(
 
 register(
     ToolSpec(
+        name="get_rider_location",
+        description=(
+            "Call this when the rider says 'from my location', 'near me', 'where I am', "
+            "or asks for a ride without giving a pickup. Returns their device location "
+            "(if shared with the app) or their most recent ride's pickup, with an "
+            "address when known. Confirm it with the rider before booking from it."
+        ),
+        input_schema={"type": "object", "properties": {}, "required": []},
+        handler=get_rider_location,
+        mcp_exposed=False,
+    )
+)
+
+register(
+    ToolSpec(
         name="get_fare_quote",
         description=(
-            "Call this once pickup and dropoff coordinates are known, to tell the rider "
-            "the approximate price per vehicle option (surge included). Always present it "
-            "as approximate — the exact total appears on the booking card."
+            "Call this once pickup and dropoff coordinates are known. Returns exact "
+            "totals per available vehicle option (taxes, fees and live surge included) "
+            "with the best eligible promo already applied, plus ETA and driver "
+            "availability — and shows the rider a quote card automatically. Quote "
+            "before proposing any booking."
         ),
         input_schema={
             "type": "object",

--- a/backend/ai/tools_booking.py
+++ b/backend/ai/tools_booking.py
@@ -245,7 +245,7 @@ async def get_rider_location(user: Dict[str, Any]) -> Dict[str, Any]:
             except Exception:
                 logger.error("ai get_rider_location reverse geocode failed", exc_info=True)
     result["note"] = (
-        "This is the rider's live device location."
+        "This is a recent fix from the rider's device — confirm the address with them before booking."
         if hint["source"] == "device"
         else "This is the pickup of their most recent ride — confirm it's still where they are."
     )
@@ -328,6 +328,8 @@ async def get_fare_quote(
     pickup_lng: float,
     dropoff_lat: float,
     dropoff_lng: float,
+    pickup_address: Optional[str] = None,
+    dropoff_address: Optional[str] = None,
 ) -> Dict[str, Any]:
     try:
         from ..routes.rides import RideEstimateRequest, compute_ride_estimates
@@ -412,6 +414,14 @@ async def get_fare_quote(
         "duration_minutes": estimates[0].get("duration_minutes"),
         "currency": "CAD",
     }
+    # Addresses ride along in the card so a tapped option can send a
+    # self-contained "Book the X from A to B" message — conversation history
+    # keeps only message text, so the next turn must not depend on this
+    # turn's tool results (Codex review, PR #1843).
+    if pickup_address:
+        shared["pickup_address"] = pickup_address
+    if dropoff_address:
+        shared["dropoff_address"] = dropoff_address
 
     if not quotes:
         return {
@@ -569,12 +579,17 @@ register(
             "Call this once pickup and dropoff coordinates are known. Returns exact "
             "totals per available vehicle option (taxes, fees and live surge included) "
             "with the best eligible promo already applied, plus ETA and driver "
-            "availability — and shows the rider a quote card automatically. Quote "
-            "before proposing any booking."
+            "availability — and shows the rider a quote card automatically. Always "
+            "pass the resolved pickup_address and dropoff_address so the card's "
+            "tap-to-book works. Quote before proposing any booking."
         ),
         input_schema={
             "type": "object",
-            "properties": dict(_COORD_PROPS),
+            "properties": {
+                **_COORD_PROPS,
+                "pickup_address": {"type": "string", "maxLength": 300},
+                "dropoff_address": {"type": "string", "maxLength": 300},
+            },
             "required": ["pickup_lat", "pickup_lng", "dropoff_lat", "dropoff_lng"],
         },
         handler=get_fare_quote,

--- a/backend/ai/tools_support.py
+++ b/backend/ai/tools_support.py
@@ -2,18 +2,22 @@
 
 Available to both rider and driver audiences. escalate_to_support is the
 assistant's only potential side effect, and it is OFF by default: it
-returns a deep-link payload the client renders as a "Contact support"
-button. Only when app_settings.ai_escalation_creates_ticket is enabled does
-it open a Zoho ticket (reusing the existing /support/escalate integration).
-Safety topics always route to 911/SOS language — never just a ticket.
+returns an ``open_support`` _client_action the apps render as a "Contact
+support" button. Only when app_settings.ai_escalation_creates_ticket is
+enabled does it open a Zoho ticket (reusing the existing /support/escalate
+integration), attaching the recent chat transcript so agents get context
+without asking the user to repeat themselves. Safety topics always route
+to 911/SOS language — never just a ticket.
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 try:
+    from . import conversations
     from .tools import ToolSpec, register
 except ImportError:
+    from ai import conversations
     from ai.tools import ToolSpec, register
 
 try:
@@ -58,11 +62,19 @@ async def search_faqs(user: Dict[str, Any], query: str) -> Dict[str, Any]:
     q_tokens = _tokenize(query)
     scored = []
     for row in rows or []:
-        text = f"{row.get('question', '')} {row.get('answer', '')} {row.get('category', '')}"
-        overlap = len(q_tokens & _tokenize(text))
-        if overlap:
-            scored.append((overlap, row))
+        # Question matches count double — a query echoing the question is a
+        # far stronger signal than the same words buried in an answer body.
+        question_overlap = len(q_tokens & _tokenize(row.get("question", "")))
+        body_overlap = len(q_tokens & _tokenize(f"{row.get('answer', '')} {row.get('category', '')}"))
+        score = question_overlap * 2 + body_overlap
+        if score:
+            scored.append((score, row))
     scored.sort(key=lambda pair: pair[0], reverse=True)
+    if not scored:
+        return {
+            "results": [],
+            "note": "No matching help-centre article — say so plainly and offer escalate_to_support.",
+        }
     return {
         "results": [
             {
@@ -86,12 +98,42 @@ async def get_company_info(user: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+# Transcript bounds for escalation tickets: enough for an agent to catch up,
+# small enough to keep tickets readable.
+_TRANSCRIPT_MAX_MESSAGES = 10
+_TRANSCRIPT_MAX_MESSAGE_CHARS = 300
+
+
+async def _recent_transcript(conversation_id: Optional[str]) -> Optional[str]:
+    """Compact 'User:/Assistant:' transcript of the current conversation for
+    the support ticket. Messages are already PII-scrubbed at ingest. Returns
+    None when unavailable — a transcript must never block an escalation."""
+    if not conversation_id:
+        return None
+    try:
+        history = await conversations.load_history(conversation_id, _TRANSCRIPT_MAX_MESSAGES)
+    except Exception:
+        logger.error("ai escalation transcript load failed", exc_info=True)
+        return None
+    lines = []
+    for m in history:
+        label = "Assistant" if m.get("role") == "assistant" else "User"
+        content = (m.get("content") or "").strip()
+        if content:
+            lines.append(f"{label}: {content[:_TRANSCRIPT_MAX_MESSAGE_CHARS]}")
+    return "\n".join(lines) or None
+
+
 async def escalate_to_support(user: Dict[str, Any], reason: str, category: str) -> Dict[str, Any]:
+    link = _CATEGORY_LINKS.get(category, _DEFAULT_LINK)
     result: Dict[str, Any] = {
         "action": "open_support",
         "category": category,
-        "link": _CATEGORY_LINKS.get(category, _DEFAULT_LINK),
+        "link": link,
         "message": "I've prepared a handoff to our human support team.",
+        # Lifted into an SSE `action` frame by the orchestrator; the apps and
+        # the admin console render it as the "Contact support" card.
+        "_client_action": {"type": "open_support", "category": category, "link": link},
     }
     if category == "safety":
         # The assistant is never an emergency channel (see CLAUDE.md).
@@ -107,8 +149,9 @@ async def escalate_to_support(user: Dict[str, Any], reason: str, category: str) 
         except ImportError:
             from services.zoho_desk_integration import create_support_ticket
         try:
+            transcript = await _recent_transcript(user.get("_conversation_id"))
             ticket = await create_support_ticket(
-                user=user, message=f"[AI escalation:{category}] {reason}", transcript=None
+                user=user, message=f"[AI escalation:{category}] {reason}", transcript=transcript
             )
             result["ticket_number"] = ticket.get("ticketNumber")
             result["message"] += " A support ticket has been opened; we'll follow up by email."
@@ -147,8 +190,7 @@ register(
     ToolSpec(
         name="get_company_info",
         description=(
-            "Call this when the user asks how to contact Spinr, the support phone/email, "
-            "or where the company is based."
+            "Call this when the user asks how to contact Spinr, the support phone/email, or where the company is based."
         ),
         input_schema={"type": "object", "properties": {}, "required": []},
         handler=get_company_info,

--- a/backend/routes/ai.py
+++ b/backend/routes/ai.py
@@ -54,10 +54,20 @@ _SSE_HEADERS = {
 }
 
 
+class AiChatLocation(BaseModel):
+    lat: float = Field(..., ge=-90, le=90)
+    lng: float = Field(..., ge=-180, le=180)
+
+
 class AiChatRequest(BaseModel):
     message: str = Field(..., min_length=1, max_length=1000)
     conversation_id: Optional[str] = Field(None, max_length=64)
     stream: bool = True
+    # Rider's current device location, sent opportunistically by the app so
+    # booking tools can bias place search / resolve "my location" pickups.
+    # Ephemeral: passed to tools for this turn only — never logged, never
+    # persisted (PIPEDA: raw GPS must not reach logs or storage).
+    location: Optional[AiChatLocation] = None
 
 
 def _audience_for(user: dict) -> str:
@@ -108,6 +118,7 @@ async def ai_chat(
         conversation_id=body.conversation_id,
         user_message=body.message,
         audience=_audience_for(current_user),
+        client_location=body.location.model_dump() if body.location else None,
     )
 
     if body.stream:

--- a/backend/routes/promotions.py
+++ b/backend/routes/promotions.py
@@ -24,7 +24,7 @@ except ImportError:
     from dependencies import get_admin_user, get_current_user
     from models.ride_status import RideStatus
     from utils.datetime_utils import parse_iso_utc
-    from utils.rate_limiter import promo_validate_limit
+    from utils.rate_limiter import promo_available_limit, promo_validate_limit
 
 get_current_admin = get_admin_user
 

--- a/backend/routes/promotions.py
+++ b/backend/routes/promotions.py
@@ -24,7 +24,7 @@ except ImportError:
     from dependencies import get_admin_user, get_current_user
     from models.ride_status import RideStatus
     from utils.datetime_utils import parse_iso_utc
-    from utils.rate_limiter import promo_available_limit, promo_validate_limit
+    from utils.rate_limiter import promo_validate_limit
 
 get_current_admin = get_admin_user
 
@@ -384,17 +384,49 @@ async def apply_promo(
     }
 
 
-@api_router.get("/available")
-@promo_available_limit
-async def get_available_promos(
-    request: Request,
-    ride_fare: float = Query(0.0),  # grand total (kept for backward compat + min-fare check)
-    ride_portion: Optional[float] = Query(None),  # ride-only portion (base+dist+time) for promo calculation
-    pickup_lat: Optional[float] = Query(None),
-    pickup_lng: Optional[float] = Query(None),
-    current_user: dict = Depends(get_current_user),
-):
-    """Get all promos available to this user, filtered by pickup service area."""
+def compute_promo_discount(promo: Dict[str, Any], ride_portion: Decimal, grand_total: Decimal) -> Decimal:
+    """Discount a promo yields for a quote — pure Decimal math shared by
+    /promo/available and the AI fare-quote tool so the advertised savings
+    always equal what settlement charges.
+
+    ``ride_portion`` is base+dist+time (the only part regular promos
+    discount — never fees or taxes); ``free_ride`` promos cover the full
+    ``grand_total`` so the rider pays $0.
+    """
+    if promo.get("free_ride"):
+        return grand_total
+    discount_type = promo.get("discount_type", "flat")
+    discount_value = Decimal(str(promo.get("discount_value", 0) or 0))
+    if discount_type == "percentage":
+        if ride_portion <= 0:
+            return Decimal("0")
+        discount = (ride_portion * discount_value / Decimal("100")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        max_cap = promo.get("max_discount")
+        if max_cap and discount > Decimal(str(max_cap)):
+            discount = Decimal(str(max_cap))
+        return discount
+    # Flat discount capped at the ride portion (driver earnings). When the
+    # ride portion is unknown (0), fall back to grand_total so we never
+    # advertise a discount larger than the rider would actually be charged.
+    cap_basis = ride_portion if ride_portion > 0 else grand_total
+    return min(discount_value, cap_basis) if cap_basis > 0 else discount_value
+
+
+async def list_available_promos(
+    user_id: str,
+    *,
+    ride_fare: float = 0.0,
+    ride_portion: Optional[float] = None,
+    pickup_lat: Optional[float] = None,
+    pickup_lng: Optional[float] = None,
+) -> list:
+    """Full promo-eligibility engine behind GET /promo/available.
+
+    Shared by the route and the AI assistant's quoting tool so every
+    surface advertises the same promos with the same amounts.
+    ``ride_fare`` is the grand total; ``ride_portion`` is base+dist+time.
+    Returns entries sorted eligible-first, biggest discount first.
+    """
     now = datetime.now(timezone.utc)
 
     # Resolve pickup service area so we can filter area-specific promos.
@@ -425,15 +457,13 @@ async def get_available_promos(
         promos = [p for p in promos if p.get("service_area_id") is None]
 
     # Pre-fetch user data for targeting checks
-    user = await db_supabase.get_user_by_id(current_user["id"])
-    total_rides = await db_supabase.count_documents(
-        "rides", {"rider_id": current_user["id"], "status": RideStatus.COMPLETED}
-    )
+    user = await db_supabase.get_user_by_id(user_id)
+    total_rides = await db_supabase.count_documents("rides", {"rider_id": user_id, "status": RideStatus.COMPLETED})
     recent_cutoff_30 = (now - timedelta(days=30)).isoformat()
     await db_supabase.count_documents(
         "rides",
         {
-            "rider_id": current_user["id"],
+            "rider_id": user_id,
             "status": RideStatus.COMPLETED,
             "ride_completed_at": {"$gte": recent_cutoff_30},
         },
@@ -441,7 +471,7 @@ async def get_available_promos(
 
     # Pre-fetch all user promo applications in one query so per-promo usage
     # check is O(1) instead of one DB call per promo (N+1 reduction).
-    all_user_apps = await db_supabase.get_rows("promo_applications", {"user_id": current_user["id"]}, limit=2000) or []
+    all_user_apps = await db_supabase.get_rows("promo_applications", {"user_id": user_id}, limit=2000) or []
     user_usage_by_promo: dict = {}
     for app in all_user_apps:
         pid = app.get("promo_id")
@@ -481,7 +511,7 @@ async def get_available_promos(
 
             # Private coupon
             assigned = p.get("assigned_user_ids", [])
-            if assigned and current_user["id"] not in assigned:
+            if assigned and user_id not in assigned:
                 continue  # noqa: E701
 
             # First ride only
@@ -502,7 +532,7 @@ async def get_available_promos(
                 recent = await db_supabase.count_documents(
                     "rides",
                     {
-                        "rider_id": current_user["id"],
+                        "rider_id": user_id,
                         "status": RideStatus.COMPLETED,
                         "ride_completed_at": {"$gte": cutoff},
                     },
@@ -528,26 +558,7 @@ async def get_available_promos(
             free_ride_flag = p.get("free_ride", False)
             discount_type = p.get("discount_type", "flat")
             discount_value = Decimal(str(p.get("discount_value", 0) or 0))
-            if free_ride_flag:
-                discount = ride_fare_d  # covers everything; rider pays $0
-            elif discount_type == "percentage":
-                # Applies to ride portion only (never to fees/taxes)
-                if effective_ride > 0:
-                    discount = (effective_ride * discount_value / Decimal("100")).quantize(
-                        Decimal("0.01"), rounding=ROUND_HALF_UP
-                    )
-                else:
-                    discount = Decimal("0")
-                max_cap = p.get("max_discount")
-                if max_cap and discount > Decimal(str(max_cap)):
-                    discount = Decimal(str(max_cap))
-            else:
-                # Flat discount capped at the ride portion (driver earnings:
-                # base+dist+time). When the ride portion is unknown (0), fall
-                # back to ride_fare so we never advertise a discount larger
-                # than the rider would actually be charged.
-                cap_basis = effective_ride if effective_ride > 0 else ride_fare_d
-                discount = min(discount_value, cap_basis) if cap_basis > 0 else discount_value
+            discount = compute_promo_discount(p, effective_ride, ride_fare_d)
 
             entry: dict = {
                 "promo_id": p["id"],
@@ -574,6 +585,26 @@ async def get_available_promos(
     # Eligible first, then by biggest discount
     available.sort(key=lambda x: (not x.get("eligible", True), -x["discount_amount"]))
     return available
+
+
+@api_router.get("/available")
+@promo_available_limit
+async def get_available_promos(
+    request: Request,
+    ride_fare: float = Query(0.0),  # grand total (kept for backward compat + min-fare check)
+    ride_portion: Optional[float] = Query(None),  # ride-only portion (base+dist+time) for promo calculation
+    pickup_lat: Optional[float] = Query(None),
+    pickup_lng: Optional[float] = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    """Get all promos available to this user, filtered by pickup service area."""
+    return await list_available_promos(
+        current_user["id"],
+        ride_fare=ride_fare,
+        ride_portion=ride_portion,
+        pickup_lat=pickup_lat,
+        pickup_lng=pickup_lng,
+    )
 
 
 # ============ Admin Promo Code CRUD ============

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -115,6 +115,7 @@ except ImportError:
     from utils.insurance_periods import record_period_transition  # type: ignore[assignment]
     from utils.metrics import inc as _metric_inc  # type: ignore
     from utils.metrics import observe as _metric_observe  # type: ignore
+    from utils.metrics import timed as _metric_timed  # type: ignore
     from utils.ride_code import generate_ride_code
 
 try:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -115,7 +115,6 @@ except ImportError:
     from utils.insurance_periods import record_period_transition  # type: ignore[assignment]
     from utils.metrics import inc as _metric_inc  # type: ignore
     from utils.metrics import observe as _metric_observe  # type: ignore
-    from utils.metrics import timed as _metric_timed  # type: ignore
     from utils.ride_code import generate_ride_code
 
 try:
@@ -1339,14 +1338,21 @@ async def _filter_reachable_drivers(all_drivers: list) -> list:
     return filtered
 
 
-@api_router.post("/estimate")
-@api_rate_limit
-@_metric_timed("spinr_fare_calc_duration_ms")
-async def estimate_ride(
+async def compute_ride_estimates(
     body: RideEstimateRequest,
-    request: Request = None,
-    current_user: dict = Depends(get_current_user),
-):
+    rider_id: str,
+    *,
+    include_polyline: bool = True,
+) -> dict:
+    """Shared estimate engine behind POST /rides/estimate.
+
+    Single fare path for every quoting surface (rider app, AI assistant
+    get_fare_quote): geofence gates, live driver availability/ETA, surge,
+    area fees + taxes, and per-vehicle surge-locked estimate tokens.
+    Raises HTTPException(400 OUTSIDE_SERVICE_AREA) exactly like the route.
+    ``include_polyline=False`` skips the Directions fetch for callers that
+    don't render a map (saves a Maps API call and its latency).
+    """
     validate_ride_location(body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng)
     distance_km = calculate_distance(body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng)
     duration_minutes = int(distance_km / 30 * 60) + 5
@@ -1459,7 +1465,7 @@ async def estimate_ride(
             logger.warning("[estimate] polyline fetch failed (non-fatal): %s", _poly_err)
             return None
 
-    polyline_task = asyncio.create_task(_polyline_fetch())
+    polyline_task = asyncio.create_task(_polyline_fetch()) if include_polyline else None
 
     # Fetch nearby online+available drivers once. Order by went_online_at DESC
     # so recently-toggled-online drivers fill the 200-row page first. Ghost
@@ -1603,7 +1609,7 @@ async def estimate_ride(
         # reuse the surge_multiplier shown here instead of re-reading the
         # service area (which may have changed between estimate + confirm).
         estimate_token = sign_estimate_token(
-            rider_id=current_user["id"],
+            rider_id=rider_id,
             vehicle_type_id=vt_id,
             pickup_lat=body.pickup_lat,
             pickup_lng=body.pickup_lng,
@@ -1653,12 +1659,13 @@ async def estimate_ride(
     # must not drag the estimate past its latency budget. On timeout the
     # task is cancelled and the app falls back to straight-line rendering.
     route_polyline = None
-    try:
-        route_polyline = await asyncio.wait_for(polyline_task, timeout=0.5)
-    except asyncio.TimeoutError:
-        logger.info("[estimate] polyline not ready within budget — returning without it (non-fatal)")
-    except Exception as _poly_err:  # defensive — _polyline_fetch traps its own errors
-        logger.warning("[estimate] polyline await failed (non-fatal): %s", _poly_err)
+    if polyline_task is not None:
+        try:
+            route_polyline = await asyncio.wait_for(polyline_task, timeout=0.5)
+        except asyncio.TimeoutError:
+            logger.info("[estimate] polyline not ready within budget — returning without it (non-fatal)")
+        except Exception as _poly_err:  # defensive — _polyline_fetch traps its own errors
+            logger.warning("[estimate] polyline await failed (non-fatal): %s", _poly_err)
 
     logger.info(
         "[estimate] returning %d estimates (polyline=%d pts): %s",
@@ -1667,6 +1674,17 @@ async def estimate_ride(
         [(e["vehicle_type"].get("name", "?"), e["available"], e["driver_count"]) for e in estimates],
     )
     return {"estimates": estimates, "route_polyline": route_polyline}
+
+
+@api_router.post("/estimate")
+@api_rate_limit
+@_metric_timed("spinr_fare_calc_duration_ms")
+async def estimate_ride(
+    body: RideEstimateRequest,
+    request: Request = None,
+    current_user: dict = Depends(get_current_user),
+):
+    return await compute_ride_estimates(body, current_user["id"])
 
 
 async def ride_search_timeout(r_id: str, timeout_seconds: int = 300):

--- a/backend/tests/test_ai_tools_booking.py
+++ b/backend/tests/test_ai_tools_booking.py
@@ -1,15 +1,18 @@
-"""Booking-flow tools: find_place, get_fare_quote, propose_ride_booking.
+"""Booking-flow tools: find_place, get_rider_location, get_fare_quote,
+propose_ride_booking.
 
 Pins the trust boundary: the proposal tool performs NO writes and returns a
 _client_action payload (rendered as a native card; Confirm goes through the
-normal POST /rides path). Also pins: out-of-area refusals, the approximate-
-quote math (Decimal, surge applied, minimum fare respected), maps-budget
-gating, and that booking tools are hidden from the MCP surface.
+normal POST /rides path). Also pins: out-of-area refusals, that the quote
+runs through the real estimate engine (compute_ride_estimates) with the
+best eligible promo auto-applied, rider-location biasing of place search,
+maps-budget gating, and that booking tools are hidden from the MCP surface.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 from backend.ai import tools_booking
 from backend.ai.tools import TOOL_REGISTRY, ensure_registry_loaded, execute_tool
@@ -17,16 +20,6 @@ from backend.ai.tools import TOOL_REGISTRY, ensure_registry_loaded, execute_tool
 RIDER = {"id": "rider-1"}
 
 AREA = {"id": "area-1", "name": "Saskatoon"}
-
-FARE_ROW = {
-    "vehicle_type": {"id": "vt-1", "name": "Spinr X", "capacity": 4},
-    "base_fare": "3.00",
-    "per_km_rate": "1.50",
-    "per_minute_rate": "0.20",
-    "minimum_fare": "7.00",
-    "booking_fee": "2.00",
-    "surge_multiplier": 1.5,
-}
 
 GEOCODE_OK = {
     "status": "OK",
@@ -83,6 +76,13 @@ def _patch_budget(within=True):
     return patch.object(tools_booking, "check_budget", AsyncMock(return_value=(within, 1.0, 10.0)))
 
 
+LAST_RIDE = {"pickup_lat": 50.4501, "pickup_lng": -104.6178, "pickup_address": "4325 Wakeling St, Regina"}
+
+
+def _patch_last_ride(rows=None):
+    return patch.object(tools_booking.db_supabase, "get_rows", AsyncMock(return_value=rows or []))
+
+
 class TestFindPlace:
     @pytest.mark.anyio
     async def test_geocodes_and_flags_service_area(self):
@@ -91,6 +91,7 @@ class TestFindPlace:
             _patch_budget(),
             _patch_http(GEOCODE_OK),
             _patch_area(),
+            _patch_last_ride(),
             patch.object(tools_booking, "record_call", AsyncMock()),
         ):
             result, ok = await execute_tool("find_place", {"query": "saskatoon airport"}, user=RIDER)
@@ -98,6 +99,38 @@ class TestFindPlace:
         cand = result["candidates"][0]
         assert cand["in_service_area"] is True
         assert cand["lat"] == 52.1708
+
+    @pytest.mark.anyio
+    async def test_biases_search_to_last_ride_pickup_when_no_near_args(self):
+        with (
+            _patch_settings(),
+            _patch_budget(),
+            _patch_http(PLACES_OK),
+            _patch_area(),
+            _patch_last_ride([LAST_RIDE]),
+            patch.object(tools_booking, "record_call", AsyncMock()),
+        ):
+            result, ok = await execute_tool("find_place", {"query": "superstore"}, user=RIDER)
+        assert ok
+        assert result["search_biased_by"] == "last_ride"
+        assert len(result["candidates"]) == 3
+
+    @pytest.mark.anyio
+    async def test_biases_search_to_device_location_first(self):
+        rides_lookup = AsyncMock(return_value=[LAST_RIDE])
+        rider = {**RIDER, "_client_location": {"lat": 50.45, "lng": -104.62}}
+        with (
+            _patch_settings(),
+            _patch_budget(),
+            _patch_http(PLACES_OK),
+            _patch_area(),
+            patch.object(tools_booking.db_supabase, "get_rows", rides_lookup),
+            patch.object(tools_booking, "record_call", AsyncMock()),
+        ):
+            result, ok = await execute_tool("find_place", {"query": "superstore"}, user=rider)
+        assert ok
+        assert result["search_biased_by"] == "device"
+        rides_lookup.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_vague_place_returns_clickable_nearby_suggestions(self):
@@ -132,6 +165,83 @@ class TestFindPlace:
         assert ok and "error" in result
 
 
+class TestRiderLocation:
+    @pytest.mark.anyio
+    async def test_device_location_preferred(self):
+        rider = {**RIDER, "_client_location": {"lat": 50.45, "lng": -104.62}}
+        no_maps = AsyncMock(return_value=(None, {"error": "unavailable"}))
+        with patch.object(tools_booking, "_places_available", no_maps):
+            result, ok = await execute_tool("get_rider_location", {}, user=rider)
+        assert ok
+        assert result["source"] == "device"
+        assert result["lat"] == 50.45 and result["lng"] == -104.62
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_last_ride_pickup_with_address(self):
+        with _patch_last_ride([LAST_RIDE]):
+            result, ok = await execute_tool("get_rider_location", {}, user=RIDER)
+        assert ok
+        assert result["source"] == "last_ride"
+        assert result["address"] == "4325 Wakeling St, Regina"
+        assert "most recent ride" in result["note"]
+
+    @pytest.mark.anyio
+    async def test_no_known_location_is_a_clean_error(self):
+        with _patch_last_ride([]):
+            result, ok = await execute_tool("get_rider_location", {}, user=RIDER)
+        assert ok and "error" in result
+
+
+ESTIMATES = {
+    "estimates": [
+        {
+            "vehicle_type": {"id": "vt-1", "name": "Economy", "capacity": 4, "image_url": None},
+            "base_fare": "3.00",
+            "distance_fare": "9.60",
+            "time_fare": "3.40",
+            "grand_total": 18.48,
+            "surge_multiplier": 1.0,
+            "available": True,
+            "eta_minutes": 4,
+            "driver_count": 2,
+            "distance_km": 6.4,
+            "duration_minutes": 17,
+        },
+        {
+            "vehicle_type": {"id": "vt-2", "name": "XL", "capacity": 6},
+            "base_fare": "5.00",
+            "distance_fare": "12.00",
+            "time_fare": "4.00",
+            "grand_total": 25.00,
+            "surge_multiplier": 1.0,
+            "available": False,
+            "eta_minutes": None,
+            "driver_count": 0,
+            "distance_km": 6.4,
+            "duration_minutes": 17,
+        },
+    ],
+    "route_polyline": None,
+}
+
+PROMOS = [
+    # flat $10 — best for the Economy ride portion (3.00+9.60+3.40 = 16.00)
+    {"code": "SAVE10", "free_ride": False, "discount_type": "flat", "discount_value": 10.0, "min_ride_fare": 0},
+    # bigger on paper but requires a $20 ride portion — must be skipped
+    {"code": "BIG15", "free_ride": False, "discount_type": "flat", "discount_value": 15.0, "min_ride_fare": 20},
+]
+
+
+def _patch_estimates(payload=None, error: Exception | None = None):
+    mock = AsyncMock(side_effect=error) if error else AsyncMock(return_value=payload)
+    return patch("backend.routes.rides.compute_ride_estimates", mock)
+
+
+def _patch_promos(promos=None, error: Exception | None = None):
+    mock = AsyncMock(side_effect=error) if error else AsyncMock(return_value=promos or [])
+    return patch("backend.routes.promotions.list_available_promos", mock)
+
+
 class TestFareQuote:
     ARGS = {
         "pickup_lat": 52.1318,
@@ -141,37 +251,73 @@ class TestFareQuote:
     }
 
     @pytest.mark.anyio
-    async def test_quote_math_decimal_surge_and_booking_fee(self):
-        with (
-            _patch_area(),
-            patch("backend.routes.fares.get_fares_for_location", AsyncMock(return_value=[FARE_ROW])),
-            patch.object(tools_booking, "calculate_distance", MagicMock(return_value=10.0)),
-        ):
+    async def test_quote_uses_estimate_engine_and_applies_best_promo(self):
+        with _patch_estimates(ESTIMATES), _patch_promos(PROMOS):
             result, ok = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
         assert ok
+        # Only the available vehicle type is quoted; the other is named.
+        assert len(result["quotes"]) == 1
+        assert result["unavailable_vehicle_types"] == ["XL"]
         q = result["quotes"][0]
-        # base 3.00 + 1.50*10km + 0.20*25min = 23.00 → ×1.5 surge = 34.50 + 2.00 fee
-        assert result["duration_minutes"] == 25
-        assert q["approx_fare"] == "36.50"
-        assert q["surge_multiplier"] == 1.5
-        assert "Approximate" in result["note"]
-
-    @pytest.mark.anyio
-    async def test_minimum_fare_floor(self):
-        with (
-            _patch_area(),
-            patch("backend.routes.fares.get_fares_for_location", AsyncMock(return_value=[FARE_ROW])),
-            patch.object(tools_booking, "calculate_distance", MagicMock(return_value=0.5)),
-        ):
-            result, _ = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
-        # ride fare would be 3.00+0.75+1.20=4.95 → floored to 7.00 ×1.5 + 2.00
-        assert result["quotes"][0]["approx_fare"] == "12.50"
+        assert q["vehicle_type"] == "Economy"
+        assert q["eta_minutes"] == 4
+        assert q["total"] == "18.48"
+        # SAVE10 wins (BIG15 misses the $20 min ride portion of $16.00).
+        assert q["promo_code"] == "SAVE10"
+        assert q["promo_savings"] == "10.00"
+        assert q["final_total"] == "8.48"
+        assert result["recommended_vehicle_type_id"] == "vt-1"
+        # Rich card for both surfaces, with the same quotes.
+        action = result["_client_action"]
+        assert action["type"] == "fare_quote"
+        assert action["quotes"] == result["quotes"]
+        assert action["distance_km"] == 6.4
 
     @pytest.mark.anyio
     async def test_out_of_area_pickup_refused(self):
-        with _patch_area(area=None):
+        exc = HTTPException(
+            status_code=400,
+            detail={"code": "OUTSIDE_SERVICE_AREA", "message": "Sorry, your pickup location is outside"},
+        )
+        with _patch_estimates(error=exc):
             result, ok = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
         assert ok and "outside" in result["error"]
+
+    @pytest.mark.anyio
+    async def test_no_drivers_returns_note_without_card(self):
+        all_unavailable = {
+            "estimates": [dict(ESTIMATES["estimates"][0], available=False, eta_minutes=None, driver_count=0)],
+            "route_polyline": None,
+        }
+        with _patch_estimates(all_unavailable), _patch_promos([]):
+            result, ok = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
+        assert ok
+        assert result["no_drivers"] is True
+        assert result["quotes"] == []
+        assert "_client_action" not in result
+
+    @pytest.mark.anyio
+    async def test_promo_failure_does_not_kill_quote(self):
+        with _patch_estimates(ESTIMATES), _patch_promos(error=RuntimeError("promo db down")):
+            result, ok = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
+        assert ok
+        q = result["quotes"][0]
+        assert q["final_total"] == q["total"] == "18.48"
+        assert "promo_code" not in q
+        assert "promo lookup failed" in result["promo_note"]
+
+    @pytest.mark.anyio
+    async def test_free_ride_promo_drops_total_to_zero(self):
+        free = [
+            {"code": "FREERIDE", "free_ride": True, "discount_type": "flat", "discount_value": 0, "min_ride_fare": 0}
+        ]
+        with _patch_estimates(ESTIMATES), _patch_promos(free):
+            result, ok = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
+        assert ok
+        q = result["quotes"][0]
+        assert q["promo_code"] == "FREERIDE"
+        assert q["promo_savings"] == "18.48"
+        assert q["final_total"] == "0.00"
 
 
 class TestProposal:
@@ -242,7 +388,7 @@ class TestProposal:
 
 def test_booking_tools_hidden_from_mcp():
     ensure_registry_loaded()
-    for name in ("find_place", "get_fare_quote", "propose_ride_booking"):
+    for name in ("find_place", "get_rider_location", "get_fare_quote", "propose_ride_booking"):
         assert TOOL_REGISTRY[name].mcp_exposed is False
         assert "rider" in TOOL_REGISTRY[name].audiences
         assert "driver" not in TOOL_REGISTRY[name].audiences

--- a/backend/tests/test_ai_tools_booking.py
+++ b/backend/tests/test_ai_tools_booking.py
@@ -252,8 +252,9 @@ class TestFareQuote:
 
     @pytest.mark.anyio
     async def test_quote_uses_estimate_engine_and_applies_best_promo(self):
+        args = dict(self.ARGS, pickup_address="123 Main St, Saskatoon", dropoff_address="Saskatoon Airport")
         with _patch_estimates(ESTIMATES), _patch_promos(PROMOS):
-            result, ok = await execute_tool("get_fare_quote", self.ARGS, user=RIDER)
+            result, ok = await execute_tool("get_fare_quote", args, user=RIDER)
         assert ok
         # Only the available vehicle type is quoted; the other is named.
         assert len(result["quotes"]) == 1
@@ -267,11 +268,15 @@ class TestFareQuote:
         assert q["promo_savings"] == "10.00"
         assert q["final_total"] == "8.48"
         assert result["recommended_vehicle_type_id"] == "vt-1"
-        # Rich card for both surfaces, with the same quotes.
+        # Rich card for both surfaces, with the same quotes. Addresses ride
+        # along so a tapped option can send a self-contained booking message
+        # (history keeps only message text, never tool results).
         action = result["_client_action"]
         assert action["type"] == "fare_quote"
         assert action["quotes"] == result["quotes"]
         assert action["distance_km"] == 6.4
+        assert action["pickup_address"] == "123 Main St, Saskatoon"
+        assert action["dropoff_address"] == "Saskatoon Airport"
 
     @pytest.mark.anyio
     async def test_out_of_area_pickup_refused(self):

--- a/backend/tests/test_ai_tools_support.py
+++ b/backend/tests/test_ai_tools_support.py
@@ -1,8 +1,10 @@
 """FAQ / company / escalation tools.
 
-Pins: audience filtering on FAQ search, the deep-link-only default for
-escalation (Zoho ticket only behind the settings flag, and a Zoho outage
-never strands the user), and the 911/SOS language on safety escalations.
+Pins: audience filtering on FAQ search (question matches outrank answer
+matches), the deep-link-only default for escalation (Zoho ticket only
+behind the settings flag, and a Zoho outage never strands the user), the
+open_support _client_action card contract, the conversation transcript on
+tickets, and the 911/SOS language on safety escalations.
 """
 
 from unittest.mock import AsyncMock, patch
@@ -50,9 +52,7 @@ class TestSearchFaqs:
     async def test_keyword_match_and_shape(self):
         get_rows = AsyncMock(return_value=FAQS)
         with patch.object(tools_support.db_supabase, "get_rows", get_rows):
-            result, ok = await execute_tool(
-                "search_faqs", {"query": "can I schedule a ride for tomorrow"}, user=RIDER
-            )
+            result, ok = await execute_tool("search_faqs", {"query": "can I schedule a ride for tomorrow"}, user=RIDER)
         assert ok
         assert result["results"][0]["question"].startswith("Can I schedule")
         # audience filter is server-decided and sent to the DB query
@@ -66,10 +66,36 @@ class TestSearchFaqs:
         assert get_rows.await_args.args[1]["audience"] == {"$in": ["both", "driver"]}
 
     @pytest.mark.anyio
-    async def test_no_match_returns_empty(self):
+    async def test_no_match_returns_empty_with_note(self):
         with patch.object(tools_support.db_supabase, "get_rows", AsyncMock(return_value=FAQS)):
             result, ok = await execute_tool("search_faqs", {"query": "zzzqqq"}, user=RIDER)
         assert ok and result["results"] == []
+        assert "No matching" in result["note"]
+
+    @pytest.mark.anyio
+    async def test_question_match_outranks_answer_match(self):
+        faqs = [
+            {
+                # Query tokens appear only in the ANSWER (3 hits, weight 1 → 3)
+                "question": "How do refunds work?",
+                "answer": "You can schedule advance ride pickups from the booking screen.",
+                "category": "rides",
+                "audience": "both",
+                "is_active": True,
+            },
+            {
+                # Query tokens appear in the QUESTION (2 hits, weight 2 → 4)
+                "question": "Can I schedule a ride?",
+                "answer": "Yes.",
+                "category": "rides",
+                "audience": "both",
+                "is_active": True,
+            },
+        ]
+        with patch.object(tools_support.db_supabase, "get_rows", AsyncMock(return_value=faqs)):
+            result, ok = await execute_tool("search_faqs", {"query": "schedule advance ride"}, user=RIDER)
+        assert ok
+        assert result["results"][0]["question"] == "Can I schedule a ride?"
 
 
 class TestCompanyInfo:
@@ -93,6 +119,9 @@ class TestEscalation:
         assert ok
         assert result["action"] == "open_support"
         assert result["link"] == "/support"
+        # The card contract: orchestrator lifts this into an SSE action frame
+        # so the apps/console render the "Contact support" card.
+        assert result["_client_action"] == {"type": "open_support", "category": "refund", "link": "/support"}
         assert "ticket_number" not in result
         ticket.assert_not_awaited()
 
@@ -120,8 +149,9 @@ class TestEscalation:
     @pytest.mark.anyio
     async def test_flag_enables_zoho_ticket(self):
         ticket = AsyncMock(return_value={"ticketNumber": "T-123"})
-        with _settings(ai_escalation_creates_ticket=True), patch(
-            "backend.services.zoho_desk_integration.create_support_ticket", ticket
+        with (
+            _settings(ai_escalation_creates_ticket=True),
+            patch("backend.services.zoho_desk_integration.create_support_ticket", ticket),
         ):
             result, ok = await execute_tool(
                 "escalate_to_support",
@@ -130,12 +160,55 @@ class TestEscalation:
             )
         assert ok and result["ticket_number"] == "T-123"
         ticket.assert_awaited_once()
+        # No conversation id on the user → no transcript on the ticket.
+        assert ticket.await_args.kwargs["transcript"] is None
+
+    @pytest.mark.anyio
+    async def test_ticket_includes_conversation_transcript(self):
+        ticket = AsyncMock(return_value={"ticketNumber": "T-124"})
+        history = AsyncMock(
+            return_value=[
+                {"role": "user", "content": "My driver took a wrong turn and I was overcharged"},
+                {"role": "assistant", "content": "I can see the fare — let me hand you to support."},
+            ]
+        )
+        with (
+            _settings(ai_escalation_creates_ticket=True),
+            patch("backend.services.zoho_desk_integration.create_support_ticket", ticket),
+            patch.object(tools_support.conversations, "load_history", history),
+        ):
+            result, ok = await execute_tool(
+                "escalate_to_support",
+                {"reason": "billing dispute", "category": "payment_issue"},
+                user={**RIDER, "_conversation_id": "conv-1"},
+            )
+        assert ok and result["ticket_number"] == "T-124"
+        transcript = ticket.await_args.kwargs["transcript"]
+        assert "User: My driver took a wrong turn" in transcript
+        assert "Assistant: I can see the fare" in transcript
+
+    @pytest.mark.anyio
+    async def test_transcript_failure_never_blocks_ticket(self):
+        ticket = AsyncMock(return_value={"ticketNumber": "T-125"})
+        with (
+            _settings(ai_escalation_creates_ticket=True),
+            patch("backend.services.zoho_desk_integration.create_support_ticket", ticket),
+            patch.object(tools_support.conversations, "load_history", AsyncMock(side_effect=RuntimeError("db down"))),
+        ):
+            result, ok = await execute_tool(
+                "escalate_to_support",
+                {"reason": "billing dispute", "category": "payment_issue"},
+                user={**RIDER, "_conversation_id": "conv-1"},
+            )
+        assert ok and result["ticket_number"] == "T-125"
+        assert ticket.await_args.kwargs["transcript"] is None
 
     @pytest.mark.anyio
     async def test_zoho_outage_still_returns_deep_link(self):
         ticket = AsyncMock(side_effect=RuntimeError("zoho down"))
-        with _settings(ai_escalation_creates_ticket=True), patch(
-            "backend.services.zoho_desk_integration.create_support_ticket", ticket
+        with (
+            _settings(ai_escalation_creates_ticket=True),
+            patch("backend.services.zoho_desk_integration.create_support_ticket", ticket),
         ):
             result, ok = await execute_tool(
                 "escalate_to_support",

--- a/backend/tests/test_dual_import_parity.py
+++ b/backend/tests/test_dual_import_parity.py
@@ -44,6 +44,16 @@ EXTRA_GUARDED_MODULES = [
     "socket_manager.py",
     "utils/breadcrumbs.py",
     "utils/breadcrumb_buffer.py",
+    # AI assistant modules — same hazard class hit PR #1843 (Codex P2s:
+    # a formatter stripped _metric_timed / promo_available_limit from
+    # fallback branches mid-refactor).
+    "ai/conversations.py",
+    "ai/orchestrator.py",
+    "ai/tools.py",
+    "ai/tools_account.py",
+    "ai/tools_booking.py",
+    "ai/tools_rides.py",
+    "ai/tools_support.py",
 ]
 
 # Pre-existing fallback gaps (file → names missing from the except branch).

--- a/rider-app/app/ai-assistant.tsx
+++ b/rider-app/app/ai-assistant.tsx
@@ -28,6 +28,7 @@ import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
 import type { AiChatMessage, LocationSuggestionCandidate } from '@shared/types/ai';
 import BookingProposalCard from '../components/BookingProposalCard';
+import FareQuoteCard from '../components/FareQuoteCard';
 import { useAiChatStore } from '../store/aiChatStore';
 import { useRideStore } from '../store/rideStore';
 
@@ -229,6 +230,14 @@ export default function AiAssistantScreen() {
     }
     if (item.kind === 'booking_proposal' && item.action?.type === 'booking_proposal') {
       return <BookingProposalCard proposal={item.action.proposal} />;
+    }
+    if (item.kind === 'fare_quote' && item.action?.type === 'fare_quote') {
+      return (
+        <FareQuoteCard
+          quote={item.action}
+          onSelect={(option) => handleSend(`Book the ${option.vehicle_type ?? 'recommended option'}.`)}
+        />
+      );
     }
     if (item.kind === 'location_suggestions' && item.action?.type === 'location_suggestions') {
       return (

--- a/rider-app/app/ai-assistant.tsx
+++ b/rider-app/app/ai-assistant.tsx
@@ -232,10 +232,18 @@ export default function AiAssistantScreen() {
       return <BookingProposalCard proposal={item.action.proposal} />;
     }
     if (item.kind === 'fare_quote' && item.action?.type === 'fare_quote') {
+      const quote = item.action;
       return (
         <FareQuoteCard
-          quote={item.action}
-          onSelect={(option) => handleSend(`Book the ${option.vehicle_type ?? 'recommended option'}.`)}
+          quote={quote}
+          onSelect={(option) => {
+            // Self-contained message: the assistant's next turn sees only
+            // message text, so the tap must restate the trip context.
+            const from = quote.pickup_address ? ` from ${quote.pickup_address}` : '';
+            const to = quote.dropoff_address ? ` to ${quote.dropoff_address}` : '';
+            const promo = option.promo_code ? ` with promo ${option.promo_code}` : '';
+            handleSend(`Book the ${option.vehicle_type ?? 'recommended option'}${from}${to}${promo}.`);
+          }}
         />
       );
     }

--- a/rider-app/components/FareQuoteCard.tsx
+++ b/rider-app/components/FareQuoteCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * In-chat fare quote card.
+ *
+ * Renders a fare_quote action from the AI: exact totals per available
+ * vehicle option (same estimate engine as the booking screen) with the
+ * best eligible promo pre-applied. Tapping an option asks the assistant
+ * to book it — the binding confirmation still happens on the booking
+ * proposal card.
+ */
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+import type { AiAction, FareQuoteOption } from '@shared/types/ai';
+
+type FareQuoteAction = Extract<AiAction, { type: 'fare_quote' }>;
+
+interface Props {
+  quote: FareQuoteAction;
+  onSelect: (option: FareQuoteOption) => void;
+}
+
+export default function FareQuoteCard({ quote, onSelect }: Props) {
+  const { colors } = useTheme();
+  const styles = createStyles(colors);
+
+  const meta = [
+    quote.distance_km != null ? `${quote.distance_km} km` : null,
+    quote.duration_minutes != null ? `about ${quote.duration_minutes} min` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.headerRow}>
+        <Ionicons name="pricetags-outline" size={17} color={colors.primary} />
+        <Text style={styles.headerText}>Your ride options</Text>
+      </View>
+      {meta ? <Text style={styles.metaText}>{meta}</Text> : null}
+
+      {quote.quotes.map((option, index) => {
+        const hasSavings = !!option.promo_savings && option.final_total !== option.total;
+        const surge = option.surge_multiplier ?? 1;
+        const optionMeta = [
+          option.eta_minutes != null ? `${option.eta_minutes} min away` : null,
+          option.capacity != null ? `${option.capacity} seats` : null,
+        ]
+          .filter(Boolean)
+          .join(' · ');
+        return (
+          <TouchableOpacity
+            key={option.vehicle_type_id ?? `${option.vehicle_type}-${index}`}
+            style={styles.option}
+            onPress={() => onSelect(option)}
+            accessibilityRole="button"
+            accessibilityLabel={`Book ${option.vehicle_type ?? 'this option'} for $${option.final_total}`}
+          >
+            <View style={styles.optionCopy}>
+              <Text style={styles.vehicleName}>{option.vehicle_type ?? 'Ride'}</Text>
+              {optionMeta ? <Text style={styles.optionMeta}>{optionMeta}</Text> : null}
+              {hasSavings ? (
+                <View style={styles.savingsPill}>
+                  <Ionicons name="pricetag-outline" size={11} color={colors.success} />
+                  <Text style={styles.savingsText}>
+                    {option.promo_code} · save ${option.promo_savings}
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+            <View style={styles.priceCol}>
+              {hasSavings ? <Text style={styles.strikePrice}>${option.total}</Text> : null}
+              <Text style={styles.finalPrice}>${option.final_total}</Text>
+              {surge > 1 ? (
+                <Text style={styles.surgeText}>{surge}x surge</Text>
+              ) : null}
+            </View>
+          </TouchableOpacity>
+        );
+      })}
+
+      <Text style={styles.fineprint}>Totals include taxes & fees. Tap an option to book it.</Text>
+    </View>
+  );
+}
+
+const createStyles = (colors: ThemeColors) =>
+  StyleSheet.create({
+    card: {
+      marginLeft: 34,
+      padding: 14,
+      borderRadius: 14,
+      backgroundColor: colors.surface,
+      borderWidth: 1,
+      borderColor: colors.border,
+      gap: 8,
+      alignSelf: 'stretch',
+    },
+    headerRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    headerText: { fontSize: 15, fontWeight: '700', color: colors.text },
+    metaText: { fontSize: 12, color: colors.textDim },
+    option: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      paddingVertical: 10,
+      paddingHorizontal: 10,
+      borderRadius: 10,
+      backgroundColor: colors.surfaceLight,
+    },
+    optionCopy: { flex: 1, gap: 3 },
+    vehicleName: { fontSize: 14, fontWeight: '700', color: colors.text },
+    optionMeta: { fontSize: 12, color: colors.textDim },
+    savingsPill: { flexDirection: 'row', alignItems: 'center', gap: 4, marginTop: 2 },
+    savingsText: { fontSize: 11, fontWeight: '600', color: colors.success },
+    priceCol: { alignItems: 'flex-end', gap: 1 },
+    strikePrice: { fontSize: 12, color: colors.textDim, textDecorationLine: 'line-through' },
+    finalPrice: { fontSize: 16, fontWeight: '700', color: colors.text },
+    surgeText: { fontSize: 11, fontWeight: '600', color: colors.warning },
+    fineprint: { fontSize: 11, color: colors.textDim, textAlign: 'center' },
+  });

--- a/rider-app/store/aiChatStore.ts
+++ b/rider-app/store/aiChatStore.ts
@@ -41,13 +41,19 @@ const TOOL_STATUS: Record<string, string> = {
 let nextId = 0;
 const newId = () => `local-${Date.now()}-${nextId++}`;
 
+/** Reject cached fixes older than this — a stale position would send "my
+ * location" pickups to the wrong area; the backend then falls back to the
+ * rider's last ride pickup instead. */
+const LOCATION_MAX_AGE_MS = 5 * 60 * 1000;
+
 /** Last-known device position, only when permission is already granted —
- * the chat never triggers a permission prompt. Null on any failure. */
+ * the chat never triggers a permission prompt. Null on any failure or when
+ * the only available fix is older than LOCATION_MAX_AGE_MS. */
 async function deviceLocation(): Promise<{ lat: number; lng: number } | null> {
   try {
     const { granted } = await Location.getForegroundPermissionsAsync();
     if (!granted) return null;
-    const pos = await Location.getLastKnownPositionAsync();
+    const pos = await Location.getLastKnownPositionAsync({ maxAge: LOCATION_MAX_AGE_MS });
     if (!pos) return null;
     return { lat: pos.coords.latitude, lng: pos.coords.longitude };
   } catch {

--- a/rider-app/store/aiChatStore.ts
+++ b/rider-app/store/aiChatStore.ts
@@ -10,6 +10,7 @@
  */
 import { create } from 'zustand';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Location from 'expo-location';
 import api from '@shared/api/client';
 import type { AiAction, AiChatMessage, AiSseEvent } from '@shared/types/ai';
 import { streamChat } from '../utils/aiChat';
@@ -31,13 +32,28 @@ const TOOL_STATUS: Record<string, string> = {
   search_faqs: 'Searching the help centre…',
   get_company_info: 'Getting contact info…',
   find_place: 'Finding that place…',
-  get_fare_quote: 'Getting a quote…',
+  get_rider_location: 'Finding your location…',
+  get_fare_quote: 'Getting exact prices…',
   propose_ride_booking: 'Preparing your booking…',
   escalate_to_support: 'Preparing a support handoff…',
 };
 
 let nextId = 0;
 const newId = () => `local-${Date.now()}-${nextId++}`;
+
+/** Last-known device position, only when permission is already granted —
+ * the chat never triggers a permission prompt. Null on any failure. */
+async function deviceLocation(): Promise<{ lat: number; lng: number } | null> {
+  try {
+    const { granted } = await Location.getForegroundPermissionsAsync();
+    if (!granted) return null;
+    const pos = await Location.getLastKnownPositionAsync();
+    if (!pos) return null;
+    return { lat: pos.coords.latitude, lng: pos.coords.longitude };
+  } catch {
+    return null;
+  }
+}
 
 const ERROR_MESSAGES: Record<string, string> = {
   ai_disabled: 'The AI assistant is currently unavailable.',
@@ -167,7 +183,9 @@ export const useAiChatStore = create<AiChatState>((set, get) => ({
                     ? 'booking_proposal'
                     : action.type === 'location_suggestions'
                       ? 'location_suggestions'
-                      : 'support_action',
+                      : action.type === 'fare_quote'
+                        ? 'fare_quote'
+                        : 'support_action',
                 content: '',
                 action,
                 createdAt: Date.now(),
@@ -188,6 +206,7 @@ export const useAiChatStore = create<AiChatState>((set, get) => ({
       await streamChat({
         message: trimmed,
         conversationId: get().conversationId,
+        location: await deviceLocation(),
         onEvent,
         signal: abortController.signal,
       });

--- a/rider-app/utils/aiChat.ts
+++ b/rider-app/utils/aiChat.ts
@@ -53,6 +53,9 @@ export class SseFrameParser {
 export interface StreamChatOptions {
   message: string;
   conversationId: string | null;
+  /** Rider's current device location (only when permission already granted) —
+   * lets booking tools resolve "my location" without asking. */
+  location?: { lat: number; lng: number } | null;
   onEvent: (event: AiSseEvent) => void;
   signal?: AbortSignal;
   /** Test seams — default to expo/fetch + the shared auth helpers. */
@@ -82,6 +85,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
   const {
     message,
     conversationId,
+    location,
     onEvent,
     signal,
     fetchImpl = defaultFetch,
@@ -98,7 +102,12 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
       Accept: 'text/event-stream',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ message, conversation_id: conversationId, stream: true }),
+    body: JSON.stringify({
+      message,
+      conversation_id: conversationId,
+      stream: true,
+      ...(location ? { location } : {}),
+    }),
     signal,
   });
 

--- a/shared/types/ai.ts
+++ b/shared/types/ai.ts
@@ -7,6 +7,10 @@ export interface AiChatRequest {
   message: string;
   conversation_id: string | null;
   stream: boolean;
+  /** Rider's current device location, sent opportunistically so booking
+   * tools can bias place search / resolve "my location" pickups.
+   * Ephemeral on the backend — never logged or persisted. */
+  location?: { lat: number; lng: number } | null;
 }
 
 export interface AiConfig {
@@ -39,6 +43,25 @@ export interface LocationSuggestionCandidate {
   service_area?: string | null;
 }
 
+/** One vehicle option inside a fare_quote action. Amounts are exact
+ * Decimal strings (taxes and fees included) from the same estimate engine
+ * as the booking screen; the best eligible promo is pre-applied. */
+export interface FareQuoteOption {
+  vehicle_type_id?: string | null;
+  vehicle_type?: string | null;
+  capacity?: number | null;
+  image_url?: string | null;
+  eta_minutes?: number | null;
+  drivers_nearby?: number | null;
+  surge_multiplier?: number | null;
+  /** Total before promo savings. */
+  total: string;
+  promo_code?: string;
+  promo_savings?: string;
+  /** What the rider pays after the auto-applied promo. */
+  final_total: string;
+}
+
 export type AiAction =
   | { type: 'booking_proposal'; proposal: BookingProposal }
   | {
@@ -46,6 +69,13 @@ export type AiAction =
       query: string;
       location_role?: 'pickup' | 'dropoff' | null;
       candidates: LocationSuggestionCandidate[];
+    }
+  | {
+      type: 'fare_quote';
+      distance_km?: number | null;
+      duration_minutes?: number | null;
+      currency?: string;
+      quotes: FareQuoteOption[];
     }
   | { type: 'open_support'; category: string; link: string; message?: string };
 
@@ -69,7 +99,7 @@ export type AiSseEvent =
 export interface AiChatMessage {
   id: string;
   role: 'user' | 'assistant';
-  kind: 'text' | 'booking_proposal' | 'location_suggestions' | 'support_action' | 'ride_status';
+  kind: 'text' | 'booking_proposal' | 'location_suggestions' | 'fare_quote' | 'support_action' | 'ride_status';
   content: string;
   action?: AiAction;
   createdAt: number;

--- a/shared/types/ai.ts
+++ b/shared/types/ai.ts
@@ -75,6 +75,11 @@ export type AiAction =
       distance_km?: number | null;
       duration_minutes?: number | null;
       currency?: string;
+      /** Resolved trip endpoints — included so a tapped option can send a
+       * self-contained booking message (conversation history keeps only
+       * message text, never tool results). */
+      pickup_address?: string;
+      dropoff_address?: string;
       quotes: FareQuoteOption[];
     }
   | { type: 'open_support'; category: string; link: string; message?: string };


### PR DESCRIPTION
Single reusable estimate engine (geofence gates, driver availability/ETA,
surge, fees+taxes, estimate tokens) so the AI assistant can quote through
the exact same path as POST /rides/estimate. include_polyline=False lets
non-map callers skip the Directions fetch. No behavior change for the route.

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
