### PR TITLE
Fix Spinr Pass subscription: implement Stripe Checkout Session payment flow

### DIFF
--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -199,6 +199,22 @@ export default function SettingsPage() {
                                     From Stripe Dashboard &rarr; Developers &rarr; Webhooks
                                 </p>
                             </div>
+                            <div className="space-y-2">
+                                <Label>Connect Webhook Secret</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.stripe_connect_webhook_secret || ""}
+                                    onChange={(e) =>
+                                        update("stripe_connect_webhook_secret", e.target.value)
+                                    }
+                                    placeholder="whsec_..."
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Signing secret for the separate Connected-accounts webhook
+                                    endpoint (account.updated, payout.paid, payout.failed). Leave
+                                    blank if you only use one Stripe webhook endpoint.
+                                </p>
+                            </div>
                         </CardContent>
                     </Card>
 

--- a/admin-dashboard/src/app/dashboard/subscriptions/page.tsx
+++ b/admin-dashboard/src/app/dashboard/subscriptions/page.tsx
@@ -48,6 +48,9 @@ interface SubscriptionPlan {
     is_active: boolean;
     subscriber_count?: number;
     created_at?: string;
+    // Recurring Stripe Price (price_...). When set, the plan auto-renews via
+    // Stripe Billing; blank keeps it on one-off Checkout-per-period.
+    stripe_price_id?: string;
 }
 
 interface DriverSubscription {
@@ -80,6 +83,7 @@ const EMPTY_PLAN: Omit<SubscriptionPlan, "id" | "created_at"> = {
     description: "",
     features: [],
     is_active: true,
+    stripe_price_id: "",
 };
 
 const STATUS_CONFIG: Record<string, { label: string; variant: "default" | "secondary" | "destructive" }> = {
@@ -118,6 +122,7 @@ function PlanModal({ open, plan, onClose, onSave }: PlanModalProps) {
                 description: plan.description ?? "",
                 features: plan.features ?? [],
                 is_active: plan.is_active ?? true,
+                stripe_price_id: plan.stripe_price_id ?? "",
             });
             setFeaturesText((plan.features ?? []).join("\n"));
         } else {
@@ -232,6 +237,20 @@ function PlanModal({ open, plan, onClose, onSave }: PlanModalProps) {
                                 onChange={(e) => setFeaturesText(e.target.value)}
                                 placeholder={"Priority support\nSurge protection\nUnlimited rides"}
                             />
+                        </div>
+                        <div className="col-span-2 space-y-1">
+                            <Label htmlFor="plan-price-id">Stripe Price ID (recurring)</Label>
+                            <Input
+                                id="plan-price-id"
+                                value={form.stripe_price_id || ""}
+                                onChange={(e) => setForm((f) => ({ ...f, stripe_price_id: e.target.value }))}
+                                placeholder="price_... (leave blank for one-off per period)"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Set a recurring Stripe Price to auto-renew this plan via Stripe
+                                Billing. Its amount/currency must match the price above. Blank =
+                                one-off Checkout each period.
+                            </p>
                         </div>
                     </div>
                     {error && <p className="text-sm text-red-500">{error}</p>}

--- a/backend/migrations/148_driver_subscriptions_stripe_fields.sql
+++ b/backend/migrations/148_driver_subscriptions_stripe_fields.sql
@@ -1,0 +1,45 @@
+-- Migration 148: Add Stripe checkout session fields to driver_subscriptions
+--
+-- The driver_subscriptions table had conflicting definitions across migrations.
+-- This migration consolidates the schema to support Stripe Checkout Session payment flow:
+-- - stripe_session_id: Stripe Checkout Session ID, used for verify-session polling
+-- - stripe_charge_id: legacy, kept for off-session fallback auditing
+-- - payment_status: "pending" | "paid" | "failed" | "requires_action"
+-- - expiry_warned: tracks if the driver was notified of upcoming expiry
+--
+-- Rollback: These columns can be dropped if the Checkout flow is reverted,
+-- but the feature remains functional for any active subscriptions (these
+-- columns are optional side-effects).
+
+ALTER TABLE IF EXISTS public.driver_subscriptions
+    ADD COLUMN IF NOT EXISTS stripe_session_id TEXT,
+    ADD COLUMN IF NOT EXISTS stripe_charge_id TEXT,
+    ADD COLUMN IF NOT EXISTS payment_status TEXT DEFAULT 'pending',
+    ADD COLUMN IF NOT EXISTS expiry_warned BOOLEAN DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS plan_name TEXT,
+    ADD COLUMN IF NOT EXISTS price NUMERIC(10,2),
+    ADD COLUMN IF NOT EXISTS rides_per_day INTEGER DEFAULT -1,
+    ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ;
+
+-- Index for webhook lookup by stripe_session_id
+CREATE INDEX IF NOT EXISTS idx_driver_subscriptions_stripe_session
+    ON public.driver_subscriptions(stripe_session_id);
+
+-- Index for expiry enforcement lookup
+CREATE INDEX IF NOT EXISTS idx_driver_subscriptions_expires_at
+    ON public.driver_subscriptions(expires_at, status)
+    WHERE status = 'active' AND expires_at IS NOT NULL;
+
+COMMENT ON COLUMN public.driver_subscriptions.stripe_session_id IS
+    'Stripe Checkout Session ID for the payment. Used by verify-session endpoint to poll payment status.';
+
+COMMENT ON COLUMN public.driver_subscriptions.payment_status IS
+    '"pending" until checkout.session.completed webhook fires, then "paid" (or "failed" if payment failed).';
+
+COMMENT ON COLUMN public.driver_subscriptions.expiry_warned IS
+    'True if driver was notified of expiry within 24h. Prevents duplicate notifications.';
+
+COMMENT ON COLUMN public.driver_subscriptions.expires_at IS
+    'Subscription expiry timestamp. Used by check_expiring_subscriptions() background loop.';

--- a/backend/migrations/149_settings_stripe_connect_webhook_secret.sql
+++ b/backend/migrations/149_settings_stripe_connect_webhook_secret.sql
@@ -1,0 +1,27 @@
+-- Migration 149: Add stripe_connect_webhook_secret to settings
+--
+-- account.updated (driver Connect KYC) and payout.paid / payout.failed
+-- (driver bank settlement) are Connected-accounts events. Stripe delivers
+-- them from a webhook endpoint scoped to "Connected accounts", which gets
+-- its OWN signing secret (whsec_) — distinct from the platform endpoint's
+-- stripe_webhook_secret. routes/webhooks.py now verifies incoming events
+-- against both secrets so a single URL can receive both endpoints' traffic.
+--
+-- Credential: masked on GET via _mask_credentials in routes/admin/settings.py;
+-- super-admin reveal flow is the only way to read the plaintext value.
+--
+-- Forward-compatible: nullable, no backfill. Absent value reads as NULL,
+-- which the Pydantic model handles via the "" default and the webhook
+-- handler treats as "no connect endpoint configured" (single-secret mode).
+--
+-- Rollback:
+--   ALTER TABLE settings DROP COLUMN IF EXISTS stripe_connect_webhook_secret;
+
+ALTER TABLE public.settings
+    ADD COLUMN IF NOT EXISTS stripe_connect_webhook_secret TEXT;
+
+COMMENT ON COLUMN public.settings.stripe_connect_webhook_secret IS
+    'Signing secret (whsec_) for the Stripe Connected-accounts webhook endpoint '
+    '(account.updated, payout.paid, payout.failed). Separate from '
+    'stripe_webhook_secret, which signs the platform endpoint. Masked on GET; '
+    'verified alongside the platform secret in routes/webhooks.py.';

--- a/backend/migrations/150_subscription_recurring_billing.sql
+++ b/backend/migrations/150_subscription_recurring_billing.sql
@@ -1,0 +1,43 @@
+-- Migration 150: Recurring-billing fields for Spinr Pass (B3)
+--
+-- Enables true Stripe-Billing auto-renew alongside the existing one-off
+-- Checkout-per-period flow:
+--   • subscription_plans.stripe_price_id — the recurring Price created in
+--     the Stripe dashboard for this plan. When set, subscribe_to_plan uses
+--     mode="subscription" Checkout (auto-renew); when null it falls back to
+--     the one-off mode="payment" Checkout. Plans are therefore opt-in to
+--     recurring with zero change to existing one-off plans.
+--   • driver_subscriptions.stripe_subscription_id — the Stripe Subscription
+--     (sub_...) id, captured from checkout.session.completed and used to
+--     match invoice.paid / invoice.payment_failed / customer.subscription.*
+--     webhook events back to the driver's row.
+--
+-- stripe_subscription_id may already exist from the legacy 08_complete_schema
+-- definition of driver_subscriptions; IF NOT EXISTS makes this idempotent.
+--
+-- Forward-compatible: both columns nullable, no backfill. Absent values read
+-- as NULL — existing one-off subscriptions and plans are unaffected.
+--
+-- Rollback:
+--   ALTER TABLE subscription_plans   DROP COLUMN IF EXISTS stripe_price_id;
+--   ALTER TABLE driver_subscriptions DROP COLUMN IF EXISTS stripe_subscription_id;
+
+ALTER TABLE public.subscription_plans
+    ADD COLUMN IF NOT EXISTS stripe_price_id TEXT;
+
+ALTER TABLE public.driver_subscriptions
+    ADD COLUMN IF NOT EXISTS stripe_subscription_id TEXT;
+
+-- Renewal/cancellation webhooks look up the row by stripe_subscription_id.
+CREATE INDEX IF NOT EXISTS idx_driver_subscriptions_stripe_subscription
+    ON public.driver_subscriptions(stripe_subscription_id);
+
+COMMENT ON COLUMN public.subscription_plans.stripe_price_id IS
+    'Recurring Stripe Price (price_...) for auto-renew billing. When set, '
+    'subscribe_to_plan uses mode=subscription Checkout; null = one-off '
+    'Checkout-per-period. Create the Price in the Stripe dashboard.';
+
+COMMENT ON COLUMN public.driver_subscriptions.stripe_subscription_id IS
+    'Stripe Subscription id (sub_...) for recurring plans. Captured from '
+    'checkout.session.completed; matches invoice.paid / invoice.payment_failed '
+    '/ customer.subscription.* events back to this row.';

--- a/backend/migrations/151_subscription_payments_ledger.sql
+++ b/backend/migrations/151_subscription_payments_ledger.sql
@@ -56,7 +56,7 @@ DROP POLICY IF EXISTS subscription_payments_select_own ON public.subscription_pa
 CREATE POLICY subscription_payments_select_own ON public.subscription_payments
     FOR SELECT TO authenticated
     USING (
-        driver_id IN (SELECT id FROM public.drivers WHERE user_id = auth.uid())
+        driver_id IN (SELECT id FROM public.drivers WHERE user_id = auth.uid()::text)
     );
 
 -- Financial table: all writes go through the backend service role (bypasses

--- a/backend/migrations/151_subscription_payments_ledger.sql
+++ b/backend/migrations/151_subscription_payments_ledger.sql
@@ -1,0 +1,79 @@
+-- Migration 151: subscription_payments ledger
+--
+-- Records each realized Spinr Pass payment as its own row so admin revenue and
+-- transaction stats capture recurring renewals (not just the first charge) and
+-- stay accurate independent of driver_subscriptions row mutations
+-- (cancel/supersede/expire).
+--
+-- Write points (backend):
+--   - invoice.paid webhook       → billing_reason subscription_create / subscription_cycle
+--   - _activate_subscription     → billing_reason one_off  (one-off Checkout activation)
+--   - subscribe_to_plan dev path → billing_reason dev      (no-Stripe instant activation)
+-- Recurring rows dedupe on stripe_invoice_id (one ledger row per Stripe invoice).
+--
+-- The backfill seeds one 'legacy' row per pre-existing realized subscription so
+-- historical revenue isn't lost when stats switch to reading this table.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.subscription_payments;
+
+CREATE TABLE IF NOT EXISTS public.subscription_payments (
+    id                       TEXT PRIMARY KEY,
+    driver_id                TEXT NOT NULL,
+    subscription_id          TEXT,
+    plan_id                  TEXT,
+    plan_name                TEXT,
+    amount                   NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    currency                 TEXT NOT NULL DEFAULT 'cad',
+    -- subscription_create | subscription_cycle | one_off | dev | legacy
+    billing_reason           TEXT NOT NULL DEFAULT 'one_off',
+    stripe_invoice_id        TEXT,
+    stripe_session_id        TEXT,
+    stripe_payment_intent_id TEXT,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- One ledger row per Stripe invoice — makes recurring renewal inserts idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_subscription_payments_invoice
+    ON public.subscription_payments (stripe_invoice_id)
+    WHERE stripe_invoice_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_subscription_payments_driver
+    ON public.subscription_payments (driver_id);
+CREATE INDEX IF NOT EXISTS idx_subscription_payments_created
+    ON public.subscription_payments (created_at);
+
+ALTER TABLE public.subscription_payments ENABLE ROW LEVEL SECURITY;
+
+-- Driver can read their own payment history; backend (service role) bypasses RLS.
+DROP POLICY IF EXISTS subscription_payments_select_own ON public.subscription_payments;
+CREATE POLICY subscription_payments_select_own ON public.subscription_payments
+    FOR SELECT TO authenticated
+    USING (
+        driver_id IN (SELECT id FROM public.drivers WHERE user_id = auth.uid())
+    );
+
+-- Backfill realized revenue from existing subscriptions (idempotent via id).
+-- Excludes never-paid checkout rows (pending/superseded). Runs once (the runner
+-- keys on filename); ON CONFLICT guards against any accidental re-run.
+INSERT INTO public.subscription_payments
+    (id, driver_id, subscription_id, plan_id, plan_name, amount, currency, billing_reason, created_at)
+SELECT
+    'legacy_' || ds.id,
+    ds.driver_id,
+    ds.id,
+    ds.plan_id,
+    ds.plan_name,
+    COALESCE(ds.price, 0),
+    'cad',
+    'legacy',
+    COALESCE(ds.started_at, ds.created_at, NOW())
+FROM public.driver_subscriptions ds
+WHERE ds.status NOT IN ('pending', 'superseded')
+  AND COALESCE(ds.price, 0) > 0
+ON CONFLICT (id) DO NOTHING;
+
+COMMENT ON TABLE public.subscription_payments IS
+    'Append-only ledger of realized Spinr Pass payments. Source of truth for '
+    'admin subscription revenue/transaction stats (driver_subscriptions tracks '
+    'current subscription STATE; this tracks money MOVED).';

--- a/backend/migrations/151_subscription_payments_ledger.sql
+++ b/backend/migrations/151_subscription_payments_ledger.sql
@@ -34,12 +34,18 @@ CREATE TABLE IF NOT EXISTS public.subscription_payments (
 );
 
 -- One ledger row per Stripe invoice — makes recurring renewal inserts idempotent.
+-- Plain (not CONCURRENTLY) indexes are correct here: the table is created EMPTY
+-- in this same transactional migration, so no concurrent session can touch it
+-- and the builds are instant + lock-free. CONCURRENTLY would also be illegal
+-- inside the transaction that creates the table.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_subscription_payments_invoice
     ON public.subscription_payments (stripe_invoice_id)
     WHERE stripe_invoice_id IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS idx_subscription_payments_driver
-    ON public.subscription_payments (driver_id);
+-- Compound index serves both the per-driver history read and the date-range
+-- aggregation the admin stats endpoint performs.
+CREATE INDEX IF NOT EXISTS idx_subscription_payments_driver_created
+    ON public.subscription_payments (driver_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_subscription_payments_created
     ON public.subscription_payments (created_at);
 
@@ -52,6 +58,17 @@ CREATE POLICY subscription_payments_select_own ON public.subscription_payments
     USING (
         driver_id IN (SELECT id FROM public.drivers WHERE user_id = auth.uid())
     );
+
+-- Financial table: all writes go through the backend service role (bypasses
+-- RLS). Block direct PostgREST write access from JWT roles, matching the
+-- lockdown pattern migration 142 applied to the other money tables. Without
+-- this, any authenticated anon-key JWT could INSERT/UPDATE/DELETE payment rows.
+REVOKE ALL ON public.subscription_payments FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.subscription_payments FROM authenticated;
+GRANT SELECT ON public.subscription_payments TO authenticated;
+-- NOTE: no admin SELECT policy — the admin stats endpoint reads via the service
+-- role, which bypasses RLS. A direct authenticated-role admin read would see
+-- zero rows by design.
 
 -- Backfill realized revenue from existing subscriptions (idempotent via id).
 -- Excludes never-paid checkout rows (pending/superseded). Runs once (the runner

--- a/backend/migrations/152_driver_subscriptions_one_pending_index.sql
+++ b/backend/migrations/152_driver_subscriptions_one_pending_index.sql
@@ -1,17 +1,17 @@
--- Migration 152: one pending checkout per driver
+-- Migration 152: collapse duplicate pending checkouts (prep for the unique index)
 --
--- Prevents two concurrent /drivers/subscription/subscribe requests from both
--- inserting a pending driver_subscriptions row (each backing a live Checkout
--- URL), which could let a stale session activate over a newer one. The endpoint
--- already supersedes its OWN prior pending rows before inserting, so this unique
--- index only bites the true simultaneous race; subscribe_to_plan catches the
--- resulting unique violation and returns 409.
+-- Repair step for migration 153's partial unique index `WHERE status='pending'`.
+-- Demotes all-but-the-newest pending row per driver to 'superseded' so the
+-- CONCURRENTLY index build in 153 can't fail on pre-existing duplicates. Split
+-- from the index build (separate file) because 153 must run CONCURRENTLY in
+-- autocommit, whereas this repair runs transactionally — same pattern as
+-- migrations 142 (repair) → 143 (CONCURRENTLY index).
 --
--- Rollback:
---   DROP INDEX IF EXISTS idx_driver_subscriptions_one_pending;
+-- Tie-break on id after created_at so two pending rows sharing a created_at
+-- still pick a single deterministic winner.
+--
+-- Rollback: none needed (data-only repair; superseded rows are terminal).
 
--- Collapse any pre-existing duplicate pending rows to one (keep the newest)
--- before the unique index is created, otherwise creation fails.
 UPDATE public.driver_subscriptions
 SET status = 'superseded'
 WHERE status = 'pending'
@@ -19,13 +19,5 @@ WHERE status = 'pending'
       SELECT DISTINCT ON (driver_id) id
       FROM public.driver_subscriptions
       WHERE status = 'pending'
-      ORDER BY driver_id, created_at DESC
+      ORDER BY driver_id, created_at DESC NULLS LAST, id DESC
   );
-
-CREATE UNIQUE INDEX IF NOT EXISTS idx_driver_subscriptions_one_pending
-    ON public.driver_subscriptions (driver_id)
-    WHERE status = 'pending';
-
-COMMENT ON INDEX idx_driver_subscriptions_one_pending IS
-    'At most one pending checkout per driver — closes the concurrent '
-    'double-checkout race in subscribe_to_plan.';

--- a/backend/migrations/152_driver_subscriptions_one_pending_index.sql
+++ b/backend/migrations/152_driver_subscriptions_one_pending_index.sql
@@ -1,0 +1,31 @@
+-- Migration 152: one pending checkout per driver
+--
+-- Prevents two concurrent /drivers/subscription/subscribe requests from both
+-- inserting a pending driver_subscriptions row (each backing a live Checkout
+-- URL), which could let a stale session activate over a newer one. The endpoint
+-- already supersedes its OWN prior pending rows before inserting, so this unique
+-- index only bites the true simultaneous race; subscribe_to_plan catches the
+-- resulting unique violation and returns 409.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS idx_driver_subscriptions_one_pending;
+
+-- Collapse any pre-existing duplicate pending rows to one (keep the newest)
+-- before the unique index is created, otherwise creation fails.
+UPDATE public.driver_subscriptions
+SET status = 'superseded'
+WHERE status = 'pending'
+  AND id NOT IN (
+      SELECT DISTINCT ON (driver_id) id
+      FROM public.driver_subscriptions
+      WHERE status = 'pending'
+      ORDER BY driver_id, created_at DESC
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_driver_subscriptions_one_pending
+    ON public.driver_subscriptions (driver_id)
+    WHERE status = 'pending';
+
+COMMENT ON INDEX idx_driver_subscriptions_one_pending IS
+    'At most one pending checkout per driver — closes the concurrent '
+    'double-checkout race in subscribe_to_plan.';

--- a/backend/migrations/153_driver_subscriptions_one_pending_index.sql
+++ b/backend/migrations/153_driver_subscriptions_one_pending_index.sql
@@ -1,0 +1,23 @@
+-- Migration 153: at most one pending checkout per driver (partial unique index)
+--
+-- Closes the concurrent double-checkout race in subscribe_to_plan: two
+-- simultaneous requests that both pass the supersede step would otherwise each
+-- insert a pending row (each backing a live Checkout URL). This index makes the
+-- second insert fail; the endpoint catches it and returns 409.
+--
+-- driver_subscriptions is written by the webhook path, the subscribe endpoint,
+-- and the expiry loop concurrently with production traffic, so the index is
+-- built CONCURRENTLY (no SHARE lock blocking those writes). The runner detects
+-- CONCURRENTLY and executes this file statement-by-statement in autocommit.
+-- The DROP CONCURRENTLY IF EXISTS first clears any INVALID leftover from an
+-- interrupted prior build (IF NOT EXISTS alone would skip rebuilding it).
+-- Migration 152 already demoted duplicate pending rows so the build can't fail
+-- on existing data.
+--
+-- Rollback: DROP INDEX CONCURRENTLY IF EXISTS idx_driver_subscriptions_one_pending;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_driver_subscriptions_one_pending;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_driver_subscriptions_one_pending
+    ON public.driver_subscriptions (driver_id)
+    WHERE status = 'pending';

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -43,6 +43,7 @@ _CREDENTIAL_FIELDS = frozenset(
     {
         "stripe_secret_key",
         "stripe_webhook_secret",
+        "stripe_connect_webhook_secret",
         "twilio_auth_token",
         "google_maps_api_key",
         # Resend API key is a credential too — without masking it would
@@ -101,6 +102,8 @@ class SettingsUpdateRequest(BaseModel):
     stripe_publishable_key: Optional[str] = None
     stripe_secret_key: Optional[str] = None
     stripe_webhook_secret: Optional[str] = None
+    # Connected-accounts endpoint signing secret (account.updated, payout.*).
+    stripe_connect_webhook_secret: Optional[str] = None
     twilio_account_sid: Optional[str] = None
     twilio_auth_token: Optional[str] = None
     twilio_from_number: Optional[str] = None

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -188,8 +188,15 @@ async def admin_get_subscription_stats(
     active = [s for s in all_subs if s.get("status") == "active"]
     expired = [s for s in all_subs if s.get("status") == "expired"]
     cancelled = [s for s in all_subs if s.get("status") == "cancelled"]
+
     # Current MRR-ish: sum of active subscriptions' plan price.
-    active_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in active))
+    # Money stays in Decimal through every aggregation; we convert to a clean
+    # 2-dp float only at the JSON boundary (the admin API contract is numeric).
+    def _money(v) -> float:
+        return float(Decimal(str(v or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+    # Current MRR-ish: sum of active subscriptions' plan price.
+    active_revenue = sum((Decimal(str(s.get("price") or 0)) for s in active), Decimal("0"))
 
     def parse_dt(s):
         try:
@@ -205,14 +212,14 @@ async def admin_get_subscription_stats(
     if area_filter:
         payments = [p for p in payments if driver_area_map.get(p.get("driver_id", "")) in area_filter]
 
-    total_revenue = float(sum(Decimal(str(p.get("amount") or 0)) for p in payments))
+    total_revenue = sum((Decimal(str(p.get("amount") or 0)) for p in payments), Decimal("0"))
 
     payments_in_range = []
     for p in payments:
         dt = parse_dt(p.get("created_at"))
         if dt and range_start <= dt <= range_end:
             payments_in_range.append(p)
-    range_revenue = float(sum(Decimal(str(p.get("amount") or 0)) for p in payments_in_range))
+    range_revenue = sum((Decimal(str(p.get("amount") or 0)) for p in payments_in_range), Decimal("0"))
 
     # New-subscriber chart counts new subscriptions (state), not payments.
     new_subs_in_range = []
@@ -222,7 +229,7 @@ async def admin_get_subscription_stats(
             new_subs_in_range.append(s)
 
     # Per-plan breakdown: revenue from the ledger, subscriber counts from subs.
-    plan_stats = defaultdict(lambda: {"name": "", "count": 0, "revenue": 0.0, "active": 0})
+    plan_stats = defaultdict(lambda: {"name": "", "count": 0, "revenue": Decimal("0"), "active": 0})
     for s in real_subs:
         pid = s.get("plan_id") or "unknown"
         plan_stats[pid]["name"] = s.get("plan_name") or plan_map.get(pid, {}).get("name", "Unknown")
@@ -233,19 +240,16 @@ async def admin_get_subscription_stats(
         pid = p.get("plan_id") or "unknown"
         if not plan_stats[pid]["name"]:
             plan_stats[pid]["name"] = p.get("plan_name") or plan_map.get(pid, {}).get("name", "Unknown")
-        plan_stats[pid]["revenue"] = float(
-            Decimal(str(plan_stats[pid]["revenue"])) + Decimal(str(p.get("amount") or 0))
-        )
+        plan_stats[pid]["revenue"] += Decimal(str(p.get("amount") or 0))
 
     # Daily charts (within date range)
     num_days = min((range_end - range_start).days + 1, 365)
-    daily_revenue = defaultdict(float)
+    daily_revenue: Dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
     daily_new_subs = defaultdict(int)
     for p in payments_in_range:
         dt = parse_dt(p.get("created_at"))
         if dt:
-            day_key = dt.strftime("%Y-%m-%d")
-            daily_revenue[day_key] = float(Decimal(str(daily_revenue[day_key])) + Decimal(str(p.get("amount") or 0)))
+            daily_revenue[dt.strftime("%Y-%m-%d")] += Decimal(str(p.get("amount") or 0))
     for s in new_subs_in_range:
         dt = parse_dt(s.get("created_at") or s.get("started_at"))
         if dt:
@@ -257,9 +261,7 @@ async def admin_get_subscription_stats(
         day = range_start + timedelta(days=i)
         day_key = day.strftime("%Y-%m-%d")
         day_label = day.strftime("%b %d")
-        revenue_chart.append(
-            {"date": day_label, "date_raw": day_key, "amount": round(daily_revenue.get(day_key, 0), 2)}
-        )
+        revenue_chart.append({"date": day_label, "date_raw": day_key, "amount": _money(daily_revenue.get(day_key, 0))})
         subscribers_chart.append({"date": day_label, "date_raw": day_key, "count": daily_new_subs.get(day_key, 0)})
 
     # Transaction list = ledger payments in range (each a realized charge,
@@ -273,7 +275,7 @@ async def admin_get_subscription_stats(
                 "driver_id": _did,
                 "driver_name": drivers_map.get(_did, _did[:8]),
                 "plan_name": p.get("plan_name") or plan_map.get(p.get("plan_id", ""), {}).get("name", "Unknown"),
-                "price": float(p.get("amount") or 0),
+                "price": _money(p.get("amount")),
                 "billing_reason": p.get("billing_reason"),
                 "created_at": p.get("created_at"),
             }
@@ -285,12 +287,21 @@ async def admin_get_subscription_stats(
             "active": len(active),
             "expired": len(expired),
             "cancelled": len(cancelled),
-            "total_revenue": round(total_revenue, 2),
-            "active_mrr": round(active_revenue, 2),
-            "range_revenue": round(range_revenue, 2),
+            "total_revenue": _money(total_revenue),
+            "active_mrr": _money(active_revenue),
+            "range_revenue": _money(range_revenue),
             "range_transactions": len(payments_in_range),
         },
-        "plan_breakdown": [{"plan_id": k, **v} for k, v in plan_stats.items()],
+        "plan_breakdown": [
+            {
+                "plan_id": k,
+                "name": v["name"],
+                "count": v["count"],
+                "active": v["active"],
+                "revenue": _money(v["revenue"]),
+            }
+            for k, v in plan_stats.items()
+        ],
         "charts": {
             "daily_revenue": revenue_chart,
             "daily_subscribers": subscribers_chart,

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -179,11 +179,16 @@ async def admin_get_subscription_stats(
     if area_filter:
         all_subs = [s for s in all_subs if driver_area_map.get(s.get("driver_id", "")) in area_filter]
 
+    # Only paid rows represent realized revenue/subscribers. A pending or
+    # superseded checkout row carries a price but no cleared payment, so it
+    # must not inflate revenue, transaction, or subscriber metrics.
+    paid_subs = [s for s in all_subs if s.get("payment_status") == "paid"]
+
     # Overall stats
     active = [s for s in all_subs if s.get("status") == "active"]
     expired = [s for s in all_subs if s.get("status") == "expired"]
     cancelled = [s for s in all_subs if s.get("status") == "cancelled"]
-    total_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in all_subs))
+    total_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in paid_subs))
     active_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in active))
 
     # Filter to date range for transactions and charts
@@ -194,7 +199,7 @@ async def admin_get_subscription_stats(
             return None
 
     in_range = []
-    for s in all_subs:
+    for s in paid_subs:
         dt = parse_dt(s.get("created_at") or s.get("started_at"))
         if dt and range_start <= dt <= range_end:
             in_range.append(s)
@@ -203,7 +208,7 @@ async def admin_get_subscription_stats(
 
     # Per-plan breakdown
     plan_stats = defaultdict(lambda: {"name": "", "count": 0, "revenue": 0.0, "active": 0})
-    for s in all_subs:
+    for s in paid_subs:
         pid = s.get("plan_id") or "unknown"
         plan_stats[pid]["name"] = s.get("plan_name") or plan_map.get(pid, {}).get("name", "Unknown")
         plan_stats[pid]["count"] += 1
@@ -262,7 +267,7 @@ async def admin_get_subscription_stats(
 
     return {
         "stats": {
-            "total_subscribers": len(all_subs),
+            "total_subscribers": len(paid_subs),
             "active": len(active),
             "expired": len(expired),
             "cancelled": len(cancelled),

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -179,58 +179,77 @@ async def admin_get_subscription_stats(
     if area_filter:
         all_subs = [s for s in all_subs if driver_area_map.get(s.get("driver_id", "")) in area_filter]
 
-    # Only realized-revenue rows count toward revenue/subscriber metrics.
-    # A pending/superseded checkout row carries a price but no cleared payment,
-    # so it's excluded. Everything else counts — including legacy pre-checkout
-    # rows whose payment_status defaults to "pending" after migration 148 but
-    # whose status is a real subscription state (active/expired/cancelled/
-    # cancel_pending) — otherwise admin totals would silently drop every
-    # subscriber created before the Checkout flow until they renew.
+    # ── Subscriber state (counts) — from driver_subscriptions ────────────
+    # A pending/superseded checkout row carries no realized subscriber; every
+    # other state is a real subscriber (incl. legacy pre-checkout rows whose
+    # payment_status defaults to "pending" after migration 148).
     _UNPAID_STATUSES = {"pending", "superseded"}
-    paid_subs = [s for s in all_subs if s.get("payment_status") == "paid" or s.get("status") not in _UNPAID_STATUSES]
-
-    # Overall stats
+    real_subs = [s for s in all_subs if s.get("payment_status") == "paid" or s.get("status") not in _UNPAID_STATUSES]
     active = [s for s in all_subs if s.get("status") == "active"]
     expired = [s for s in all_subs if s.get("status") == "expired"]
     cancelled = [s for s in all_subs if s.get("status") == "cancelled"]
-    total_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in paid_subs))
+    # Current MRR-ish: sum of active subscriptions' plan price.
     active_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in active))
 
-    # Filter to date range for transactions and charts
     def parse_dt(s):
         try:
             return datetime.fromisoformat(str(s).replace("Z", "").replace("+00:00", ""))
         except Exception:
             return None
 
-    in_range = []
-    for s in paid_subs:
+    # ── Realized revenue & transactions — from the subscription_payments
+    #    ledger, which records the first charge AND every recurring renewal
+    #    (driver_subscriptions only holds current state, so reading it would
+    #    miss renewals). Legacy rows were backfilled by migration 151. ───────
+    payments = await db_supabase.get_rows("subscription_payments", {}, limit=20000) or []
+    if area_filter:
+        payments = [p for p in payments if driver_area_map.get(p.get("driver_id", "")) in area_filter]
+
+    total_revenue = float(sum(Decimal(str(p.get("amount") or 0)) for p in payments))
+
+    payments_in_range = []
+    for p in payments:
+        dt = parse_dt(p.get("created_at"))
+        if dt and range_start <= dt <= range_end:
+            payments_in_range.append(p)
+    range_revenue = float(sum(Decimal(str(p.get("amount") or 0)) for p in payments_in_range))
+
+    # New-subscriber chart counts new subscriptions (state), not payments.
+    new_subs_in_range = []
+    for s in real_subs:
         dt = parse_dt(s.get("created_at") or s.get("started_at"))
         if dt and range_start <= dt <= range_end:
-            in_range.append(s)
+            new_subs_in_range.append(s)
 
-    range_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in in_range))
-
-    # Per-plan breakdown
+    # Per-plan breakdown: revenue from the ledger, subscriber counts from subs.
     plan_stats = defaultdict(lambda: {"name": "", "count": 0, "revenue": 0.0, "active": 0})
-    for s in paid_subs:
+    for s in real_subs:
         pid = s.get("plan_id") or "unknown"
         plan_stats[pid]["name"] = s.get("plan_name") or plan_map.get(pid, {}).get("name", "Unknown")
         plan_stats[pid]["count"] += 1
-        plan_stats[pid]["revenue"] = float(Decimal(str(plan_stats[pid]["revenue"])) + Decimal(str(s.get("price") or 0)))
         if s.get("status") == "active":
             plan_stats[pid]["active"] += 1
+    for p in payments:
+        pid = p.get("plan_id") or "unknown"
+        if not plan_stats[pid]["name"]:
+            plan_stats[pid]["name"] = p.get("plan_name") or plan_map.get(pid, {}).get("name", "Unknown")
+        plan_stats[pid]["revenue"] = float(
+            Decimal(str(plan_stats[pid]["revenue"])) + Decimal(str(p.get("amount") or 0))
+        )
 
     # Daily charts (within date range)
     num_days = min((range_end - range_start).days + 1, 365)
     daily_revenue = defaultdict(float)
     daily_new_subs = defaultdict(int)
-    for s in in_range:
-        dt = parse_dt(s.get("created_at") or s.get("started_at"))
+    for p in payments_in_range:
+        dt = parse_dt(p.get("created_at"))
         if dt:
             day_key = dt.strftime("%Y-%m-%d")
-            daily_revenue[day_key] = float(Decimal(str(daily_revenue[day_key])) + Decimal(str(s.get("price") or 0)))
-            daily_new_subs[day_key] += 1
+            daily_revenue[day_key] = float(Decimal(str(daily_revenue[day_key])) + Decimal(str(p.get("amount") or 0)))
+    for s in new_subs_in_range:
+        dt = parse_dt(s.get("created_at") or s.get("started_at"))
+        if dt:
+            daily_new_subs[dt.strftime("%Y-%m-%d")] += 1
 
     revenue_chart = []
     subscribers_chart = []
@@ -239,47 +258,37 @@ async def admin_get_subscription_stats(
         day_key = day.strftime("%Y-%m-%d")
         day_label = day.strftime("%b %d")
         revenue_chart.append(
-            {
-                "date": day_label,
-                "date_raw": day_key,
-                "amount": round(daily_revenue.get(day_key, 0), 2),
-            }
+            {"date": day_label, "date_raw": day_key, "amount": round(daily_revenue.get(day_key, 0), 2)}
         )
-        subscribers_chart.append(
-            {
-                "date": day_label,
-                "date_raw": day_key,
-                "count": daily_new_subs.get(day_key, 0),
-            }
-        )
+        subscribers_chart.append({"date": day_label, "date_raw": day_key, "count": daily_new_subs.get(day_key, 0)})
 
-    # Transaction list (in range, enriched)
+    # Transaction list = ledger payments in range (each a realized charge,
+    # including recurring renewals).
     transactions = []
-    for s in sorted(in_range, key=lambda x: x.get("created_at", ""), reverse=True):
+    for p in sorted(payments_in_range, key=lambda x: x.get("created_at", ""), reverse=True):
+        _did = p.get("driver_id") or ""
         transactions.append(
             {
-                "id": s.get("id"),
-                "driver_id": s.get("driver_id"),
-                "driver_name": drivers_map.get(s.get("driver_id"), s.get("driver_id", "")[:8]),
-                "plan_name": s.get("plan_name") or plan_map.get(s.get("plan_id", ""), {}).get("name", "Unknown"),
-                "price": float(s.get("price") or 0),
-                "status": s.get("status", "unknown"),
-                "started_at": s.get("started_at"),
-                "expires_at": s.get("expires_at"),
-                "created_at": s.get("created_at"),
+                "id": p.get("id"),
+                "driver_id": _did,
+                "driver_name": drivers_map.get(_did, _did[:8]),
+                "plan_name": p.get("plan_name") or plan_map.get(p.get("plan_id", ""), {}).get("name", "Unknown"),
+                "price": float(p.get("amount") or 0),
+                "billing_reason": p.get("billing_reason"),
+                "created_at": p.get("created_at"),
             }
         )
 
     return {
         "stats": {
-            "total_subscribers": len(paid_subs),
+            "total_subscribers": len(real_subs),
             "active": len(active),
             "expired": len(expired),
             "cancelled": len(cancelled),
             "total_revenue": round(total_revenue, 2),
             "active_mrr": round(active_revenue, 2),
             "range_revenue": round(range_revenue, 2),
-            "range_transactions": len(in_range),
+            "range_transactions": len(payments_in_range),
         },
         "plan_breakdown": [{"plan_id": k, **v} for k, v in plan_stats.items()],
         "charts": {

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -37,6 +37,10 @@ class SubscriptionPlanCreate(BaseModel):
     vehicle_types: Optional[List[str]] = None  # restrict to vehicle type IDs, null=all
     service_areas: Optional[List[str]] = None  # restrict to area IDs, null=all
     is_active: bool = True
+    # Recurring Stripe Price (price_...) created in the Stripe dashboard.
+    # When set, subscribe_to_plan uses mode="subscription" auto-renew Checkout;
+    # when null the plan stays on the one-off Checkout-per-period flow.
+    stripe_price_id: Optional[str] = None
 
 
 class SubscriptionPlanUpdate(BaseModel):
@@ -49,6 +53,7 @@ class SubscriptionPlanUpdate(BaseModel):
     vehicle_types: Optional[List[str]] = None
     service_areas: Optional[List[str]] = None
     is_active: Optional[bool] = None
+    stripe_price_id: Optional[str] = None
 
 
 @router.get("/subscription-plans")
@@ -59,9 +64,7 @@ async def list_subscription_plans():
 
 
 @router.post("/subscription-plans")
-async def create_subscription_plan(
-    req: SubscriptionPlanCreate, admin: dict = Depends(get_admin_user)
-):
+async def create_subscription_plan(req: SubscriptionPlanCreate, admin: dict = Depends(get_admin_user)):
     """Create a new driver subscription plan."""
     plan = {
         "id": str(uuid.uuid4()),
@@ -74,6 +77,7 @@ async def create_subscription_plan(
         "vehicle_types": req.vehicle_types,
         "service_areas": req.service_areas,
         "is_active": req.is_active,
+        "stripe_price_id": req.stripe_price_id,
         "subscriber_count": 0,
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
@@ -89,9 +93,7 @@ async def create_subscription_plan(
 
 
 @router.put("/subscription-plans/{plan_id}")
-async def update_subscription_plan(
-    plan_id: str, req: SubscriptionPlanUpdate, admin: dict = Depends(get_admin_user)
-):
+async def update_subscription_plan(plan_id: str, req: SubscriptionPlanUpdate, admin: dict = Depends(get_admin_user)):
     """Update a subscription plan."""
     updates = {k: v for k, v in req.dict().items() if v is not None}
     if updates:
@@ -111,9 +113,7 @@ async def update_subscription_plan(
 async def delete_subscription_plan(plan_id: str, admin: dict = Depends(get_admin_user)):
     """Delete a subscription plan."""
     await db_supabase.delete_many("subscription_plans", {"id": plan_id})
-    await log_admin_action(
-        admin, "subscription_plan_deleted", "subscription_plans", plan_id, {}
-    )
+    await log_admin_action(admin, "subscription_plan_deleted", "subscription_plans", plan_id, {})
     return {"success": True}
 
 
@@ -145,17 +145,13 @@ async def admin_get_subscription_stats(
 
     now = datetime.now(timezone.utc)
     if start_date:
-        range_start = datetime.fromisoformat(
-            start_date.replace("Z", "").replace("+00:00", "")
-        )
+        range_start = datetime.fromisoformat(start_date.replace("Z", "").replace("+00:00", ""))
     else:
         range_start = now - timedelta(days=30)
     range_start = range_start.replace(hour=0, minute=0, second=0, microsecond=0)
 
     if end_date:
-        range_end = datetime.fromisoformat(
-            end_date.replace("Z", "").replace("+00:00", "")
-        )
+        range_end = datetime.fromisoformat(end_date.replace("Z", "").replace("+00:00", ""))
         range_end = range_end.replace(hour=23, minute=59, second=59)
     else:
         range_end = now
@@ -169,9 +165,7 @@ async def admin_get_subscription_stats(
 
     # Fetch drivers for name + area lookup (batch)
     driver_ids = list({s.get("driver_id") for s in all_subs if s.get("driver_id")})
-    raw_drivers_map, raw_users_map = await _batch_fetch_drivers_and_users(
-        [], driver_ids
-    )
+    raw_drivers_map, raw_users_map = await _batch_fetch_drivers_and_users([], driver_ids)
     drivers_map: Dict[str, str] = {}
     driver_area_map: Dict[str, str] = {}
     for did, d in raw_drivers_map.items():
@@ -183,11 +177,7 @@ async def admin_get_subscription_stats(
 
     # Filter by service area if requested
     if area_filter:
-        all_subs = [
-            s
-            for s in all_subs
-            if driver_area_map.get(s.get("driver_id", "")) in area_filter
-        ]
+        all_subs = [s for s in all_subs if driver_area_map.get(s.get("driver_id", "")) in area_filter]
 
     # Overall stats
     active = [s for s in all_subs if s.get("status") == "active"]
@@ -212,18 +202,12 @@ async def admin_get_subscription_stats(
     range_revenue = float(sum(Decimal(str(s.get("price") or 0)) for s in in_range))
 
     # Per-plan breakdown
-    plan_stats = defaultdict(
-        lambda: {"name": "", "count": 0, "revenue": 0.0, "active": 0}
-    )
+    plan_stats = defaultdict(lambda: {"name": "", "count": 0, "revenue": 0.0, "active": 0})
     for s in all_subs:
         pid = s.get("plan_id") or "unknown"
-        plan_stats[pid]["name"] = s.get("plan_name") or plan_map.get(pid, {}).get(
-            "name", "Unknown"
-        )
+        plan_stats[pid]["name"] = s.get("plan_name") or plan_map.get(pid, {}).get("name", "Unknown")
         plan_stats[pid]["count"] += 1
-        plan_stats[pid]["revenue"] = float(
-            Decimal(str(plan_stats[pid]["revenue"])) + Decimal(str(s.get("price") or 0))
-        )
+        plan_stats[pid]["revenue"] = float(Decimal(str(plan_stats[pid]["revenue"])) + Decimal(str(s.get("price") or 0)))
         if s.get("status") == "active":
             plan_stats[pid]["active"] += 1
 
@@ -235,9 +219,7 @@ async def admin_get_subscription_stats(
         dt = parse_dt(s.get("created_at") or s.get("started_at"))
         if dt:
             day_key = dt.strftime("%Y-%m-%d")
-            daily_revenue[day_key] = float(
-                Decimal(str(daily_revenue[day_key])) + Decimal(str(s.get("price") or 0))
-            )
+            daily_revenue[day_key] = float(Decimal(str(daily_revenue[day_key])) + Decimal(str(s.get("price") or 0)))
             daily_new_subs[day_key] += 1
 
     revenue_chart = []
@@ -268,11 +250,8 @@ async def admin_get_subscription_stats(
             {
                 "id": s.get("id"),
                 "driver_id": s.get("driver_id"),
-                "driver_name": drivers_map.get(
-                    s.get("driver_id"), s.get("driver_id", "")[:8]
-                ),
-                "plan_name": s.get("plan_name")
-                or plan_map.get(s.get("plan_id", ""), {}).get("name", "Unknown"),
+                "driver_name": drivers_map.get(s.get("driver_id"), s.get("driver_id", "")[:8]),
+                "plan_name": s.get("plan_name") or plan_map.get(s.get("plan_id", ""), {}).get("name", "Unknown"),
                 "price": float(s.get("price") or 0),
                 "status": s.get("status", "unknown"),
                 "started_at": s.get("started_at"),
@@ -300,9 +279,7 @@ async def admin_get_subscription_stats(
         "transactions": transactions,
         "service_areas": [
             {"id": a["id"], "name": a.get("name", "Unknown")}
-            for a in await db_supabase.get_rows(
-                "service_areas", order="name", limit=200
-            )
+            for a in await db_supabase.get_rows("service_areas", order="name", limit=200)
             if not a.get("parent_service_area_id")
         ],
     }

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -179,10 +179,15 @@ async def admin_get_subscription_stats(
     if area_filter:
         all_subs = [s for s in all_subs if driver_area_map.get(s.get("driver_id", "")) in area_filter]
 
-    # Only paid rows represent realized revenue/subscribers. A pending or
-    # superseded checkout row carries a price but no cleared payment, so it
-    # must not inflate revenue, transaction, or subscriber metrics.
-    paid_subs = [s for s in all_subs if s.get("payment_status") == "paid"]
+    # Only realized-revenue rows count toward revenue/subscriber metrics.
+    # A pending/superseded checkout row carries a price but no cleared payment,
+    # so it's excluded. Everything else counts — including legacy pre-checkout
+    # rows whose payment_status defaults to "pending" after migration 148 but
+    # whose status is a real subscription state (active/expired/cancelled/
+    # cancel_pending) — otherwise admin totals would silently drop every
+    # subscriber created before the Checkout flow until they renew.
+    _UNPAID_STATUSES = {"pending", "superseded"}
+    paid_subs = [s for s in all_subs if s.get("payment_status") == "paid" or s.get("status") not in _UNPAID_STATUSES]
 
     # Overall stats
     active = [s for s in all_subs if s.get("status") == "active"]

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5546,7 +5546,26 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         "created_at": now.isoformat(),
     }
 
-    await db_supabase.insert_one("driver_subscriptions", subscription)
+    try:
+        await db_supabase.insert_one("driver_subscriptions", subscription)
+    except Exception as _insert_err:
+        # The partial unique index (migration 152) allows at most one pending
+        # checkout per driver. A concurrent subscribe request that races past the
+        # supersede step hits it here — surface a clean 409 rather than a 500,
+        # and expire the Stripe session we just created so it can't be paid.
+        if checkout_url and stripe_session_id and _stripe_secret:
+            try:
+                stripe.checkout.Session.expire(stripe_session_id, api_key=_stripe_secret)
+            except Exception:
+                logger.info(f"[SUBSCRIBE] Could not expire race-loser session {stripe_session_id}")
+        logger.warning(
+            f"[SUBSCRIBE] Subscription insert failed (concurrent pending checkout?) for driver {driver['id']}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=409,
+            detail="A checkout is already in progress. Please finish or cancel it first.",
+        ) from _insert_err
 
     if checkout_url:
         # Payment pending — defer cancelling the driver's existing pass and
@@ -5580,6 +5599,16 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         "subscription_plans",
         {"id": plan_id},
         {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1},
+    )
+    # Dev/immediate activation realizes revenue without a Stripe invoice —
+    # record it in the ledger so admin stats see it.
+    await _record_subscription_payment(
+        driver_id=driver["id"],
+        subscription_id=subscription_id,
+        plan_id=plan_id,
+        plan_name=plan.get("name"),
+        amount=plan.get("price"),
+        billing_reason="dev",
     )
     return {"success": True, "subscription": subscription, "mode": "dev"}
 
@@ -5662,6 +5691,60 @@ async def verify_subscription_session(
     return {"status": "pending"}
 
 
+async def _record_subscription_payment(
+    *,
+    driver_id: str,
+    subscription_id: str | None,
+    plan_id: str | None,
+    plan_name: str | None,
+    amount,
+    billing_reason: str,
+    stripe_invoice_id: str | None = None,
+    stripe_session_id: str | None = None,
+    stripe_payment_intent_id: str | None = None,
+) -> None:
+    """Append a realized-payment row to the subscription_payments ledger.
+
+    The ledger (migration 151) is the source of truth for admin subscription
+    revenue/transaction stats — driver_subscriptions tracks current STATE, this
+    tracks money MOVED, so recurring renewals are captured (not just the first
+    charge). Recurring inserts dedupe on the unique stripe_invoice_id index, so
+    a replay is benign. Never raises — a ledger failure must not break the
+    activation/webhook flow that already moved the money.
+    """
+    try:
+        amt = Decimal(str(amount or 0)).quantize(Decimal("0.01"))
+        if amt <= 0:
+            return  # nothing realized — don't clutter the ledger
+        await db_supabase.insert_one(
+            "subscription_payments",
+            {
+                "id": str(uuid.uuid4()),
+                "driver_id": driver_id,
+                "subscription_id": subscription_id,
+                "plan_id": plan_id,
+                "plan_name": plan_name,
+                "amount": str(amt),
+                "currency": "cad",
+                "billing_reason": billing_reason,
+                "stripe_invoice_id": stripe_invoice_id,
+                "stripe_session_id": stripe_session_id,
+                "stripe_payment_intent_id": stripe_payment_intent_id,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except Exception:
+        # Duplicate recurring invoice (unique index) or any other write error —
+        # benign for the duplicate case; logged so a real failure is visible.
+        logger.warning(
+            "subscription_payments insert skipped (duplicate or error) driver=%s reason=%s invoice=%s",
+            driver_id,
+            billing_reason,
+            stripe_invoice_id,
+            exc_info=True,
+        )
+
+
 async def _activate_subscription(subscription_id: str, plan_id: str | None = None):
     """Activate a pending subscription after payment confirmation.
 
@@ -5742,6 +5825,21 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
             "subscription_plans",
             {"id": plan_id},
             {"$set": {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1}},
+        )
+
+    # Record one-off Checkout revenue in the ledger. Recurring plans are NOT
+    # recorded here — their invoice.paid webhook (subscription_create + every
+    # renewal) writes the ledger, so recording here too would double-count the
+    # first charge.
+    if plan and not plan.get("stripe_price_id"):
+        await _record_subscription_payment(
+            driver_id=driver_id,
+            subscription_id=subscription_id,
+            plan_id=plan_id,
+            plan_name=sub.get("plan_name") or plan.get("name"),
+            amount=plan.get("price"),
+            billing_reason="one_off",
+            stripe_session_id=sub.get("stripe_session_id"),
         )
 
     logger.info(f"[SUBSCRIBE] Subscription {subscription_id} activated for driver {driver_id}")
@@ -5862,6 +5960,34 @@ async def check_expiring_subscriptions():
         try:
             now = datetime.now(timezone.utc)
             window = now + timedelta(hours=24)
+
+            # Retry subscriptions stuck in cancel_pending — a plan-switch Stripe
+            # cancel that failed transiently. On success, finalize as cancelled;
+            # a row still failing stays cancel_pending and is logged for ops.
+            try:
+                stuck_cancels = await db.get_rows("driver_subscriptions", {"status": "cancel_pending"}, limit=200) or []
+                for pc in stuck_cancels:
+                    try:
+                        await _cancel_stripe_subscription(pc.get("stripe_subscription_id"), raise_on_error=True)
+                        await db.update_one(
+                            "driver_subscriptions",
+                            {"id": pc["id"]},
+                            {"$set": {"status": "cancelled"}},
+                        )
+                        logger.info(
+                            "[SUB-EXPIRY] cancel_pending resolved row=%s",
+                            pc["id"],
+                            extra={"domain": "payments"},
+                        )
+                    except Exception:
+                        logger.error(
+                            "[SUB-EXPIRY] cancel_pending retry still failing row=%s — manual Stripe cancel needed",
+                            pc["id"],
+                            exc_info=True,
+                            extra={"domain": "payments"},
+                        )
+            except Exception:
+                logger.error("[SUB-EXPIRY] cancel_pending sweep query failed", exc_info=True)
 
             active_subs = await db.get_rows("driver_subscriptions", {"status": "active"}, limit=500)
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5315,72 +5315,85 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
 
     now = datetime.now(timezone.utc)
     expires = now + timedelta(days=plan.get("duration_days", 30))
-
-    # Attempt Stripe charge if configured; fall back gracefully if not.
-    payment_status = "paid"
-    stripe_charge_id = None
     plan_price = Decimal(str(plan.get("price", 0) or 0))
-    if plan_price > 0:
-        try:
-            from ..settings_loader import get_app_settings
+    subscription_id = str(uuid.uuid4())
 
-            _settings = await get_app_settings()
-            _stripe_secret = _settings.get("stripe_secret_key", "")
-            if _stripe_secret:
-                # Use the driver's saved default payment method via their Stripe customer
-                _user = await db.find_one("users", {"id": current_user["id"]})
-                _customer_id = _user.get("stripe_customer_id") if _user else None
-                if _customer_id:
-                    _amount_cents = dollars_to_cents(plan_price)
-                    _charge = stripe.PaymentIntent.create(
-                        amount=_amount_cents,
-                        currency="cad",
-                        customer=_customer_id,
-                        confirm=True,
-                        off_session=True,
-                        metadata={
-                            "driver_id": driver["id"],
-                            "plan_id": plan["id"],
-                            "scope": "driver_subscription",
+    # Try Stripe Checkout if configured; otherwise dev-mode instant activation.
+    checkout_url = None
+    stripe_session_id = None
+    payment_status = "pending"
+
+    try:
+        from ..settings_loader import get_app_settings
+
+        _settings = await get_app_settings()
+        _stripe_secret = _settings.get("stripe_secret_key", "")
+        _base_url = _settings.get("base_url", "http://localhost:8000")
+
+        if _stripe_secret and plan_price > 0:
+            # Create a Checkout Session for the driver to complete payment.
+            # The webhook (checkout.session.completed) will activate the subscription.
+            _amount_cents = int(plan_price * 100)
+            _session = stripe.checkout.Session.create(
+                payment_method_types=["card"],
+                mode="payment",
+                customer_creation="always",
+                line_items=[
+                    {
+                        "price_data": {
+                            "currency": "cad",
+                            "product_data": {
+                                "name": plan.get("name", "Spinr Pass"),
+                                "description": plan.get("description", ""),
+                            },
+                            "unit_amount": _amount_cents,
                         },
-                        api_key=_stripe_secret,
-                        idempotency_key=f"sub-charge-{driver['id']}-{plan['id']}-{now.strftime('%Y%m%d')}",
-                    )
-                    stripe_charge_id = _charge.id
-                    payment_status = _charge.status  # "succeeded" | "requires_action" | …
-                    logger.info(f"Stripe charge {stripe_charge_id} status={payment_status} for driver {driver['id']}")
-                else:
-                    logger.info(f"No Stripe customer for driver {driver['id']}, marking paid without charge")
-            else:
-                logger.info("Stripe not configured; marking subscription paid without charge")
-        except Exception as _stripe_err:
-            # B-P2-1: NEVER interpolate the underlying exception into the
-            # client-facing detail. Stripe error strings carry charge IDs
-            # (ch_…), customer IDs (cus_…), decline codes, and sometimes
-            # last-4-digits — none of which the rider/driver app should
-            # see. logger.exception captures the full traceback server-
-            # side; the request_id in the response body lets support
-            # correlate against the log entry. This is the canonical
-            # pattern referenced by docs/runbooks/error-responses.md.
-            logger.exception(f"Stripe subscription charge failed for driver {driver['id']}")
-            raise HTTPException(
-                status_code=402,
-                detail="Payment failed. Please try another payment method or contact support.",
-            ) from _stripe_err
+                        "quantity": 1,
+                    }
+                ],
+                metadata={
+                    "driver_id": driver["id"],
+                    "subscription_id": subscription_id,
+                    "plan_id": plan_id,
+                },
+                success_url=f"{_base_url}/api/v1/drivers/subscription/verify-session?session_id={{CHECKOUT_SESSION_ID}}",
+                cancel_url=f"{_base_url}/drivers/subscription",
+                api_key=_stripe_secret,
+            )
+            checkout_url = _session.url
+            stripe_session_id = _session.id
+            payment_status = "pending"
+            logger.info(
+                f"[SUBSCRIBE] Checkout session created: session={stripe_session_id} "
+                f"subscription={subscription_id} driver={driver['id']}"
+            )
+        else:
+            # Dev/demo mode: no Stripe or free plan — activate immediately.
+            payment_status = "paid"
+            logger.info(
+                f"[SUBSCRIBE] Dev mode (no Stripe/free plan): subscription {subscription_id} for driver {driver['id']}"
+            )
+    except Exception as _stripe_err:
+        logger.exception(f"[SUBSCRIBE] Stripe Checkout creation failed for driver {driver['id']}")
+        raise HTTPException(
+            status_code=502,
+            detail="Payment service unavailable. Please try again later.",
+        ) from _stripe_err
 
+    # Create the subscription row (pending payment if Checkout, or paid in dev mode)
     subscription = {
-        "id": str(uuid.uuid4()),
+        "id": subscription_id,
         "driver_id": driver["id"],
-        "plan_id": plan["id"],
-        "plan_name": plan["name"],
-        "price": plan["price"],
+        "plan_id": plan_id,
+        "plan_name": plan.get("name"),
+        "price": plan.get("price"),
         "rides_per_day": plan.get("rides_per_day", -1),
-        "duration_days": plan.get("duration_days", 30),
-        "status": "active",
+        "status": "active" if payment_status == "paid" else "pending",
         "started_at": now.isoformat(),
         "expires_at": expires.isoformat(),
         "payment_status": payment_status,
-        "stripe_charge_id": stripe_charge_id,
+        "stripe_session_id": stripe_session_id,
+        "expiry_warned": False,
         "created_at": now.isoformat(),
     }
 
@@ -5393,9 +5406,11 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1},
     )
 
-    logger.info(f"[SUBSCRIBE] Dev mode: driver {driver['id']} subscribed to {plan['name']} (${plan['price']})")
-
-    return {"success": True, "subscription": subscription, "mode": "dev"}
+    if checkout_url:
+        return {"success": True, "checkout_url": checkout_url, "subscription_id": subscription_id}
+    else:
+        # Dev mode: subscription is already active
+        return {"success": True, "subscription": subscription, "mode": "dev"}
 
 
 @api_router.get("/subscription/verify-session")

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5389,6 +5389,36 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         _cancel_url = "spinr-driver://subscription/cancel"
 
         if _stripe_secret and _price_id:
+            # Guard against a Stripe Price that disagrees with the DB price the
+            # driver was shown (admin edited plan.price after attaching a Price,
+            # or pasted the wrong Price id). Retrieve it and refuse on an
+            # amount/currency mismatch so we never bill a surprise amount.
+            try:
+                _price_obj = stripe.Price.retrieve(_price_id, api_key=_stripe_secret)
+            except Exception as _price_err:
+                logger.exception(f"[SUBSCRIBE] Could not retrieve Stripe Price {_price_id} for plan {plan_id}")
+                raise HTTPException(
+                    status_code=502,
+                    detail="Payment service unavailable. Please try again later.",
+                ) from _price_err
+            _expected_cents = dollars_to_cents(plan_price)
+            _price_cents = _price_obj.get("unit_amount")
+            _price_currency = (_price_obj.get("currency") or "").lower()
+            if _price_cents != _expected_cents or _price_currency != "cad":
+                logger.error(
+                    "[SUBSCRIBE] Stripe Price %s mismatch for plan %s: stripe=%s/%s plan=%s/cad — refusing to charge",
+                    _price_id,
+                    plan_id,
+                    _price_cents,
+                    _price_currency,
+                    _expected_cents,
+                    extra={"domain": "payments"},
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail="This subscription plan is misconfigured. Please contact support.",
+                )
+
             # Recurring billing: Stripe Subscription mode. Stripe auto-renews
             # the driver's card each period and fires invoice.paid (renewal)
             # / invoice.payment_failed (dunning) / customer.subscription.*
@@ -5416,7 +5446,7 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
             # One-off Checkout (no recurring Price on this plan). The webhook
             # (checkout.session.completed) activates the subscription; renewal
             # is expiry-driven (driver re-subscribes each period).
-            _amount_cents = int(plan_price * 100)
+            _amount_cents = dollars_to_cents(plan_price)
             _session = stripe.checkout.Session.create(
                 payment_method_types=["card"],
                 mode="payment",
@@ -5452,6 +5482,10 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
             logger.info(
                 f"[SUBSCRIBE] Dev mode (no Stripe/free plan): subscription {subscription_id} for driver {driver['id']}"
             )
+    except HTTPException:
+        # Intentional rejections (e.g. Price mismatch 409) must propagate with
+        # their own status, not be masked as a generic 502.
+        raise
     except Exception as _stripe_err:
         logger.exception(f"[SUBSCRIBE] Stripe Checkout creation failed for driver {driver['id']}")
         raise HTTPException(
@@ -5469,12 +5503,26 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
             await db_supabase.get_rows(
                 "driver_subscriptions",
                 {"driver_id": driver["id"], "status": "pending"},
-                columns="id",
+                columns="id,stripe_session_id",
                 limit=20,
             )
             or []
         )
         for row in stale_pending:
+            # Expire the stale Stripe Checkout Session first so it can never be
+            # paid — otherwise a superseded one-off session that completes later
+            # charges the driver's card for a pass they won't receive (one-off
+            # sessions carry no subscription to cancel). Best-effort: a session
+            # that's already completed/expired raises, which we ignore.
+            _stale_session = row.get("stripe_session_id")
+            if _stale_session and _stripe_secret:
+                try:
+                    stripe.checkout.Session.expire(_stale_session, api_key=_stripe_secret)
+                except Exception:
+                    logger.info(
+                        f"[SUBSCRIBE] Could not expire superseded checkout session {_stale_session} "
+                        "(already completed/expired?) — continuing",
+                    )
             await db_supabase.update_one(
                 "driver_subscriptions",
                 {"id": row["id"]},
@@ -5507,7 +5555,14 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         # keeps their current pass valid if they abandon Checkout, and avoids
         # double-counting (abandoned sessions would otherwise inflate the count
         # and successful payments would count twice).
-        return {"success": True, "checkout_url": checkout_url, "subscription_id": subscription_id}
+        return {
+            "success": True,
+            "checkout_url": checkout_url,
+            "subscription_id": subscription_id,
+            # The driver app reads `session_id` to poll verify-session if the
+            # deep-link return is delayed/missed after openURL().
+            "session_id": stripe_session_id,
+        }
 
     # Dev/immediate-activation mode: no payment step, so the activation path
     # never runs — cancel the prior active subscription and bump the count here.
@@ -5623,30 +5678,11 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
 
     driver_id = sub.get("driver_id")
 
-    # Cancel any prior active subscription for this driver.
-    existing = await db.find_one("driver_subscriptions", {"driver_id": driver_id, "status": "active"})
-    if existing and existing["id"] != subscription_id:
-        # Stop the prior recurring Stripe subscription so a plan switch doesn't
-        # double-bill. Best-effort: we've already activated a paid replacement,
-        # so a Stripe failure here is logged (reconcile loop +
-        # customer.subscription.* webhooks backstop) but must not block.
-        await _cancel_stripe_subscription(existing.get("stripe_subscription_id"))
-        await db.update_one(
-            "driver_subscriptions",
-            {"id": existing["id"]},
-            {
-                "$set": {
-                    "status": RideStatus.CANCELLED,
-                    "cancelled_at": datetime.now(timezone.utc).isoformat(),
-                }
-            },
-        )
-
-    # Activate. Recompute the period from activation time so a driver who
-    # completes Checkout hours after creating it (Stripe sessions live up to
-    # 24h) doesn't lose paid access — matters most on daily/weekly one-off
-    # plans. (Recurring plans get expires_at overwritten by invoice.paid's
-    # authoritative period end on the next event.)
+    # Recompute the period from activation time so a driver who completes
+    # Checkout hours after creating it (Stripe sessions live up to 24h) doesn't
+    # lose paid access — matters most on daily/weekly one-off plans. (Recurring
+    # plans get expires_at overwritten by invoice.paid's authoritative period
+    # end on the next event.)
     plan = await db.find_one("subscription_plans", {"id": plan_id}) if plan_id else None
     now = datetime.now(timezone.utc)
     activate_updates = {
@@ -5656,11 +5692,49 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
     }
     if plan and plan.get("duration_days"):
         activate_updates["expires_at"] = (now + timedelta(days=plan["duration_days"])).isoformat()
-    await db.update_one(
+
+    # Atomic claim: flip pending→active filtering on status='pending'. Only the
+    # caller that wins (webhook vs verify-session can race) gets a row back and
+    # runs the one-time side effects below; the loser matches 0 rows and returns,
+    # so cancel-prior / count-increment / push never run twice.
+    claimed = await db.update_one(
         "driver_subscriptions",
-        {"id": subscription_id},
+        {"id": subscription_id, "status": "pending"},
         {"$set": activate_updates},
     )
+    if not claimed:
+        return
+
+    # Cancel any prior active subscription for this driver (plan switch).
+    existing = await db.find_one("driver_subscriptions", {"driver_id": driver_id, "status": "active"})
+    if existing and existing["id"] != subscription_id:
+        try:
+            # Durable cancel: raise on failure so we don't claim the old pass is
+            # cancelled while Stripe keeps billing it.
+            await _cancel_stripe_subscription(existing.get("stripe_subscription_id"), raise_on_error=True)
+            await db.update_one(
+                "driver_subscriptions",
+                {"id": existing["id"]},
+                {"$set": {"status": RideStatus.CANCELLED, "cancelled_at": now.isoformat()}},
+            )
+        except Exception:
+            # The new pass is already active (driver paid), so we can't block,
+            # but the old Stripe subscription may still bill. Mark the old row
+            # cancel_pending (terminal — won't be reactivated) and log loudly so
+            # ops can cancel it in Stripe. (No auto-retry yet — tracked follow-up.)
+            logger.error(
+                "[SUBSCRIBE] Prior Stripe subscription cancel failed on plan switch — "
+                "old row marked cancel_pending; manual Stripe cancel needed. driver=%s old_row=%s",
+                driver_id,
+                existing["id"],
+                exc_info=True,
+                extra={"domain": "payments", "driver_id": driver_id},
+            )
+            await db.update_one(
+                "driver_subscriptions",
+                {"id": existing["id"]},
+                {"$set": {"status": "cancel_pending", "cancelled_at": now.isoformat()}},
+            )
 
     # Increment subscriber count (reuse the plan already fetched above).
     if plan:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5362,9 +5362,15 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
     stripe_session_id = None
     payment_status = "pending"
 
+    # Dual-import (package vs top-level run modes) — must be OUTSIDE the broad
+    # Stripe try below, else an ImportError in top-level mode is swallowed as a
+    # 502 before we can reach the no-Stripe/free-plan activation path.
     try:
         from ..settings_loader import get_app_settings
+    except ImportError:
+        from settings_loader import get_app_settings
 
+    try:
         _settings = await get_app_settings()
         _stripe_secret = _settings.get("stripe_secret_key", "")
         _price_id = plan.get("stripe_price_id")
@@ -5452,6 +5458,28 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
             status_code=502,
             detail="Payment service unavailable. Please try again later.",
         ) from _stripe_err
+
+    # Supersede any older pending checkout rows for this driver before
+    # inserting the new one. Without this, a double-tap / retry / plan-change
+    # leaves multiple valid Checkout URLs, and a stale session completing late
+    # could activate over a newer choice (_activate_subscription only acts on
+    # rows still in "pending", so superseding neutralises the old ones).
+    if checkout_url:
+        stale_pending = (
+            await db_supabase.get_rows(
+                "driver_subscriptions",
+                {"driver_id": driver["id"], "status": "pending"},
+                columns="id",
+                limit=20,
+            )
+            or []
+        )
+        for row in stale_pending:
+            await db_supabase.update_one(
+                "driver_subscriptions",
+                {"id": row["id"]},
+                {"status": "superseded"},
+            )
 
     # Create the subscription row (pending payment if Checkout, or paid in dev mode)
     subscription = {
@@ -5576,8 +5604,12 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
     (whichever runs first). Idempotent — skips if already active.
     """
     sub = await db.find_one("driver_subscriptions", {"id": subscription_id})
-    if not sub or sub.get("status") == "active":
-        return  # already done
+    # Only a still-pending checkout row activates. A row that is already
+    # active (idempotent replay), cancelled, or superseded by a newer checkout
+    # is terminal — never (re)activate it, so a stale session completing late
+    # can't replace the driver's current plan.
+    if not sub or sub.get("status") != "pending":
+        return
 
     driver_id = sub.get("driver_id")
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5579,20 +5579,30 @@ async def verify_subscription_session(
         return {"status": "pending"}
 
     if session.payment_status == "paid":
-        # Persist the Stripe Subscription id (recurring plans) so renewal /
-        # dunning / cancellation webhooks can match this row even if the
-        # checkout webhook was delayed or missed.
-        stripe_subscription_id = session.get("subscription")
-        if stripe_subscription_id:
-            await db.update_one(
-                "driver_subscriptions",
-                {"id": sub["id"]},
-                {"stripe_subscription_id": stripe_subscription_id},
-            )
-        # Activate the subscription (same as webhook path, idempotent).
+        # Activate first (idempotent; a no-op if the row was superseded by a
+        # newer checkout), then re-read to decide whether to link.
         await _activate_subscription(sub["id"], sub.get("plan_id"))
         sub = await db.find_one("driver_subscriptions", {"id": sub["id"]})
-        return {"status": "active", "subscription": sub}
+        stripe_subscription_id = session.get("subscription")
+
+        if sub and sub.get("status") == "active":
+            # Persist the Stripe Subscription id (recurring plans) so renewal /
+            # dunning / cancellation webhooks can match this row even if the
+            # checkout webhook was delayed or missed. Only on an active row —
+            # never link a superseded one.
+            if stripe_subscription_id and not sub.get("stripe_subscription_id"):
+                await db.update_one(
+                    "driver_subscriptions",
+                    {"id": sub["id"]},
+                    {"stripe_subscription_id": stripe_subscription_id},
+                )
+            return {"status": "active", "subscription": sub}
+
+        # Superseded by a newer checkout — don't link/activate; cancel the
+        # orphaned Stripe subscription so the driver isn't billed for it.
+        if stripe_subscription_id:
+            await _cancel_stripe_subscription(stripe_subscription_id)
+        return {"status": "superseded"}
 
     return {"status": "pending"}
 
@@ -5632,22 +5642,33 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
             },
         )
 
-    # Activate.
+    # Activate. Recompute the period from activation time so a driver who
+    # completes Checkout hours after creating it (Stripe sessions live up to
+    # 24h) doesn't lose paid access — matters most on daily/weekly one-off
+    # plans. (Recurring plans get expires_at overwritten by invoice.paid's
+    # authoritative period end on the next event.)
+    plan = await db.find_one("subscription_plans", {"id": plan_id}) if plan_id else None
+    now = datetime.now(timezone.utc)
+    activate_updates = {
+        "status": "active",
+        "payment_status": "paid",
+        "started_at": now.isoformat(),
+    }
+    if plan and plan.get("duration_days"):
+        activate_updates["expires_at"] = (now + timedelta(days=plan["duration_days"])).isoformat()
     await db.update_one(
         "driver_subscriptions",
         {"id": subscription_id},
-        {"$set": {"status": "active", "payment_status": "paid"}},
+        {"$set": activate_updates},
     )
 
-    # Increment subscriber count.
-    if plan_id:
-        plan = await db.find_one("subscription_plans", {"id": plan_id})
-        if plan:
-            await db.update_one(
-                "subscription_plans",
-                {"id": plan_id},
-                {"$set": {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1}},
-            )
+    # Increment subscriber count (reuse the plan already fetched above).
+    if plan:
+        await db.update_one(
+            "subscription_plans",
+            {"id": plan_id},
+            {"$set": {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1}},
+        )
 
     logger.info(f"[SUBSCRIBE] Subscription {subscription_id} activated for driver {driver_id}")
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5282,6 +5282,11 @@ async def _cancel_stripe_subscription(stripe_subscription_id: str | None, *, rai
     settings = await get_app_settings()
     stripe_secret = settings.get("stripe_secret_key", "")
     if not stripe_secret:
+        # There IS a Stripe subscription to cancel (guarded above) but no key —
+        # e.g. key removed mid-rotation. With raise_on_error the caller must NOT
+        # mark the row cancelled while Stripe keeps billing, so fail loudly.
+        if raise_on_error:
+            raise RuntimeError("stripe_secret_key not configured — cannot cancel Stripe subscription")
         return
     try:
         stripe.Subscription.delete(stripe_subscription_id, api_key=stripe_secret)
@@ -5812,8 +5817,15 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
         return
 
     # Cancel any prior active subscription for this driver (plan switch).
-    existing = await db.find_one("driver_subscriptions", {"driver_id": driver_id, "status": "active"})
-    if existing and existing["id"] != subscription_id:
+    # NOTE: the atomic claim above already flipped THIS row to active, so an
+    # unordered limit-1 lookup could return it. Fetch all active rows and pick
+    # one that isn't the row we just activated, so the prior pass is always
+    # retired.
+    _active_rows = (
+        await db.get_rows("driver_subscriptions", {"driver_id": driver_id, "status": "active"}, limit=10) or []
+    )
+    existing = next((r for r in _active_rows if r.get("id") != subscription_id), None)
+    if existing:
         try:
             # Durable cancel: raise on failure so we don't claim the old pass is
             # cancelled while Stripe keeps billing it.

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2038,6 +2038,12 @@ async def request_payout(
 
     status = "pending"
     stripe_payout_id = None
+    # Pre-allocate the payout id so the Stripe Transfer carries a stable
+    # idempotency key — a retry of this same payout never double-transfers.
+    # (The @idempotent_endpoint decorator dedupes at the HTTP layer, but a
+    # Stripe-level key is defence in depth against any path that re-enters
+    # this block, matching the money-safety contract of request_instant_payout.)
+    payout_id = str(uuid.uuid4())
 
     if stripe_secret and stripe_account_id:
         try:
@@ -2046,6 +2052,7 @@ async def request_payout(
                 currency="cad",
                 destination=stripe_account_id,
                 api_key=stripe_secret,
+                idempotency_key=f"payout-transfer-{payout_id}",
             )
             status = RideStatus.COMPLETED
             stripe_payout_id = transfer.id
@@ -2062,7 +2069,7 @@ async def request_payout(
             ) from e
 
     payout = {
-        "id": str(uuid.uuid4()),
+        "id": payout_id,
         "driver_id": driver["id"],
         "amount": req.amount,
         "status": status,

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5383,6 +5383,9 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
             "driver_id": driver["id"],
             "subscription_id": subscription_id,
             "plan_id": plan_id,
+            # scope lets utils/stripe_reconcile.py recognise a subscription
+            # PaymentIntent and not flag it as a STRIPE_ORPHAN ride.
+            "scope": "driver_subscription",
         }
         # Stripe redirects the in-app browser back to the driver app via its
         # deep-link scheme (app.config.ts SCHEME = "spinr-driver"). The
@@ -5417,6 +5420,32 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
                     _price_cents,
                     _price_currency,
                     _expected_cents,
+                    extra={"domain": "payments"},
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail="This subscription plan is misconfigured. Please contact support.",
+                )
+
+            # Also validate the billing cadence: a same-price monthly Price on a
+            # weekly plan (or vice versa) would bill on a different period than
+            # the driver is shown. Compare the Price's recurring interval (in
+            # days) to the plan's duration_days with a small tolerance for the
+            # calendar-month/year approximations.
+            _INTERVAL_DAYS = {"day": 1, "week": 7, "month": 30, "year": 365}
+            _recurring = _price_obj.get("recurring") or {}
+            _price_days = _INTERVAL_DAYS.get(_recurring.get("interval"), 0) * (_recurring.get("interval_count") or 1)
+            _plan_days = plan.get("duration_days") or 0
+            if not _recurring.get("interval") or abs(_price_days - _plan_days) > 3:
+                logger.error(
+                    "[SUBSCRIBE] Stripe Price %s interval mismatch for plan %s: "
+                    "stripe=%sx%s (~%sd) plan=%sd — refusing to charge",
+                    _price_id,
+                    plan_id,
+                    _recurring.get("interval"),
+                    _recurring.get("interval_count"),
+                    _price_days,
+                    _plan_days,
                     extra={"domain": "payments"},
                 )
                 raise HTTPException(
@@ -5470,6 +5499,11 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
                     }
                 ],
                 metadata=_metadata,
+                # Propagate our ids onto the underlying PaymentIntent so the
+                # nightly reconciler (stripe_reconcile.py) can identify a
+                # subscription charge instead of flagging it STRIPE_ORPHAN if
+                # checkout.session.completed is ever missed.
+                payment_intent_data={"metadata": _metadata},
                 success_url=_success_url,
                 cancel_url=_cancel_url,
                 api_key=_stripe_secret,
@@ -5689,8 +5723,9 @@ async def verify_subscription_session(
 
     if session.payment_status == "paid":
         # Activate first (idempotent; a no-op if the row was superseded by a
-        # newer checkout), then re-read to decide whether to link.
-        await _activate_subscription(sub["id"], sub.get("plan_id"))
+        # newer checkout), then re-read to decide whether to link. Pass the
+        # session's actual mode so ledger recording matches what was created.
+        await _activate_subscription(sub["id"], sub.get("plan_id"), session.get("mode"))
         sub = await db.find_one("driver_subscriptions", {"id": sub["id"]})
         stripe_subscription_id = session.get("subscription")
 
@@ -5758,26 +5793,41 @@ async def _record_subscription_payment(
                 "created_at": datetime.now(timezone.utc).isoformat(),
             },
         )
-    except Exception:
-        # The only benign failure is the unique stripe_invoice_id collision on a
-        # recurring-invoice replay — but the event-claim gate already prevents
-        # webhook replays, so a failure almost always means a real lost ledger
-        # write. Log at error (not warning) per the payment-error rule; never
-        # raise — the money already moved.
-        logger.error(
-            "subscription_payments insert failed (lost ledger row?) driver=%s reason=%s invoice=%s",
-            driver_id,
-            billing_reason,
-            stripe_invoice_id,
-            exc_info=True,
-        )
+    except Exception as _ledger_err:
+        # Distinguish a benign duplicate (unique stripe_invoice_id replay) from a
+        # real write failure. A duplicate means the row already exists — nothing
+        # lost — so log at debug. Any other error means the ledger row that drives
+        # admin revenue/stats is now missing, which must be surfaced at error so
+        # ops/reconciliation can repair it. Never raise — the money already moved.
+        _msg = str(_ledger_err).lower()
+        _is_duplicate = "duplicate" in _msg or "unique" in _msg or "23505" in _msg
+        if _is_duplicate:
+            logger.debug(
+                "subscription_payments duplicate ignored driver=%s invoice=%s",
+                driver_id,
+                stripe_invoice_id,
+            )
+        else:
+            logger.error(
+                "subscription_payments insert FAILED (revenue row lost — repair needed) driver=%s reason=%s invoice=%s",
+                driver_id,
+                billing_reason,
+                stripe_invoice_id,
+                exc_info=True,
+            )
 
 
-async def _activate_subscription(subscription_id: str, plan_id: str | None = None):
+async def _activate_subscription(subscription_id: str, plan_id: str | None = None, checkout_mode: str | None = None):
     """Activate a pending subscription after payment confirmation.
 
     Called by both the webhook handler and the verify-session endpoint
     (whichever runs first). Idempotent — skips if already active.
+
+    ``checkout_mode`` is the Stripe Checkout Session's actual mode
+    ("payment" for one-off, "subscription" for recurring). It decides whether
+    to write the one-off ledger row here — based on what was actually created,
+    NOT the plan's current stripe_price_id, which an admin could flip between
+    checkout start and payment completion.
     """
     sub = await db.find_one("driver_subscriptions", {"id": subscription_id})
     # Only a still-pending checkout row activates. A row that is already
@@ -5862,11 +5912,17 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
             {"$set": {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1}},
         )
 
-    # Record one-off Checkout revenue in the ledger. Recurring plans are NOT
-    # recorded here — their invoice.paid webhook (subscription_create + every
-    # renewal) writes the ledger, so recording here too would double-count the
-    # first charge.
-    if plan and not plan.get("stripe_price_id"):
+    # Record one-off Checkout revenue in the ledger. Recurring (mode=subscription)
+    # checkouts are NOT recorded here — their invoice.paid webhook writes the
+    # ledger, so recording here too would double-count the first charge.
+    # Decide from the ACTUAL session mode when known (not the plan's current
+    # stripe_price_id, which an admin could flip mid-checkout); fall back to the
+    # plan flag only when the mode wasn't passed.
+    if checkout_mode is not None:
+        _is_one_off = checkout_mode == "payment"
+    else:
+        _is_one_off = bool(plan) and not plan.get("stripe_price_id")
+    if plan and _is_one_off:
         await _record_subscription_payment(
             driver_id=driver_id,
             subscription_id=subscription_id,

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5257,6 +5257,36 @@ async def get_current_subscription(current_user: dict = Depends(get_current_user
     }
 
 
+async def _cancel_stripe_subscription(stripe_subscription_id: str | None) -> None:
+    """Cancel a Stripe Subscription so a recurring plan stops billing.
+
+    No-op when there's no Stripe subscription (one-off / dev-mode rows) or
+    Stripe isn't configured. Best-effort: a Stripe failure is logged but never
+    blocks the DB-side cancellation — the customer.subscription.* webhooks and
+    the reconcile loop are the backstop. Critical for plan changes: without
+    this, switching a driver from one recurring plan to another would leave
+    the old Stripe subscription billing alongside the new one.
+    """
+    if not stripe_subscription_id:
+        return
+    try:
+        from ..settings_loader import get_app_settings
+    except ImportError:
+        from settings_loader import get_app_settings
+    settings = await get_app_settings()
+    stripe_secret = settings.get("stripe_secret_key", "")
+    if not stripe_secret:
+        return
+    try:
+        stripe.Subscription.delete(stripe_subscription_id, api_key=stripe_secret)
+        logger.info(f"[SUBSCRIBE] Stripe subscription {stripe_subscription_id} cancelled")
+    except Exception:
+        logger.exception(
+            f"[SUBSCRIBE] Failed to cancel Stripe subscription {stripe_subscription_id}; "
+            "DB row still cancelled — webhook/reconcile will backstop"
+        )
+
+
 @api_router.post("/subscription/subscribe")
 async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_current_user)):
     """Subscribe driver to a plan.
@@ -5310,7 +5340,9 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         )
     )
     if existing:
-        # Cancel old subscription
+        # Cancel old subscription — stop Stripe billing first so switching
+        # between recurring plans doesn't double-charge, then update our row.
+        await _cancel_stripe_subscription(existing.get("stripe_subscription_id"))
         await db_supabase.update_one(
             "driver_subscriptions",
             {"id": existing["id"]},
@@ -5579,6 +5611,8 @@ async def cancel_subscription(current_user: dict = Depends(get_current_user)):
     if not sub:
         raise HTTPException(status_code=400, detail="No active subscription")
 
+    # Stop Stripe billing for recurring plans before cancelling our row.
+    await _cancel_stripe_subscription(sub.get("stripe_subscription_id"))
     await db_supabase.update_one(
         "driver_subscriptions",
         {"id": sub["id"]},

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5257,15 +5257,21 @@ async def get_current_subscription(current_user: dict = Depends(get_current_user
     }
 
 
-async def _cancel_stripe_subscription(stripe_subscription_id: str | None) -> None:
+async def _cancel_stripe_subscription(stripe_subscription_id: str | None, *, raise_on_error: bool = False) -> None:
     """Cancel a Stripe Subscription so a recurring plan stops billing.
 
     No-op when there's no Stripe subscription (one-off / dev-mode rows) or
-    Stripe isn't configured. Best-effort: a Stripe failure is logged but never
-    blocks the DB-side cancellation — the customer.subscription.* webhooks and
-    the reconcile loop are the backstop. Critical for plan changes: without
-    this, switching a driver from one recurring plan to another would leave
-    the old Stripe subscription billing alongside the new one.
+    Stripe isn't configured.
+
+    ``raise_on_error`` controls failure handling:
+      - False (default): best-effort. Used on plan-switch activation, where a
+        paid replacement already exists and the reconcile loop /
+        customer.subscription.* webhooks backstop a lingering old subscription;
+        a failure must not block activation.
+      - True: re-raise on failure. Used by the driver-initiated cancel so the
+        caller can refuse to mark the row cancelled — otherwise the app would
+        show "cancelled" while Stripe keeps billing (and a later invoice.paid
+        would silently re-activate the row).
     """
     if not stripe_subscription_id:
         return
@@ -5281,10 +5287,9 @@ async def _cancel_stripe_subscription(stripe_subscription_id: str | None) -> Non
         stripe.Subscription.delete(stripe_subscription_id, api_key=stripe_secret)
         logger.info(f"[SUBSCRIBE] Stripe subscription {stripe_subscription_id} cancelled")
     except Exception:
-        logger.exception(
-            f"[SUBSCRIBE] Failed to cancel Stripe subscription {stripe_subscription_id}; "
-            "DB row still cancelled — webhook/reconcile will backstop"
-        )
+        logger.exception(f"[SUBSCRIBE] Failed to cancel Stripe subscription {stripe_subscription_id}")
+        if raise_on_error:
+            raise
 
 
 @api_router.post("/subscription/subscribe")
@@ -5340,17 +5345,12 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         )
     )
     if existing:
-        # Cancel old subscription — stop Stripe billing first so switching
-        # between recurring plans doesn't double-charge, then update our row.
-        await _cancel_stripe_subscription(existing.get("stripe_subscription_id"))
-        await db_supabase.update_one(
-            "driver_subscriptions",
-            {"id": existing["id"]},
-            {
-                "status": RideStatus.CANCELLED,
-                "cancelled_at": datetime.now(timezone.utc).isoformat(),
-            },
-        )
+        # Do NOT cancel `existing` here. For the paid Checkout path the driver
+        # must keep their current pass until the new payment is confirmed —
+        # _activate_subscription (called by the checkout webhook / verify-session)
+        # cancels the prior active subscription and bumps the subscriber count.
+        # Dev/immediate-activation mode handles `existing` at the end of this fn.
+        pass
 
     now = datetime.now(timezone.utc)
     expires = now + timedelta(days=plan.get("duration_days", 30))
@@ -5367,15 +5367,20 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
 
         _settings = await get_app_settings()
         _stripe_secret = _settings.get("stripe_secret_key", "")
-        _base_url = _settings.get("base_url", "http://localhost:8000")
         _price_id = plan.get("stripe_price_id")
         _metadata = {
             "driver_id": driver["id"],
             "subscription_id": subscription_id,
             "plan_id": plan_id,
         }
-        _success_url = f"{_base_url}/api/v1/drivers/subscription/verify-session?session_id={{CHECKOUT_SESSION_ID}}"
-        _cancel_url = f"{_base_url}/drivers/subscription"
+        # Stripe redirects the in-app browser back to the driver app via its
+        # deep-link scheme (app.config.ts SCHEME = "spinr-driver"). The
+        # subscription screen listens for spinr-driver://subscription/success
+        # and then calls verify-session with its authenticated API client.
+        # Pointing success_url at the backend API would land the browser on an
+        # unauthenticated endpoint and strand the driver outside the app.
+        _success_url = "spinr-driver://subscription/success?session_id={CHECKOUT_SESSION_ID}"
+        _cancel_url = "spinr-driver://subscription/cancel"
 
         if _stripe_secret and _price_id:
             # Recurring billing: Stripe Subscription mode. Stripe auto-renews
@@ -5467,18 +5472,33 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
 
     await db_supabase.insert_one("driver_subscriptions", subscription)
 
-    # Update plan subscriber count
+    if checkout_url:
+        # Payment pending — defer cancelling the driver's existing pass and
+        # bumping the subscriber count to _activate_subscription (runs on the
+        # checkout webhook / verify-session once payment is confirmed). This
+        # keeps their current pass valid if they abandon Checkout, and avoids
+        # double-counting (abandoned sessions would otherwise inflate the count
+        # and successful payments would count twice).
+        return {"success": True, "checkout_url": checkout_url, "subscription_id": subscription_id}
+
+    # Dev/immediate-activation mode: no payment step, so the activation path
+    # never runs — cancel the prior active subscription and bump the count here.
+    if existing:
+        await _cancel_stripe_subscription(existing.get("stripe_subscription_id"))
+        await db_supabase.update_one(
+            "driver_subscriptions",
+            {"id": existing["id"]},
+            {
+                "status": RideStatus.CANCELLED,
+                "cancelled_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
     await db_supabase.update_one(
         "subscription_plans",
         {"id": plan_id},
         {"subscriber_count": (plan.get("subscriber_count", 0) or 0) + 1},
     )
-
-    if checkout_url:
-        return {"success": True, "checkout_url": checkout_url, "subscription_id": subscription_id}
-    else:
-        # Dev mode: subscription is already active
-        return {"success": True, "subscription": subscription, "mode": "dev"}
+    return {"success": True, "subscription": subscription, "mode": "dev"}
 
 
 @api_router.get("/subscription/verify-session")
@@ -5498,6 +5518,15 @@ async def verify_subscription_session(
     """
     sub = await db.find_one("driver_subscriptions", {"stripe_session_id": session_id})
     if not sub:
+        raise HTTPException(status_code=404, detail="Subscription session not found")
+
+    # Authorize: the session must belong to the calling driver. Session ids can
+    # leak via redirect URLs, browser history, or support logs, so a non-owner
+    # gets the same 404 as a non-existent session (no existence oracle).
+    driver = (lambda _r: _r[0] if _r else None)(
+        await db_supabase.get_rows("drivers", {"user_id": current_user["id"]}, limit=1)
+    )
+    if not driver or sub.get("driver_id") != driver["id"]:
         raise HTTPException(status_code=404, detail="Subscription session not found")
 
     # Already activated (webhook beat us)
@@ -5522,6 +5551,16 @@ async def verify_subscription_session(
         return {"status": "pending"}
 
     if session.payment_status == "paid":
+        # Persist the Stripe Subscription id (recurring plans) so renewal /
+        # dunning / cancellation webhooks can match this row even if the
+        # checkout webhook was delayed or missed.
+        stripe_subscription_id = session.get("subscription")
+        if stripe_subscription_id:
+            await db.update_one(
+                "driver_subscriptions",
+                {"id": sub["id"]},
+                {"stripe_subscription_id": stripe_subscription_id},
+            )
         # Activate the subscription (same as webhook path, idempotent).
         await _activate_subscription(sub["id"], sub.get("plan_id"))
         sub = await db.find_one("driver_subscriptions", {"id": sub["id"]})
@@ -5545,6 +5584,11 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
     # Cancel any prior active subscription for this driver.
     existing = await db.find_one("driver_subscriptions", {"driver_id": driver_id, "status": "active"})
     if existing and existing["id"] != subscription_id:
+        # Stop the prior recurring Stripe subscription so a plan switch doesn't
+        # double-bill. Best-effort: we've already activated a paid replacement,
+        # so a Stripe failure here is logged (reconcile loop +
+        # customer.subscription.* webhooks backstop) but must not block.
+        await _cancel_stripe_subscription(existing.get("stripe_subscription_id"))
         await db.update_one(
             "driver_subscriptions",
             {"id": existing["id"]},
@@ -5611,8 +5655,18 @@ async def cancel_subscription(current_user: dict = Depends(get_current_user)):
     if not sub:
         raise HTTPException(status_code=400, detail="No active subscription")
 
-    # Stop Stripe billing for recurring plans before cancelling our row.
-    await _cancel_stripe_subscription(sub.get("stripe_subscription_id"))
+    # Stop Stripe billing for recurring plans first. If Stripe cancellation
+    # fails we must NOT mark the row cancelled — otherwise the app shows
+    # "cancelled" while Stripe keeps billing (and a later invoice.paid would
+    # silently re-activate it). Surface a retryable error instead.
+    try:
+        await _cancel_stripe_subscription(sub.get("stripe_subscription_id"), raise_on_error=True)
+    except Exception as e:
+        raise HTTPException(
+            status_code=502,
+            detail="Could not cancel your subscription with the payment provider. Please try again.",
+        ) from e
+
     await db_supabase.update_one(
         "driver_subscriptions",
         {"id": sub["id"]},

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5336,10 +5336,43 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
         _settings = await get_app_settings()
         _stripe_secret = _settings.get("stripe_secret_key", "")
         _base_url = _settings.get("base_url", "http://localhost:8000")
+        _price_id = plan.get("stripe_price_id")
+        _metadata = {
+            "driver_id": driver["id"],
+            "subscription_id": subscription_id,
+            "plan_id": plan_id,
+        }
+        _success_url = f"{_base_url}/api/v1/drivers/subscription/verify-session?session_id={{CHECKOUT_SESSION_ID}}"
+        _cancel_url = f"{_base_url}/drivers/subscription"
 
-        if _stripe_secret and plan_price > 0:
-            # Create a Checkout Session for the driver to complete payment.
-            # The webhook (checkout.session.completed) will activate the subscription.
+        if _stripe_secret and _price_id:
+            # Recurring billing: Stripe Subscription mode. Stripe auto-renews
+            # the driver's card each period and fires invoice.paid (renewal)
+            # / invoice.payment_failed (dunning) / customer.subscription.*
+            # which routes/webhooks.py reconciles. Requires a recurring Price
+            # created in the Stripe dashboard and stored on the plan.
+            _session = stripe.checkout.Session.create(
+                mode="subscription",
+                line_items=[{"price": _price_id, "quantity": 1}],
+                metadata=_metadata,
+                # Mirror our ids onto the Stripe Subscription so renewal
+                # invoices and subscription events are self-identifying.
+                subscription_data={"metadata": _metadata},
+                success_url=_success_url,
+                cancel_url=_cancel_url,
+                api_key=_stripe_secret,
+            )
+            checkout_url = _session.url
+            stripe_session_id = _session.id
+            payment_status = "pending"
+            logger.info(
+                f"[SUBSCRIBE] Recurring checkout session created: session={stripe_session_id} "
+                f"subscription={subscription_id} driver={driver['id']} price={_price_id}"
+            )
+        elif _stripe_secret and plan_price > 0:
+            # One-off Checkout (no recurring Price on this plan). The webhook
+            # (checkout.session.completed) activates the subscription; renewal
+            # is expiry-driven (driver re-subscribes each period).
             _amount_cents = int(plan_price * 100)
             _session = stripe.checkout.Session.create(
                 payment_method_types=["card"],
@@ -5358,20 +5391,16 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
                         "quantity": 1,
                     }
                 ],
-                metadata={
-                    "driver_id": driver["id"],
-                    "subscription_id": subscription_id,
-                    "plan_id": plan_id,
-                },
-                success_url=f"{_base_url}/api/v1/drivers/subscription/verify-session?session_id={{CHECKOUT_SESSION_ID}}",
-                cancel_url=f"{_base_url}/drivers/subscription",
+                metadata=_metadata,
+                success_url=_success_url,
+                cancel_url=_cancel_url,
                 api_key=_stripe_secret,
             )
             checkout_url = _session.url
             stripe_session_id = _session.id
             payment_status = "pending"
             logger.info(
-                f"[SUBSCRIBE] Checkout session created: session={stripe_session_id} "
+                f"[SUBSCRIBE] One-off checkout session created: session={stripe_session_id} "
                 f"subscription={subscription_id} driver={driver['id']}"
             )
         else:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4,7 +4,7 @@ import logging
 import os
 import socket
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Dict, List, Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -98,7 +98,7 @@ _TWO_PLACES = Decimal("0.01")
 
 def _money_str(v) -> str:
     """Serialise a money value as an exact 2-dp Decimal string (never float)."""
-    from decimal import ROUND_HALF_UP, InvalidOperation
+    from decimal import InvalidOperation
 
     try:
         return str(Decimal(str(v)).quantize(_TWO_PLACES, rounding=ROUND_HALF_UP))
@@ -5549,22 +5549,42 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
     try:
         await db_supabase.insert_one("driver_subscriptions", subscription)
     except Exception as _insert_err:
-        # The partial unique index (migration 152) allows at most one pending
-        # checkout per driver. A concurrent subscribe request that races past the
-        # supersede step hits it here — surface a clean 409 rather than a 500,
-        # and expire the Stripe session we just created so it can't be paid.
+        # Distinguish the expected concurrency conflict from a real DB failure:
+        # the partial unique index (migration 153) allows at most one pending
+        # checkout per driver, so if a pending row already exists this was a
+        # concurrent subscribe → 409. Otherwise the insert genuinely failed
+        # (schema/network/RLS) → surface 503, not a misleading "checkout in
+        # progress". Either way, expire the Stripe session we just created so it
+        # can't be paid, and log at error (payment-path failure).
         if checkout_url and stripe_session_id and _stripe_secret:
             try:
                 stripe.checkout.Session.expire(stripe_session_id, api_key=_stripe_secret)
             except Exception:
                 logger.info(f"[SUBSCRIBE] Could not expire race-loser session {stripe_session_id}")
-        logger.warning(
-            f"[SUBSCRIBE] Subscription insert failed (concurrent pending checkout?) for driver {driver['id']}",
+        existing_pending = (
+            await db_supabase.get_rows(
+                "driver_subscriptions",
+                {"driver_id": driver["id"], "status": "pending"},
+                columns="id",
+                limit=1,
+            )
+            or []
+        )
+        if existing_pending:
+            logger.warning(
+                f"[SUBSCRIBE] Concurrent pending checkout for driver {driver['id']} — returning 409",
+            )
+            raise HTTPException(
+                status_code=409,
+                detail="A checkout is already in progress. Please finish or cancel it first.",
+            ) from _insert_err
+        logger.error(
+            f"[SUBSCRIBE] Subscription insert failed for driver {driver['id']}",
             exc_info=True,
         )
         raise HTTPException(
-            status_code=409,
-            detail="A checkout is already in progress. Please finish or cancel it first.",
+            status_code=503,
+            detail="Could not start checkout. Please try again.",
         ) from _insert_err
 
     if checkout_url:
@@ -5713,7 +5733,7 @@ async def _record_subscription_payment(
     activation/webhook flow that already moved the money.
     """
     try:
-        amt = Decimal(str(amount or 0)).quantize(Decimal("0.01"))
+        amt = Decimal(str(amount or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         if amt <= 0:
             return  # nothing realized — don't clutter the ledger
         await db_supabase.insert_one(
@@ -5734,10 +5754,13 @@ async def _record_subscription_payment(
             },
         )
     except Exception:
-        # Duplicate recurring invoice (unique index) or any other write error —
-        # benign for the duplicate case; logged so a real failure is visible.
-        logger.warning(
-            "subscription_payments insert skipped (duplicate or error) driver=%s reason=%s invoice=%s",
+        # The only benign failure is the unique stripe_invoice_id collision on a
+        # recurring-invoice replay — but the event-claim gate already prevents
+        # webhook replays, so a failure almost always means a real lost ledger
+        # write. Log at error (not warning) per the payment-error rule; never
+        # raise — the money already moved.
+        logger.error(
+            "subscription_payments insert failed (lost ledger row?) driver=%s reason=%s invoice=%s",
             driver_id,
             billing_reason,
             stripe_invoice_id,

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -672,6 +672,16 @@ async def stripe_webhook(request: Request):
                     stripe_sub_id,
                     extra={"domain": "drivers", "event_id": event_id},
                 )
+            elif row.get("status") == "cancelled" or row.get("cancelled_at"):
+                # Terminal row — a late/duplicate invoice.paid arriving after a
+                # local cancel or customer.subscription.deleted must NOT flip
+                # the row back to active and restore gated access.
+                logger.warning(
+                    "invoice.paid ignored for cancelled subscription: row=%s stripe_sub=%s",
+                    row["id"],
+                    stripe_sub_id,
+                    extra={"domain": "drivers", "event_id": event_id},
+                )
             else:
                 new_expires = _invoice_period_end_iso(invoice)
                 if not new_expires:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -608,16 +608,30 @@ async def stripe_webhook(request: Request):
         if stripe_sub_id:
             active_sub = await db_supabase.find_one("driver_subscriptions", {"stripe_subscription_id": stripe_sub_id})
 
-        # Fallback: legacy customer-based lookup.
+        # Fallback: legacy customer-based lookup — only for rows that were never
+        # linked to a Stripe subscription. A live active row carrying a DIFFERENT
+        # stripe_subscription_id is a newer pass (e.g. after a plan switch on the
+        # same customer); deleting this older sub must not cancel it.
         if not active_sub and stripe_customer_id:
             user_row = await db_supabase.find_one("users", {"stripe_customer_id": stripe_customer_id})
             if user_row:
                 driver_row = await db_supabase.find_one("drivers", {"user_id": user_row["id"]})
                 if driver_row:
-                    active_sub = await db_supabase.find_one(
+                    candidate = await db_supabase.find_one(
                         "driver_subscriptions",
                         {"driver_id": driver_row["id"], "status": "active"},
                     )
+                    if candidate and not candidate.get("stripe_subscription_id"):
+                        active_sub = candidate
+                    elif candidate:
+                        logger.warning(
+                            "customer.subscription.deleted: active row %s is linked to a different "
+                            "stripe_sub (%s != %s) — not cancelling the newer pass",
+                            candidate["id"],
+                            candidate.get("stripe_subscription_id"),
+                            stripe_sub_id,
+                            extra={"domain": "drivers", "event_id": event_id},
+                        )
 
         if not active_sub:
             logger.warning(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -15,7 +15,7 @@ except ImportError:
     from settings_loader import get_app_settings
     from utils.money import cents_to_dollars
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 _TWO_PLACES = Decimal("0.01")
 
@@ -375,22 +375,43 @@ async def stripe_webhook(request: Request):
 
             await _activate_subscription(subscription_id, plan_id)
 
-            # Recurring plans (mode="subscription") return a Stripe
-            # Subscription id on the session — persist it so the renewal /
-            # dunning / cancellation webhooks can match this row.
+            # Re-read: _activate_subscription is a no-op for a row that was
+            # superseded by a newer checkout (or otherwise non-pending). Only
+            # link the Stripe Subscription id when the row actually activated —
+            # linking a superseded row would let a later invoice.paid /
+            # customer.subscription.updated flip it back to active.
+            row = await db_supabase.find_one("driver_subscriptions", {"id": subscription_id})
             stripe_subscription_id = data_object.get("subscription")
-            if stripe_subscription_id:
-                await db_supabase.update_one(
-                    "driver_subscriptions",
-                    {"id": subscription_id},
-                    {"stripe_subscription_id": stripe_subscription_id},
-                )
 
-            logger.info(
-                f"[WEBHOOK] Spinr Pass activated via checkout.session.completed: "
-                f"subscription={subscription_id} driver={driver_id} plan={plan_id} "
-                f"stripe_sub={stripe_subscription_id}"
-            )
+            if row and row.get("status") == "active":
+                if stripe_subscription_id:
+                    await db_supabase.update_one(
+                        "driver_subscriptions",
+                        {"id": subscription_id},
+                        {"stripe_subscription_id": stripe_subscription_id},
+                    )
+                logger.info(
+                    f"[WEBHOOK] Spinr Pass activated via checkout.session.completed: "
+                    f"subscription={subscription_id} driver={driver_id} plan={plan_id} "
+                    f"stripe_sub={stripe_subscription_id}"
+                )
+            else:
+                # Stale session paid after being superseded — don't activate or
+                # link. Cancel the orphaned Stripe subscription so the driver
+                # isn't billed for a plan they already replaced.
+                if stripe_subscription_id:
+                    try:
+                        from ..routes.drivers import _cancel_stripe_subscription  # type: ignore
+                    except ImportError:
+                        from routes.drivers import _cancel_stripe_subscription  # type: ignore
+                    await _cancel_stripe_subscription(stripe_subscription_id)
+                logger.warning(
+                    "[WEBHOOK] checkout.session.completed for non-active row %s "
+                    "(superseded?) — not linking; cancelled orphan Stripe sub %s",
+                    subscription_id,
+                    stripe_subscription_id,
+                    extra={"domain": "drivers", "event_id": event_id},
+                )
         else:
             logger.info(
                 f"[WEBHOOK] checkout.session.completed but payment not yet paid: "
@@ -672,10 +693,10 @@ async def stripe_webhook(request: Request):
                     stripe_sub_id,
                     extra={"domain": "drivers", "event_id": event_id},
                 )
-            elif row.get("status") == "cancelled" or row.get("cancelled_at"):
+            elif row.get("status") in ("cancelled", "superseded") or row.get("cancelled_at"):
                 # Terminal row — a late/duplicate invoice.paid arriving after a
-                # local cancel or customer.subscription.deleted must NOT flip
-                # the row back to active and restore gated access.
+                # local cancel, customer.subscription.deleted, or supersede must
+                # NOT flip the row back to active and restore gated access.
                 logger.warning(
                     "invoice.paid ignored for cancelled subscription: row=%s stripe_sub=%s",
                     row["id"],
@@ -795,7 +816,11 @@ async def stripe_webhook(request: Request):
             elif stripe_status == "past_due":
                 updates = {"payment_status": "past_due"}
             elif stripe_status == "active":
-                updates = {"status": "active", "payment_status": "paid"}
+                # Don't resurrect a row already cancelled (driver/Stripe) or
+                # superseded by a newer checkout — a late "active" update must
+                # not restore gated access.
+                if row.get("status") not in ("cancelled", "superseded") and not row.get("cancelled_at"):
+                    updates = {"status": "active", "payment_status": "paid"}
             if updates:
                 await db_supabase.update_one("driver_subscriptions", {"id": row["id"]}, updates)
                 logger.info(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -41,6 +41,12 @@ _STRIPE_HANDLED_EVENTS = frozenset(
         # the account's status. Drives the Payouts tab's Tax & Identity
         # section in the admin slideout.
         "account.updated",
+        # Connected-account bank settlement of a driver payout. Lets us
+        # reconcile the payouts row to the true outcome — an instant payout
+        # marked "completed" synchronously can still be rejected by the bank
+        # days later (closed account, etc.); payout.failed is how we learn.
+        "payout.paid",
+        "payout.failed",
     }
 )
 # Public alias exported for tests
@@ -612,6 +618,87 @@ async def stripe_webhook(request: Request):
         except ImportError:
             from services.stripe_kyc_sync import apply_account_update
         await apply_account_update(data_object, event_id=event_id)
+
+    elif event_type in ("payout.paid", "payout.failed"):
+        # Connected-account bank settlement of a driver payout. Instant
+        # payouts (routes/drivers.py request_instant_payout) do an explicit
+        # Payout.create and store its po_ id in payouts.stripe_payout_id, so
+        # those reconcile here. Standard payouts only do a Transfer and store
+        # a tr_ id — those won't match a Payout event, and Stripe's automatic
+        # scheduled payouts of the connected balance also fire here with no
+        # tracked row. A no-match is therefore expected: log and ack, never
+        # 5xx (a 5xx would make Stripe retry a payout we don't track for days).
+        stripe_payout_id = data_object.get("id")
+        payout_row = None
+        if stripe_payout_id:
+            payout_row = await db_supabase.find_one("payouts", {"stripe_payout_id": stripe_payout_id})
+
+        if not payout_row:
+            logger.info(
+                "payout webhook %s: no tracked payout row for %s "
+                "(auto-scheduled connected-account payout or standard transfer) — acking",
+                event_type,
+                stripe_payout_id,
+                extra={"domain": "payments", "event_id": event_id},
+            )
+        elif event_type == "payout.paid":
+            await db_supabase.update_one(
+                "payouts",
+                {"id": payout_row["id"]},
+                {
+                    "status": "completed",
+                    "processed_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+            logger.info(
+                "Payout settled to bank: payout_row=%s po=%s",
+                payout_row["id"],
+                stripe_payout_id,
+                extra={"domain": "payments", "event_id": event_id},
+            )
+        else:  # payout.failed
+            failure_message = (
+                data_object.get("failure_message")
+                or data_object.get("failure_code")
+                or "Bank payout failed"
+            )
+            await db_supabase.update_one(
+                "payouts",
+                {"id": payout_row["id"]},
+                {
+                    "status": "failed",
+                    "failure_reason": str(failure_message)[:500],
+                    "requires_manual_review": True,
+                    "processed_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+            logger.error(
+                "PAYOUT FAILED at bank: payout_row=%s po=%s reason=%s",
+                payout_row["id"],
+                stripe_payout_id,
+                failure_message,
+                extra={
+                    "domain": "payments",
+                    "event_id": event_id,
+                    "driver_id": payout_row.get("driver_id") or "",
+                },
+            )
+            # Notify the driver their money didn't land so they can fix their
+            # bank details and retry.
+            driver_row = await db_supabase.find_one("drivers", {"id": payout_row.get("driver_id")})
+            if driver_row and driver_row.get("user_id"):
+                try:
+                    await send_push_notification(
+                        driver_row["user_id"],
+                        "Payout failed",
+                        "Your payout could not be deposited. Please check your bank details and try again.",
+                        data={"type": "payout_failed", "deeplink": "/driver/earnings"},
+                    )
+                except Exception:
+                    logger.warning(
+                        "Push notification failed for payout_failed event; continuing",
+                        exc_info=True,
+                    )
 
     else:
         if event_type in _STRIPE_HANDLED_EVENTS:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -739,12 +739,18 @@ async def stripe_webhook(request: Request):
                     from ..routes.drivers import _record_subscription_payment  # type: ignore
                 except ImportError:
                     from routes.drivers import _record_subscription_payment  # type: ignore
+                # amount_paid is the authoritative charged amount; it can be a
+                # legitimate 0 (100% coupon / trial), which is falsy, so test
+                # for None rather than truthiness before falling back.
+                _amount_cents = invoice.get("amount_paid")
+                if _amount_cents is None:
+                    _amount_cents = invoice.get("amount_due") or 0
                 await _record_subscription_payment(
                     driver_id=row.get("driver_id"),
                     subscription_id=row["id"],
                     plan_id=row.get("plan_id"),
                     plan_name=row.get("plan_name"),
-                    amount=cents_to_dollars(invoice.get("amount_paid") or invoice.get("amount_due") or 0),
+                    amount=cents_to_dollars(_amount_cents),
                     billing_reason=invoice.get("billing_reason") or "subscription_cycle",
                     stripe_invoice_id=invoice.get("id"),
                 )

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -55,6 +55,7 @@ async def stripe_webhook(request: Request):
 
     settings = await get_app_settings()
     webhook_secret = settings.get("stripe_webhook_secret", "")
+    connect_webhook_secret = settings.get("stripe_connect_webhook_secret", "")
     stripe_secret = settings.get("stripe_secret_key", "")
 
     if not webhook_secret:
@@ -68,15 +69,36 @@ async def stripe_webhook(request: Request):
         logger.error("Stripe secret key not configured in app settings")
         raise HTTPException(status_code=500, detail="Stripe not configured")
 
-    try:
-        import stripe
+    import stripe
 
-        event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid payload") from None
-    except Exception as e:
-        logger.error(f"Stripe webhook signature verification failed: {e}")
-        raise HTTPException(status_code=400, detail="Invalid signature") from e
+    # Both the platform endpoint and the Connected-accounts endpoint POST to
+    # this same URL, but Stripe signs each with that endpoint's own whsec_.
+    # We can't tell them apart before verifying, so try the platform secret
+    # first, then the connect secret (if configured). A SignatureVerification
+    # failure on one is expected for events from the other — only reject when
+    # BOTH fail. ValueError = malformed payload, reject immediately.
+    candidate_secrets = [webhook_secret]
+    if connect_webhook_secret:
+        candidate_secrets.append(connect_webhook_secret)
+
+    event = None
+    last_sig_error: Exception | None = None
+    for secret in candidate_secrets:
+        try:
+            event = stripe.Webhook.construct_event(payload, sig_header, secret)
+            break
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid payload") from None
+        except stripe.error.SignatureVerificationError as e:
+            last_sig_error = e
+            continue
+        except Exception as e:
+            last_sig_error = e
+            continue
+
+    if event is None:
+        logger.error(f"Stripe webhook signature verification failed: {last_sig_error}")
+        raise HTTPException(status_code=400, detail="Invalid signature") from last_sig_error
 
     event_id = event.get("id", "")
     event_type = event.get("type", "")

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -34,6 +34,11 @@ _STRIPE_HANDLED_EVENTS = frozenset(
         "charge.refunded",
         "charge.dispute.created",
         "charge.dispute.closed",
+        # Recurring Spinr Pass (mode="subscription" plans): renewal succeeded,
+        # renewal failed (dunning), and status changes (past_due → canceled).
+        "invoice.paid",
+        "invoice.payment_failed",
+        "customer.subscription.updated",
         "customer.subscription.deleted",
         # Connect Express KYC mirror — fired whenever the driver progresses
         # through Stripe's hosted onboarding (uploads ID, accepts ToS,
@@ -51,6 +56,26 @@ _STRIPE_HANDLED_EVENTS = frozenset(
 )
 # Public alias exported for tests
 ALLOWED_STRIPE_EVENTS = _STRIPE_HANDLED_EVENTS
+
+
+def _invoice_period_end_iso(invoice: dict) -> str | None:
+    """Extract the billing-period end (ISO UTC) from a Stripe Invoice.
+
+    Stripe's invoice line carries the authoritative period end for the cycle
+    just paid. Returns None if the structure is missing so the caller can fall
+    back to plan duration. Defensive on every nested path — Stripe trims
+    fields and StripeObjects flatten to plain dicts via to_dict_recursive.
+    """
+    try:
+        lines = (invoice.get("lines") or {}).get("data") or []
+        if lines:
+            period = lines[0].get("period") or {}
+            end = period.get("end")
+            if end:
+                return datetime.fromtimestamp(int(end), tz=timezone.utc).isoformat()
+    except Exception:
+        pass
+    return None
 
 
 @api_router.post("/stripe")
@@ -631,6 +656,149 @@ async def stripe_webhook(request: Request):
         except ImportError:
             from services.stripe_kyc_sync import apply_account_update
         await apply_account_update(data_object, event_id=event_id)
+
+    elif event_type == "invoice.paid":
+        # Recurring Spinr Pass renewal succeeded (also fires for the first
+        # invoice of a new subscription). Extend the driver's row to the
+        # invoice's period end — idempotent for both subscription_create and
+        # subscription_cycle.
+        invoice = data_object
+        stripe_sub_id = invoice.get("subscription")
+        if not stripe_sub_id:
+            logger.info(
+                "invoice.paid without subscription id — skipping",
+                extra={"domain": "drivers", "event_id": event_id},
+            )
+        else:
+            row = await db_supabase.find_one("driver_subscriptions", {"stripe_subscription_id": stripe_sub_id})
+            if not row:
+                logger.warning(
+                    "invoice.paid: no subscription row for stripe_sub %s",
+                    stripe_sub_id,
+                    extra={"domain": "drivers", "event_id": event_id},
+                )
+            else:
+                new_expires = _invoice_period_end_iso(invoice)
+                if not new_expires:
+                    duration_days = 30
+                    if row.get("plan_id"):
+                        plan = await db_supabase.find_one("subscription_plans", {"id": row["plan_id"]})
+                        if plan and plan.get("duration_days"):
+                            duration_days = plan["duration_days"]
+                    new_expires = (datetime.now(timezone.utc) + timedelta(days=duration_days)).isoformat()
+
+                await db_supabase.update_one(
+                    "driver_subscriptions",
+                    {"id": row["id"]},
+                    {
+                        "status": "active",
+                        "payment_status": "paid",
+                        "expires_at": new_expires,
+                        "expiry_warned": False,
+                    },
+                )
+                logger.info(
+                    "Spinr Pass renewed: row=%s stripe_sub=%s until=%s",
+                    row["id"],
+                    stripe_sub_id,
+                    new_expires,
+                    extra={"domain": "drivers", "event_id": event_id},
+                )
+                # Only notify on actual renewal cycles — the initial invoice's
+                # activation push already went out from the checkout handler.
+                if invoice.get("billing_reason") == "subscription_cycle":
+                    driver_row = await db_supabase.find_one("drivers", {"id": row.get("driver_id")})
+                    if driver_row and driver_row.get("user_id"):
+                        try:
+                            await send_push_notification(
+                                driver_row["user_id"],
+                                "Spinr Pass renewed",
+                                "Your Spinr Pass renewed. You're all set to keep accepting rides.",
+                                data={"type": "subscription_renewed", "deeplink": "/driver/subscription"},
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Push notification failed for subscription_renewed; continuing",
+                                exc_info=True,
+                            )
+
+    elif event_type == "invoice.payment_failed":
+        # Recurring renewal charge failed. Flag the row past_due and nudge the
+        # driver to update their card. We don't terminate here — Stripe retries
+        # per its dunning settings, then fires customer.subscription.updated
+        # (past_due) / .deleted (canceled), which we handle separately.
+        invoice = data_object
+        stripe_sub_id = invoice.get("subscription")
+        row = None
+        if stripe_sub_id:
+            row = await db_supabase.find_one("driver_subscriptions", {"stripe_subscription_id": stripe_sub_id})
+        if not row:
+            logger.warning(
+                "invoice.payment_failed: no subscription row for stripe_sub %s",
+                stripe_sub_id,
+                extra={"domain": "drivers", "event_id": event_id},
+            )
+        else:
+            await db_supabase.update_one(
+                "driver_subscriptions",
+                {"id": row["id"]},
+                {"payment_status": "past_due"},
+            )
+            logger.warning(
+                "Spinr Pass renewal payment failed: row=%s stripe_sub=%s",
+                row["id"],
+                stripe_sub_id,
+                extra={"domain": "drivers", "event_id": event_id},
+            )
+            driver_row = await db_supabase.find_one("drivers", {"id": row.get("driver_id")})
+            if driver_row and driver_row.get("user_id"):
+                try:
+                    await send_push_notification(
+                        driver_row["user_id"],
+                        "Spinr Pass payment failed",
+                        "We couldn't renew your Spinr Pass. Please update your card to keep accepting rides.",
+                        data={"type": "subscription_past_due", "deeplink": "/driver/subscription"},
+                    )
+                except Exception:
+                    logger.warning(
+                        "Push notification failed for subscription_past_due; continuing",
+                        exc_info=True,
+                    )
+
+    elif event_type == "customer.subscription.updated":
+        # Mirror Stripe's authoritative subscription status onto our row.
+        # Fires often; we act only on meaningful transitions and ack the rest.
+        subscription = data_object
+        stripe_sub_id = subscription.get("id")
+        stripe_status = subscription.get("status")
+        row = None
+        if stripe_sub_id:
+            row = await db_supabase.find_one("driver_subscriptions", {"stripe_subscription_id": stripe_sub_id})
+        if not row:
+            logger.info(
+                "customer.subscription.updated: no row for stripe_sub %s — skipping",
+                stripe_sub_id,
+                extra={"domain": "drivers", "event_id": event_id},
+            )
+        else:
+            updates: dict = {}
+            if stripe_status in ("canceled", "unpaid", "incomplete_expired"):
+                updates = {
+                    "status": "cancelled",
+                    "cancelled_at": datetime.now(timezone.utc).isoformat(),
+                }
+            elif stripe_status == "past_due":
+                updates = {"payment_status": "past_due"}
+            elif stripe_status == "active":
+                updates = {"status": "active", "payment_status": "paid"}
+            if updates:
+                await db_supabase.update_one("driver_subscriptions", {"id": row["id"]}, updates)
+                logger.info(
+                    "Spinr Pass subscription updated: row=%s stripe_status=%s",
+                    row["id"],
+                    stripe_status,
+                    extra={"domain": "drivers", "event_id": event_id},
+                )
 
     elif event_type in ("payout.paid", "payout.failed"):
         # Connected-account bank settlement of a driver payout. Instant

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -575,75 +575,70 @@ async def stripe_webhook(request: Request):
 
     elif event_type == "customer.subscription.deleted":
         subscription = data_object
+        stripe_sub_id = subscription.get("id")
         stripe_customer_id = subscription.get("customer")
-        if stripe_customer_id:
-            # Look up the user by their Stripe customer ID, then find the linked driver
+
+        # Primary: match our row by the Stripe Subscription id, which we persist
+        # for recurring plans. Checkout-created subs may not have
+        # users.stripe_customer_id populated, so the customer lookup below can
+        # miss them — without this match the row would stay active and the
+        # driver would keep subscription-gated access after Stripe stopped.
+        active_sub = None
+        if stripe_sub_id:
+            active_sub = await db_supabase.find_one("driver_subscriptions", {"stripe_subscription_id": stripe_sub_id})
+
+        # Fallback: legacy customer-based lookup.
+        if not active_sub and stripe_customer_id:
             user_row = await db_supabase.find_one("users", {"stripe_customer_id": stripe_customer_id})
             if user_row:
-                user_id = user_row["id"]
-                driver_row = await db_supabase.find_one("drivers", {"user_id": user_id})
+                driver_row = await db_supabase.find_one("drivers", {"user_id": user_row["id"]})
                 if driver_row:
-                    driver_id = driver_row["id"]
-                    # Cancel the active driver_subscriptions row for this driver
                     active_sub = await db_supabase.find_one(
                         "driver_subscriptions",
-                        {"driver_id": driver_id, "status": "active"},
+                        {"driver_id": driver_row["id"], "status": "active"},
                     )
-                    if active_sub:
-                        await db_supabase.update_one(
-                            "driver_subscriptions",
-                            {"id": active_sub["id"]},
-                            {
-                                "status": "cancelled",
-                                "cancelled_at": datetime.now(timezone.utc).isoformat(),
-                                "updated_at": datetime.now(timezone.utc).isoformat(),
-                            },
-                        )
-                        logger.info(
-                            f"Stripe subscription cancelled for driver {driver_id} "
-                            f"(subscription row {active_sub['id']})",
-                            extra={
-                                "domain": "drivers",
-                                "driver_id": driver_id,
-                                "event_id": event_id,
-                            },
-                        )
-                    else:
-                        logger.info(
-                            f"customer.subscription.deleted: no active subscription row for driver {driver_id}",
-                            extra={
-                                "domain": "drivers",
-                                "driver_id": driver_id,
-                                "event_id": event_id,
-                            },
-                        )
-                    try:
-                        await send_push_notification(
-                            user_id,
-                            "Subscription cancelled",
-                            "Your Spinr subscription has been cancelled. Renew to continue accepting rides.",
-                            data={
-                                "type": "subscription_cancelled",
-                                "deeplink": "/driver/subscription",
-                            },
-                        )
-                    except Exception as _e:
-                        logger.debug(f"Subscription cancel push failed: {_e}")
-                else:
-                    logger.warning(
-                        f"customer.subscription.deleted: no driver found for user {user_id}",
-                        extra={"domain": "drivers", "event_id": event_id},
-                    )
-            else:
-                logger.warning(
-                    "customer.subscription.deleted: no user found for stripe_customer_id",
-                    extra={"domain": "drivers", "event_id": event_id},
-                )
-        else:
+
+        if not active_sub:
             logger.warning(
-                "customer.subscription.deleted: event has no customer field — skipping",
+                "customer.subscription.deleted: no matching subscription row (sub=%s customer=%s)",
+                stripe_sub_id,
+                stripe_customer_id,
                 extra={"domain": "drivers", "event_id": event_id},
             )
+        else:
+            if active_sub.get("status") != "cancelled":
+                await db_supabase.update_one(
+                    "driver_subscriptions",
+                    {"id": active_sub["id"]},
+                    {
+                        "status": "cancelled",
+                        "cancelled_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                )
+            logger.info(
+                "Stripe subscription cancelled: row=%s sub=%s",
+                active_sub["id"],
+                stripe_sub_id,
+                extra={
+                    "domain": "drivers",
+                    "driver_id": active_sub.get("driver_id") or "",
+                    "event_id": event_id,
+                },
+            )
+            driver_row = await db_supabase.find_one("drivers", {"id": active_sub.get("driver_id")})
+            if driver_row and driver_row.get("user_id"):
+                try:
+                    await send_push_notification(
+                        driver_row["user_id"],
+                        "Subscription cancelled",
+                        "Your Spinr subscription has been cancelled. Renew to continue accepting rides.",
+                        data={
+                            "type": "subscription_cancelled",
+                            "deeplink": "/driver/subscription",
+                        },
+                    )
+                except Exception as _e:
+                    logger.debug(f"Subscription cancel push failed: {_e}")
 
     elif event_type == "account.updated":
         # Stripe Connect Express KYC mirror. Fires whenever the driver

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -373,7 +373,10 @@ async def stripe_webhook(request: Request):
             except ImportError:
                 from routes.drivers import _activate_subscription  # type: ignore
 
-            await _activate_subscription(subscription_id, plan_id)
+            # Pass the session's actual mode so one-off vs recurring ledger
+            # recording is decided by what was created, not the plan's current
+            # stripe_price_id.
+            await _activate_subscription(subscription_id, plan_id, data_object.get("mode"))
 
             # Re-read: _activate_subscription is a no-op for a row that was
             # superseded by a newer checkout (or otherwise non-pending). Only
@@ -701,6 +704,32 @@ async def stripe_webhook(request: Request):
             )
         else:
             row = await db_supabase.find_one("driver_subscriptions", {"stripe_subscription_id": stripe_sub_id})
+            if not row and stripe_secret:
+                # Out-of-order delivery: checkout.session.completed / verify-session
+                # hasn't linked stripe_subscription_id onto the row yet. Recover it
+                # from the subscription's metadata (set via subscription_data.metadata
+                # at checkout) and link it, so the FIRST renewal charge still lands in
+                # the ledger instead of being silently dropped.
+                try:
+                    import stripe as _stripe
+
+                    _sub_obj = _stripe.Subscription.retrieve(stripe_sub_id, api_key=stripe_secret)
+                    _meta_sub_id = (_sub_obj.get("metadata") or {}).get("subscription_id")
+                    if _meta_sub_id:
+                        row = await db_supabase.find_one("driver_subscriptions", {"id": _meta_sub_id})
+                        if row and not row.get("stripe_subscription_id"):
+                            await db_supabase.update_one(
+                                "driver_subscriptions",
+                                {"id": row["id"]},
+                                {"stripe_subscription_id": stripe_sub_id},
+                            )
+                except Exception:
+                    logger.error(
+                        "invoice.paid: failed to recover subscription row from metadata for %s",
+                        stripe_sub_id,
+                        exc_info=True,
+                        extra={"domain": "drivers", "event_id": event_id},
+                    )
             if not row:
                 logger.warning(
                     "invoice.paid: no subscription row for stripe_sub %s",

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -349,9 +349,22 @@ async def stripe_webhook(request: Request):
                 from routes.drivers import _activate_subscription  # type: ignore
 
             await _activate_subscription(subscription_id, plan_id)
+
+            # Recurring plans (mode="subscription") return a Stripe
+            # Subscription id on the session — persist it so the renewal /
+            # dunning / cancellation webhooks can match this row.
+            stripe_subscription_id = data_object.get("subscription")
+            if stripe_subscription_id:
+                await db_supabase.update_one(
+                    "driver_subscriptions",
+                    {"id": subscription_id},
+                    {"stripe_subscription_id": stripe_subscription_id},
+                )
+
             logger.info(
                 f"[WEBHOOK] Spinr Pass activated via checkout.session.completed: "
-                f"subscription={subscription_id} driver={driver_id} plan={plan_id}"
+                f"subscription={subscription_id} driver={driver_id} plan={plan_id} "
+                f"stripe_sub={stripe_subscription_id}"
             )
         else:
             logger.info(
@@ -658,9 +671,7 @@ async def stripe_webhook(request: Request):
             )
         else:  # payout.failed
             failure_message = (
-                data_object.get("failure_message")
-                or data_object.get("failure_code")
-                or "Bank payout failed"
+                data_object.get("failure_message") or data_object.get("failure_code") or "Bank payout failed"
             )
             await db_supabase.update_one(
                 "payouts",

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -730,6 +730,25 @@ async def stripe_webhook(request: Request):
                     new_expires,
                     extra={"domain": "drivers", "event_id": event_id},
                 )
+
+                # Record this charge (first invoice + every renewal) in the
+                # subscription_payments ledger so admin revenue stats capture
+                # recurring renewals. Deduped on the unique stripe_invoice_id
+                # index, so a replay is a no-op.
+                try:
+                    from ..routes.drivers import _record_subscription_payment  # type: ignore
+                except ImportError:
+                    from routes.drivers import _record_subscription_payment  # type: ignore
+                await _record_subscription_payment(
+                    driver_id=row.get("driver_id"),
+                    subscription_id=row["id"],
+                    plan_id=row.get("plan_id"),
+                    plan_name=row.get("plan_name"),
+                    amount=cents_to_dollars(invoice.get("amount_paid") or invoice.get("amount_due") or 0),
+                    billing_reason=invoice.get("billing_reason") or "subscription_cycle",
+                    stripe_invoice_id=invoice.get("id"),
+                )
+
                 # Only notify on actual renewal cycles — the initial invoice's
                 # activation push already went out from the checkout handler.
                 if invoice.get("billing_reason") == "subscription_cycle":

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -122,6 +122,13 @@ class AppSettings(BaseModel):
     stripe_publishable_key: str = ""
     stripe_secret_key: str = ""
     stripe_webhook_secret: str = ""
+    # Separate signing secret for the Stripe Connect (Connected accounts)
+    # webhook endpoint. account.updated / payout.paid / payout.failed are
+    # delivered by an endpoint scoped to connected accounts, which Stripe
+    # gives its own whsec_. The platform endpoint's stripe_webhook_secret
+    # cannot verify those — see construct_event dual-secret logic in
+    # routes/webhooks.py.
+    stripe_connect_webhook_secret: str = ""
     twilio_account_sid: str = ""
     twilio_auth_token: str = ""
     twilio_from_number: str = ""

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -88,11 +88,11 @@ class TestSubscriptionCheckoutFlow:
         ):
             # Setup mocks
             mock_get_rows.side_effect = lambda table, filters, limit=None: {
-                "drivers": [[mock_driver]],
-                "service_areas": [[{"spinr_pass_enabled": True}]],
-                "subscription_plans": [[mock_plan]],
-                "driver_subscriptions": [[]],
-            }.get(table, [[]])
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [mock_plan],
+                "driver_subscriptions": [],
+            }.get(table, [])
 
             mock_get_settings.return_value = mock_settings
             mock_checkout_session = MagicMock()
@@ -142,11 +142,11 @@ class TestSubscriptionCheckoutFlow:
             patch("backend.settings_loader.get_app_settings") as mock_get_settings,
         ):
             mock_get_rows.side_effect = lambda table, filters, limit=None: {
-                "drivers": [[mock_driver]],
-                "service_areas": [[{"spinr_pass_enabled": True}]],
-                "subscription_plans": [[mock_plan]],
-                "driver_subscriptions": [[]],
-            }.get(table, [[]])
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [mock_plan],
+                "driver_subscriptions": [],
+            }.get(table, [])
 
             mock_get_settings.return_value = mock_settings_no_stripe
 
@@ -175,9 +175,9 @@ class TestSubscriptionCheckoutFlow:
 
         with patch("backend.db_supabase.get_rows") as mock_get_rows, patch("backend.settings_loader.get_app_settings"):
             mock_get_rows.side_effect = lambda table, filters, limit=None: {
-                "drivers": [[mock_driver]],
-                "service_areas": [[{"spinr_pass_enabled": False}]],
-            }.get(table, [[]])
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": False}],
+            }.get(table, [])
 
             # Execute and expect 403
             with pytest.raises(HTTPException) as exc_info:
@@ -239,7 +239,7 @@ class TestWebhookActivation:
 
 
 class TestVerifySession:
-    """Test verify-session endpoint polls and activates on payment."""
+    """Test verify-session endpoint polls, authorizes, and activates on payment."""
 
     async def test_verify_session_already_active(self):
         """verify-session returns early if subscription already active."""
@@ -247,9 +247,16 @@ class TestVerifySession:
 
         current_user = {"id": "user-123"}
 
-        with patch("backend.db_supabase.find_one") as mock_find:
+        with (
+            patch("backend.db_supabase.find_one") as mock_find,
+            patch(
+                "backend.db_supabase.get_rows",
+                AsyncMock(return_value=[{"id": "driver-1"}]),
+            ),
+        ):
             mock_find.return_value = {
                 "id": "sub-123",
+                "driver_id": "driver-1",
                 "status": "active",
                 "payment_status": "paid",
             }
@@ -257,16 +264,40 @@ class TestVerifySession:
             result = await verify_subscription_session("cs_test_123", current_user)
 
             assert result["status"] == "active"
-            assert mock_find.call_count == 1
 
-    async def test_verify_session_polls_stripe_and_activates(self):
-        """verify-session retrieves session from Stripe and activates on paid."""
+    async def test_verify_session_rejects_non_owner(self):
+        """A driver cannot verify a session belonging to a different driver."""
+        from fastapi import HTTPException
+
         from backend.routes.drivers import verify_subscription_session
 
         current_user = {"id": "user-123"}
 
+        with (
+            patch(
+                "backend.db_supabase.find_one",
+                AsyncMock(return_value={"id": "sub-123", "driver_id": "driver-OTHER"}),
+            ),
+            patch(
+                "backend.db_supabase.get_rows",
+                AsyncMock(return_value=[{"id": "driver-1"}]),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await verify_subscription_session("cs_test_123", current_user)
+
+        # 404 (not 403) so the session id is not an existence oracle.
+        assert exc.value.status_code == 404
+
+    async def test_verify_session_persists_subscription_id(self):
+        """On paid, verify-session copies session.subscription onto the row so
+        renewal/cancellation webhooks can match it (B4 fallback)."""
+        from backend.routes.drivers import verify_subscription_session
+
+        current_user = {"id": "user-123"}
         mock_sub = {
             "id": "sub-123",
+            "driver_id": "driver-1",
             "plan_id": "plan-premium",
             "status": "pending",
             "payment_status": "pending",
@@ -274,26 +305,27 @@ class TestVerifySession:
 
         mock_session = MagicMock()
         mock_session.payment_status = "paid"
+        mock_session.get = lambda k, d=None: "sub_stripe_99" if k == "subscription" else d
+
+        update_mock = AsyncMock()
 
         with (
-            patch("backend.db_supabase.find_one") as mock_find,
-            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
-            patch("stripe.checkout.Session.retrieve") as mock_retrieve,
-            patch("backend.routes.drivers._activate_subscription") as mock_activate,
+            patch("backend.db_supabase.find_one", AsyncMock(return_value=mock_sub)),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[{"id": "driver-1"}])),
+            patch("backend.db_supabase.update_one", update_mock),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": "sk_test_123"}),
+            ),
+            patch("stripe.checkout.Session.retrieve", return_value=mock_session),
+            patch("backend.routes.drivers._activate_subscription", AsyncMock()),
         ):
-            mock_find.return_value = mock_sub
-            mock_get_settings.return_value = {"stripe_secret_key": "sk_test_123"}
-            mock_retrieve.return_value = mock_session
-
             result = await verify_subscription_session("cs_test_123", current_user)
 
-            # Verify Stripe was queried
-            mock_retrieve.assert_called_once_with("cs_test_123", api_key="sk_test_123")
-
-            # Verify subscription was activated
-            mock_activate.assert_called_once_with("sub-123", "plan-premium")
-
-            assert result["status"] == "active"
+        assert result["status"] == "active"
+        # stripe_subscription_id persisted onto the row.
+        persisted = [c for c in update_mock.await_args_list if c.args and c.args[0] == "driver_subscriptions"]
+        assert any(c.args[2].get("stripe_subscription_id") == "sub_stripe_99" for c in persisted)
 
     async def test_verify_session_pending_payment(self):
         """verify-session returns pending if Stripe session not yet paid."""
@@ -303,6 +335,7 @@ class TestVerifySession:
 
         mock_sub = {
             "id": "sub-123",
+            "driver_id": "driver-1",
             "status": "pending",
             "payment_status": "pending",
         }
@@ -311,14 +344,14 @@ class TestVerifySession:
         mock_session.payment_status = "unpaid"
 
         with (
-            patch("backend.db_supabase.find_one") as mock_find,
-            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
-            patch("stripe.checkout.Session.retrieve") as mock_retrieve,
+            patch("backend.db_supabase.find_one", AsyncMock(return_value=mock_sub)),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[{"id": "driver-1"}])),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": "sk_test_123"}),
+            ),
+            patch("stripe.checkout.Session.retrieve", return_value=mock_session),
         ):
-            mock_find.return_value = mock_sub
-            mock_get_settings.return_value = {"stripe_secret_key": "sk_test_123"}
-            mock_retrieve.return_value = mock_session
-
             result = await verify_subscription_session("cs_test_123", current_user)
 
             assert result["status"] == "pending"
@@ -328,11 +361,10 @@ class TestRecurringSubscription:
     """B3/B5: plans with a stripe_price_id use mode=subscription Checkout, and
     cancelling stops Stripe billing (not just the DB row)."""
 
-    async def test_subscribe_recurring_uses_subscription_mode(
-        self, mock_driver, mock_settings
-    ):
-        from backend.routes.drivers import subscribe_to_plan
+    async def test_subscribe_recurring_uses_subscription_mode(self, mock_driver, mock_settings):
         from fastapi import Request
+
+        from backend.routes.drivers import subscribe_to_plan
 
         recurring_plan = {
             "id": "plan-recurring",
@@ -358,11 +390,11 @@ class TestRecurringSubscription:
             patch("stripe.checkout.Session.create") as mock_session_create,
         ):
             mock_get_rows.side_effect = lambda table, filters, limit=None: {
-                "drivers": [[mock_driver]],
-                "service_areas": [[{"spinr_pass_enabled": True}]],
-                "subscription_plans": [[recurring_plan]],
-                "driver_subscriptions": [[]],
-            }.get(table, [[]])
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [recurring_plan],
+                "driver_subscriptions": [],
+            }.get(table, [])
             mock_get_settings.return_value = mock_settings
 
             session = MagicMock()
@@ -432,3 +464,51 @@ class TestCancelStripeSubscription:
         ):
             # Best-effort: must swallow so the DB-side cancel still proceeds.
             await _cancel_stripe_subscription("sub_123")
+
+
+class TestCancelSubscriptionEndpoint:
+    """/subscription/cancel must not mark the row cancelled if the Stripe
+    cancellation fails (comment 7) — otherwise the app shows 'cancelled'
+    while Stripe keeps billing."""
+
+    @staticmethod
+    def _rows(table, filters, limit=None):
+        return {
+            "drivers": [{"id": "driver-1"}],
+            "driver_subscriptions": [{"id": "sub-1", "stripe_subscription_id": "sub_stripe_1"}],
+        }.get(table, [])
+
+    async def test_cancel_502_when_stripe_fails_row_not_cancelled(self):
+        from fastapi import HTTPException
+
+        from backend.routes.drivers import cancel_subscription
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one") as update_mock,
+            patch("backend.routes.drivers._cancel_stripe_subscription") as cancel_mock,
+        ):
+            mock_get_rows.side_effect = self._rows
+            cancel_mock.side_effect = Exception("stripe down")
+
+            with pytest.raises(HTTPException) as exc:
+                await cancel_subscription({"id": "user-123"})
+
+        assert exc.value.status_code == 502
+        update_mock.assert_not_awaited()
+
+    async def test_cancel_succeeds_marks_row_cancelled(self):
+        from backend.routes.drivers import cancel_subscription
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one") as update_mock,
+            patch("backend.routes.drivers._cancel_stripe_subscription", AsyncMock()),
+        ):
+            mock_get_rows.side_effect = self._rows
+
+            result = await cancel_subscription({"id": "user-123"})
+
+        assert result["success"] is True
+        update_mock.assert_awaited_once()
+        assert "cancelled_at" in update_mock.await_args.args[2]

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -116,6 +116,8 @@ class TestSubscriptionCheckoutFlow:
             assert result["success"] is True
             assert result["checkout_url"] == "https://checkout.stripe.com/pay/session123"
             assert result["subscription_id"] == str(sub_id)
+            # session_id returned so the app can poll verify-session as a fallback
+            assert result["session_id"] == "cs_test_session123"
 
             # Verify subscription row was inserted with pending status
             mock_insert.assert_called_once()
@@ -415,11 +417,15 @@ class TestRecurringSubscription:
         request.json = AsyncMock(return_value={"plan_id": "plan-recurring"})
         current_user = {"id": "user-123"}
 
+        # Stripe Price matches the plan price (49.99 → 4999 cents, cad).
+        price_obj = {"unit_amount": 4999, "currency": "cad"}
+
         with (
             patch("backend.db_supabase.get_rows") as mock_get_rows,
             patch("backend.db_supabase.update_one"),
             patch("backend.db_supabase.insert_one"),
             patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+            patch("stripe.Price.retrieve", return_value=price_obj),
             patch("stripe.checkout.Session.create") as mock_session_create,
         ):
             mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
@@ -443,6 +449,37 @@ class TestRecurringSubscription:
         # ids mirrored onto the Stripe Subscription for renewal-event matching
         assert call_kwargs["subscription_data"]["metadata"]["plan_id"] == "plan-recurring"
         assert result["checkout_url"] == "https://checkout.stripe.com/pay/recurring"
+
+    async def test_subscribe_recurring_price_mismatch_rejected(self, mock_driver, mock_plan, mock_settings):
+        """A Stripe Price whose amount disagrees with the plan is refused (409)
+        rather than silently charging a surprise amount."""
+        from fastapi import HTTPException, Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        recurring_plan = {**mock_plan, "id": "plan-recurring", "stripe_price_id": "price_wrong"}
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-recurring"})
+
+        # Plan is 49.99 (4999) but the Stripe Price says 9999.
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.settings_loader.get_app_settings", AsyncMock(return_value=mock_settings)),
+            patch("stripe.Price.retrieve", return_value={"unit_amount": 9999, "currency": "cad"}),
+            patch("stripe.checkout.Session.create") as mock_session_create,
+        ):
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [recurring_plan],
+                "driver_subscriptions": [],
+            }.get(table, [])
+
+            with pytest.raises(HTTPException) as exc:
+                await subscribe_to_plan(request, {"id": "user-123"})
+
+        assert exc.value.status_code == 409
+        mock_session_create.assert_not_called()
 
 
 class TestCancelStripeSubscription:
@@ -584,11 +621,12 @@ class TestActivationAndSuperseding:
             if table == "driver_subscriptions":
                 # No existing active sub; one stale pending row to supersede.
                 if filters.get("status") == "pending":
-                    return [{"id": "stale-1"}]
+                    return [{"id": "stale-1", "stripe_session_id": "cs_stale"}]
                 return []
             return []
 
         update_mock = AsyncMock()
+        expire_mock = MagicMock()
         with (
             patch("backend.db_supabase.get_rows") as mock_get_rows,
             patch("backend.db_supabase.update_one", update_mock),
@@ -598,6 +636,7 @@ class TestActivationAndSuperseding:
                 AsyncMock(return_value=mock_settings),
             ),
             patch("stripe.checkout.Session.create") as mock_session_create,
+            patch("stripe.checkout.Session.expire", expire_mock),
         ):
             mock_get_rows.side_effect = _rows
             session = MagicMock()
@@ -614,6 +653,9 @@ class TestActivationAndSuperseding:
         ]
         assert superseded, "stale pending row should be superseded"
         assert superseded[0].args[1] == {"id": "stale-1"}
+        # the stale Stripe Checkout Session is expired so it can't be paid later
+        expire_mock.assert_called_once()
+        assert expire_mock.call_args[0][0] == "cs_stale"
         assert result.get("checkout_url")
 
 
@@ -625,12 +667,12 @@ class TestActivationPeriodAndVerifySuperseded:
         from backend.routes import drivers as drv
 
         update_mock = AsyncMock()
-        # find_one order: the pending sub, prior-active (none), plan, driver (none)
+        # find_one order: pending sub, plan, prior-active (none), driver (none).
         find_mock = AsyncMock(
             side_effect=[
                 {"id": "s1", "status": "pending", "driver_id": "d1"},
-                None,
                 {"id": "plan-1", "duration_days": 7, "subscriber_count": 0},
+                None,
                 None,
             ]
         )
@@ -640,10 +682,11 @@ class TestActivationPeriodAndVerifySuperseded:
         ):
             await drv._activate_subscription("s1", "plan-1")
 
+        # The activation is an atomic claim filtered on status='pending'.
         activates = [
             c
             for c in update_mock.await_args_list
-            if c.args and c.args[0] == "driver_subscriptions" and c.args[1] == {"id": "s1"}
+            if c.args and c.args[0] == "driver_subscriptions" and c.args[1] == {"id": "s1", "status": "pending"}
         ]
         assert activates
         payload = activates[0].args[2]["$set"]
@@ -685,3 +728,31 @@ class TestActivationPeriodAndVerifySuperseded:
 
         assert result["status"] == "superseded"
         cancel_mock.assert_awaited_once_with("sub_y")
+
+
+class TestActivationAtomicClaim:
+    """P2 follow-up: activation is an atomic pending→active claim; the loser of
+    a webhook/verify race runs no side effects."""
+
+    async def test_activate_lost_race_skips_side_effects(self):
+        from backend.routes import drivers as drv
+
+        # The claim update_one returns None → another caller already flipped it.
+        update_mock = AsyncMock(return_value=None)
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "s1", "status": "pending", "driver_id": "d1"},
+                {"id": "plan-1", "duration_days": 7, "subscriber_count": 0},
+            ]
+        )
+        push_mock = AsyncMock()
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.update_one", update_mock),
+            patch("backend.routes.drivers.send_push_notification", push_mock),
+        ):
+            await drv._activate_subscription("s1", "plan-1")
+
+        # Only the claim ran — no count increment, no push.
+        assert update_mock.await_count == 1
+        push_mock.assert_not_awaited()

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -667,17 +667,18 @@ class TestActivationPeriodAndVerifySuperseded:
         from backend.routes import drivers as drv
 
         update_mock = AsyncMock()
-        # find_one order: pending sub, plan, prior-active (none), driver (none).
+        # find_one order: pending sub, plan, driver (none, no push). The prior-
+        # active lookup is now a get_rows (patched to no prior active).
         find_mock = AsyncMock(
             side_effect=[
                 {"id": "s1", "status": "pending", "driver_id": "d1"},
                 {"id": "plan-1", "duration_days": 7, "subscriber_count": 0},
                 None,
-                None,
             ]
         )
         with (
             patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])),
             patch("backend.db_supabase.update_one", update_mock),
         ):
             await drv._activate_subscription("s1", "plan-1")
@@ -805,11 +806,11 @@ class TestSubscriptionPaymentsLedger:
                 {"id": "s1", "status": "pending", "driver_id": "d1", "plan_name": "Pro", "stripe_session_id": "cs1"},
                 {"id": "p1", "duration_days": 30, "price": 49.99, "subscriber_count": 0},
                 None,
-                None,
             ]
         )
         with (
             patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])),
             patch("backend.db_supabase.update_one", AsyncMock()),
             patch("backend.routes.drivers._record_subscription_payment", record_mock),
         ):
@@ -826,11 +827,11 @@ class TestSubscriptionPaymentsLedger:
                 {"id": "s1", "status": "pending", "driver_id": "d1"},
                 {"id": "p1", "duration_days": 30, "price": 49.99, "stripe_price_id": "price_x", "subscriber_count": 0},
                 None,
-                None,
             ]
         )
         with (
             patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])),
             patch("backend.db_supabase.update_one", AsyncMock()),
             patch("backend.routes.drivers._record_subscription_payment", record_mock),
         ):

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -87,7 +87,7 @@ class TestSubscriptionCheckoutFlow:
             patch("uuid.uuid4", return_value=sub_id),
         ):
             # Setup mocks
-            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
                 "drivers": [mock_driver],
                 "service_areas": [{"spinr_pass_enabled": True}],
                 "subscription_plans": [mock_plan],
@@ -141,7 +141,7 @@ class TestSubscriptionCheckoutFlow:
             patch("backend.db_supabase.insert_one") as mock_insert,
             patch("backend.settings_loader.get_app_settings") as mock_get_settings,
         ):
-            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
                 "drivers": [mock_driver],
                 "service_areas": [{"spinr_pass_enabled": True}],
                 "subscription_plans": [mock_plan],
@@ -174,7 +174,7 @@ class TestSubscriptionCheckoutFlow:
         current_user = {"id": "user-123"}
 
         with patch("backend.db_supabase.get_rows") as mock_get_rows, patch("backend.settings_loader.get_app_settings"):
-            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
                 "drivers": [mock_driver],
                 "service_areas": [{"spinr_pass_enabled": False}],
             }.get(table, [])
@@ -389,7 +389,7 @@ class TestRecurringSubscription:
             patch("backend.settings_loader.get_app_settings") as mock_get_settings,
             patch("stripe.checkout.Session.create") as mock_session_create,
         ):
-            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
                 "drivers": [mock_driver],
                 "service_areas": [{"spinr_pass_enabled": True}],
                 "subscription_plans": [recurring_plan],
@@ -512,3 +512,73 @@ class TestCancelSubscriptionEndpoint:
         assert result["success"] is True
         update_mock.assert_awaited_once()
         assert "cancelled_at" in update_mock.await_args.args[2]
+
+
+class TestActivationAndSuperseding:
+    """P2 follow-ups: only pending rows activate, and starting a new checkout
+    supersedes older pending sessions so a stale one can't activate late."""
+
+    async def test_activate_skips_non_pending_row(self):
+        from backend.routes.drivers import _activate_subscription
+
+        update_mock = AsyncMock()
+        with (
+            patch(
+                "backend.db_supabase.find_one",
+                AsyncMock(return_value={"id": "s1", "status": "superseded", "driver_id": "d1"}),
+            ),
+            patch("backend.db_supabase.update_one", update_mock),
+        ):
+            await _activate_subscription("s1", "plan-1")
+
+        update_mock.assert_not_awaited()
+
+    async def test_subscribe_supersedes_pending_sessions(self, mock_driver, mock_plan, mock_settings):
+        from fastapi import Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-premium"})
+
+        def _rows(table, filters, columns=None, limit=None):
+            if table == "drivers":
+                return [mock_driver]
+            if table == "service_areas":
+                return [{"spinr_pass_enabled": True}]
+            if table == "subscription_plans":
+                return [mock_plan]
+            if table == "driver_subscriptions":
+                # No existing active sub; one stale pending row to supersede.
+                if filters.get("status") == "pending":
+                    return [{"id": "stale-1"}]
+                return []
+            return []
+
+        update_mock = AsyncMock()
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one", update_mock),
+            patch("backend.db_supabase.insert_one", AsyncMock()),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value=mock_settings),
+            ),
+            patch("stripe.checkout.Session.create") as mock_session_create,
+        ):
+            mock_get_rows.side_effect = _rows
+            session = MagicMock()
+            session.url = "https://checkout.stripe.com/pay/x"
+            session.id = "cs_new"
+            mock_session_create.return_value = session
+
+            result = await subscribe_to_plan(request, {"id": "user-123"})
+
+        superseded = [
+            c
+            for c in update_mock.await_args_list
+            if c.args and c.args[0] == "driver_subscriptions" and c.args[2].get("status") == "superseded"
+        ]
+        assert superseded, "stale pending row should be superseded"
+        assert superseded[0].args[1] == {"id": "stale-1"}
+        assert result.get("checkout_url")

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -189,53 +189,86 @@ class TestSubscriptionCheckoutFlow:
 class TestWebhookActivation:
     """Test checkout.session.completed webhook activates subscription."""
 
-    async def test_webhook_activates_subscription(self):
-        """checkout.session.completed webhook activates pending subscription."""
+    def _webhook_event(self, with_subscription="sub_stripe_x"):
+        obj = {
+            "id": "cs_test_session456",
+            "payment_status": "paid",
+            "metadata": {
+                "subscription_id": "sub-id-123",
+                "plan_id": "plan-premium",
+                "driver_id": "driver-456",
+            },
+        }
+        if with_subscription:
+            obj["subscription"] = with_subscription
+        return {"id": "evt_test123", "type": "checkout.session.completed", "data": {"object": obj}}
+
+    async def _run(self, find_return, activate_mock, update_mock, cancel_mock=None):
         from fastapi import Request
 
         from backend.routes.webhooks import stripe_webhook
-
-        webhook_event = {
-            "id": "evt_test123",
-            "type": "checkout.session.completed",
-            "data": {
-                "object": {
-                    "id": "cs_test_session456",
-                    "payment_status": "paid",
-                    "metadata": {
-                        "subscription_id": "sub-id-123",
-                        "plan_id": "plan-premium",
-                        "driver_id": "driver-456",
-                    },
-                }
-            },
-        }
 
         request = AsyncMock(spec=Request)
         request.body = AsyncMock(return_value=b'{"dummy": "event"}')
         request.headers = {"stripe-signature": "sig_test"}
 
-        with (
-            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
-            patch("stripe.Webhook.construct_event") as mock_construct,
-            patch("backend.db_supabase.claim_stripe_event") as mock_claim,
-            patch("backend.db_supabase.mark_stripe_event_processed") as mock_mark,
-            patch("backend.routes.drivers._activate_subscription") as mock_activate,
-        ):
-            mock_get_settings.return_value = {
-                "stripe_webhook_secret": "whsec_test123",
-                "stripe_secret_key": "sk_test_123",
-            }
-            mock_construct.return_value = webhook_event
-            mock_claim.return_value = True  # First time seeing this event
+        async def _settings():
+            return {"stripe_webhook_secret": "whsec_test123", "stripe_secret_key": "sk_test_123"}
 
-            # Execute
-            result = await stripe_webhook(request)
+        patches = [
+            patch("backend.routes.webhooks.get_app_settings", _settings),
+            patch("stripe.Webhook.construct_event", return_value=self._webhook_event()),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.drivers._activate_subscription", activate_mock),
+            patch("backend.routes.webhooks.db_supabase.find_one", AsyncMock(return_value=find_return)),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ]
+        if cancel_mock is not None:
+            patches.append(patch("backend.routes.drivers._cancel_stripe_subscription", cancel_mock))
+        import contextlib
 
-            # Verify subscription was activated
-            mock_activate.assert_called_once_with("sub-id-123", "plan-premium")
-            mock_mark.assert_called_once_with("evt_test123")
-            assert result["received"] is True
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            return await stripe_webhook(request)
+
+    async def test_webhook_activates_and_links_active_row(self):
+        """checkout.session.completed activates a pending row and links the
+        Stripe Subscription id once the row is active."""
+        activate_mock = AsyncMock()
+        update_mock = AsyncMock()
+        result = await self._run(
+            find_return={"id": "sub-id-123", "status": "active"},
+            activate_mock=activate_mock,
+            update_mock=update_mock,
+        )
+        activate_mock.assert_called_once_with("sub-id-123", "plan-premium")
+        # stripe_subscription_id linked
+        linked = [
+            c
+            for c in update_mock.await_args_list
+            if c.args and c.args[2].get("stripe_subscription_id") == "sub_stripe_x"
+        ]
+        assert linked
+        assert result["received"] is True
+
+    async def test_webhook_superseded_row_not_linked_orphan_cancelled(self):
+        """If the row was superseded before this stale session paid, don't link
+        the id; cancel the orphaned Stripe subscription instead."""
+        activate_mock = AsyncMock()
+        update_mock = AsyncMock()
+        cancel_mock = AsyncMock()
+        result = await self._run(
+            find_return={"id": "sub-id-123", "status": "superseded"},
+            activate_mock=activate_mock,
+            update_mock=update_mock,
+            cancel_mock=cancel_mock,
+        )
+        # No stripe_subscription_id linked
+        assert not [c for c in update_mock.await_args_list if c.args and c.args[2].get("stripe_subscription_id")]
+        cancel_mock.assert_awaited_once_with("sub_stripe_x")
+        assert result["received"] is True
 
 
 class TestVerifySession:
@@ -582,3 +615,73 @@ class TestActivationAndSuperseding:
         assert superseded, "stale pending row should be superseded"
         assert superseded[0].args[1] == {"id": "stale-1"}
         assert result.get("checkout_url")
+
+
+class TestActivationPeriodAndVerifySuperseded:
+    """P2 follow-ups: activation recomputes the period; verify-session refuses
+    to activate/link a superseded row and cancels the orphan Stripe sub."""
+
+    async def test_activate_recomputes_period_for_pending_row(self):
+        from backend.routes import drivers as drv
+
+        update_mock = AsyncMock()
+        # find_one order: the pending sub, prior-active (none), plan, driver (none)
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "s1", "status": "pending", "driver_id": "d1"},
+                None,
+                {"id": "plan-1", "duration_days": 7, "subscriber_count": 0},
+                None,
+            ]
+        )
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.update_one", update_mock),
+        ):
+            await drv._activate_subscription("s1", "plan-1")
+
+        activates = [
+            c
+            for c in update_mock.await_args_list
+            if c.args and c.args[0] == "driver_subscriptions" and c.args[1] == {"id": "s1"}
+        ]
+        assert activates
+        payload = activates[0].args[2]["$set"]
+        assert payload["status"] == "active"
+        assert "started_at" in payload
+        assert "expires_at" in payload
+
+    async def test_verify_session_superseded_returns_superseded(self):
+        from backend.routes.drivers import verify_subscription_session
+
+        mock_sub = {
+            "id": "sub-123",
+            "driver_id": "driver-1",
+            "plan_id": "p1",
+            "status": "pending",
+            "payment_status": "pending",
+        }
+        find_mock = AsyncMock(
+            side_effect=[
+                mock_sub,
+                {"id": "sub-123", "status": "superseded", "driver_id": "driver-1"},
+            ]
+        )
+        session = MagicMock()
+        session.payment_status = "paid"
+        session.get = lambda k, d=None: "sub_y" if k == "subscription" else d
+        cancel_mock = AsyncMock()
+
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[{"id": "driver-1"}])),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.settings_loader.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk"})),
+            patch("stripe.checkout.Session.retrieve", return_value=session),
+            patch("backend.routes.drivers._activate_subscription", AsyncMock()),
+            patch("backend.routes.drivers._cancel_stripe_subscription", cancel_mock),
+        ):
+            result = await verify_subscription_session("cs_x", {"id": "user-123"})
+
+        assert result["status"] == "superseded"
+        cancel_mock.assert_awaited_once_with("sub_y")

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -417,8 +417,9 @@ class TestRecurringSubscription:
         request.json = AsyncMock(return_value={"plan_id": "plan-recurring"})
         current_user = {"id": "user-123"}
 
-        # Stripe Price matches the plan price (49.99 → 4999 cents, cad).
-        price_obj = {"unit_amount": 4999, "currency": "cad"}
+        # Stripe Price matches the plan price (49.99 → 4999 cents, cad) and the
+        # plan's 30-day cadence (monthly).
+        price_obj = {"unit_amount": 4999, "currency": "cad", "recurring": {"interval": "month", "interval_count": 1}}
 
         with (
             patch("backend.db_supabase.get_rows") as mock_get_rows,
@@ -918,3 +919,83 @@ class TestSubscribeConcurrencyConflict:
                 await subscribe_to_plan(request, {"id": "user-123"})
 
         assert exc.value.status_code == 503
+
+
+class TestRecurringIntervalAndModeLedger:
+    """Round-6 P2s: validate Price interval; one-off ledger keys on actual mode."""
+
+    async def test_subscribe_recurring_interval_mismatch_rejected(self, mock_driver, mock_plan, mock_settings):
+        from fastapi import HTTPException, Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        # 30-day plan, but the Stripe Price bills weekly → reject even though the
+        # amount/currency match.
+        recurring_plan = {**mock_plan, "id": "plan-recurring", "duration_days": 30, "stripe_price_id": "price_wk"}
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-recurring"})
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.settings_loader.get_app_settings", AsyncMock(return_value=mock_settings)),
+            patch(
+                "stripe.Price.retrieve",
+                return_value={"unit_amount": 4999, "currency": "cad", "recurring": {"interval": "week", "interval_count": 1}},
+            ),
+            patch("stripe.checkout.Session.create") as mock_session_create,
+        ):
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [recurring_plan],
+                "driver_subscriptions": [],
+            }.get(table, [])
+
+            with pytest.raises(HTTPException) as exc:
+                await subscribe_to_plan(request, {"id": "user-123"})
+
+        assert exc.value.status_code == 409
+        mock_session_create.assert_not_called()
+
+    async def test_activate_records_oneoff_when_mode_payment_despite_price_id(self):
+        from backend.routes import drivers as drv
+
+        # Plan HAS a price_id now, but the session actually created was one-off
+        # (mode="payment") — the ledger write must follow the real mode.
+        record_mock = AsyncMock()
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "s1", "status": "pending", "driver_id": "d1", "plan_name": "Pro", "stripe_session_id": "cs1"},
+                {"id": "p1", "duration_days": 30, "price": 49.99, "stripe_price_id": "price_x", "subscriber_count": 0},
+                None,
+            ]
+        )
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.routes.drivers._record_subscription_payment", record_mock),
+        ):
+            await drv._activate_subscription("s1", "p1", "payment")
+        record_mock.assert_awaited_once()
+        assert record_mock.await_args.kwargs["billing_reason"] == "one_off"
+
+    async def test_activate_skips_ledger_when_mode_subscription(self):
+        from backend.routes import drivers as drv
+
+        record_mock = AsyncMock()
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "s1", "status": "pending", "driver_id": "d1"},
+                {"id": "p1", "duration_days": 30, "price": 49.99, "subscriber_count": 0},
+                None,
+            ]
+        )
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.routes.drivers._record_subscription_payment", record_mock),
+        ):
+            await drv._activate_subscription("s1", "p1", "subscription")
+        record_mock.assert_not_awaited()

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -322,3 +322,113 @@ class TestVerifySession:
             result = await verify_subscription_session("cs_test_123", current_user)
 
             assert result["status"] == "pending"
+
+
+class TestRecurringSubscription:
+    """B3/B5: plans with a stripe_price_id use mode=subscription Checkout, and
+    cancelling stops Stripe billing (not just the DB row)."""
+
+    async def test_subscribe_recurring_uses_subscription_mode(
+        self, mock_driver, mock_settings
+    ):
+        from backend.routes.drivers import subscribe_to_plan
+        from fastapi import Request
+
+        recurring_plan = {
+            "id": "plan-recurring",
+            "name": "Pro Pass",
+            "price": 49.99,
+            "duration_days": 30,
+            "rides_per_day": -1,
+            "description": "Auto-renew",
+            "is_active": True,
+            "subscriber_count": 0,
+            "stripe_price_id": "price_abc123",
+        }
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-recurring"})
+        current_user = {"id": "user-123"}
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one"),
+            patch("backend.db_supabase.insert_one"),
+            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+            patch("stripe.checkout.Session.create") as mock_session_create,
+        ):
+            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+                "drivers": [[mock_driver]],
+                "service_areas": [[{"spinr_pass_enabled": True}]],
+                "subscription_plans": [[recurring_plan]],
+                "driver_subscriptions": [[]],
+            }.get(table, [[]])
+            mock_get_settings.return_value = mock_settings
+
+            session = MagicMock()
+            session.url = "https://checkout.stripe.com/pay/recurring"
+            session.id = "cs_recurring_1"
+            mock_session_create.return_value = session
+
+            result = await subscribe_to_plan(request, current_user)
+
+        call_kwargs = mock_session_create.call_args[1]
+        assert call_kwargs["mode"] == "subscription"
+        assert call_kwargs["line_items"][0]["price"] == "price_abc123"
+        # ids mirrored onto the Stripe Subscription for renewal-event matching
+        assert call_kwargs["subscription_data"]["metadata"]["plan_id"] == "plan-recurring"
+        assert result["checkout_url"] == "https://checkout.stripe.com/pay/recurring"
+
+
+class TestCancelStripeSubscription:
+    """_cancel_stripe_subscription stops recurring billing; no-ops otherwise."""
+
+    async def test_cancels_when_configured(self):
+        from backend.routes.drivers import _cancel_stripe_subscription
+
+        with (
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": "sk_test"}),
+            ),
+            patch("stripe.Subscription.delete") as del_mock,
+        ):
+            await _cancel_stripe_subscription("sub_123")
+
+        del_mock.assert_called_once()
+        assert del_mock.call_args[0][0] == "sub_123"
+
+    async def test_noop_without_subscription_id(self):
+        from backend.routes.drivers import _cancel_stripe_subscription
+
+        with patch("stripe.Subscription.delete") as del_mock:
+            await _cancel_stripe_subscription(None)
+
+        del_mock.assert_not_called()
+
+    async def test_noop_without_stripe_secret(self):
+        from backend.routes.drivers import _cancel_stripe_subscription
+
+        with (
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={}),
+            ),
+            patch("stripe.Subscription.delete") as del_mock,
+        ):
+            await _cancel_stripe_subscription("sub_123")
+
+        del_mock.assert_not_called()
+
+    async def test_stripe_failure_does_not_raise(self):
+        from backend.routes.drivers import _cancel_stripe_subscription
+
+        with (
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": "sk_test"}),
+            ),
+            patch("stripe.Subscription.delete", side_effect=Exception("stripe down")),
+        ):
+            # Best-effort: must swallow so the DB-side cancel still proceeds.
+            await _cancel_stripe_subscription("sub_123")

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -840,7 +840,24 @@ class TestSubscriptionPaymentsLedger:
 
 
 class TestSubscribeConcurrencyConflict:
-    """The partial unique index (migration 152) surfaces as a clean 409."""
+    """The partial unique index (migration 153) surfaces as a clean 409;
+    a genuine insert failure surfaces as 503."""
+
+    def _rows_factory(self, mock_driver, mock_plan, pending_after_conflict):
+        # pending_after_conflict simulates whether the post-failure pending
+        # re-query finds a row (concurrent winner exists → 409) or not (→ 503).
+        def _rows(table, filters, columns=None, limit=None):
+            if table == "driver_subscriptions":
+                if filters.get("status") == "pending":
+                    return [{"id": "other-pending"}] if pending_after_conflict else []
+                return []
+            return {
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [mock_plan],
+            }.get(table, [])
+
+        return _rows
 
     async def test_subscribe_insert_conflict_returns_409(self, mock_driver, mock_plan, mock_settings):
         from fastapi import HTTPException, Request
@@ -859,12 +876,7 @@ class TestSubscribeConcurrencyConflict:
             patch("stripe.checkout.Session.create") as mock_session_create,
             patch("stripe.checkout.Session.expire", expire_mock),
         ):
-            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
-                "drivers": [mock_driver],
-                "service_areas": [{"spinr_pass_enabled": True}],
-                "subscription_plans": [mock_plan],
-                "driver_subscriptions": [],
-            }.get(table, [])
+            mock_get_rows.side_effect = self._rows_factory(mock_driver, mock_plan, pending_after_conflict=True)
             session = MagicMock()
             session.url = "https://checkout.stripe.com/pay/x"
             session.id = "cs_new"
