### PR TITLE
fix(surge): filter surge_enabled in the service_areas query

### DIFF
--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -250,6 +250,18 @@ async def lifespan(app: FastAPI):
     # persistent flag. See backend/utils/driver_online.py for the
     # effective-online helper used by readers.
 
+    # Stale intent reconciler — every 15 min, flips is_online=False for
+    # drivers whose app has been unreachable for hours (default 4h, durable
+    # drivers.updated_at signal, Redis-healthy gate + presence double-check).
+    # Closes the insurance-period audit gap left by force-killed apps without
+    # repeating the retired presence_sweeper's 30s-scale mass-flip failure.
+    try:
+        from utils.stale_intent_reconciler import stale_intent_reconciler_loop
+
+        _spawn("stale_intent_reconciler (15min)", stale_intent_reconciler_loop)
+    except Exception as e:
+        logger.error(f"Failed to import stale intent reconciler: {e}", exc_info=True)
+
     # Safety check-in — every 30s: sends a push to riders whose trip has been
     # in_progress for ≥ 20 minutes.  If the rider does not respond within 90s,
     # an open safety incident is created for the trust-and-safety team.
@@ -347,6 +359,7 @@ async def lifespan(app: FastAPI):
             "payment_retry (5min)",
             "document_expiry (12h)",
             "driver_onboarding_reminders (15min)",
+            "stale_intent_reconciler (15min)",
             "corporate_autotopup (10min)",
             "corporate_low_balance (1h)",
             "allowance_reset (1h)",

--- a/backend/migrations/146_settings_stale_intent_hours.sql
+++ b/backend/migrations/146_settings_stale_intent_hours.sql
@@ -1,0 +1,24 @@
+-- 146_settings_stale_intent_hours.sql
+--
+-- Tuning knob for the stale-intent reconciler (utils/stale_intent_reconciler.py).
+-- The loop flips drivers.is_online=false for drivers whose app has been
+-- unreachable for this many hours; the code default is 4 when the column is
+-- NULL or absent, so this migration only makes the value operator-tunable.
+--
+-- Lives in the settings wide-table (one column per setting) so operators can
+-- change it from the admin Settings API / Supabase table editor and have it
+-- take effect within the 60s settings cache TTL — no redeploy.
+--
+-- Range 1-48: below 1h would re-create the retired presence_sweeper's
+-- failure mode (flipping on transient gaps); above 48h the insurance-period
+-- audit gap this loop exists to close becomes meaningless.
+--
+-- Rollback:
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS stale_intent_offline_hours;
+
+ALTER TABLE public.settings
+    ADD COLUMN IF NOT EXISTS stale_intent_offline_hours NUMERIC DEFAULT 4
+        CONSTRAINT settings_stale_intent_hours_range CHECK (stale_intent_offline_hours BETWEEN 1 AND 48);
+
+COMMENT ON COLUMN public.settings.stale_intent_offline_hours IS
+    'Hours a driver''s app must be unreachable (no location batch / presence) before the stale-intent reconciler flips is_online=false and logs insurance Period 0. Code default 4. Range 1-48.';

--- a/backend/migrations/147_drivers_stale_intent_index.sql
+++ b/backend/migrations/147_drivers_stale_intent_index.sql
@@ -14,10 +14,15 @@
 -- the query pattern without the index, violating the index-with-query-pattern
 -- migration rule.
 --
+-- CONCURRENTLY because drivers is a hot table (every location batch and
+-- online/offline toggle writes to it); a plain CREATE INDEX would hold a
+-- write-blocking lock for the duration of the build. The migration runner
+-- detects CONCURRENTLY and switches to autocommit (scripts/migrate.py).
+--
 -- Rollback:
---   DROP INDEX IF EXISTS idx_drivers_online_updated_at;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_drivers_online_updated_at;
 
-CREATE INDEX IF NOT EXISTS idx_drivers_online_updated_at
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_drivers_online_updated_at
     ON public.drivers (updated_at)
     WHERE is_online = true;
 

--- a/backend/migrations/147_drivers_stale_intent_index.sql
+++ b/backend/migrations/147_drivers_stale_intent_index.sql
@@ -1,0 +1,25 @@
+-- 147_drivers_stale_intent_index.sql
+--
+-- Index for the stale-intent reconciler's candidate scan
+-- (utils/stale_intent_reconciler.py):
+--
+--   SELECT ... FROM drivers WHERE is_online = true AND updated_at < cutoff
+--
+-- Runs every 15 minutes on every backend process. Without an index this is
+-- a sequential scan over drivers; a partial index over the online subset
+-- keeps it O(stale rows) and stays small because offline drivers (the vast
+-- majority at any time) are excluded.
+--
+-- Flagged by review on PR #1848 — the reconciler and migration 146 shipped
+-- the query pattern without the index, violating the index-with-query-pattern
+-- migration rule.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS idx_drivers_online_updated_at;
+
+CREATE INDEX IF NOT EXISTS idx_drivers_online_updated_at
+    ON public.drivers (updated_at)
+    WHERE is_online = true;
+
+COMMENT ON INDEX public.idx_drivers_online_updated_at IS
+    'Partial index for the stale-intent reconciler scan (is_online = true AND updated_at < cutoff). Small by construction: only online drivers are indexed.';

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -148,6 +148,9 @@ class SettingsUpdateRequest(BaseModel):
     max_simultaneous_offers: Optional[int] = Field(default=None, ge=1, le=10)
     ride_offer_timeout_seconds: Optional[int] = Field(default=None, ge=5, le=60)
     use_eta_ranking: Optional[bool] = None
+    # Hours of unreachability before the stale-intent reconciler flips a
+    # driver's is_online=false (migration 146). Bounds mirror the DB CHECK.
+    stale_intent_offline_hours: Optional[float] = Field(default=None, ge=1, le=48)
     # AI assistant (rider AI mode, backend/ai/) — provider/model swap at
     # runtime, keys masked like the Stripe/Twilio credentials above.
     ai_assistant_enabled: Optional[bool] = None

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -154,6 +154,10 @@ class AppSettings(BaseModel):
     # Distribution list for safety-incident transactional emails. See
     # migration 95 + the _notify_safety_team helper in features.py.
     safety_alert_emails: str = ""
+    # Hours of app unreachability before the stale-intent reconciler flips
+    # a driver's is_online=false (utils/stale_intent_reconciler.py,
+    # migration 146). Range 1-48 enforced by the admin API + DB CHECK.
+    stale_intent_offline_hours: float = 4.0
     # ── AI assistant (rider AI mode, backend/ai/) ────────────────────────
     # Master kill switch. Defaults OFF: the feature ships dark and is enabled
     # from the admin dashboard once a provider key is set. Effective within

--- a/backend/tests/test_driver_onboarding_reminders.py
+++ b/backend/tests/test_driver_onboarding_reminders.py
@@ -19,6 +19,7 @@ class FakeReminderDB:
         self.claims: list[dict] = []
         self.updates: list[tuple[dict, dict]] = []
         self.tables_read: list[str] = []
