### PR TITLE
feat(ai): allow chat surfaces to request an explicit audience

### DIFF
--- a/backend/routes/ai.py
+++ b/backend/routes/ai.py
@@ -68,11 +68,22 @@ class AiChatRequest(BaseModel):
     # Ephemeral: passed to tools for this turn only — never logged, never
     # persisted (PIPEDA: raw GPS must not reach logs or storage).
     location: Optional[AiChatLocation] = None
+    # Persona the calling surface wants. Dual-role (rider+driver) accounts
+    # would otherwise always infer "driver", which strips the booking tools
+    # from the rider app's main-screen assistant. "rider" is open to every
+    # account (anyone can ride); "driver" is gated on the user row.
+    audience: Optional[str] = Field(None, pattern="^(rider|driver)$")
 
 
 def _audience_for(user: dict) -> str:
     # SupportScreen is shared by both apps; the user row decides the tool set.
     return "driver" if user.get("is_driver") else "rider"
+
+
+def _resolve_audience(requested: Optional[str], user: dict) -> str:
+    if requested == "driver" and not user.get("is_driver"):
+        raise HTTPException(status_code=403, detail="Driver assistant is only available to driver accounts")
+    return requested or _audience_for(user)
 
 
 def _sse(event: str, payload: dict) -> str:
@@ -117,7 +128,7 @@ async def ai_chat(
         user=current_user,
         conversation_id=body.conversation_id,
         user_message=body.message,
-        audience=_audience_for(current_user),
+        audience=_resolve_audience(body.audience, current_user),
         client_location=body.location.model_dump() if body.location else None,
     )
 

--- a/backend/tests/test_ai_chat_route.py
+++ b/backend/tests/test_ai_chat_route.py
@@ -87,6 +87,39 @@ class TestChatStreaming:
             rider_client.post("/api/v1/ai/chat", json={"message": "payout question"})
         assert gen.kwargs["audience"] == "driver"
 
+    def test_explicit_rider_audience_wins_for_dual_role_user(self, rider_client):
+        # The rider app's main-screen assistant must get rider tools even when
+        # the account is also a driver (dual-role).
+        from backend.server import app
+        from dependencies import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: {"id": "d-1", "is_driver": True}
+        gen = _frames_gen(HAPPY_FRAMES)
+        with patch("backend.routes.ai.run_chat_turn", gen):
+            rider_client.post("/api/v1/ai/chat", json={"message": "book me a ride", "audience": "rider"})
+        assert gen.kwargs["audience"] == "rider"
+
+    def test_driver_audience_rejected_for_non_driver(self, rider_client):
+        gen = _frames_gen(HAPPY_FRAMES)
+        with patch("backend.routes.ai.run_chat_turn", gen):
+            resp = rider_client.post("/api/v1/ai/chat", json={"message": "payouts?", "audience": "driver"})
+        assert resp.status_code == 403
+        assert not hasattr(gen, "kwargs")
+
+    def test_explicit_driver_audience_allowed_for_driver(self, rider_client):
+        from backend.server import app
+        from dependencies import get_current_user
+
+        app.dependency_overrides[get_current_user] = lambda: {"id": "d-1", "is_driver": True}
+        gen = _frames_gen(HAPPY_FRAMES)
+        with patch("backend.routes.ai.run_chat_turn", gen):
+            rider_client.post("/api/v1/ai/chat", json={"message": "payouts?", "audience": "driver"})
+        assert gen.kwargs["audience"] == "driver"
+
+    def test_invalid_audience_rejected(self, rider_client):
+        resp = rider_client.post("/api/v1/ai/chat", json={"message": "hi", "audience": "admin"})
+        assert resp.status_code == 422
+
 
 class TestChatNonStreaming:
     def test_json_reply_shape(self, rider_client):

--- a/rider-app/store/__tests__/aiChatStore.test.ts
+++ b/rider-app/store/__tests__/aiChatStore.test.ts
@@ -79,6 +79,12 @@ describe('sendMessage', () => {
     expect(mockStream.mock.calls[0][0].conversationId).toBe('conv-9');
   });
 
+  it('always requests the rider persona so dual-role accounts keep booking tools', async () => {
+    scriptStream([]);
+    await useAiChatStore.getState().sendMessage('book me a ride');
+    expect(mockStream.mock.calls[0][0].audience).toBe('rider');
+  });
+
   it('tracks tool status while a tool runs and clears it on tokens', async () => {
     const seen: (string | null)[] = [];
     mockStream.mockImplementation(async ({ onEvent }) => {

--- a/rider-app/store/aiChatStore.ts
+++ b/rider-app/store/aiChatStore.ts
@@ -212,6 +212,10 @@ export const useAiChatStore = create<AiChatState>((set, get) => ({
       await streamChat({
         message: trimmed,
         conversationId: get().conversationId,
+        // Main-screen assistant is always the rider persona — dual-role
+        // accounts must keep booking tools here (help-centre chat stays on
+        // the backend-inferred persona for driver grievances).
+        audience: 'rider',
         location: await deviceLocation(),
         onEvent,
         signal: abortController.signal,

--- a/rider-app/utils/__tests__/aiChat.test.ts
+++ b/rider-app/utils/__tests__/aiChat.test.ts
@@ -82,6 +82,7 @@ describe('streamChat', () => {
     await streamChat({
       message: 'where is my driver?',
       conversationId: 'conv-1',
+      audience: 'rider',
       onEvent: (e) => events.push(e),
       fetchImpl,
     });
@@ -94,6 +95,17 @@ describe('streamChat', () => {
     expect(JSON.parse(init.body)).toEqual({
       message: 'where is my driver?',
       conversation_id: 'conv-1',
+      stream: true,
+      audience: 'rider',
+    });
+  });
+
+  it('omits audience from the body when not provided', async () => {
+    const fetchImpl = jest.fn(async (_url: string, _init: any) => streamResponse([FRAME]));
+    await streamChat({ message: 'hi', conversationId: null, onEvent: jest.fn(), fetchImpl });
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({
+      message: 'hi',
+      conversation_id: null,
       stream: true,
     });
   });

--- a/rider-app/utils/aiChat.ts
+++ b/rider-app/utils/aiChat.ts
@@ -53,6 +53,10 @@ export class SseFrameParser {
 export interface StreamChatOptions {
   message: string;
   conversationId: string | null;
+  /** Persona for this surface. The main-screen assistant always sends
+   * 'rider' so dual-role (rider+driver) accounts still get the booking
+   * tools; omitting it lets the backend infer from the user row. */
+  audience?: 'rider' | 'driver';
   /** Rider's current device location (only when permission already granted) —
    * lets booking tools resolve "my location" without asking. */
   location?: { lat: number; lng: number } | null;
@@ -85,6 +89,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
   const {
     message,
     conversationId,
+    audience,
     location,
     onEvent,
     signal,
@@ -106,6 +111,7 @@ export async function streamChat(options: StreamChatOptions): Promise<void> {
       message,
       conversation_id: conversationId,
       stream: true,
+      ...(audience ? { audience } : {}),
       ...(location ? { location } : {}),
     }),
     signal,


### PR DESCRIPTION
Dual-role (rider+driver) accounts always inferred the driver persona on
/ai/chat, stripping booking tools from the rider app's main-screen
assistant. Accept an optional audience field; 'rider' is open to every
account, 'driver' stays gated on the user row (403 otherwise). Default
behaviour (inference from is_driver) is unchanged.

https://claude.ai/code/session_01F1ZagPLHwDb1vDJxD9PBWJ

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