@@ -877,3 +889,31 @@ class TestSubscribeConcurrencyConflict:
         # the race-loser's Stripe session is expired so it can't be paid
         expire_mock.assert_called_once()
         assert expire_mock.call_args[0][0] == "cs_new"
+
+    async def test_subscribe_insert_failure_without_conflict_returns_503(self, mock_driver, mock_plan, mock_settings):
+        from fastapi import HTTPException, Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-premium"})
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.db_supabase.insert_one", AsyncMock(side_effect=Exception("network down"))),
+            patch("backend.settings_loader.get_app_settings", AsyncMock(return_value=mock_settings)),
+            patch("stripe.checkout.Session.create") as mock_session_create,
+            patch("stripe.checkout.Session.expire", MagicMock()),
+        ):
+            # No pending row exists after the failure → not a concurrency conflict.
+            mock_get_rows.side_effect = self._rows_factory(mock_driver, mock_plan, pending_after_conflict=False)
+            session = MagicMock()
+            session.url = "https://checkout.stripe.com/pay/x"
+            session.id = "cs_new"
+            mock_session_create.return_value = session
+
+            with pytest.raises(HTTPException) as exc:
+                await subscribe_to_plan(request, {"id": "user-123"})
+
+        assert exc.value.status_code == 503

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -756,3 +756,124 @@ class TestActivationAtomicClaim:
         # Only the claim ran — no count increment, no push.
         assert update_mock.await_count == 1
         push_mock.assert_not_awaited()