+        self.failing_tables: set[str] = set()
         self.driver = {
             "id": "driver-1",
             "user_id": "user-1",
@@ -33,6 +34,8 @@ class FakeReminderDB:
 
     async def get_rows(self, table: str, filters: dict | None = None, **kwargs):
         self.tables_read.append(table)
+        if table in self.failing_tables:
+            raise RuntimeError(f"simulated DB failure reading {table}")
         if table == "service_areas":
             return [
                 {
@@ -150,3 +153,28 @@ async def test_scan_runs_once_per_send_window(monkeypatch):
 
     next_day = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 10, 14, 5, tzinfo=timezone.utc))
     assert next_day["drivers_scanned"] == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_scan_does_not_complete_window(monkeypatch):
+    """A DB failure mid-scan must leave the send window incomplete so the
+    next tick in the same hour retries — not silently skip the day."""
+    from utils import driver_onboarding_reminders as reminders
+
+    fake_db = FakeReminderDB()
+    send_push = AsyncMock(return_value=True)
+    monkeypatch.setattr(reminders, "db", fake_db)
+    monkeypatch.setattr(reminders, "send_push_notification", send_push)
+
+    # First tick: the drivers read fails inside the 08:00 window.
+    fake_db.failing_tables = {"drivers"}
+    failed = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc))
+    assert failed == {"drivers_scanned": 0, "claims_attempted": 0, "pushes_delivered": 0}
+    assert reminders._completed_windows == set()
+    send_push.assert_not_awaited()
+
+    # Next tick, DB recovered: the scan runs and the reminders go out.
+    fake_db.failing_tables = set()
+    retried = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 20, tzinfo=timezone.utc))
+    assert retried["drivers_scanned"] == 1
+    assert retried["pushes_delivered"] == 2

--- a/backend/tests/test_driver_onboarding_reminders.py
+++ b/backend/tests/test_driver_onboarding_reminders.py
@@ -20,6 +20,7 @@ class FakeReminderDB:
         self.updates: list[tuple[dict, dict]] = []
         self.tables_read: list[str] = []
         self.failing_tables: set[str] = set()
+        self.failing_claims = False
         self.driver = {
             "id": "driver-1",
             "user_id": "user-1",
@@ -56,6 +57,8 @@ class FakeReminderDB:
 
     async def insert_one(self, table: str, doc: dict):
         assert table == "driver_onboarding_reminder_log"
+        if self.failing_claims:
+            raise RuntimeError("simulated claim insert outage")
         if self.duplicate_claims:
             from utils.driver_onboarding_reminders import DuplicateRecordError
 
@@ -178,3 +181,27 @@ async def test_failed_scan_does_not_complete_window(monkeypatch):
     retried = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 20, tzinfo=timezone.utc))
     assert retried["drivers_scanned"] == 1
     assert retried["pushes_delivered"] == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_claim_insert_does_not_complete_window(monkeypatch):
+    """A claim-log insert outage leaves no dedupe row, so the window must
+    stay incomplete and the next tick must retry the sends (only duplicate
+    claims are a definitive 'already sent today')."""
+    from utils import driver_onboarding_reminders as reminders
+
+    fake_db = FakeReminderDB()
+    send_push = AsyncMock(return_value=True)
+    monkeypatch.setattr(reminders, "db", fake_db)
+    monkeypatch.setattr(reminders, "send_push_notification", send_push)
+
+    fake_db.failing_claims = True
+    failed = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc))
+    assert failed["pushes_delivered"] == 0
+    assert reminders._completed_windows == set()
+    send_push.assert_not_awaited()
+
+    fake_db.failing_claims = False
+    retried = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 20, tzinfo=timezone.utc))
+    assert retried["pushes_delivered"] == 2
+    assert reminders._completed_windows != set()

--- a/backend/tests/test_driver_onboarding_reminders.py
+++ b/backend/tests/test_driver_onboarding_reminders.py
@@ -4,12 +4,21 @@ from unittest.mock import AsyncMock
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_completed_windows(monkeypatch):
+    """Each test starts with a fresh once-per-window memo."""
+    from utils import driver_onboarding_reminders as reminders
+
+    monkeypatch.setattr(reminders, "_completed_windows", set())
+
+
 class FakeReminderDB:
     def __init__(self, *, duplicate_claims: bool = False, docs: list[dict] | None = None):
         self.duplicate_claims = duplicate_claims
         self.docs = docs or []
         self.claims: list[dict] = []
         self.updates: list[tuple[dict, dict]] = []
+        self.tables_read: list[str] = []
         self.driver = {
             "id": "driver-1",
             "user_id": "user-1",
@@ -23,6 +32,7 @@ class FakeReminderDB:
         }
 
     async def get_rows(self, table: str, filters: dict | None = None, **kwargs):
+        self.tables_read.append(table)
         if table == "service_areas":
             return [
                 {
@@ -98,3 +108,45 @@ async def test_duplicate_daily_claim_suppresses_duplicate_pushes(monkeypatch):
     assert fake_db.claims == []
     assert fake_db.updates == []
     send_push.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_outside_send_window_skips_drivers_scan(monkeypatch):
+    """Outside the 08:00 local hour, a tick reads only service_areas — the
+    drivers/documents scan (the egress-heavy part) must not run."""
+    from utils import driver_onboarding_reminders as reminders
+
+    fake_db = FakeReminderDB()
+    send_push = AsyncMock(return_value=True)
+    monkeypatch.setattr(reminders, "db", fake_db)
+    monkeypatch.setattr(reminders, "send_push_notification", send_push)
+
+    # 18:05 UTC is 12:05 in America/Regina — no window open.
+    stats = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 18, 5, tzinfo=timezone.utc))
+
+    assert stats == {"drivers_scanned": 0, "claims_attempted": 0, "pushes_delivered": 0}
+    assert fake_db.tables_read == ["service_areas"]
+    send_push.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_scan_runs_once_per_send_window(monkeypatch):
+    """A second tick inside the same 08:00 window skips the drivers scan
+    (in-process memo); the next day's window scans again."""
+    from utils import driver_onboarding_reminders as reminders
+
+    fake_db = FakeReminderDB()
+    send_push = AsyncMock(return_value=True)
+    monkeypatch.setattr(reminders, "db", fake_db)
+    monkeypatch.setattr(reminders, "send_push_notification", send_push)
+
+    first = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 5, tzinfo=timezone.utc))
+    assert first["drivers_scanned"] == 1
+
+    fake_db.tables_read.clear()
+    second = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 9, 14, 20, tzinfo=timezone.utc))
+    assert second == {"drivers_scanned": 0, "claims_attempted": 0, "pushes_delivered": 0}
+    assert fake_db.tables_read == ["service_areas"]
+
+    next_day = await reminders.check_driver_onboarding_reminders(datetime(2026, 6, 10, 14, 5, tzinfo=timezone.utc))
+    assert next_day["drivers_scanned"] == 1

--- a/backend/tests/test_stale_intent_reconciler.py
+++ b/backend/tests/test_stale_intent_reconciler.py
@@ -1,0 +1,149 @@
+"""Tests for utils/stale_intent_reconciler.py.
+
+The reconciler must only flip intent offline for drivers that are stale on
+the durable DB signal AND absent from Redis presence AND not on an active
+ride — and must refuse to act at all when Redis is in fallback mode (the
+retired presence_sweeper's failure class).
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+NOW = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeReconcilerDB:
+    def __init__(self, drivers: list[dict] | None = None, active_rides: list[dict] | None = None):
+        self.drivers = drivers or []
+        self.active_rides = active_rides or []
+        self.updates: list[tuple[dict, dict]] = []
+        self.claim_returns_row = True
+
+    async def get_rows(self, table: str, filters: dict | None = None, **kwargs):
+        if table == "drivers":
+            return self.drivers
+        if table == "rides":
+            return self.active_rides
+        return []
+
+    async def update_one(self, table: str, filters: dict, update: dict):
+        assert table == "drivers"
+        assert filters.get("is_online") is True, "flip must be an atomic claim on is_online=true"
+        self.updates.append((filters, update))
+        return {**filters, **update} if self.claim_returns_row else None
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    from utils import stale_intent_reconciler as rec
+
+    fake_db = FakeReconcilerDB()
+    monkeypatch.setattr(rec, "db", fake_db)
+    monkeypatch.setattr(rec, "get_redis_stats", AsyncMock(return_value={"connected": True}))
+    monkeypatch.setattr(rec, "present_driver_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr(rec, "record_period_transition", AsyncMock())
+    monkeypatch.setattr(rec, "send_push_notification", AsyncMock(return_value=True))
+    monkeypatch.setattr(rec, "get_app_settings", AsyncMock(return_value={}))
+    return rec, fake_db
+
+
+@pytest.mark.asyncio
+async def test_flips_stale_absent_driver(patched):
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "2026-06-12T06:00:00+00:00"}]
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 1
+    filters, update = fake_db.updates[0]
+    assert filters == {"id": "d1", "is_online": True}
+    assert update["is_online"] is False
+    assert update["is_available"] is False
+    assert update["went_offline_at"] == NOW.isoformat()
+    rec.record_period_transition.assert_awaited_once_with("d1", 0)
+    rec.send_push_notification.assert_awaited_once()
+    assert rec.send_push_notification.await_args.kwargs["target_app"] == "driver"
+
+
+@pytest.mark.asyncio
+async def test_redis_fallback_skips_tick_entirely(patched):
+    """In-process Redis fallback → presence is per-replica → never flip."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    rec.get_redis_stats = AsyncMock(return_value={"connected": False})
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats == {"candidates": 0, "skipped_present": 0, "skipped_active_ride": 0, "flipped": 0}
+    assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_present_driver_is_never_flipped(patched):
+    """Stale DB row but live presence key (e.g. WS alive, location permission
+    revoked) → reachable → leave intent alone."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    rec.present_driver_ids = AsyncMock(return_value={"d1"})
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    assert stats["skipped_present"] == 1
+    assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_presence_lookup_failure_skips_tick(patched):
+    """No trustworthy presence → err on not flipping anyone."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    rec.present_driver_ids = AsyncMock(side_effect=RuntimeError("Redis down"))
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_driver_on_active_ride_is_skipped(patched):
+    """A Period 0 write with an open ride would corrupt the insurance log."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    fake_db.active_rides = [{"id": "r1", "driver_id": "d1"}]
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    assert stats["skipped_active_ride"] == 1
+    assert fake_db.updates == []
+    rec.record_period_transition.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lost_claim_means_no_side_effects(patched):
+    """Zero rows from the claim (other replica / driver toggled) → no period
+    transition, no push."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    fake_db.claim_returns_row = False
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    rec.record_period_transition.assert_not_awaited()
+    rec.send_push_notification.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_candidates_is_a_cheap_noop(patched):
+    rec, fake_db = patched
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["candidates"] == 0
+    assert fake_db.updates == []
+    rec.present_driver_ids.assert_not_awaited()

--- a/backend/tests/test_stale_intent_reconciler.py
+++ b/backend/tests/test_stale_intent_reconciler.py
@@ -23,6 +23,8 @@ class FakeReconcilerDB:
 
     async def get_rows(self, table: str, filters: dict | None = None, **kwargs):
         if table == "drivers":
+            # Offset paging is only sound with a stable order (PR #1848 review).
+            assert kwargs.get("order") == "updated_at", "candidate scan must be deterministically ordered"
             # Honour limit/offset over the *currently matching* set, like
             # PostgREST would: flipped drivers leave the predicate.
             flipped = {f["id"] for f, _u in self.updates} if self.claim_returns_row else set()
@@ -130,6 +132,24 @@ async def test_presence_unreachable_flag_aborts_tick(patched):
 
     assert stats["flipped"] == 0
     assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_reconnect_between_batch_check_and_claim_skips_flip(patched):
+    """A WS pong refreshes Redis presence without touching drivers.updated_at,
+    so the claim predicate can't see a reconnect — the per-driver presence
+    re-check right before the claim must catch it."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    # Batch check: absent. Per-driver re-check just before the claim: present.
+    rec.present_driver_ids_checked = AsyncMock(side_effect=[(set(), True), ({"d1"}, True)])
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    assert stats["skipped_present"] == 1
+    assert fake_db.updates == []
+    rec.record_period_transition.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_stale_intent_reconciler.py
+++ b/backend/tests/test_stale_intent_reconciler.py
@@ -23,7 +23,13 @@ class FakeReconcilerDB:
 
     async def get_rows(self, table: str, filters: dict | None = None, **kwargs):
         if table == "drivers":
-            return self.drivers
+            # Honour limit/offset over the *currently matching* set, like
+            # PostgREST would: flipped drivers leave the predicate.
+            flipped = {f["id"] for f, _u in self.updates} if self.claim_returns_row else set()
+            matching = [d for d in self.drivers if d["id"] not in flipped]
+            offset = kwargs.get("offset") or 0
+            limit = kwargs.get("limit") or len(matching)
+            return matching[offset : offset + limit]
         if table == "rides":
             return self.active_rides
         return []
@@ -31,8 +37,9 @@ class FakeReconcilerDB:
     async def update_one(self, table: str, filters: dict, update: dict):
         assert table == "drivers"
         assert filters.get("is_online") is True, "flip must be an atomic claim on is_online=true"
+        assert "$lt" in filters.get("updated_at", {}), "claim must re-assert the staleness predicate"
         self.updates.append((filters, update))
-        return {**filters, **update} if self.claim_returns_row else None
+        return {**update, "id": filters["id"]} if self.claim_returns_row else None
 
 
 @pytest.fixture
@@ -42,7 +49,7 @@ def patched(monkeypatch):
     fake_db = FakeReconcilerDB()
     monkeypatch.setattr(rec, "db", fake_db)
     monkeypatch.setattr(rec, "get_redis_stats", AsyncMock(return_value={"connected": True}))
-    monkeypatch.setattr(rec, "present_driver_ids", AsyncMock(return_value=set()))
+    monkeypatch.setattr(rec, "present_driver_ids_checked", AsyncMock(return_value=(set(), True)))
     monkeypatch.setattr(rec, "record_period_transition", AsyncMock())
     monkeypatch.setattr(rec, "send_push_notification", AsyncMock(return_value=True))
     monkeypatch.setattr(rec, "get_app_settings", AsyncMock(return_value={}))
@@ -58,7 +65,9 @@ async def test_flips_stale_absent_driver(patched):
 
     assert stats["flipped"] == 1
     filters, update = fake_db.updates[0]
-    assert filters == {"id": "d1", "is_online": True}
+    assert filters["id"] == "d1"
+    assert filters["is_online"] is True
+    assert filters["updated_at"] == {"$lt": (NOW - rec.timedelta(hours=4)).isoformat()}
     assert update["is_online"] is False
     assert update["is_available"] is False
     assert update["went_offline_at"] == NOW.isoformat()
@@ -86,7 +95,7 @@ async def test_present_driver_is_never_flipped(patched):
     revoked) → reachable → leave intent alone."""
     rec, fake_db = patched
     fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
-    rec.present_driver_ids = AsyncMock(return_value={"d1"})
+    rec.present_driver_ids_checked = AsyncMock(return_value=({"d1"}, True))
 
     stats = await rec.reconcile_stale_intent(NOW)
 
@@ -100,12 +109,61 @@ async def test_presence_lookup_failure_skips_tick(patched):
     """No trustworthy presence → err on not flipping anyone."""
     rec, fake_db = patched
     fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
-    rec.present_driver_ids = AsyncMock(side_effect=RuntimeError("Redis down"))
+    rec.present_driver_ids_checked = AsyncMock(side_effect=RuntimeError("Redis down"))
 
     stats = await rec.reconcile_stale_intent(NOW)
 
     assert stats["flipped"] == 0
     assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_presence_unreachable_flag_aborts_tick(patched):