+
+
+class TestSubscriptionPaymentsLedger:
+    """subscription_payments ledger (migration 151) records realized revenue."""
+
+    async def test_records_payment_when_amount_positive(self):
+        from backend.routes import drivers as drv
+
+        insert_mock = AsyncMock()
+        with patch("backend.db_supabase.insert_one", insert_mock):
+            await drv._record_subscription_payment(
+                driver_id="d1",
+                subscription_id="s1",
+                plan_id="p1",
+                plan_name="Pro",
+                amount=49.99,
+                billing_reason="one_off",
+            )
+        insert_mock.assert_awaited_once()
+        table, row = insert_mock.await_args.args[0], insert_mock.await_args.args[1]
+        assert table == "subscription_payments"
+        assert row["amount"] == "49.99"
+        assert row["billing_reason"] == "one_off"
+        assert row["driver_id"] == "d1"
+
+    async def test_skips_zero_amount(self):
+        from backend.routes import drivers as drv
+
+        insert_mock = AsyncMock()
+        with patch("backend.db_supabase.insert_one", insert_mock):
+            await drv._record_subscription_payment(
+                driver_id="d1",
+                subscription_id="s1",
+                plan_id="p1",
+                plan_name="Free",
+                amount=0,
+                billing_reason="dev",
+            )
+        insert_mock.assert_not_awaited()
+
+    async def test_activate_records_oneoff_payment(self):
+        from backend.routes import drivers as drv
+
+        record_mock = AsyncMock()
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "s1", "status": "pending", "driver_id": "d1", "plan_name": "Pro", "stripe_session_id": "cs1"},
+                {"id": "p1", "duration_days": 30, "price": 49.99, "subscriber_count": 0},
+                None,
+                None,
+            ]
+        )
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.routes.drivers._record_subscription_payment", record_mock),
+        ):
+            await drv._activate_subscription("s1", "p1")
+        record_mock.assert_awaited_once()
+        assert record_mock.await_args.kwargs["billing_reason"] == "one_off"
+
+    async def test_activate_skips_ledger_for_recurring(self):
+        from backend.routes import drivers as drv
+
+        record_mock = AsyncMock()
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "s1", "status": "pending", "driver_id": "d1"},
+                {"id": "p1", "duration_days": 30, "price": 49.99, "stripe_price_id": "price_x", "subscriber_count": 0},
+                None,
+                None,
+            ]
+        )
+        with (
+            patch("backend.db_supabase.find_one", find_mock),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.routes.drivers._record_subscription_payment", record_mock),
+        ):
+            await drv._activate_subscription("s1", "p1")
+        # Recurring is recorded by invoice.paid, not here.
+        record_mock.assert_not_awaited()
+
+
+class TestSubscribeConcurrencyConflict:
+    """The partial unique index (migration 152) surfaces as a clean 409."""
+
+    async def test_subscribe_insert_conflict_returns_409(self, mock_driver, mock_plan, mock_settings):
+        from fastapi import HTTPException, Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-premium"})
+
+        expire_mock = MagicMock()
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.db_supabase.insert_one", AsyncMock(side_effect=Exception("unique violation"))),
+            patch("backend.settings_loader.get_app_settings", AsyncMock(return_value=mock_settings)),
+            patch("stripe.checkout.Session.create") as mock_session_create,
+            patch("stripe.checkout.Session.expire", expire_mock),
+        ):
+            mock_get_rows.side_effect = lambda table, filters, columns=None, limit=None: {
+                "drivers": [mock_driver],
+                "service_areas": [{"spinr_pass_enabled": True}],
+                "subscription_plans": [mock_plan],
+                "driver_subscriptions": [],
+            }.get(table, [])
+            session = MagicMock()
+            session.url = "https://checkout.stripe.com/pay/x"
+            session.id = "cs_new"
+            mock_session_create.return_value = session
+
+            with pytest.raises(HTTPException) as exc:
+                await subscribe_to_plan(request, {"id": "user-123"})
+
+        assert exc.value.status_code == 409
+        # the race-loser's Stripe session is expired so it can't be paid
+        expire_mock.assert_called_once()
+        assert expire_mock.call_args[0][0] == "cs_new"

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -1,0 +1,324 @@
+"""Tests for Spinr Pass subscription flow (Checkout Session payment).
+
+Covers:
+- subscribe_to_plan: creates Checkout Session with correct metadata
+- checkout.session.completed webhook: activates pending subscription
+- verify-session: polls Checkout Session status and activates on payment
+- Dev mode: instant activation when Stripe not configured
+"""
+
+import uuid as uuid_module
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def mock_driver():
+    return {
+        "id": "driver-123",
+        "user_id": "user-123",
+        "service_area_id": "area-1",
+    }
+
+
+@pytest.fixture
+def mock_plan():
+    return {
+        "id": "plan-premium",
+        "name": "Premium Pass",
+        "price": 49.99,
+        "duration_days": 30,
+        "rides_per_day": -1,
+        "description": "Unlimited rides",
+        "is_active": True,
+        "subscriber_count": 10,
+    }
+
+
+@pytest.fixture
+def mock_user():
+    return {
+        "id": "user-123",
+        "email": "driver@example.com",
+        "stripe_customer_id": "cus_test123",
+    }
+
+
+@pytest.fixture
+def mock_settings():
+    return {
+        "stripe_secret_key": "sk_test_123abc",
+        "stripe_publishable_key": "pk_test_123abc",
+        "base_url": "https://api.spinr.ca",
+    }
+
+
+@pytest.fixture
+def mock_settings_no_stripe():
+    return {
+        "base_url": "https://api.spinr.ca",
+    }
+
+
+class TestSubscriptionCheckoutFlow:
+    """Test Stripe Checkout Session creation for subscriptions."""
+
+    async def test_subscribe_creates_checkout_session(self, mock_driver, mock_plan, mock_user, mock_settings):
+        """subscribe_to_plan creates a Checkout Session with correct metadata."""
+        from fastapi import Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-premium"})
+
+        current_user = {"id": "user-123"}
+        sub_id = str(uuid_module.uuid4())
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one") as mock_update,
+            patch("backend.db_supabase.insert_one") as mock_insert,
+            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+            patch("stripe.checkout.Session.create") as mock_session_create,
+            patch("uuid.uuid4", return_value=sub_id),
+        ):
+            # Setup mocks
+            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+                "drivers": [[mock_driver]],
+                "service_areas": [[{"spinr_pass_enabled": True}]],
+                "subscription_plans": [[mock_plan]],
+                "driver_subscriptions": [[]],
+            }.get(table, [[]])
+
+            mock_get_settings.return_value = mock_settings
+            mock_checkout_session = MagicMock()
+            mock_checkout_session.url = "https://checkout.stripe.com/pay/session123"
+            mock_checkout_session.id = "cs_test_session123"
+            mock_session_create.return_value = mock_checkout_session
+
+            # Execute
+            result = await subscribe_to_plan(request, current_user)
+
+            # Verify Checkout Session was created with correct metadata
+            mock_session_create.assert_called_once()
+            call_kwargs = mock_session_create.call_args[1]
+            assert call_kwargs["mode"] == "payment"
+            assert call_kwargs["metadata"]["subscription_id"] == str(sub_id)
+            assert call_kwargs["metadata"]["driver_id"] == "driver-123"
+            assert call_kwargs["metadata"]["plan_id"] == "plan-premium"
+            assert call_kwargs["line_items"][0]["price_data"]["unit_amount"] == 4999
+
+            # Verify response includes checkout URL
+            assert result["success"] is True
+            assert result["checkout_url"] == "https://checkout.stripe.com/pay/session123"
+            assert result["subscription_id"] == str(sub_id)
+
+            # Verify subscription row was inserted with pending status
+            mock_insert.assert_called_once()
+            inserted_sub = mock_insert.call_args[0][1]
+            assert inserted_sub["status"] == "pending"
+            assert inserted_sub["payment_status"] == "pending"
+            assert inserted_sub["stripe_session_id"] == "cs_test_session123"
+
+    async def test_subscribe_dev_mode_no_stripe(self, mock_driver, mock_plan, mock_settings_no_stripe):
+        """subscribe_to_plan activates immediately when Stripe not configured (dev mode)."""
+        from fastapi import Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-premium"})
+
+        current_user = {"id": "user-123"}
+
+        with (
+            patch("backend.db_supabase.get_rows") as mock_get_rows,
+            patch("backend.db_supabase.update_one"),
+            patch("backend.db_supabase.insert_one") as mock_insert,
+            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+        ):
+            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+                "drivers": [[mock_driver]],
+                "service_areas": [[{"spinr_pass_enabled": True}]],
+                "subscription_plans": [[mock_plan]],
+                "driver_subscriptions": [[]],
+            }.get(table, [[]])
+
+            mock_get_settings.return_value = mock_settings_no_stripe
+
+            # Execute
+            result = await subscribe_to_plan(request, current_user)
+
+            # Verify subscription is active immediately (dev mode)
+            assert result["success"] is True
+            assert result["mode"] == "dev"
+            assert result["subscription"]["status"] == "active"
+            assert result["subscription"]["payment_status"] == "paid"
+
+            # Verify no checkout URL returned
+            assert "checkout_url" not in result
+
+    async def test_subscribe_spinr_pass_disabled(self, mock_driver, mock_plan, mock_settings):
+        """subscribe_to_plan rejects subscription when Spinr Pass is disabled for area."""
+        from fastapi import HTTPException, Request
+
+        from backend.routes.drivers import subscribe_to_plan
+
+        request = AsyncMock(spec=Request)
+        request.json = AsyncMock(return_value={"plan_id": "plan-premium"})
+
+        current_user = {"id": "user-123"}
+
+        with patch("backend.db_supabase.get_rows") as mock_get_rows, patch("backend.settings_loader.get_app_settings"):
+            mock_get_rows.side_effect = lambda table, filters, limit=None: {
+                "drivers": [[mock_driver]],
+                "service_areas": [[{"spinr_pass_enabled": False}]],
+            }.get(table, [[]])
+
+            # Execute and expect 403
+            with pytest.raises(HTTPException) as exc_info:
+                await subscribe_to_plan(request, current_user)
+
+            assert exc_info.value.status_code == 403
+
+
+class TestWebhookActivation:
+    """Test checkout.session.completed webhook activates subscription."""
+
+    async def test_webhook_activates_subscription(self):
+        """checkout.session.completed webhook activates pending subscription."""
+        from fastapi import Request
+
+        from backend.routes.webhooks import stripe_webhook
+
+        webhook_event = {
+            "id": "evt_test123",
+            "type": "checkout.session.completed",
+            "data": {
+                "object": {
+                    "id": "cs_test_session456",
+                    "payment_status": "paid",
+                    "metadata": {
+                        "subscription_id": "sub-id-123",
+                        "plan_id": "plan-premium",
+                        "driver_id": "driver-456",
+                    },
+                }
+            },
+        }
+
+        request = AsyncMock(spec=Request)
+        request.body = AsyncMock(return_value=b'{"dummy": "event"}')
+        request.headers = {"stripe-signature": "sig_test"}
+
+        with (
+            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+            patch("stripe.Webhook.construct_event") as mock_construct,
+            patch("backend.db_supabase.claim_stripe_event") as mock_claim,
+            patch("backend.db_supabase.mark_stripe_event_processed") as mock_mark,
+            patch("backend.routes.drivers._activate_subscription") as mock_activate,
+        ):
+            mock_get_settings.return_value = {
+                "stripe_webhook_secret": "whsec_test123",
+                "stripe_secret_key": "sk_test_123",
+            }
+            mock_construct.return_value = webhook_event
+            mock_claim.return_value = True  # First time seeing this event
+
+            # Execute
+            result = await stripe_webhook(request)
+
+            # Verify subscription was activated
+            mock_activate.assert_called_once_with("sub-id-123", "plan-premium")
+            mock_mark.assert_called_once_with("evt_test123")
+            assert result["received"] is True
+
+
+class TestVerifySession:
+    """Test verify-session endpoint polls and activates on payment."""
+
+    async def test_verify_session_already_active(self):
+        """verify-session returns early if subscription already active."""
+        from backend.routes.drivers import verify_subscription_session
+
+        current_user = {"id": "user-123"}
+
+        with patch("backend.db_supabase.find_one") as mock_find:
+            mock_find.return_value = {
+                "id": "sub-123",
+                "status": "active",
+                "payment_status": "paid",
+            }
+
+            result = await verify_subscription_session("cs_test_123", current_user)
+
+            assert result["status"] == "active"
+            assert mock_find.call_count == 1
+
+    async def test_verify_session_polls_stripe_and_activates(self):
+        """verify-session retrieves session from Stripe and activates on paid."""
+        from backend.routes.drivers import verify_subscription_session
+
+        current_user = {"id": "user-123"}
+
+        mock_sub = {
+            "id": "sub-123",
+            "plan_id": "plan-premium",
+            "status": "pending",
+            "payment_status": "pending",
+        }
+
+        mock_session = MagicMock()
+        mock_session.payment_status = "paid"
+
+        with (
+            patch("backend.db_supabase.find_one") as mock_find,
+            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+            patch("stripe.checkout.Session.retrieve") as mock_retrieve,
+            patch("backend.routes.drivers._activate_subscription") as mock_activate,
+        ):
+            mock_find.return_value = mock_sub
+            mock_get_settings.return_value = {"stripe_secret_key": "sk_test_123"}
+            mock_retrieve.return_value = mock_session
+
+            result = await verify_subscription_session("cs_test_123", current_user)
+
+            # Verify Stripe was queried
+            mock_retrieve.assert_called_once_with("cs_test_123", api_key="sk_test_123")
+
+            # Verify subscription was activated
+            mock_activate.assert_called_once_with("sub-123", "plan-premium")
+
+            assert result["status"] == "active"
+
+    async def test_verify_session_pending_payment(self):
+        """verify-session returns pending if Stripe session not yet paid."""
+        from backend.routes.drivers import verify_subscription_session
+
+        current_user = {"id": "user-123"}
+
+        mock_sub = {
+            "id": "sub-123",
+            "status": "pending",
+            "payment_status": "pending",
+        }
+
+        mock_session = MagicMock()
+        mock_session.payment_status = "unpaid"
+
+        with (
+            patch("backend.db_supabase.find_one") as mock_find,
+            patch("backend.settings_loader.get_app_settings") as mock_get_settings,
+            patch("stripe.checkout.Session.retrieve") as mock_retrieve,
+        ):
+            mock_find.return_value = mock_sub
+            mock_get_settings.return_value = {"stripe_secret_key": "sk_test_123"}
+            mock_retrieve.return_value = mock_session
+
+            result = await verify_subscription_session("cs_test_123", current_user)
+
+            assert result["status"] == "pending"