+    """present_driver_ids_checked returning reachable=False (Redis configured
+    but down mid-tick) must abort — an empty set in that state means
+    'unknowable', not 'everyone offline'."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    rec.present_driver_ids_checked = AsyncMock(return_value=(set(), False))
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_settings_read_failure_skips_tick(patched):
+    """A settings outage must not silently apply the 4h default over an
+    operator-raised threshold."""
+    rec, fake_db = patched
+    fake_db.drivers = [{"id": "d1", "user_id": "u1", "updated_at": "old"}]
+    rec.get_app_settings = AsyncMock(side_effect=RuntimeError("settings DB down"))
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["flipped"] == 0
+    assert fake_db.updates == []
+
+
+@pytest.mark.asyncio
+async def test_pages_past_skipped_candidates(patched, monkeypatch):
+    """Skipped (present) drivers filling the first page must not shadow
+    absent drivers behind them."""
+    rec, fake_db = patched
+    monkeypatch.setattr(rec, "CANDIDATE_LIMIT", 2)
+    fake_db.drivers = [
+        {"id": "d1", "user_id": "u1", "updated_at": "old"},  # present → skip
+        {"id": "d2", "user_id": "u2", "updated_at": "old"},  # present → skip
+        {"id": "d3", "user_id": "u3", "updated_at": "old"},  # absent → flip
+    ]
+    rec.present_driver_ids_checked = AsyncMock(side_effect=lambda ids: ({"d1", "d2"} & set(ids), True))
+
+    stats = await rec.reconcile_stale_intent(NOW)
+
+    assert stats["skipped_present"] == 2
+    assert stats["flipped"] == 1
+    assert fake_db.updates[0][0]["id"] == "d3"
 
 
 @pytest.mark.asyncio
@@ -146,4 +204,4 @@ async def test_no_candidates_is_a_cheap_noop(patched):
 
     assert stats["candidates"] == 0
     assert fake_db.updates == []
-    rec.present_driver_ids.assert_not_awaited()
+    rec.present_driver_ids_checked.assert_not_awaited()

--- a/backend/tests/test_surge_engine.py
+++ b/backend/tests/test_surge_engine.py
@@ -100,7 +100,7 @@ async def test_count_demand_counts_active_statuses_only():
     rides = [
         {"status": "searching"},
         {"status": "driver_assigned"},
-        {"status": "driver_en_route"},
+        {"status": "driver_accepted"},
         {"status": "completed"},  # not active
         {"status": "cancelled"},  # not active
     ]
@@ -308,9 +308,7 @@ async def test_recalculate_skips_sub_areas():
 @pytest.mark.asyncio
 async def test_recalculate_does_not_update_db_when_multiplier_unchanged():
     """If new multiplier equals current, no DB update_one call."""
-    areas = [
-        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}
-    ]
+    areas = [{"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
     db_mock.update_one = AsyncMock()
@@ -333,9 +331,7 @@ async def test_recalculate_does_not_update_db_when_multiplier_unchanged():
 @pytest.mark.asyncio
 async def test_recalculate_updates_db_when_multiplier_changes():
     """When new multiplier differs from stored, update_one IS called."""
-    areas = [
-        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}
-    ]
+    areas = [{"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
     db_mock.update_one = AsyncMock()
@@ -355,6 +351,26 @@ async def test_recalculate_updates_db_when_multiplier_changes():
     update_payload = db_mock.update_one.call_args[0][2]
     assert update_payload["surge_multiplier"] == 1.5
     assert update_payload["surge_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_recalculate_filters_surge_enabled_in_db_query():
+    """The service_areas read filters surge_enabled=True in the DB.
+
+    Disabled areas must never be fetched at all — with the toggle off
+    everywhere, each 2-min tick costs one empty response instead of a
+    full table read (Supabase egress).
+    """
+    db_mock = MagicMock()
+    db_mock.get_rows = AsyncMock(return_value=[])
+
+    with patch("utils.surge_engine.db", db_mock):
+        from utils.surge_engine import recalculate_all_surges
+
+        results = await recalculate_all_surges()
+
+    assert results == []
+    db_mock.get_rows.assert_awaited_once_with("service_areas", {"is_active": True, "surge_enabled": True}, limit=100)
 
 
 @pytest.mark.asyncio
@@ -433,9 +449,7 @@ async def test_recalculate_service_areas_db_failure_returns_empty():
 @pytest.mark.asyncio
 async def test_recalculate_inserts_surge_pricing_history_row():
     """Every processed area gets a surge_pricing history row inserted."""
-    areas = [
-        {"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}
-    ]
+    areas = [{"id": "a1", "surge_source": "auto", "surge_enabled": True, "surge_multiplier": 1.0, "is_active": True}]
     db_mock = MagicMock()
     db_mock.get_rows = AsyncMock(return_value=areas)
     db_mock.update_one = AsyncMock()
@@ -468,6 +482,7 @@ async def test_surge_recalculated_for_auto_source_area() -> None:
         "id": "area-auto-01",
         "name": "South End",
         "is_active": True,
+        "surge_enabled": True,
         "surge_source": "auto",
         "surge_multiplier": 1.0,
         "parent_service_area_id": None,

--- a/backend/utils/driver_onboarding_reminder_rules.py
+++ b/backend/utils/driver_onboarding_reminder_rules.py
@@ -43,6 +43,20 @@ def local_date_for_send_window(
     return local_now.date().isoformat() if local_now.hour == LOCAL_SEND_HOUR else None
 
 
+def open_send_windows(timezones: set[str] | list[str], now: datetime) -> set[str]:
+    """Return '<tz>:<local-date>' keys for timezones currently inside the 08:00 send hour.
+
+    DEFAULT_TIMEZONE is always included so drivers without a service area
+    (whose timezone falls back to the default) still get a daily window.
+    """
+    keys: set[str] = set()
+    for tz_name in {t for t in timezones if t} | {DEFAULT_TIMEZONE}:
+        local_now = now.astimezone(_zone(tz_name))
+        if local_now.hour == LOCAL_SEND_HOUR:
+            keys.add(f"{tz_name}:{local_now.date().isoformat()}")
+    return keys
+
+
 def should_skip_driver(driver: dict[str, Any]) -> bool:
     return bool(
         not driver.get("id")

--- a/backend/utils/driver_onboarding_reminders.py
+++ b/backend/utils/driver_onboarding_reminders.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 try:
@@ -27,6 +27,7 @@ try:
         as_utc,
         local_date_for_send_window,
         missing_required_document_uploads,
+        open_send_windows,
         reminder_message,
         should_skip_driver,
     )
@@ -41,6 +42,7 @@ except ImportError:
         as_utc,
         local_date_for_send_window,
         missing_required_document_uploads,
+        open_send_windows,
         reminder_message,
         should_skip_driver,
     )
@@ -52,6 +54,12 @@ logger = logging.getLogger(__name__)
 CHECK_INTERVAL_SECONDS = 15 * 60
 PAGE_SIZE = 200
 LOG_TABLE = "driver_onboarding_reminder_log"
+
+# Windows ('<tz>:<local-date>') this process has already scanned. The 15-min
+# tick is only a clock check; the full drivers/documents scan runs once per
+# timezone per day, inside the 08:00 local send hour. In-process only — the
+# DB claim log keeps sends idempotent across replicas and restarts.
+_completed_windows: set[str] = set()
 
 
 async def _get_rows(table: str, filters: dict[str, Any] | None, **kwargs) -> list[dict[str, Any]]:
@@ -130,13 +138,25 @@ async def _send(driver: dict[str, Any], kind: str, local_date: str, now: datetim
 
 async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> dict[str, int]:
     now = as_utc(now_utc)
+    stats = {"drivers_scanned": 0, "claims_attempted": 0, "pushes_delivered": 0}
+
     areas = {
         str(r["id"]): r
         for r in await _get_rows("service_areas", {}, limit=1000, columns="id,timezone,required_documents")
         if r.get("id")
     }
+
+    # Daily gate: the drivers + documents scan only runs while some known
+    # timezone (area timezones + default) is inside its 08:00 send hour, and
+    # at most once per window per process. Outside the window each tick costs
+    # only the small service_areas read above. Drivers with a personal
+    # timezone matching no service area are covered by the default-timezone
+    # window rather than their own.
+    windows = open_send_windows({(a.get("timezone") or "") for a in areas.values()}, now)
+    if not windows - _completed_windows:
+        return stats
+
     global_reqs = await _get_rows("document_requirements", {}, limit=200, columns="id,name,is_mandatory")
-    stats = {"drivers_scanned": 0, "claims_attempted": 0, "pushes_delivered": 0}
 
     offset = 0
     while True:
@@ -179,6 +199,12 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
         if len(drivers) < PAGE_SIZE:
             break
         offset += PAGE_SIZE
+
+    _completed_windows.update(windows)
+    # Drop windows older than yesterday so the memo can't grow unbounded
+    # (ISO dates compare lexicographically).
+    cutoff = (now - timedelta(days=1)).date().isoformat()
+    _completed_windows.difference_update({w for w in _completed_windows if w.rsplit(":", 1)[1] < cutoff})
 
     if stats["claims_attempted"]:
         logger.info("onboarding reminders: %s", stats)

--- a/backend/utils/driver_onboarding_reminders.py
+++ b/backend/utils/driver_onboarding_reminders.py
@@ -77,7 +77,12 @@ async def _get_rows(table: str, filters: dict[str, Any] | None, **kwargs) -> lis
         return None
 
 
-async def _claim(driver_id: str, user_id: str, kind: str, local_date: str, now: datetime) -> dict[str, Any] | None:
+# Sentinel distinguishing "claim insert failed" (retry next tick) from
+# "already claimed today" (None — definitive, no retry needed).
+_CLAIM_ERROR = object()
+
+
+async def _claim(driver_id: str, user_id: str, kind: str, local_date: str, now: datetime):
     try:
         return await db.insert_one(
             LOG_TABLE,
@@ -101,7 +106,7 @@ async def _claim(driver_id: str, user_id: str, kind: str, local_date: str, now: 
             original,
             exc_info=True,
         )
-        return None
+        return _CLAIM_ERROR
 
 
 async def _mark(claim: dict[str, Any], now: datetime, delivered: bool, error: str | None) -> None:
@@ -123,10 +128,15 @@ async def _mark(claim: dict[str, Any], now: datetime, delivered: bool, error: st
         logger.error("onboarding reminders: log update failed: %s original=%s", exc, original, exc_info=True)
 
 
-async def _send(driver: dict[str, Any], kind: str, local_date: str, now: datetime) -> bool:
+async def _send(driver: dict[str, Any], kind: str, local_date: str, now: datetime) -> bool | None:
+    """True = delivered, False = not needed/failed-after-claim, None = claim
+    insert failed (no dedupe row exists — the window must stay incomplete so
+    the next tick retries)."""
     driver_id = str(driver["id"])
     user_id = str(driver["user_id"])
     claim = await _claim(driver_id, user_id, kind, local_date, now)
+    if claim is _CLAIM_ERROR:
+        return None
     if not claim:
         return False
 
@@ -210,10 +220,18 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
                 continue
             if not _has_vehicle_details(driver):
                 stats["claims_attempted"] += 1
-                stats["pushes_delivered"] += int(await _send(driver, VEHICLE_DETAILS, local_date, now))
+                sent = await _send(driver, VEHICLE_DETAILS, local_date, now)
+                if sent is None:
+                    scan_ok = False  # claim insert failed — retry this window next tick
+                else:
+                    stats["pushes_delivered"] += int(sent)
             if missing_required_document_uploads(driver, docs_by_driver.get(str(driver["id"]), []), areas, global_reqs):
                 stats["claims_attempted"] += 1
-                stats["pushes_delivered"] += int(await _send(driver, VEHICLE_DOCUMENTS, local_date, now))
+                sent = await _send(driver, VEHICLE_DOCUMENTS, local_date, now)
+                if sent is None:
+                    scan_ok = False
+                else:
+                    stats["pushes_delivered"] += int(sent)
 
         if len(drivers) < PAGE_SIZE:
             break

--- a/backend/utils/driver_onboarding_reminders.py
+++ b/backend/utils/driver_onboarding_reminders.py
@@ -164,9 +164,10 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
     # Daily gate: the drivers + documents scan only runs while some known
     # timezone (area timezones + default) is inside its 08:00 send hour, and
     # at most once per window per process. Outside the window each tick costs
-    # only the small service_areas read above. Drivers with a personal
-    # timezone matching no service area are covered by the default-timezone
-    # window rather than their own.
+    # only the small service_areas read above. The drivers table has no
+    # timezone column (the driver.timezone fallback in driver_timezone() is
+    # defensive only), so drivers without a service area always resolve to
+    # DEFAULT_TIMEZONE — whose window is always gated.
     windows = open_send_windows({(a.get("timezone") or "") for a in areas.values()}, now)
     if not windows - _completed_windows:
         return stats

--- a/backend/utils/driver_onboarding_reminders.py
+++ b/backend/utils/driver_onboarding_reminders.py
@@ -62,13 +62,19 @@ LOG_TABLE = "driver_onboarding_reminder_log"
 _completed_windows: set[str] = set()
 
 
-async def _get_rows(table: str, filters: dict[str, Any] | None, **kwargs) -> list[dict[str, Any]]:
+async def _get_rows(table: str, filters: dict[str, Any] | None, **kwargs) -> list[dict[str, Any]] | None:
+    """Rows, or None when the read failed.
+
+    None (not []) so callers can tell "table is empty" from "DB error" —
+    a failed read during the send window must leave the window incomplete
+    so the next tick retries, instead of silently skipping the day.
+    """
     try:
         return await db.get_rows(table, filters or {}, **kwargs)
     except Exception as exc:
         original = getattr(exc, "details", {}).get("original") if hasattr(exc, "details") else None
         logger.error("onboarding reminders: failed to read %s: %s original=%s", table, exc, original, exc_info=True)
-        return []
+        return None
 
 
 async def _claim(driver_id: str, user_id: str, kind: str, local_date: str, now: datetime) -> dict[str, Any] | None:
@@ -140,11 +146,10 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
     now = as_utc(now_utc)
     stats = {"drivers_scanned": 0, "claims_attempted": 0, "pushes_delivered": 0}
 
-    areas = {
-        str(r["id"]): r
-        for r in await _get_rows("service_areas", {}, limit=1000, columns="id,timezone,required_documents")
-        if r.get("id")
-    }
+    area_rows = await _get_rows("service_areas", {}, limit=1000, columns="id,timezone,required_documents")
+    if area_rows is None:
+        return stats  # read failed — retry next tick, window stays incomplete
+    areas = {str(r["id"]): r for r in area_rows if r.get("id")}
 
     # Daily gate: the drivers + documents scan only runs while some known
     # timezone (area timezones + default) is inside its 08:00 send hour, and
@@ -157,7 +162,13 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
         return stats
 
     global_reqs = await _get_rows("document_requirements", {}, limit=200, columns="id,name,is_mandatory")
+    if global_reqs is None:
+        return stats  # read failed — retry next tick, window stays incomplete
 
+    # Any failed read below leaves scan_ok False so the window is NOT marked
+    # completed — the next 15-min tick inside the same send hour retries.
+    # Claims already written for earlier pages dedupe via DuplicateRecordError.
+    scan_ok = True
     offset = 0
     while True:
         drivers = await _get_rows(
@@ -167,6 +178,9 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
             offset=offset,
             columns="id,user_id,status,deleted_at,service_area_id,vehicle_type_id,vehicle_make,vehicle_model,license_plate",
         )
+        if drivers is None:
+            scan_ok = False
+            break
         if not drivers:
             break
 
@@ -177,6 +191,11 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
             limit=max(1000, len(ids) * 10),
             columns="id,driver_id,requirement_id,requirement_key,document_type,status",
         )
+        if docs is None:
+            # Without the docs we can't tell uploaded from missing; processing
+            # the page anyway would push false "upload your documents" nags.
+            scan_ok = False
+            break
         docs_by_driver: dict[str, list[dict[str, Any]]] = {}
         for doc in docs:
             if doc.get("driver_id"):
@@ -200,7 +219,8 @@ async def check_driver_onboarding_reminders(now_utc: datetime | None = None) -> 
             break
         offset += PAGE_SIZE
 
-    _completed_windows.update(windows)
+    if scan_ok:
+        _completed_windows.update(windows)
     # Drop windows older than yesterday so the memo can't grow unbounded
     # (ISO dates compare lexicographically).
     cutoff = (now - timedelta(days=1)).date().isoformat()

--- a/backend/utils/stale_intent_reconciler.py
+++ b/backend/utils/stale_intent_reconciler.py
@@ -52,14 +52,14 @@ try:
     from .. import db_supabase as db
     from ..features import send_push_notification
     from ..settings_loader import get_app_settings
-    from .driver_presence import present_driver_ids
+    from .driver_presence import present_driver_ids_checked
     from .insurance_periods import record_period_transition
     from .redis_client import get_redis_stats
 except ImportError:
     import db_supabase as db  # type: ignore
     from features import send_push_notification  # type: ignore
     from settings_loader import get_app_settings  # type: ignore
-    from utils.driver_presence import present_driver_ids  # type: ignore
+    from utils.driver_presence import present_driver_ids_checked  # type: ignore
     from utils.insurance_periods import record_period_transition  # type: ignore
     from utils.redis_client import get_redis_stats  # type: ignore
 
@@ -68,6 +68,9 @@ logger = logging.getLogger(__name__)
 CHECK_INTERVAL_SECONDS = 15 * 60
 DEFAULT_STALE_HOURS = 4
 CANDIDATE_LIMIT = 200
+# Hard cap on rows examined per tick so a pathological backlog can't pin
+# the loop; anything beyond it is picked up by later ticks.
+MAX_CANDIDATES_PER_TICK = 2000
 
 ACTIVE_RIDE_STATUSES = [
     "searching",
@@ -78,13 +81,25 @@ ACTIVE_RIDE_STATUSES = [
 ]
 
 
-async def _stale_hours() -> float:
+async def _stale_hours() -> float | None:
+    """Configured threshold, or None when settings can't be read.
+
+    A failed settings read must NOT silently fall back to the default: an
+    operator may have raised the threshold (e.g. to 24h), and flipping
+    drivers at 4h during a settings outage would override that. The caller
+    skips the tick on None. The default only applies when settings load
+    fine but the key is absent/invalid.
+    """
     try:
         settings = await get_app_settings()
+    except Exception as exc:
+        logger.error(f"stale_intent: settings read failed — tick skipped: {exc}")
+        return None
+    try:
         hours = float(settings.get("stale_intent_offline_hours", DEFAULT_STALE_HOURS))
-        return hours if hours > 0 else DEFAULT_STALE_HOURS
-    except Exception:
+    except (TypeError, ValueError):
         return DEFAULT_STALE_HOURS
+    return hours if hours > 0 else DEFAULT_STALE_HOURS
 
 
 async def reconcile_stale_intent(now_utc: datetime | None = None) -> dict[str, int]:
@@ -98,83 +113,109 @@ async def reconcile_stale_intent(now_utc: datetime | None = None) -> dict[str, i
         logger.debug("stale_intent: Redis not connected — tick skipped")
         return stats
 
+    hours = await _stale_hours()
+    if hours is None:
+        return stats
+
     now = now_utc or datetime.now(timezone.utc)
-    cutoff = (now - timedelta(hours=await _stale_hours())).isoformat()
-
-    candidates = await db.get_rows(
-        "drivers",
-        {"is_online": True, "updated_at": {"$lt": cutoff}},
-        limit=CANDIDATE_LIMIT,
-        columns="id,user_id,updated_at",
-    )
-    stats["candidates"] = len(candidates)
-    if not candidates:
-        return stats
-
-    ids = [str(d["id"]) for d in candidates if d.get("id")]
-
-    try:
-        present = await present_driver_ids(ids)
-    except Exception as exc:
-        # Without trustworthy presence, err on NOT flipping anyone.
-        logger.warning(f"stale_intent: presence lookup failed — tick skipped: {exc}")
-        return stats
-
-    active_rides = await db.get_rows(
-        "rides",
-        {"driver_id": {"$in": ids}, "status": {"$in": ACTIVE_RIDE_STATUSES}},
-        limit=CANDIDATE_LIMIT,
-        columns="id,driver_id",
-    )
-    drivers_on_ride = {str(r["driver_id"]) for r in active_rides if r.get("driver_id")}
-
+    cutoff = (now - timedelta(hours=hours)).isoformat()
     now_iso = now.isoformat()
-    for driver in candidates:
-        driver_id = str(driver["id"])
-        if driver_id in present:
-            stats["skipped_present"] += 1
-            continue
-        if driver_id in drivers_on_ride:
-            stats["skipped_active_ride"] += 1
-            logger.warning(
-                f"stale_intent: driver {driver_id} is stale but linked to an active ride — "
-                "left online; investigate the ride"
-            )
-            continue
 
-        claimed = await db.update_one(
+    # Page through the stale set. Flipped rows leave the predicate, so the
+    # next page starts after only the rows we *skipped* (still matching);
+    # without this, >CANDIDATE_LIMIT stale drivers whose first page is all
+    # skips would shadow the rest forever.
+    offset = 0
+    while stats["candidates"] < MAX_CANDIDATES_PER_TICK:
+        candidates = await db.get_rows(
             "drivers",
-            {"id": driver_id, "is_online": True},
-            {
-                "is_online": False,
-                "is_available": False,
-                "went_offline_at": now_iso,
-                "updated_at": now_iso,
-            },
+            {"is_online": True, "updated_at": {"$lt": cutoff}},
+            limit=CANDIDATE_LIMIT,
+            offset=offset,
+            columns="id,user_id,updated_at",
         )
-        if not claimed:
-            continue  # another replica won, or the driver toggled meanwhile
+        stats["candidates"] += len(candidates)
+        if not candidates:
+            break
 
-        stats["flipped"] += 1
-        logger.info(
-            f"stale_intent: driver {driver_id} intent flipped offline (last activity {driver.get('updated_at')})"
+        ids = [str(d["id"]) for d in candidates if d.get("id")]
+
+        try:
+            present, reachable = await present_driver_ids_checked(ids)
+        except Exception as exc:
+            logger.warning(f"stale_intent: presence lookup failed — tick aborted: {exc}")
+            return stats
+        if not reachable:
+            # Redis configured but unavailable mid-tick: an empty presence
+            # set means "unknowable", not "everyone offline". Flipping on it
+            # would recreate the retired presence_sweeper's mass-offline bug.
+            logger.warning("stale_intent: presence store unreachable — tick aborted")
+            return stats
+
+        active_rides = await db.get_rows(
+            "rides",
+            {"driver_id": {"$in": ids}, "status": {"$in": ACTIVE_RIDE_STATUSES}},
+            limit=CANDIDATE_LIMIT,
+            columns="id,driver_id",
         )
-        # Period 0: fully offline, personal insurance only.
-        await record_period_transition(driver_id, 0)
+        drivers_on_ride = {str(r["driver_id"]) for r in active_rides if r.get("driver_id")}
 
-        user_id = driver.get("user_id")
-        if user_id:
-            try:
-                await send_push_notification(
-                    str(user_id),
-                    "You're now offline",
-                    "We couldn't reach your app for a while, so you were taken "
-                    "offline. Tap 'Go Online' when you're ready to drive again.",
-                    data={"type": "auto_offline", "reason": "unreachable"},
-                    target_app="driver",
+        page_skips = 0
+        for driver in candidates:
+            driver_id = str(driver["id"])
+            if driver_id in present:
+                stats["skipped_present"] += 1
+                page_skips += 1
+                continue
+            if driver_id in drivers_on_ride:
+                stats["skipped_active_ride"] += 1
+                page_skips += 1
+                logger.warning(
+                    f"stale_intent: driver {driver_id} is stale but linked to an active ride — "
+                    "left online; investigate the ride"
                 )
-            except Exception as exc:
-                logger.warning(f"stale_intent: offline push failed for driver {driver_id}: {exc}")
+                continue
+
+            # Atomic claim. Re-asserting the staleness predicate closes the
+            # race where the app came back (location batch bumped
+            # updated_at) between the candidate query and this write.
+            claimed = await db.update_one(
+                "drivers",
+                {"id": driver_id, "is_online": True, "updated_at": {"$lt": cutoff}},
+                {
+                    "is_online": False,
+                    "is_available": False,
+                    "went_offline_at": now_iso,
+                    "updated_at": now_iso,
+                },
+            )
+            if not claimed:
+                continue  # another replica won, driver toggled, or app woke up
+
+            stats["flipped"] += 1
+            logger.info(
+                f"stale_intent: driver {driver_id} intent flipped offline (last activity {driver.get('updated_at')})"
+            )
+            # Period 0: fully offline, personal insurance only.
+            await record_period_transition(driver_id, 0)
+
+            user_id = driver.get("user_id")
+            if user_id:
+                try:
+                    await send_push_notification(
+                        str(user_id),
+                        "You're now offline",
+                        "We couldn't reach your app for a while, so you were taken "
+                        "offline. Tap 'Go Online' when you're ready to drive again.",
+                        data={"type": "auto_offline", "reason": "unreachable"},
+                        target_app="driver",
+                    )
+                except Exception as exc:
+                    logger.warning(f"stale_intent: offline push failed for driver {driver_id}: {exc}")
+
+        if len(candidates) < CANDIDATE_LIMIT:
+            break
+        offset += page_skips
 
     if stats["flipped"]:
         logger.info(f"stale_intent: {stats}")

--- a/backend/utils/stale_intent_reconciler.py
+++ b/backend/utils/stale_intent_reconciler.py
@@ -130,6 +130,7 @@ async def reconcile_stale_intent(now_utc: datetime | None = None) -> dict[str, i
         candidates = await db.get_rows(
             "drivers",
             {"is_online": True, "updated_at": {"$lt": cutoff}},
+            order="updated_at",
             limit=CANDIDATE_LIMIT,
             offset=offset,
             columns="id,user_id,updated_at",
@@ -174,6 +175,24 @@ async def reconcile_stale_intent(now_utc: datetime | None = None) -> dict[str, i
                     f"stale_intent: driver {driver_id} is stale but linked to an active ride — "
                     "left online; investigate the ride"
                 )
+                continue
+
+            # Presence can have refreshed since the batched check above (a WS
+            # pong updates Redis but not drivers.updated_at, so the claim
+            # predicate alone can't see a reconnect). Re-check this one
+            # driver immediately before the claim to shrink that window to
+            # milliseconds.
+            try:
+                present_now, reachable_now = await present_driver_ids_checked([driver_id])
+            except Exception as exc:
+                logger.warning(f"stale_intent: presence re-check failed — tick aborted: {exc}")
+                return stats
+            if not reachable_now:
+                logger.warning("stale_intent: presence store unreachable — tick aborted")
+                return stats
+            if present_now:
+                stats["skipped_present"] += 1
+                page_skips += 1
                 continue
 
             # Atomic claim. Re-asserting the staleness predicate closes the

--- a/backend/utils/stale_intent_reconciler.py
+++ b/backend/utils/stale_intent_reconciler.py
@@ -1,0 +1,193 @@
+"""Stale intent reconciler — flips long-unreachable drivers' intent offline.
+
+``drivers.is_online`` is pure driver intent (see utils/driver_online.py);
+nothing on the hot path derives it from reachability. The gap that leaves:
+a driver who force-kills the app (or whose phone dies) stays intent-online
+in the DB forever. Dispatch is unaffected — Redis presence already excludes
+them — but admin views, analytics, and above all the *insurance period log*
+stay wrong: a Period 1 (TNC contingent liability) window that never closes
+is a regulatory audit problem.
+
+This loop closes that gap on an hours scale, deliberately unlike the
+retired presence_sweeper (which acted on 30-second Redis presence and
+mass-flipped drivers whenever Redis fell back to per-replica in-process
+state). Safeguards against that failure class:
+
+  * **Durable staleness signal.** Candidates are selected on
+    ``drivers.updated_at`` — a Postgres timestamp refreshed by every
+    location batch (~30 s cadence while the app is alive). A Redis outage
+    cannot make a live driver look stale.
+  * **Redis-healthy gate.** The tick is skipped entirely when Redis is in
+    in-process-fallback mode, so presence can never be misread as absent
+    merely because Redis is down.
+  * **Presence double-check.** A driver whose presence key is alive is
+    never flipped, even with a stale row (e.g. location permission revoked
+    while the WebSocket still heartbeats).
+  * **Active-ride guard.** Drivers linked to an active ride are skipped —
+    a Period 0 write while a ride is open would corrupt the insurance log;
+    stuck rides are the stuck-ride sweeper's job.
+  * **Atomic claim.** The flip filters on ``is_online = true``; zero rows
+    back means another replica (or the driver) won the race.
+
+Interval: 15 min. Threshold: ``stale_intent_offline_hours`` app setting
+(default 4 h).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import datetime, timedelta, timezone
+
+try:
+    from utils.loop_monitor import record_heartbeat as _record_heartbeat
+except ImportError:
+
+    def _record_heartbeat(name: str) -> None:  # type: ignore[misc]
+        pass
+
+
+try:
+    from .. import db_supabase as db
+    from ..features import send_push_notification
+    from ..settings_loader import get_app_settings
+    from .driver_presence import present_driver_ids
+    from .insurance_periods import record_period_transition
+    from .redis_client import get_redis_stats
+except ImportError:
+    import db_supabase as db  # type: ignore
+    from features import send_push_notification  # type: ignore
+    from settings_loader import get_app_settings  # type: ignore
+    from utils.driver_presence import present_driver_ids  # type: ignore
+    from utils.insurance_periods import record_period_transition  # type: ignore
+    from utils.redis_client import get_redis_stats  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+CHECK_INTERVAL_SECONDS = 15 * 60
+DEFAULT_STALE_HOURS = 4
+CANDIDATE_LIMIT = 200
+
+ACTIVE_RIDE_STATUSES = [
+    "searching",
+    "driver_assigned",
+    "driver_accepted",
+    "driver_arrived",
+    "in_progress",
+]
+
+
+async def _stale_hours() -> float:
+    try:
+        settings = await get_app_settings()
+        hours = float(settings.get("stale_intent_offline_hours", DEFAULT_STALE_HOURS))
+        return hours if hours > 0 else DEFAULT_STALE_HOURS
+    except Exception:
+        return DEFAULT_STALE_HOURS
+
+
+async def reconcile_stale_intent(now_utc: datetime | None = None) -> dict[str, int]:
+    """One tick. Returns counters for logging/tests."""
+    stats = {"candidates": 0, "skipped_present": 0, "skipped_active_ride": 0, "flipped": 0}
+
+    redis_stats = await get_redis_stats()
+    if not redis_stats.get("connected"):
+        # In-process fallback: presence is per-replica and cannot be trusted
+        # as evidence of absence. Never flip intent in this mode.
+        logger.debug("stale_intent: Redis not connected — tick skipped")
+        return stats
+
+    now = now_utc or datetime.now(timezone.utc)
+    cutoff = (now - timedelta(hours=await _stale_hours())).isoformat()
+
+    candidates = await db.get_rows(
+        "drivers",
+        {"is_online": True, "updated_at": {"$lt": cutoff}},
+        limit=CANDIDATE_LIMIT,
+        columns="id,user_id,updated_at",
+    )
+    stats["candidates"] = len(candidates)
+    if not candidates:
+        return stats
+
+    ids = [str(d["id"]) for d in candidates if d.get("id")]
+
+    try:
+        present = await present_driver_ids(ids)
+    except Exception as exc:
+        # Without trustworthy presence, err on NOT flipping anyone.
+        logger.warning(f"stale_intent: presence lookup failed — tick skipped: {exc}")
+        return stats
+
+    active_rides = await db.get_rows(
+        "rides",
+        {"driver_id": {"$in": ids}, "status": {"$in": ACTIVE_RIDE_STATUSES}},
+        limit=CANDIDATE_LIMIT,
+        columns="id,driver_id",
+    )
+    drivers_on_ride = {str(r["driver_id"]) for r in active_rides if r.get("driver_id")}
+
+    now_iso = now.isoformat()
+    for driver in candidates:
+        driver_id = str(driver["id"])
+        if driver_id in present:
+            stats["skipped_present"] += 1
+            continue
+        if driver_id in drivers_on_ride:
+            stats["skipped_active_ride"] += 1
+            logger.warning(
+                f"stale_intent: driver {driver_id} is stale but linked to an active ride — "
+                "left online; investigate the ride"
+            )
+            continue
+
+        claimed = await db.update_one(
+            "drivers",
+            {"id": driver_id, "is_online": True},
+            {
+                "is_online": False,
+                "is_available": False,
+                "went_offline_at": now_iso,
+                "updated_at": now_iso,
+            },
+        )
+        if not claimed:
+            continue  # another replica won, or the driver toggled meanwhile
+
+        stats["flipped"] += 1
+        logger.info(
+            f"stale_intent: driver {driver_id} intent flipped offline (last activity {driver.get('updated_at')})"
+        )
+        # Period 0: fully offline, personal insurance only.
+        await record_period_transition(driver_id, 0)
+
+        user_id = driver.get("user_id")
+        if user_id:
+            try:
+                await send_push_notification(
+                    str(user_id),
+                    "You're now offline",
+                    "We couldn't reach your app for a while, so you were taken "
+                    "offline. Tap 'Go Online' when you're ready to drive again.",
+                    data={"type": "auto_offline", "reason": "unreachable"},
+                    target_app="driver",
+                )
+            except Exception as exc:
+                logger.warning(f"stale_intent: offline push failed for driver {driver_id}: {exc}")
+
+    if stats["flipped"]:
+        logger.info(f"stale_intent: {stats}")
+    return stats
+
+
+async def stale_intent_reconciler_loop() -> None:
+    """Every 15 min: close intent-online windows for drivers unreachable for hours."""
+    logger.info("Stale intent reconciler started")
+    while True:
+        try:
+            await reconcile_stale_intent()
+        except Exception:
+            logger.error("stale_intent_reconciler tick failed", exc_info=True)
+        _record_heartbeat("stale_intent_reconciler (15min)")
+        await asyncio.sleep(CHECK_INTERVAL_SECONDS + random.uniform(-60, 60))

--- a/backend/utils/surge_engine.py
+++ b/backend/utils/surge_engine.py
@@ -153,16 +153,21 @@ async def calculate_surge_for_area(area: Dict[str, Any]) -> Dict[str, Any]:
 
 async def recalculate_all_surges() -> List[Dict[str, Any]]:
     """
-    Recalculate surge for all active service areas.
+    Recalculate surge for all surge-enabled active service areas.
 
     Only updates areas where surge_source == 'auto' (or not set).
     Areas with surge_source == 'manual' are skipped — the admin's
     override takes precedence until they reset it to auto.
+
+    surge_enabled is filtered in the DB query (not just in Python) so a
+    deployment where no area has the surge toggle on costs one empty
+    response per tick instead of a full service_areas read every 2 min
+    (Supabase egress).
     """
     results = []
 
     try:
-        areas = await db.get_rows("service_areas", {"is_active": True}, limit=100)
+        areas = await db.get_rows("service_areas", {"is_active": True, "surge_enabled": True}, limit=100)
     except Exception as e:
         original = getattr(e, "details", {}).get("original") if hasattr(e, "details") else None
         logger.error(f"Surge: failed to fetch service areas: {e} | original={original}")
@@ -179,10 +184,10 @@ async def recalculate_all_surges() -> List[Dict[str, Any]]:
             continue
 
         # Per-area admin master gate: never auto-activate surge for an area the