--- a/backend/tests/test_stripe_reconcile.py
+++ b/backend/tests/test_stripe_reconcile.py
@@ -558,3 +558,75 @@ async def test_ride_with_no_fare_skips_amount_check():
     audit_detail = db_mock.insert_one.call_args[0][1]["details"]
     types = [d["type"] for d in audit_detail["discrepancy_detail"]]
     assert "DB_PAID_AMOUNT_MISMATCH" not in types
+
+
+# ── Payout settlement backstop (A4) ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_payouts_flags_stranded_and_stuck():
+    """Stranded (manual-review) and stuck (transfer_completed) payouts older
+    than 1h are surfaced as discrepancies."""
+    from utils import stripe_reconcile as sr
+
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat()
+    stranded = {
+        "id": "p1",
+        "driver_id": "d1",
+        "status": "stranded",
+        "requires_manual_review": True,
+        "created_at": old_ts,
+    }
+    stuck = {
+        "id": "p2",
+        "driver_id": "d2",
+        "status": "transfer_completed",
+        "requires_manual_review": False,
+        "created_at": old_ts,
+    }
+
+    def _rows(table, flt, columns=None, limit=None):
+        if flt.get("requires_manual_review"):
+            return [stranded]
+        if flt.get("status") == "transfer_completed":
+            return [stuck]
+        return []
+
+    db_mock = AsyncMock()
+    db_mock.get_rows.side_effect = _rows
+
+    with patch("utils.stripe_reconcile.db_supabase", db_mock):
+        result = await sr._reconcile_payouts()
+
+    types = sorted(d["type"] for d in result)
+    assert types == ["PAYOUT_STRANDED", "PAYOUT_STUCK"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_payouts_skips_recent_and_terminal():
+    """Recent rows (<1h) and terminal rows are never flagged, even if a
+    filter-agnostic query returns them."""
+    from utils import stripe_reconcile as sr
+
+    recent = {
+        "id": "p3",
+        "driver_id": "d3",
+        "status": "stranded",
+        "requires_manual_review": True,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    terminal = {
+        "id": "p4",
+        "driver_id": "d4",
+        "status": "completed",
+        "requires_manual_review": False,
+        "created_at": (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat(),
+    }
+
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [recent, terminal]
+
+    with patch("utils.stripe_reconcile.db_supabase", db_mock):
+        result = await sr._reconcile_payouts()
+
+    assert result == []

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -208,6 +208,115 @@ class TestStripeWebhookConnectSecret:
         assert exc.value.status_code == 400
 
 
+class TestStripeWebhookPayoutSettlement:
+    """payout.paid / payout.failed reconcile the payouts row to the true
+    bank-settlement outcome (A2)."""
+
+    def _event(self, event_type, data_object, event_id="evt_payout_1"):
+        raw = _make_stripe_event(event_type, data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {
+                "stripe_webhook_secret": "ws",
+                "stripe_secret_key": "sk",
+                "stripe_connect_webhook_secret": "wc",
+            }
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_payout_paid_marks_completed(self):
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        event_obj = self._event("payout.paid", {"id": "po_123"})
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.find_one",
+                AsyncMock(return_value={"id": "payout_row_1", "driver_id": "d1"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        update_mock.assert_awaited_once()
+        assert update_mock.await_args.args[0] == "payouts"
+        assert update_mock.await_args.args[2]["status"] == "completed"
+
+    def test_payout_failed_flags_and_notifies(self):
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        event_obj = self._event("payout.failed", {"id": "po_456", "failure_message": "account_closed"})
+        update_mock = AsyncMock()
+        push_mock = AsyncMock()
+        # find_one is called twice: the payouts row, then the drivers row.
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "payout_row_2", "driver_id": "d2"},
+                {"id": "d2", "user_id": "u2"},
+            ]
+        )
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", find_mock),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+            patch("backend.routes.webhooks.send_push_notification", push_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        upd = update_mock.await_args.args[2]
+        assert upd["status"] == "failed"
+        assert upd["requires_manual_review"] is True
+        assert "account_closed" in upd["failure_reason"]
+        push_mock.assert_awaited_once()
+
+    def test_payout_no_matching_row_acks_without_update(self):
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        event_obj = self._event("payout.paid", {"id": "po_orphan"})
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", AsyncMock(return_value=None)),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        update_mock.assert_not_awaited()
+
+
 class TestStripeWebhookDuplicateEvent:
     def test_duplicate_event_returns_received_duplicate(self):
         from backend.routes import webhooks as wh

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1222,3 +1222,50 @@ class TestStripeWebhookInvoicePaidCancelledGuard:
 
         assert result["received"] is True
         update_mock.assert_not_awaited()
+
+
+class TestStripeWebhookSubscriptionUpdatedGuard:
+    """customer.subscription.updated with status=active must not resurrect a
+    cancelled/superseded row (P2 follow-up)."""
+
+    def _event(self, data_object, event_id="evt_upd_g"):
+        raw = _make_stripe_event("customer.subscription.updated", data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_active_update_does_not_reactivate_cancelled_row(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        event_obj = self._event({"id": "sub_g", "status": "active"})
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.find_one",
+                AsyncMock(return_value={"id": "row_c", "status": "cancelled", "cancelled_at": "2026-01-01T00:00:00Z"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        update_mock.assert_not_awaited()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1119,3 +1119,58 @@ class TestStripeWebhookRecurringSubscription:
 
         assert result["received"] is True
         update_mock.assert_not_awaited()
+
+
+class TestStripeWebhookSubscriptionDeleted:
+    """customer.subscription.deleted now matches our row by
+    stripe_subscription_id (recurring Checkout subs may lack a
+    users.stripe_customer_id link) — comment 1."""
+
+    def _event(self, data_object, event_id="evt_del_1"):
+        raw = _make_stripe_event("customer.subscription.deleted", data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_deleted_matches_by_subscription_id(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        event_obj = self._event({"id": "sub_del_1", "customer": "cus_x"})
+        update_mock = AsyncMock()
+        push_mock = AsyncMock()
+        # find_one: the row matched by stripe_subscription_id, then drivers for push.
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "row1", "driver_id": "d1", "status": "active"},
+                {"id": "d1", "user_id": "u1"},
+            ]
+        )
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", find_mock),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+            patch("backend.routes.webhooks.send_push_notification", push_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        assert update_mock.await_args.args[2]["status"] == "cancelled"
+        push_mock.assert_awaited_once()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1174,3 +1174,51 @@ class TestStripeWebhookSubscriptionDeleted:
         assert result["received"] is True
         assert update_mock.await_args.args[2]["status"] == "cancelled"
         push_mock.assert_awaited_once()
+
+
+class TestStripeWebhookInvoicePaidCancelledGuard:
+    """invoice.paid must not resurrect a cancelled subscription (P2 follow-up)."""
+
+    def _event(self, data_object, event_id="evt_inv_c"):
+        raw = _make_stripe_event("invoice.paid", data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_invoice_paid_ignored_for_cancelled_row(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        event_obj = self._event(
+            {"id": "in_x", "subscription": "sub_cancelled", "billing_reason": "subscription_cycle"}
+        )
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.find_one",
+                AsyncMock(return_value={"id": "row_c", "driver_id": "d1", "status": "cancelled"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        update_mock.assert_not_awaited()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1269,3 +1269,66 @@ class TestStripeWebhookSubscriptionUpdatedGuard:
 
         assert result["received"] is True
         update_mock.assert_not_awaited()
+
+
+class TestStripeWebhookInvoiceLedger:
+    """invoice.paid records the charge in the subscription_payments ledger."""
+
+    def _event(self, data_object, event_id="evt_inv_l"):
+        raw = _make_stripe_event("invoice.paid", data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_invoice_paid_records_ledger_payment(self):
+        from datetime import datetime, timedelta, timezone
+
+        from backend.routes import webhooks as wh
+        import stripe
+
+        period_end = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+        data_obj = {
+            "id": "in_99",
+            "subscription": "sub_1",
+            "billing_reason": "subscription_cycle",
+            "amount_paid": 4999,
+            "lines": {"data": [{"period": {"end": period_end}}]},
+        }
+        event_obj = self._event(data_obj)
+        record_mock = AsyncMock()
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "row1", "driver_id": "d1", "plan_id": "p1", "plan_name": "Pro"},
+                {"id": "d1", "user_id": "u1"},
+            ]
+        )
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", find_mock),
+            patch("backend.routes.webhooks.db_supabase.update_one", AsyncMock()),
+            patch("backend.routes.webhooks.send_push_notification", AsyncMock()),
+            patch("backend.routes.drivers._record_subscription_payment", record_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        record_mock.assert_awaited_once()
+        assert record_mock.await_args.kwargs["stripe_invoice_id"] == "in_99"
+        assert record_mock.await_args.kwargs["billing_reason"] == "subscription_cycle"

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -978,3 +978,144 @@ class TestStripeWebhookCheckoutNotPaid:
             result = asyncio.run(wh.stripe_webhook(request=req))
 
         assert result["received"] is True
+
+
+class TestStripeWebhookRecurringSubscription:
+    """invoice.paid / invoice.payment_failed / customer.subscription.updated
+    reconcile recurring Spinr Pass state (B4)."""
+
+    def _event(self, event_type, data_object, event_id="evt_sub_1"):
+        raw = _make_stripe_event(event_type, data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_invoice_paid_renews_and_notifies_on_cycle(self):
+        from datetime import datetime, timedelta, timezone
+
+        from backend.routes import webhooks as wh
+        import stripe
+
+        period_end = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+        data_obj = {
+            "id": "in_1",
+            "subscription": "sub_123",
+            "billing_reason": "subscription_cycle",
+            "lines": {"data": [{"period": {"end": period_end}}]},
+        }
+        event_obj = self._event("invoice.paid", data_obj)
+        update_mock = AsyncMock()
+        push_mock = AsyncMock()
+        # find_one: driver_subscriptions row, then drivers row (for the push).
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "row1", "driver_id": "d1", "plan_id": "p1"},
+                {"id": "d1", "user_id": "u1"},
+            ]
+        )
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", find_mock),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+            patch("backend.routes.webhooks.send_push_notification", push_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        upd = update_mock.await_args.args[2]
+        assert upd["status"] == "active"
+        assert upd["payment_status"] == "paid"
+        assert "expires_at" in upd
+        push_mock.assert_awaited_once()
+
+    def test_invoice_payment_failed_marks_past_due_and_notifies(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        data_obj = {"id": "in_2", "subscription": "sub_456"}
+        event_obj = self._event("invoice.payment_failed", data_obj)
+        update_mock = AsyncMock()
+        push_mock = AsyncMock()
+        find_mock = AsyncMock(
+            side_effect=[
+                {"id": "row2", "driver_id": "d2"},
+                {"id": "d2", "user_id": "u2"},
+            ]
+        )
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", find_mock),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+            patch("backend.routes.webhooks.send_push_notification", push_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        assert update_mock.await_args.args[2]["payment_status"] == "past_due"
+        push_mock.assert_awaited_once()
+
+    def test_subscription_updated_canceled_cancels_row(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        data_obj = {"id": "sub_789", "status": "canceled"}
+        event_obj = self._event("customer.subscription.updated", data_obj)
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.find_one",
+                AsyncMock(return_value={"id": "row3", "driver_id": "d3"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        assert update_mock.await_args.args[2]["status"] == "cancelled"
+
+    def test_invoice_paid_no_matching_row_acks(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        data_obj = {"id": "in_3", "subscription": "sub_orphan", "lines": {"data": []}}
+        event_obj = self._event("invoice.paid", data_obj)
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", AsyncMock(return_value=None)),
+            patch("backend.routes.webhooks.db_supabase.update_one", update_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        update_mock.assert_not_awaited()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -133,6 +133,81 @@ class TestStripeWebhookSignatureFailure:
         assert exc.value.status_code == 400
 
 
+class TestStripeWebhookConnectSecret:
+    """Dual-secret verification: the Connected-accounts endpoint signs with
+    its own whsec_, so an event the platform secret can't verify must still
+    be accepted when the connect secret verifies it."""
+
+    def test_connect_secret_verifies_when_platform_fails(self):
+        from backend.routes import webhooks as wh
+
+        event = _make_stripe_event("some.unhandled.event", {}, event_id="evt_connect_1")
+        event_obj = MagicMock()
+        event_obj.get = lambda k, d=None: event.get(k, d)
+        event_obj.to_dict_recursive = lambda: event
+
+        async def mock_get_app_settings():
+            return {
+                "stripe_webhook_secret": "whsec_platform",
+                "stripe_connect_webhook_secret": "whsec_connect",
+                "stripe_secret_key": "sk_test",
+            }
+
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "t=123,v1=sig"}
+
+        import stripe
+
+        def _construct(payload, sig, secret):
+            # Platform secret rejects (event came from the connect endpoint);
+            # connect secret verifies.
+            if secret == "whsec_platform":
+                raise stripe.error.SignatureVerificationError("wrong secret", "sig")
+            return event_obj
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", mock_get_app_settings),
+            patch.object(stripe.Webhook, "construct_event", side_effect=_construct),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=req))
+
+        # Verified via the connect secret → reaches dispatch (unhandled type
+        # acks 200 without processing).
+        assert result["received"] is True
+        assert result.get("unhandled") is True
+        assert result["event_id"] == "evt_connect_1"
+
+    def test_both_secrets_fail_returns_400(self):
+        from backend.routes import webhooks as wh
+
+        async def mock_get_app_settings():
+            return {
+                "stripe_webhook_secret": "whsec_platform",
+                "stripe_connect_webhook_secret": "whsec_connect",
+                "stripe_secret_key": "sk_test",
+            }
+
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "forged"}
+
+        import stripe
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", mock_get_app_settings),
+            patch.object(
+                stripe.Webhook,
+                "construct_event",
+                side_effect=stripe.error.SignatureVerificationError("fail", "sig"),
+            ),
+        ):
+            with pytest.raises(Exception) as exc:
+                asyncio.run(wh.stripe_webhook(request=req))
+        assert exc.value.status_code == 400
+
+
 class TestStripeWebhookDuplicateEvent:
     def test_duplicate_event_returns_received_duplicate(self):
         from backend.routes import webhooks as wh

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1332,3 +1332,66 @@ class TestStripeWebhookInvoiceLedger:
         record_mock.assert_awaited_once()
         assert record_mock.await_args.kwargs["stripe_invoice_id"] == "in_99"
         assert record_mock.await_args.kwargs["billing_reason"] == "subscription_cycle"
+
+
+class TestStripeWebhookInvoiceRecovery:
+    """invoice.paid recovers the row from subscription metadata when it arrives
+    before checkout linked stripe_subscription_id (round-6 P2)."""
+
+    def _event(self, data_object, event_id="evt_inv_r"):
+        raw = _make_stripe_event("invoice.paid", data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_invoice_paid_recovers_row_via_subscription_metadata(self):
+        from datetime import datetime, timedelta, timezone
+
+        from backend.routes import webhooks as wh
+        import stripe
+
+        period_end = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
+        data_obj = {
+            "id": "in_r",
+            "subscription": "sub_unlinked",
+            "billing_reason": "subscription_create",
+            "amount_paid": 4999,
+            "lines": {"data": [{"period": {"end": period_end}}]},
+        }
+        event_obj = self._event(data_obj)
+        record_mock = AsyncMock()
+        # 1st find_one (by stripe_subscription_id) misses; 2nd (by metadata id) hits.
+        find_mock = AsyncMock(
+            side_effect=[None, {"id": "row1", "driver_id": "d1", "plan_id": "p1", "plan_name": "Pro"}]
+        )
+        sub_obj = MagicMock()
+        sub_obj.get = lambda k, d=None: {"metadata": {"subscription_id": "row1"}}.get(k, d)
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", find_mock),
+            patch("backend.routes.webhooks.db_supabase.update_one", AsyncMock()),
+            patch.object(stripe.Subscription, "retrieve", return_value=sub_obj),
+            patch("backend.routes.drivers._record_subscription_payment", record_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        record_mock.assert_awaited_once()
+        assert record_mock.await_args.kwargs["stripe_invoice_id"] == "in_r"

--- a/backend/utils/stripe_reconcile.py
+++ b/backend/utils/stripe_reconcile.py
@@ -222,11 +222,20 @@ async def _run_reconciliation_tick() -> None:
                 pi.get("amount_received", 0),
             )
 
+    # ── 3c. Payout settlement backstop ──────────────────────────────────
+    # The payout.paid/payout.failed webhooks are the primary settlement
+    # signal; this catches payouts whose webhook never arrived and money
+    # that is stranded (transfer succeeded but payout + reversal both
+    # failed). Detection only — never moves money.
+    payout_discrepancies = await _reconcile_payouts()
+    discrepancies.extend(payout_discrepancies)
+
     # ── 4. Write summary to audit_logs ──────────────────────────────────
     summary = {
         "date": yesterday.isoformat(),
         "stripe_pis_checked": len(stripe_pis),
         "db_rides_checked": len(db_rides),
+        "payouts_flagged": len(payout_discrepancies),
         "discrepancies": len(discrepancies),
         "discrepancy_detail": discrepancies[:50],  # cap at 50 to avoid huge rows
     }
@@ -256,6 +265,75 @@ async def _run_reconciliation_tick() -> None:
             len(stripe_pis),
             len(db_rides),
         )
+
+
+async def _reconcile_payouts() -> List[Dict[str, Any]]:
+    """Detect driver payouts stuck in a non-terminal state or flagged for review.
+
+    Two concerning sets:
+      - requires_manual_review=true → instant payout where the payout step
+        AND the compensating reversal both failed; money is stranded in the
+        connected account and an operator must intervene.
+      - status='transfer_completed' → instant payout whose payout step never
+        completed (crash between transfer and payout, or a missed
+        payout.paid/payout.failed webhook).
+
+    Rows newer than one hour are skipped — they may still be resolving in
+    flight. Detection only: we surface to logs + the audit summary, never
+    move money, so a hiccup here cannot double-pay or reverse a driver.
+    """
+    discrepancies: List[Dict[str, Any]] = []
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+    cols = "id,driver_id,amount,status,requires_manual_review,stripe_payout_id,stripe_transfer_id,created_at"
+
+    candidates: Dict[str, Dict[str, Any]] = {}
+    for flt in ({"requires_manual_review": True}, {"status": "transfer_completed"}):
+        try:
+            rows = await db_supabase.get_rows("payouts", flt, columns=cols, limit=500) or []
+        except Exception:
+            logger.error("stripe_reconcile: payouts query failed for %s", flt, exc_info=True)
+            continue
+        for r in rows:
+            candidates[r["id"]] = r
+
+    for row in candidates.values():
+        # Defensive: only flag rows actually in a concerning state, never
+        # trusting the query filter alone — a terminal payout must never be
+        # surfaced as stuck.
+        review = bool(row.get("requires_manual_review"))
+        stuck = row.get("status") == "transfer_completed"
+        if not (review or stuck):
+            continue
+        created = row.get("created_at")
+        if created and not _is_older_than(created, cutoff):
+            continue  # still in-flight
+        kind = "PAYOUT_STRANDED" if review else "PAYOUT_STUCK"
+        discrepancies.append(
+            {
+                "type": kind,
+                "payout_id": row["id"],
+                "driver_id": row.get("driver_id"),
+                "status": row.get("status"),
+            }
+        )
+        logger.error(
+            "stripe_reconcile: %s payout=%s driver=%s status=%s",
+            kind,
+            row["id"],
+            row.get("driver_id"),
+            row.get("status"),
+            extra={"domain": "payments"},
+        )
+    return discrepancies
+
+
+def _is_older_than(created_at: str, cutoff: datetime) -> bool:
+    """Return True if the created_at ISO string is at or before cutoff."""
+    try:
+        dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        return dt <= cutoff
+    except Exception:
+        return True  # unparseable timestamp → surface it rather than hide it
 
 
 def _in_window(completed_at: str, window_start: int, window_end: int) -> bool:

--- a/backend/utils/stripe_reconcile.py
+++ b/backend/utils/stripe_reconcile.py
@@ -208,6 +208,11 @@ async def _run_reconciliation_tick() -> None:
     for pi_id, pi in stripe_pis.items():
         if pi["status"] != "succeeded":
             continue
+        # Spinr Pass charges (one-off subscription Checkout, corporate/wallet
+        # top-ups) are not rides — skip them so they aren't flagged as orphans.
+        _scope = (pi.get("metadata") or {}).get("scope")
+        if _scope in ("driver_subscription", "corporate_topup", "wallet_topup"):
+            continue
         if pi_id not in db_pi_to_ride:
             discrepancies.append(
                 {


### PR DESCRIPTION
- Migration 148: Add missing schema columns to driver_subscriptions
  (stripe_session_id, payment_status, expiry_warned, plan_name, etc.)
- Implement real Stripe Checkout Session creation in subscribe_to_plan
  instead of broken off-session charging
- Payment workflow: driver → Checkout Session URL → Stripe payment page
  → deep-link redirect → verify-session or webhook activation
- Webhook checkout.session.completed now correctly activates pending subscriptions
- verify-session endpoint works for post-checkout verification/polling
- Dev mode (no Stripe): instant activation preserved for internal testing
- Idempotent subscription activation via _activate_subscription

Before: subscribe_to_plan advertised Checkout but created no sessions,
verify-session looked up non-existent columns, webhook had no valid events.

After: Full subscription flow works end-to-end.

https://claude.ai/code/session_01EcN2bzQnrj3iimgtVJ4Ax6

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