-        # operator hasn't explicitly enabled (surge_enabled defaults FALSE). The
-        # fare paths also refuse to apply surge for disabled areas, but skipping
-        # here keeps surge_active/multiplier from ever being written in the first
-        # place, so nothing stale lingers if the area is later enabled.
+        # operator hasn't explicitly enabled (surge_enabled defaults FALSE).
+        # The DB query above already filters on surge_enabled; this guard is a
+        # backstop so a caller passing unfiltered rows can never auto-activate
+        # a disabled area. The fare paths apply the same gate.
         if not area.get("surge_enabled", False):
             continue
 

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -1107,62 +1107,14 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
     return () => clearInterval(id);
   }, [connectionState]);
 
-  // ─── Engagement Check (Zombie Driver Prevention) ─────────────────
-  // Uber/Lyft prompt "Are you still there?" after ~15 mins of idle online time.
-  // Prevents drivers from leaving the app open on a desk and walking away,
-  // which causes missed offers and bad rider experiences.
-  const [idleResetCount, setIdleResetCount] = useState(0);
-  useEffect(() => {
-    if (!isOnline || rideState !== 'idle') {
-      return;
-    }
-
-    let promptTimeout: ReturnType<typeof setTimeout>;
-    let offlineTimeout: ReturnType<typeof setTimeout>;
-
-    const IDLE_MINUTES = 15;
-    const RESPONSE_SECONDS = 60;
-
-    promptTimeout = setTimeout(() => {
-      showAlert(
-        "Still driving?",
-        "You've been online but idle for a while. Do you want to stay online and receive rides?",
-        [
-          {
-            text: "Go Offline",
-            style: "destructive",
-            onPress: () => {
-              clearTimeout(offlineTimeout);
-              setIsOnline(false);
-              updateDriverStatus(false).catch(() => {});
-            }
-          },
-          {
-            text: "Stay Online",
-            style: "default",
-            onPress: () => {
-              clearTimeout(offlineTimeout);
-              setIdleResetCount(c => c + 1);
-            }
-          }
-        ],
-      );
-
-      // Force offline if no response
-      offlineTimeout = setTimeout(() => {
-        setIsOnline(false);
-        updateDriverStatus(false).catch(() => {});
-        showAlert("Went Offline", "You were taken offline due to inactivity.");
-      }, RESPONSE_SECONDS * 1000);
-
-    }, IDLE_MINUTES * 60 * 1000);
-
-    return () => {
-      clearTimeout(promptTimeout);
-      clearTimeout(offlineTimeout);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOnline, rideState, idleResetCount]);
+  // ─── No idle-time auto-offline ───────────────────────────────────
+  // A 15-min "Still driving?" prompt used to force drivers offline here.
+  // Removed: long offer-less stretches are normal in a low-density market,
+  // and the prompt silently offlined drivers whose phone was locked in a
+  // dash mount. Zombie drivers are handled where Uber/Lyft handle them:
+  // the backend auto-offlines after N consecutive missed offers
+  // (auto_offline_miss_threshold) and the stale-intent reconciler flips
+  // intent for apps that have been unreachable for hours.
 
   // ─── Toggle Online/Offline ───────────────────────────────────────
   const toggleOnline = async () => {


### PR DESCRIPTION
The 2-min surge loop fetched every active service area (all columns)
and only then skipped surge-disabled ones in Python, so deployments
with the surge toggle off everywhere still paid a full service_areas
read per tick in Supabase egress. Filter surge_enabled=true in the DB
query so disabled areas are never fetched; keep the in-Python guard as
a backstop for callers passing unfiltered rows.

Also repair two stale tests: an invalid 'driver_en_route' ride status
and a fixture missing surge_enabled (failing since the toggle gate
landed).

https://claude.ai/code/session_01QCf6VLQQLv41EsrMeJ3zhG

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
