### PR TITLE
feat(email): add AWS SES primary + Resend guardrail provider

### DIFF
--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -218,16 +218,78 @@ export default function SettingsPage() {
                         </CardContent>
                     </Card>
 
-                    {/* Email / Resend */}
+                    {/* Email — AWS SES (primary) */}
                     <Card className="border-border/50">
                         <CardHeader>
-                            <CardTitle className="text-base">Email (Resend)</CardTitle>
+                            <CardTitle className="text-base">Email — AWS SES (primary)</CardTitle>
                         </CardHeader>
                         <Separator />
                         <CardContent className="pt-4 space-y-4">
                             <p className="text-xs text-muted-foreground">
-                                Used to send ride receipt emails to riders. If <strong>From Email</strong> is
-                                blank, the <code>email_from</code> setting is used as a fallback.
+                                Primary provider for ride receipts, T4A links, DSAR exports and
+                                safety/corporate alerts. When the access key and secret are set,
+                                email is sent via SES; if SES is blank or a send fails, Spinr falls
+                                back to Resend below. The <strong>From Email</strong> must be a
+                                verified identity in the SES account.
+                            </p>
+                            <div className="space-y-2">
+                                <Label>Region</Label>
+                                <Input
+                                    type="text"
+                                    value={settings.aws_ses_region || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_region", e.target.value)
+                                    }
+                                    placeholder="ca-central-1"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Access Key ID</Label>
+                                <Input
+                                    type="text"
+                                    value={settings.aws_ses_access_key_id || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_access_key_id", e.target.value)
+                                    }
+                                    placeholder="AKIA...."
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Secret Access Key</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.aws_ses_secret_access_key || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_secret_access_key", e.target.value)
+                                    }
+                                    placeholder="••••••••"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>From Email</Label>
+                                <Input
+                                    type="email"
+                                    value={settings.aws_ses_from_email || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_from_email", e.target.value)
+                                    }
+                                    placeholder="receipts@spinr.ca"
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Email — Resend (fallback guardrail) */}
+                    <Card className="border-border/50">
+                        <CardHeader>
+                            <CardTitle className="text-base">Email — Resend (fallback)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <p className="text-xs text-muted-foreground">
+                                Guardrail provider. Used only when AWS SES above is unconfigured or a
+                                send fails. If <strong>From Email</strong> is blank, the SES from
+                                address (then a code default) is used as a fallback.
                             </p>
                             <div className="space-y-2">
                                 <Label>API Key</Label>

--- a/backend/features.py
+++ b/backend/features.py
@@ -1444,46 +1444,22 @@ async def send_push_notification(
 
 
 async def send_email(*, to: str, subject: str, body: str) -> bool:
-    """Send a plain-text email via Resend when configured, log otherwise.
+    """Send a plain-text email: AWS SES primary, Resend guardrail.
 
-    Mirrors the fallback behaviour of utils.email_receipt.send_receipt_email —
-    in dev/test we don't require Resend credentials and the message is just
-    logged. Returns True if delivery was attempted against Resend and
-    accepted (2xx), False otherwise.
+    Delegates to utils.email_provider.send_transactional_email, which tries
+    AWS SES first and falls back to Resend when SES is unconfigured or fails.
+    In dev/test (neither provider configured) the message is log-only.
+    Returns True if either provider accepted the message, False otherwise.
     """
     if not to:
         return False
 
     try:
-        from settings_loader import get_app_settings
+        from .utils.email_provider import send_transactional_email
+    except ImportError:
+        from utils.email_provider import send_transactional_email  # type: ignore
 
-        settings = await get_app_settings()
-        resend_key = settings.get("resend_api_key", "")
-        from_email = settings.get("resend_from_email") or "noreply@spinr.ca"
-
-        if resend_key:
-            import httpx
-
-            response = await httpx.AsyncClient().post(
-                "https://api.resend.com/emails",
-                headers={
-                    "Authorization": f"Bearer {resend_key}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "from": f"Spinr <{from_email}>",
-                    "to": [to],
-                    "subject": subject,
-                    "text": body,
-                },
-            )
-            logger.info(f"[EMAIL] Resend sent subject={subject!r} status={response.status_code}")
-            return response.status_code in (200, 201, 202)
-    except Exception as e:
-        logger.warning(f"[EMAIL] Resend failed: {e}")
-
-    logger.info(f"[EMAIL] (fallback log) subject={subject!r}")
-    return False
+    return await send_transactional_email(to=to, subject=subject, text=body)
 
 
 async def notify_safety_team(incident: dict) -> dict:

--- a/backend/migrations/154_settings_aws_ses_email.sql
+++ b/backend/migrations/154_settings_aws_ses_email.sql
@@ -38,12 +38,18 @@
 --   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_access_key_id;
 --   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_secret_access_key;
 --   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_from_email;
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_sns_topic_arn;
 
 ALTER TABLE public.settings
     ADD COLUMN IF NOT EXISTS aws_ses_region            TEXT DEFAULT 'ca-central-1',
     ADD COLUMN IF NOT EXISTS aws_ses_access_key_id     TEXT,
     ADD COLUMN IF NOT EXISTS aws_ses_secret_access_key TEXT,
-    ADD COLUMN IF NOT EXISTS aws_ses_from_email        TEXT;
+    ADD COLUMN IF NOT EXISTS aws_ses_from_email        TEXT,
+    -- Expected SNS topic ARN for the SES bounce/complaint webhook. When set,
+    -- /webhooks/ses rejects any (otherwise validly signed) SNS message whose
+    -- TopicArn differs — closing a denial-of-email vector where an attacker
+    -- subscribes our endpoint to a foreign topic. Blank = allow + warn (dev).
+    ADD COLUMN IF NOT EXISTS aws_ses_sns_topic_arn     TEXT;
 
 -- Carry the verified Resend sender forward as the SES default so operators
 -- only have to verify the same address in SES — keeps receipts sending from

--- a/backend/migrations/154_settings_aws_ses_email.sql
+++ b/backend/migrations/154_settings_aws_ses_email.sql
@@ -1,0 +1,65 @@
+-- 154_settings_aws_ses_email.sql
+--
+-- Add AWS SES as the PRIMARY transactional-email provider, with Resend kept
+-- as a guardrail fallback.
+--
+-- Rationale: SES is materially cheaper than Resend at our send volume
+-- (ride receipts, T4A links, DSAR exports, corporate low-balance + safety
+-- alerts). We make SES primary and fall back to the existing Resend path
+-- when SES is unconfigured OR a send fails, so a SES outage/mis-config never
+-- silently drops a receipt.
+--
+-- Fields landed:
+--   • aws_ses_region            — SES region. Defaults to Canada (ca-central-1)
+--     for PIPEDA data-residency alignment; operator may override.
+--   • aws_ses_access_key_id      — IAM access key id (not masked on GET; it is
+--     an identifier, unusable without the secret — same treatment as
+--     twilio_account_sid).
+--   • aws_ses_secret_access_key  — IAM secret (CREDENTIAL: masked on GET via
+--     _mask_credentials in routes/admin/settings.py; never returned in
+--     plaintext on a settings GET).
+--   • aws_ses_from_email         — SES verified sender address, e.g.
+--     receipts@spinr.ca. Must be a verified identity in the SES account/
+--     domain. Falls back to resend_from_email / a code default when blank.
+--
+-- The Resend columns (migration 110) are intentionally left untouched — they
+-- remain the fallback provider. Nothing is dropped here.
+--
+-- All columns are nullable so the migration is forward-compatible with
+-- running traffic. Blank aws_ses_secret_access_key (or blank access key id)
+-- = SES considered unconfigured, and email routes straight to the Resend
+-- guardrail (same behaviour as before this migration).
+--
+-- RLS: the settings table is service-role-only (backend) — no user-facing
+-- RLS policy is added or required here.
+--
+-- Rollback:
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_region;
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_access_key_id;
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_secret_access_key;
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS aws_ses_from_email;
+
+ALTER TABLE public.settings
+    ADD COLUMN IF NOT EXISTS aws_ses_region            TEXT DEFAULT 'ca-central-1',
+    ADD COLUMN IF NOT EXISTS aws_ses_access_key_id     TEXT,
+    ADD COLUMN IF NOT EXISTS aws_ses_secret_access_key TEXT,
+    ADD COLUMN IF NOT EXISTS aws_ses_from_email        TEXT;
+
+-- Carry the verified Resend sender forward as the SES default so operators
+-- only have to verify the same address in SES — keeps receipts sending from
+-- the same address once SES credentials are entered.
+UPDATE public.settings
+   SET aws_ses_from_email = resend_from_email
+ WHERE id = 'app_settings'
+   AND (aws_ses_from_email IS NULL OR aws_ses_from_email = '')
+   AND resend_from_email IS NOT NULL
+   AND resend_from_email <> '';
+
+COMMENT ON COLUMN public.settings.aws_ses_region IS
+    'AWS SES region for transactional email. Defaults to ca-central-1 (Canada) for PIPEDA data residency.';
+COMMENT ON COLUMN public.settings.aws_ses_access_key_id IS
+    'AWS IAM access key id for SES SendEmail. Not masked on GET (identifier only; unusable without the secret).';
+COMMENT ON COLUMN public.settings.aws_ses_secret_access_key IS
+    'AWS IAM secret access key for SES. CREDENTIAL — masked on GET via _mask_credentials in routes/admin/settings.py; never returned in plaintext.';
+COMMENT ON COLUMN public.settings.aws_ses_from_email IS
+    'Verified SES sender address (e.g. receipts@spinr.ca). Must be a verified identity in the SES account. Falls back to resend_from_email when blank.';

--- a/backend/migrations/155_email_suppressions_and_send_log.sql
+++ b/backend/migrations/155_email_suppressions_and_send_log.sql
@@ -31,10 +31,18 @@
 --   DROP TABLE IF EXISTS public.email_suppressions;
 
 -- ── Suppression list ─────────────────────────────────────────────────────
+-- PIPEDA note (conscious trade-off): email is stored in PLAINTEXT, not via the
+-- pgsodium/vault pattern used for driver PII. A suppression check runs on the
+-- hot path of every send and must do an exact-match lookup by address; vault
+-- encryption is non-deterministic (decrypt-on-read) so it cannot be indexed
+-- for equality, and decrypt-all-on-each-send is untenable. The table is
+-- service-role-only (RLS enabled, no policies) and the address never appears
+-- in logs. This plaintext storage is therefore a deliberate, documented
+-- decision — not an oversight.
 CREATE TABLE IF NOT EXISTS public.email_suppressions (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    email       TEXT        NOT NULL,                 -- stored normalized (lower/trim)
-    reason      TEXT        NOT NULL,                 -- 'bounce' | 'complaint' | 'manual'
+    email       TEXT        NOT NULL,                 -- stored normalized (lower/trim); plaintext by design (see note above)
+    reason      TEXT        NOT NULL CHECK (reason IN ('bounce', 'complaint', 'manual')),
     detail      TEXT,                                 -- bounce subtype / diagnostic, optional
     source      TEXT        NOT NULL DEFAULT 'ses',   -- 'ses' | 'manual'
     message_id  TEXT,                                 -- SES MessageId that triggered it, if any
@@ -57,10 +65,13 @@ COMMENT ON TABLE public.email_suppressions IS
 CREATE TABLE IF NOT EXISTS public.email_send_log (
     id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
     message_id         TEXT,                              -- provider message id (SES MessageId / Resend id)
-    email_type         TEXT,                              -- 'receipt' | 'safety_alert' | 'dsar' | 'corporate_low_balance' | 'transactional'
+    -- email_type is free-form (new categories ship without a migration) but
+    -- DEFAULTs to 'transactional' so it matches the Python default and never
+    -- lands NULL, which would silently drop rows from GROUP BY email_type.
+    email_type         TEXT        NOT NULL DEFAULT 'transactional',
     recipient_user_id  UUID,                              -- PIPEDA: user id only, never the email address; NULL for non-user recipients
     provider           TEXT,                              -- 'ses' | 'resend' | 'none'
-    status             TEXT        NOT NULL,              -- 'sent' | 'failed' | 'suppressed'
+    status             TEXT        NOT NULL CHECK (status IN ('sent', 'failed', 'suppressed')),
     created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/backend/migrations/155_email_suppressions_and_send_log.sql
+++ b/backend/migrations/155_email_suppressions_and_send_log.sql
@@ -1,0 +1,78 @@
+-- 155_email_suppressions_and_send_log.sql
+--
+-- Email deliverability tracking for the SES-primary / Resend-fallback sender
+-- (utils/email_provider.py). Two append-style tables:
+--
+--   • email_suppressions — addresses we must NOT email because SES reported a
+--     hard bounce or a spam complaint (or an operator suppressed manually).
+--     send_transactional_email checks this before every send. Keeping a local
+--     copy of SES's suppression decisions stops us re-sending to dead/hostile
+--     addresses, which is what protects the SES account from being throttled
+--     or suspended for a high bounce/complaint rate.
+--
+--   • email_send_log — one row per send attempt for support + an ops
+--     deliverability view ("did the rider get their receipt?"). PIPEDA: we
+--     store recipient_user_id, NEVER the email address, in this table.
+--
+-- Populated by:
+--   • email_suppressions ← POST /api/v1/webhooks/ses (SNS Bounce/Complaint)
+--   • email_send_log     ← email_provider.send_transactional_email
+--
+-- RLS: both tables hold user-linked data, so RLS is ENABLED with NO policies —
+-- that denies all anon/authenticated access; only the backend service role
+-- (which bypasses RLS by design) can read/write them. The frontend anon key
+-- must never touch these directly.
+--
+-- Forward-compatible: pure CREATE TABLE / CREATE INDEX, safe under live
+-- traffic. No money columns.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.email_send_log;
+--   DROP TABLE IF EXISTS public.email_suppressions;
+
+-- ── Suppression list ─────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.email_suppressions (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email       TEXT        NOT NULL,                 -- stored normalized (lower/trim)
+    reason      TEXT        NOT NULL,                 -- 'bounce' | 'complaint' | 'manual'
+    detail      TEXT,                                 -- bounce subtype / diagnostic, optional
+    source      TEXT        NOT NULL DEFAULT 'ses',   -- 'ses' | 'manual'
+    message_id  TEXT,                                 -- SES MessageId that triggered it, if any
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- One suppression row per address; the SES webhook is idempotent against this
+-- (checks before insert) so SNS redeliveries don't duplicate. Unique on the
+-- normalized address — callers must lowercase/trim before insert.
+CREATE UNIQUE INDEX IF NOT EXISTS email_suppressions_email_key
+    ON public.email_suppressions (email);
+
+ALTER TABLE public.email_suppressions ENABLE ROW LEVEL SECURITY;
+-- Intentionally no policies: service-role-only (backend). Locked to anon/auth.
+
+COMMENT ON TABLE public.email_suppressions IS
+    'Addresses excluded from transactional email after a hard bounce/complaint (or manual). Checked by email_provider.send_transactional_email; populated by the SES SNS webhook. Service-role-only (RLS enabled, no policies).';
+
+-- ── Send log ─────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.email_send_log (
+    id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    message_id         TEXT,                              -- provider message id (SES MessageId / Resend id)
+    email_type         TEXT,                              -- 'receipt' | 'safety_alert' | 'dsar' | 'corporate_low_balance' | 'transactional'
+    recipient_user_id  UUID,                              -- PIPEDA: user id only, never the email address; NULL for non-user recipients
+    provider           TEXT,                              -- 'ses' | 'resend' | 'none'
+    status             TEXT        NOT NULL,              -- 'sent' | 'failed' | 'suppressed'
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- "Recent emails for this user" support lookups, newest first.
+CREATE INDEX IF NOT EXISTS email_send_log_recipient_idx
+    ON public.email_send_log (recipient_user_id, created_at DESC);
+-- Correlate a provider message id back to its send (e.g. from an SES event).
+CREATE INDEX IF NOT EXISTS email_send_log_message_id_idx
+    ON public.email_send_log (message_id);
+
+ALTER TABLE public.email_send_log ENABLE ROW LEVEL SECURITY;
+-- Intentionally no policies: service-role-only (backend). Locked to anon/auth.
+
+COMMENT ON TABLE public.email_send_log IS
+    'Append-only audit of transactional email sends (provider, status, message id, recipient_user_id). PIPEDA: never stores the email address. Service-role-only (RLS enabled, no policies).';

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -49,6 +49,10 @@ _CREDENTIAL_FIELDS = frozenset(
         # Resend API key is a credential too — without masking it would
         # otherwise round-trip in plaintext on every settings GET.
         "resend_api_key",
+        # AWS SES secret (primary email provider, migration 154). The access
+        # key id is left visible (identifier, unusable without the secret —
+        # same treatment as twilio_account_sid); only the secret is masked.
+        "aws_ses_secret_access_key",
         # Legacy SendGrid key: no longer read for sending, but migration 110
         # leaves the column in place, so a still-populated value would round-
         # trip in plaintext on GET unless it stays masked here. Keeps the
@@ -114,6 +118,13 @@ class SettingsUpdateRequest(BaseModel):
     # api_key is a credential (masked on GET); from_email is plain.
     resend_api_key: Optional[str] = None
     resend_from_email: Optional[str] = None
+    # AWS SES is the PRIMARY transactional-email provider (migration 154);
+    # Resend above is the guardrail fallback. secret_access_key is a
+    # credential (masked on GET); the rest are plain.
+    aws_ses_region: Optional[str] = None
+    aws_ses_access_key_id: Optional[str] = None
+    aws_ses_secret_access_key: Optional[str] = None
+    aws_ses_from_email: Optional[str] = None
     # Company info shown on rider receipts + driver T4A slips + the
     # admin dashboard footer. Edited via the Settings page → Company tab.
     company_name: Optional[str] = None

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -125,6 +125,9 @@ class SettingsUpdateRequest(BaseModel):
     aws_ses_access_key_id: Optional[str] = None
     aws_ses_secret_access_key: Optional[str] = None
     aws_ses_from_email: Optional[str] = None
+    # Expected SNS topic ARN for the SES bounce/complaint webhook. When set,
+    # /webhooks/ses rejects SNS messages from any other topic.
+    aws_ses_sns_topic_arn: Optional[str] = None
     # Company info shown on rider receipts + driver T4A slips + the
     # admin dashboard footer. Edited via the Settings page → Company tab.
     company_name: Optional[str] = None

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -1002,3 +1002,133 @@ async def stripe_webhook(request: Request):
     await mark_stripe_event_processed(event_id)
 
     return {"received": True, "event_id": event_id}
+
+
+# ---------------------------------------------------------------------------
+# Amazon SES bounce/complaint feedback (via SNS)
+# ---------------------------------------------------------------------------
+#
+# SES publishes Bounce/Complaint/Delivery notifications to an SNS topic; SNS
+# POSTs them here. We verify the SNS signature (the endpoint is public), then
+# on a *permanent* bounce or a complaint we add the address to
+# email_suppressions so email_provider stops sending to it — that's what keeps
+# our SES bounce/complaint rate (and thus our sending reputation) healthy.
+
+
+async def _confirm_sns_subscription(payload: dict) -> None:
+    """Confirm an SNS subscription by GETting its SubscribeURL.
+
+    The URL host is validated (https + sns.*.amazonaws.com) first so a forged
+    confirmation can't make us issue a request to an arbitrary host.
+    """
+    try:
+        from ..utils.sns_verify import is_trusted_sns_url
+    except ImportError:
+        from utils.sns_verify import is_trusted_sns_url  # type: ignore
+
+    url = payload.get("SubscribeURL") or ""
+    if not is_trusted_sns_url(url):
+        logger.error("[SES] refusing to confirm subscription — untrusted SubscribeURL")
+        return
+    import httpx
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        await client.get(url)
+    logger.info("[SES] SNS subscription confirmed topic=%s", payload.get("TopicArn"))
+
+
+async def _suppress_address(email: str, *, reason: str, detail, message_id) -> None:
+    """Idempotently add one address to email_suppressions.
+
+    PIPEDA: the email address itself is never logged — only the reason and the
+    SES message id (which carries no PII).
+    """
+    try:
+        from ..utils.email_provider import normalize_email
+    except ImportError:
+        from utils.email_provider import normalize_email  # type: ignore
+
+    norm = normalize_email(email)
+    if not norm:
+        return
+    # SNS may redeliver — skip if we already suppressed this address.
+    existing = await db_supabase.find_one("email_suppressions", {"email": norm})
+    if existing:
+        return
+    await db_supabase.insert_one(
+        "email_suppressions",
+        {"email": norm, "reason": reason, "detail": detail, "source": "ses", "message_id": message_id},
+    )
+    logger.warning("[SES] address suppressed reason=%s message_id=%s", reason, message_id or "-")
+
+
+async def _handle_ses_notification(payload: dict) -> dict:
+    """Parse an SES notification and suppress hard-bounced/complained recipients."""
+    import json
+
+    try:
+        inner = json.loads(payload.get("Message") or "{}")
+    except (ValueError, TypeError):
+        logger.error("[SES] notification Message was not valid JSON — ignoring")
+        return {"received": True, "ignored": "bad_message"}
+
+    ntype = inner.get("notificationType") or inner.get("eventType")
+    message_id = (inner.get("mail") or {}).get("messageId")
+    suppressed = 0
+
+    if ntype == "Bounce":
+        bounce = inner.get("bounce") or {}
+        # Only PERMANENT (hard) bounces suppress; transient bounces may recover.
+        if bounce.get("bounceType") == "Permanent":
+            for r in bounce.get("bouncedRecipients") or []:
+                await _suppress_address(
+                    r.get("emailAddress"),
+                    reason="bounce",
+                    detail=bounce.get("bounceSubType"),
+                    message_id=message_id,
+                )
+                suppressed += 1
+    elif ntype == "Complaint":
+        complaint = inner.get("complaint") or {}
+        for r in complaint.get("complainedRecipients") or []:
+            await _suppress_address(
+                r.get("emailAddress"),
+                reason="complaint",
+                detail=complaint.get("complaintFeedbackType"),
+                message_id=message_id,
+            )
+            suppressed += 1
+    # Delivery / transient bounce / other: acknowledged, no suppression.
+
+    return {"received": True, "type": ntype, "suppressed": suppressed}
+
+
+@api_router.post("/ses")
+async def ses_sns_webhook(request: Request):
+    """Receive SES bounce/complaint feedback via SNS. Signature-verified."""
+    import json
+
+    raw = await request.body()
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="invalid JSON") from None
+
+    try:
+        from ..utils.sns_verify import verify_sns_signature
+    except ImportError:
+        from utils.sns_verify import verify_sns_signature  # type: ignore
+
+    if not verify_sns_signature(payload):
+        # 403: do not act on an unverified message.
+        raise HTTPException(status_code=403, detail="invalid SNS signature")
+
+    msg_type = payload.get("Type")
+    if msg_type == "SubscriptionConfirmation":
+        await _confirm_sns_subscription(payload)
+        return {"received": True, "confirmed": True}
+    if msg_type == "Notification":
+        return await _handle_ses_notification(payload)
+
+    # UnsubscribeConfirmation / unknown — acknowledge without action.
+    return {"received": True, "ignored": msg_type}

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -4,16 +4,19 @@ from fastapi import APIRouter, HTTPException, Request
 
 try:
     from .. import db_supabase
-    from ..db_supabase import claim_stripe_event, mark_stripe_event_processed
+    from ..db_supabase import DatabaseError, DuplicateRecordError, claim_stripe_event, mark_stripe_event_processed
     from ..features import send_push_notification
     from ..settings_loader import get_app_settings
     from ..utils.money import cents_to_dollars
+    from ..utils.rate_limiter import default_limiter
 except ImportError:
     import db_supabase
-    from db_supabase import claim_stripe_event, mark_stripe_event_processed
+    from db_supabase import DatabaseError, DuplicateRecordError, claim_stripe_event, mark_stripe_event_processed
     from features import send_push_notification
     from settings_loader import get_app_settings
     from utils.money import cents_to_dollars
+    from utils.rate_limiter import default_limiter
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -1032,16 +1035,42 @@ async def _confirm_sns_subscription(payload: dict) -> None:
         return
     import httpx
 
-    async with httpx.AsyncClient(timeout=5.0) as client:
-        await client.get(url)
-    logger.info("[SES] SNS subscription confirmed topic=%s", payload.get("TopicArn"))
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(url)
+        if resp.status_code >= 400:
+            logger.error("[SES] subscription confirm returned %s — not confirmed", resp.status_code)
+            return
+        logger.info("[SES] SNS subscription confirmed topic=%s", payload.get("TopicArn"))
+    except Exception:
+        logger.error("[SES] subscription confirm request failed", exc_info=True)
+
+
+async def _topic_arn_allowed(topic_arn) -> bool:
+    """True if this SNS message's TopicArn is the one we expect.
+
+    A valid AWS signature only proves the message came from *some* SNS topic;
+    without this check an attacker could subscribe our endpoint to a foreign
+    topic and suppress our addresses. Blank setting = allow + warn (dev).
+    """
+    settings = await get_app_settings()
+    expected = (settings.get("aws_ses_sns_topic_arn") or "").strip()
+    if not expected:
+        logger.warning("[SES] aws_ses_sns_topic_arn not configured — accepting SNS topic without allowlist")
+        return True
+    if topic_arn != expected:
+        logger.error("[SES] rejected SNS message from unexpected topic")
+        return False
+    return True
 
 
 async def _suppress_address(email: str, *, reason: str, detail, message_id) -> None:
     """Idempotently add one address to email_suppressions.
 
     PIPEDA: the email address itself is never logged — only the reason and the
-    SES message id (which carries no PII).
+    SES message id (which carries no PII). DuplicateRecordError (a concurrent
+    SNS redelivery losing the insert race) is treated as success; any other
+    DatabaseError propagates so the webhook returns 503 and SNS retries.
     """
     try:
         from ..utils.email_provider import normalize_email
@@ -1051,15 +1080,27 @@ async def _suppress_address(email: str, *, reason: str, detail, message_id) -> N
     norm = normalize_email(email)
     if not norm:
         return
-    # SNS may redeliver — skip if we already suppressed this address.
-    existing = await db_supabase.find_one("email_suppressions", {"email": norm})
-    if existing:
-        return
-    await db_supabase.insert_one(
-        "email_suppressions",
-        {"email": norm, "reason": reason, "detail": detail, "source": "ses", "message_id": message_id},
-    )
-    logger.warning("[SES] address suppressed reason=%s message_id=%s", reason, message_id or "-")
+    try:
+        # SNS may redeliver — skip if we already suppressed this address.
+        existing = await db_supabase.find_one("email_suppressions", {"email": norm})
+        if existing:
+            return
+        await db_supabase.insert_one(
+            "email_suppressions",
+            {"email": norm, "reason": reason, "detail": detail, "source": "ses", "message_id": message_id},
+        )
+        logger.warning("[SES] address suppressed reason=%s message_id=%s", reason, message_id or "-")
+    except DuplicateRecordError:
+        # Concurrent redelivery already inserted it — idempotent success.
+        logger.info("[SES] suppression already present (insert race) reason=%s message_id=%s", reason, message_id or "-")
+    except DatabaseError as e:
+        logger.error(
+            "[SES] suppression write failed reason=%s: %s",
+            reason,
+            (e.details or {}).get("original", str(e)),
+            exc_info=True,
+        )
+        raise
 
 
 async def _handle_ses_notification(payload: dict) -> dict:
@@ -1104,6 +1145,7 @@ async def _handle_ses_notification(payload: dict) -> dict:
 
 
 @api_router.post("/ses")
+@default_limiter.limit("100/minute")
 async def ses_sns_webhook(request: Request):
     """Receive SES bounce/complaint feedback via SNS. Signature-verified."""
     import json
@@ -1119,16 +1161,26 @@ async def ses_sns_webhook(request: Request):
     except ImportError:
         from utils.sns_verify import verify_sns_signature  # type: ignore
 
-    if not verify_sns_signature(payload):
+    # Verification fetches the signing cert + does an RSA verify — both
+    # blocking — so run it off the event loop.
+    if not await asyncio.to_thread(verify_sns_signature, payload):
         # 403: do not act on an unverified message.
         raise HTTPException(status_code=403, detail="invalid SNS signature")
+
+    # Even a validly-signed message must be from our expected topic.
+    if not await _topic_arn_allowed(payload.get("TopicArn")):
+        raise HTTPException(status_code=403, detail="unexpected SNS topic")
 
     msg_type = payload.get("Type")
     if msg_type == "SubscriptionConfirmation":
         await _confirm_sns_subscription(payload)
         return {"received": True, "confirmed": True}
     if msg_type == "Notification":
-        return await _handle_ses_notification(payload)
+        try:
+            return await _handle_ses_notification(payload)
+        except DatabaseError as e:
+            # Surface as 503 so SNS retries rather than dropping the bounce.
+            raise HTTPException(status_code=503, detail="suppression store unavailable") from e
 
     # UnsubscribeConfirmation / unknown — acknowledge without action.
     return {"received": True, "ignored": msg_type}

--- a/backend/tests/test_email_provider.py
+++ b/backend/tests/test_email_provider.py
@@ -46,6 +46,21 @@ _RESEND_SETTINGS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def _stub_email_db():
+    """Stub the suppression lookup + send-log write for every test.
+
+    email_provider does `import db_supabase` (fallback path) and calls
+    db_supabase.find_one / insert_one, so we patch them there. Defaults:
+    not suppressed, log write is a no-op. Individual tests re-patch to assert.
+    """
+    with (
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(return_value=None)),
+    ):
+        yield
+
+
 def _settings(**overrides):
     return AsyncMock(return_value=dict(overrides))
 
@@ -231,3 +246,117 @@ async def test_empty_body_returns_false_without_loading_settings():
         ok = await send_transactional_email(to="r@example.com", subject="x")
     assert ok is False
     load.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Suppression list + send log
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_suppressed_recipient_skips_send_and_logs():
+    resend_client = _async_client_mock()
+    inserts: list = []
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS, **_RESEND_SETTINGS)) as load,
+        patch("db_supabase.find_one", AsyncMock(return_value={"email": "rider@example.com"})),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+        patch("boto3.client", MagicMock()) as boto_factory,
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(
+            to="rider@example.com", subject="x", text="hi", email_type="receipt", recipient_user_id="u1"
+        )
+
+    assert ok is False
+    # Neither provider is touched, and settings aren't even loaded.
+    load.assert_not_awaited()
+    boto_factory.assert_not_called()
+    resend_client.post.assert_not_awaited()
+    # Logged as suppressed.
+    assert inserts and inserts[0][0] == "email_send_log"
+    assert inserts[0][1]["status"] == "suppressed"
+    assert inserts[0][1]["email_type"] == "receipt"
+    assert inserts[0][1]["recipient_user_id"] == "u1"
+
+
+@pytest.mark.anyio
+async def test_send_log_written_on_ses_success():
+    factory, _ses = _boto3_mock()
+    inserts: list = []
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS)),
+        patch("boto3.client", factory),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+    ):
+        ok = await send_transactional_email(
+            to="r@example.com", subject="x", html="<p>h</p>", email_type="receipt", recipient_user_id="u1"
+        )
+
+    assert ok is True
+    assert inserts and inserts[0][0] == "email_send_log"
+    row = inserts[0][1]
+    assert row["provider"] == "ses"
+    assert row["status"] == "sent"
+    assert row["message_id"] == "msg-123"
+    assert row["email_type"] == "receipt"
+    assert row["recipient_user_id"] == "u1"
+
+
+@pytest.mark.anyio
+async def test_send_log_records_resend_provider_on_fallback():
+    factory, _ses = _boto3_mock(send_side_effect=RuntimeError("SES down"))
+    resend_client = _async_client_mock()
+    resend_client.post = AsyncMock(return_value=_mock_resp(202))
+    resend_client.post.return_value.json = lambda: {"id": "resend-abc"}
+    inserts: list = []
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS, **_RESEND_SETTINGS)),
+        patch("boto3.client", factory),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(to="r@example.com", subject="x", text="hi")
+
+    assert ok is True
+    row = inserts[0][1]
+    assert row["provider"] == "resend"
+    assert row["status"] == "sent"
+    assert row["message_id"] == "resend-abc"
+
+
+@pytest.mark.anyio
+async def test_failed_send_logged_as_failed():
+    inserts: list = []
+    with (
+        patch("settings_loader.get_app_settings", _settings()),  # nothing configured
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+    ):
+        ok = await send_transactional_email(to="r@example.com", subject="x", text="hi")
+
+    assert ok is False
+    row = inserts[0][1]
+    assert row["provider"] == "none"
+    assert row["status"] == "failed"
+
+
+@pytest.mark.anyio
+async def test_suppression_lookup_error_fails_open():
+    factory, ses_client = _boto3_mock()
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS)),
+        patch("boto3.client", factory),
+        patch("db_supabase.find_one", AsyncMock(side_effect=RuntimeError("db down"))),
+        patch("db_supabase.insert_one", AsyncMock(return_value=None)),
+    ):
+        ok = await send_transactional_email(to="r@example.com", subject="x", text="hi")
+
+    # Fail-open: a suppression-lookup error must not block the send.
+    assert ok is True
+    ses_client.send_raw_email.assert_called_once()

--- a/backend/tests/test_email_provider.py
+++ b/backend/tests/test_email_provider.py
@@ -1,0 +1,222 @@
+"""Unit tests for utils.email_provider.send_transactional_email.
+
+Provider strategy under test: AWS SES primary, Resend guardrail fallback.
+
+Covers:
+- SES configured + succeeds → SES used, Resend never called, returns True
+- SES configured + raises → falls back to Resend, returns True
+- SES unconfigured + Resend configured → Resend used, returns True
+- SES succeeds → boto3 receives html/text body + the SES from address
+- Resend non-2xx → returns False
+- Neither provider configured → returns False, no network calls
+- Empty body / no recipient → returns False, no network calls
+
+Patching notes:
+  email_provider._load_settings imports get_app_settings inline as
+  `from settings_loader import get_app_settings`, so we patch
+  `settings_loader.get_app_settings`.
+
+  boto3 is imported inline inside _send_ses_sync as `import boto3`, so we
+  patch `boto3.client`. httpx is imported inline in the Resend path as
+  `import httpx`, so we patch `httpx.AsyncClient`.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+try:
+    from utils.email_provider import send_transactional_email
+except ImportError:
+    from backend.utils.email_provider import send_transactional_email  # type: ignore[no-redef]
+
+
+_SES_SETTINGS = {
+    "aws_ses_region": "ca-central-1",
+    "aws_ses_access_key_id": "AKIATEST",
+    "aws_ses_secret_access_key": "secret-shh",
+    "aws_ses_from_email": "ses@spinr.ca",
+}
+
+_RESEND_SETTINGS = {
+    "resend_api_key": "re_test-key",
+    "resend_from_email": "resend@spinr.ca",
+}
+
+
+def _settings(**overrides):
+    return AsyncMock(return_value=dict(overrides))
+
+
+def _mock_resp(status_code: int = 202) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = ""
+    return resp
+
+
+def _async_client_mock(post_side_effect=None) -> MagicMock:
+    mock = AsyncMock()
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    if post_side_effect is not None:
+        mock.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        mock.post = AsyncMock(return_value=_mock_resp(202))
+    return mock
+
+
+def _boto3_mock(send_side_effect=None) -> MagicMock:
+    """Return a fake boto3 module-level client() factory and the SES client."""
+    ses_client = MagicMock()
+    if send_side_effect is not None:
+        ses_client.send_email = MagicMock(side_effect=send_side_effect)
+    else:
+        ses_client.send_email = MagicMock(return_value={"MessageId": "msg-123"})
+    factory = MagicMock(return_value=ses_client)
+    return factory, ses_client
+
+
+# ---------------------------------------------------------------------------
+# SES primary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ses_used_when_configured_and_resend_not_called():
+    factory, ses_client = _boto3_mock()
+    resend_client = _async_client_mock()
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS, **_RESEND_SETTINGS)),
+        patch("boto3.client", factory),
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(to="rider@example.com", subject="Receipt", html="<p>hi</p>")
+
+    assert ok is True
+    ses_client.send_email.assert_called_once()
+    resend_client.post.assert_not_awaited()  # guardrail must not fire on SES success
+
+
+@pytest.mark.anyio
+async def test_ses_receives_body_and_from_address():
+    factory, ses_client = _boto3_mock()
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS)),
+        patch("boto3.client", factory),
+    ):
+        ok = await send_transactional_email(
+            to="rider@example.com",
+            subject="Receipt",
+            html="<p>hi</p>",
+            text="hi",
+            default_from="receipts@spinr.ca",
+        )
+
+    assert ok is True
+    # Region + credentials forwarded to boto3.client
+    _, kwargs = factory.call_args
+    assert kwargs["region_name"] == "ca-central-1"
+    assert kwargs["aws_access_key_id"] == "AKIATEST"
+    assert kwargs["aws_secret_access_key"] == "secret-shh"
+    # SES uses its own verified from address, both body parts present
+    _, send_kwargs = ses_client.send_email.call_args
+    assert send_kwargs["Source"] == "Spinr <ses@spinr.ca>"
+    assert send_kwargs["Message"]["Body"]["Html"]["Data"] == "<p>hi</p>"
+    assert send_kwargs["Message"]["Body"]["Text"]["Data"] == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Guardrail fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ses_failure_falls_back_to_resend():
+    factory, ses_client = _boto3_mock(send_side_effect=RuntimeError("SES down"))
+    resend_client = _async_client_mock()
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_SES_SETTINGS, **_RESEND_SETTINGS)),
+        patch("boto3.client", factory),
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(to="rider@example.com", subject="Receipt", text="hi")
+
+    assert ok is True
+    ses_client.send_email.assert_called_once()
+    resend_client.post.assert_awaited_once()  # guardrail caught the SES failure
+
+
+@pytest.mark.anyio
+async def test_resend_used_when_ses_unconfigured():
+    resend_client = _async_client_mock()
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_RESEND_SETTINGS)),
+        patch("boto3.client", MagicMock()) as boto_factory,
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(to="rider@example.com", subject="Receipt", html="<p>hi</p>")
+
+    assert ok is True
+    boto_factory.assert_not_called()  # SES skipped without touching boto3
+    resend_client.post.assert_awaited_once()
+    _, post_kwargs = resend_client.post.call_args
+    assert post_kwargs["json"]["from"] == "Spinr <resend@spinr.ca>"
+    assert post_kwargs["json"]["html"] == "<p>hi</p>"
+
+
+@pytest.mark.anyio
+async def test_resend_non_2xx_returns_false():
+    resend_client = _async_client_mock()
+    resend_client.post = AsyncMock(return_value=_mock_resp(500))
+
+    with (
+        patch("settings_loader.get_app_settings", _settings(**_RESEND_SETTINGS)),
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(to="rider@example.com", subject="Receipt", text="hi")
+
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Nothing configured / bad input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_no_provider_configured_returns_false():
+    resend_client = _async_client_mock()
+
+    with (
+        patch("settings_loader.get_app_settings", _settings()),
+        patch("boto3.client", MagicMock()) as boto_factory,
+        patch("httpx.AsyncClient", return_value=resend_client),
+    ):
+        ok = await send_transactional_email(to="rider@example.com", subject="Receipt", text="hi")
+
+    assert ok is False
+    boto_factory.assert_not_called()
+    resend_client.post.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_no_recipient_returns_false_without_loading_settings():
+    with patch("settings_loader.get_app_settings", AsyncMock()) as load:
+        ok = await send_transactional_email(to="", subject="x", text="hi")
+    assert ok is False
+    load.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_empty_body_returns_false_without_loading_settings():
+    with patch("settings_loader.get_app_settings", AsyncMock()) as load:
+        ok = await send_transactional_email(to="r@example.com", subject="x")
+    assert ok is False
+    load.assert_not_awaited()

--- a/backend/tests/test_email_provider.py
+++ b/backend/tests/test_email_provider.py
@@ -72,9 +72,9 @@ def _boto3_mock(send_side_effect=None) -> MagicMock:
     """Return a fake boto3 module-level client() factory and the SES client."""
     ses_client = MagicMock()
     if send_side_effect is not None:
-        ses_client.send_email = MagicMock(side_effect=send_side_effect)
+        ses_client.send_raw_email = MagicMock(side_effect=send_side_effect)
     else:
-        ses_client.send_email = MagicMock(return_value={"MessageId": "msg-123"})
+        ses_client.send_raw_email = MagicMock(return_value={"MessageId": "msg-123"})
     factory = MagicMock(return_value=ses_client)
     return factory, ses_client
 
@@ -97,7 +97,7 @@ async def test_ses_used_when_configured_and_resend_not_called():
         ok = await send_transactional_email(to="rider@example.com", subject="Receipt", html="<p>hi</p>")
 
     assert ok is True
-    ses_client.send_email.assert_called_once()
+    ses_client.send_raw_email.assert_called_once()
     resend_client.post.assert_not_awaited()  # guardrail must not fire on SES success
 
 
@@ -123,11 +123,22 @@ async def test_ses_receives_body_and_from_address():
     assert kwargs["region_name"] == "ca-central-1"
     assert kwargs["aws_access_key_id"] == "AKIATEST"
     assert kwargs["aws_secret_access_key"] == "secret-shh"
-    # SES uses its own verified from address, both body parts present
-    _, send_kwargs = ses_client.send_email.call_args
+    # SendRawEmail with the verified SES from address as Source + envelope dest.
+    _, send_kwargs = ses_client.send_raw_email.call_args
     assert send_kwargs["Source"] == "Spinr <ses@spinr.ca>"
-    assert send_kwargs["Message"]["Body"]["Html"]["Data"] == "<p>hi</p>"
-    assert send_kwargs["Message"]["Body"]["Text"]["Data"] == "hi"
+    assert send_kwargs["Destinations"] == ["rider@example.com"]
+    # Raw MIME carries both alternatives + the headers (parse, don't substring:
+    # MIMEText base64-encodes the payloads under a utf-8 charset).
+    import email as _email
+
+    parsed = _email.message_from_string(send_kwargs["RawMessage"]["Data"])
+    assert parsed.get_content_type() == "multipart/alternative"
+    assert parsed["Subject"] == "Receipt"
+    assert parsed["From"] == "Spinr <ses@spinr.ca>"
+    assert parsed["To"] == "rider@example.com"
+    parts = {p.get_content_type(): p.get_payload(decode=True).decode("utf-8") for p in parsed.get_payload()}
+    assert parts["text/plain"] == "hi"
+    assert parts["text/html"] == "<p>hi</p>"
 
 
 # ---------------------------------------------------------------------------
@@ -148,7 +159,7 @@ async def test_ses_failure_falls_back_to_resend():
         ok = await send_transactional_email(to="rider@example.com", subject="Receipt", text="hi")
 
     assert ok is True
-    ses_client.send_email.assert_called_once()
+    ses_client.send_raw_email.assert_called_once()
     resend_client.post.assert_awaited_once()  # guardrail caught the SES failure
 
 

--- a/backend/tests/test_ses_webhook.py
+++ b/backend/tests/test_ses_webhook.py
@@ -1,0 +1,280 @@
+"""Tests for the SES bounce/complaint webhook (routes/webhooks.py) and the
+SNS signature verifier (utils/sns_verify.py).
+
+Covers:
+- is_trusted_sns_url host/scheme allowlist (SSRF guard)
+- verify_sns_signature: valid roundtrip, tampered signature, untrusted cert URL
+- POST /api/v1/webhooks/ses: 403 on bad signature, 400 on bad JSON,
+  subscription confirmation, hard-bounce suppression, complaint suppression,
+  idempotent re-delivery, transient bounce ignored
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import NameOID
+from fastapi.testclient import TestClient
+
+try:
+    from utils.sns_verify import _string_to_sign, is_trusted_sns_url, verify_sns_signature
+except ImportError:
+    from backend.utils.sns_verify import (  # type: ignore[no-redef]
+        _string_to_sign,
+        is_trusted_sns_url,
+        verify_sns_signature,
+    )
+
+_CERT_URL = "https://sns.ca-central-1.amazonaws.com/SimpleNotificationService-abc.pem"
+
+
+# ---------------------------------------------------------------------------
+# Signing helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cert_and_key():
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "sns.amazonaws.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(dt.datetime.utcnow() - dt.timedelta(days=1))
+        .not_valid_after(dt.datetime.utcnow() + dt.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _signed_payload(key, payload: dict) -> dict:
+    payload = dict(payload)
+    payload.setdefault("SigningCertURL", _CERT_URL)
+    payload.setdefault("SignatureVersion", "1")
+    sig = key.sign(_string_to_sign(payload), padding.PKCS1v15(), hashes.SHA1())
+    payload["Signature"] = base64.b64encode(sig).decode()
+    return payload
+
+
+def _bounce_message(addr: str, bounce_type: str = "Permanent") -> str:
+    return json.dumps(
+        {
+            "notificationType": "Bounce",
+            "mail": {"messageId": "ses-msg-1"},
+            "bounce": {
+                "bounceType": bounce_type,
+                "bounceSubType": "General",
+                "bouncedRecipients": [{"emailAddress": addr}],
+            },
+        }
+    )
+
+
+def _complaint_message(addr: str) -> str:
+    return json.dumps(
+        {
+            "notificationType": "Complaint",
+            "mail": {"messageId": "ses-msg-2"},
+            "complaint": {
+                "complaintFeedbackType": "abuse",
+                "complainedRecipients": [{"emailAddress": addr}],
+            },
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_trusted_sns_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://sns.ca-central-1.amazonaws.com/x.pem", True),
+        ("https://sns.us-east-1.amazonaws.com/x.pem", True),
+        ("http://sns.ca-central-1.amazonaws.com/x.pem", False),  # not https
+        ("https://evil.com/x.pem", False),  # wrong host
+        ("https://sns.ca-central-1.amazonaws.com.evil.com/x.pem", False),  # suffix trick
+        ("https://notsns.amazonaws.com/x.pem", False),  # not an sns. host
+        ("", False),
+    ],
+)
+def test_is_trusted_sns_url(url, expected):
+    assert is_trusted_sns_url(url) is expected
+
+
+# ---------------------------------------------------------------------------
+# verify_sns_signature
+# ---------------------------------------------------------------------------
+
+
+def test_verify_signature_valid_roundtrip():
+    key, pem = _make_cert_and_key()
+    payload = _signed_payload(
+        key,
+        {
+            "Type": "Notification",
+            "MessageId": "m1",
+            "TopicArn": "arn:aws:sns:ca-central-1:1:ses",
+            "Message": _bounce_message("a@b.com"),
+            "Timestamp": "2026-06-15T00:00:00.000Z",
+        },
+    )
+    assert verify_sns_signature(payload, fetch=lambda _u: pem) is True
+
+
+def test_verify_signature_rejects_tampered_message():
+    key, pem = _make_cert_and_key()
+    payload = _signed_payload(
+        key,
+        {
+            "Type": "Notification",
+            "MessageId": "m1",
+            "TopicArn": "arn:aws:sns:ca-central-1:1:ses",
+            "Message": _bounce_message("a@b.com"),
+            "Timestamp": "2026-06-15T00:00:00.000Z",
+        },
+    )
+    payload["Message"] = _bounce_message("attacker@evil.com")  # tamper after signing
+    assert verify_sns_signature(payload, fetch=lambda _u: pem) is False
+
+
+def test_verify_signature_rejects_untrusted_cert_url():
+    key, pem = _make_cert_and_key()
+    payload = _signed_payload(
+        key,
+        {
+            "Type": "Notification",
+            "MessageId": "m1",
+            "TopicArn": "arn:aws:sns:ca-central-1:1:ses",
+            "Message": _bounce_message("a@b.com"),
+            "Timestamp": "2026-06-15T00:00:00.000Z",
+            "SigningCertURL": "https://evil.com/cert.pem",
+        },
+    )
+    # fetch must never be called for an untrusted URL
+    called = {"n": 0}
+
+    def _fetch(_u):
+        called["n"] += 1
+        return pem
+
+    assert verify_sns_signature(payload, fetch=_fetch) is False
+    assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/webhooks/ses
+# ---------------------------------------------------------------------------
+
+_SES_URL = "/api/v1/webhooks/ses"
+
+
+def test_webhook_rejects_invalid_signature(test_client: TestClient):
+    with patch("utils.sns_verify.verify_sns_signature", return_value=False):
+        r = test_client.post(_SES_URL, json={"Type": "Notification", "Message": "{}"})
+    assert r.status_code == 403
+
+
+def test_webhook_rejects_bad_json(test_client: TestClient):
+    r = test_client.post(_SES_URL, content=b"not json", headers={"content-type": "application/json"})
+    assert r.status_code == 400
+
+
+def test_webhook_confirms_subscription(test_client: TestClient):
+    confirm_client = MagicMock()
+    confirm_client.__aenter__ = AsyncMock(return_value=confirm_client)
+    confirm_client.__aexit__ = AsyncMock(return_value=False)
+    confirm_client.get = AsyncMock(return_value=MagicMock(status_code=200))
+
+    payload = {
+        "Type": "SubscriptionConfirmation",
+        "TopicArn": "arn:aws:sns:ca-central-1:1:ses",
+        "SubscribeURL": "https://sns.ca-central-1.amazonaws.com/?Action=ConfirmSubscription",
+    }
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("httpx.AsyncClient", return_value=confirm_client),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+
+    assert r.status_code == 200
+    assert r.json()["confirmed"] is True
+    confirm_client.get.assert_awaited_once()
+
+
+def test_webhook_hard_bounce_suppresses(test_client: TestClient):
+    inserts: list = []
+    payload = {"Type": "Notification", "Message": _bounce_message("Bad@Example.com")}
+
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+
+    assert r.status_code == 200
+    assert r.json()["suppressed"] == 1
+    assert inserts and inserts[0][0] == "email_suppressions"
+    row = inserts[0][1]
+    assert row["email"] == "bad@example.com"  # normalized
+    assert row["reason"] == "bounce"
+    assert row["message_id"] == "ses-msg-1"
+
+
+def test_webhook_complaint_suppresses(test_client: TestClient):
+    inserts: list = []
+    payload = {"Type": "Notification", "Message": _complaint_message("c@example.com")}
+
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+
+    assert r.status_code == 200
+    assert r.json()["suppressed"] == 1
+    assert inserts[0][1]["reason"] == "complaint"
+
+
+def test_webhook_idempotent_when_already_suppressed(test_client: TestClient):
+    inserts: list = []
+    payload = {"Type": "Notification", "Message": _bounce_message("dup@example.com")}
+
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("db_supabase.find_one", AsyncMock(return_value={"email": "dup@example.com"})),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+
+    assert r.status_code == 200
+    assert inserts == []  # no duplicate insert
+
+
+def test_webhook_transient_bounce_not_suppressed(test_client: TestClient):
+    inserts: list = []
+    payload = {"Type": "Notification", "Message": _bounce_message("t@example.com", bounce_type="Transient")}
+
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=lambda t, d: inserts.append((t, d)))),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+
+    assert r.status_code == 200
+    assert r.json()["suppressed"] == 0
+    assert inserts == []

--- a/backend/tests/test_ses_webhook.py
+++ b/backend/tests/test_ses_webhook.py
@@ -24,6 +24,11 @@ from cryptography.x509.oid import NameOID
 from fastapi.testclient import TestClient
 
 try:
+    from utils.error_handling import DatabaseError, DuplicateRecordError
+except ImportError:
+    from backend.utils.error_handling import DatabaseError, DuplicateRecordError  # type: ignore[no-redef]
+
+try:
     from utils.sns_verify import _fetch_cert, _string_to_sign, is_trusted_sns_url, verify_sns_signature
 except ImportError:
     from backend.utils.sns_verify import (  # type: ignore[no-redef]
@@ -307,3 +312,58 @@ def test_webhook_transient_bounce_not_suppressed(test_client: TestClient):
     assert r.status_code == 200
     assert r.json()["suppressed"] == 0
     assert inserts == []
+
+
+def test_webhook_rejects_unexpected_topic(test_client: TestClient):
+    payload = {
+        "Type": "Notification",
+        "TopicArn": "arn:aws:sns:ca-central-1:1:ATTACKER",
+        "Message": _bounce_message("x@example.com"),
+    }
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("routes.webhooks.get_app_settings", AsyncMock(return_value={"aws_ses_sns_topic_arn": "arn:expected"})),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+    assert r.status_code == 403
+
+
+def test_webhook_accepts_matching_topic(test_client: TestClient):
+    payload = {
+        "Type": "Notification",
+        "TopicArn": "arn:expected",
+        "Message": _bounce_message("ok@example.com"),
+    }
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("routes.webhooks.get_app_settings", AsyncMock(return_value={"aws_ses_sns_topic_arn": "arn:expected"})),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(return_value=None)),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+    assert r.status_code == 200
+    assert r.json()["suppressed"] == 1
+
+
+def test_webhook_duplicate_insert_race_is_ok(test_client: TestClient):
+    payload = {"Type": "Notification", "Message": _bounce_message("race@example.com")}
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("db_supabase.insert_one", AsyncMock(side_effect=DuplicateRecordError())),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+    # Lost the insert race to a concurrent redelivery → still a success.
+    assert r.status_code == 200
+    assert r.json()["suppressed"] == 1
+
+
+def test_webhook_db_error_returns_503(test_client: TestClient):
+    payload = {"Type": "Notification", "Message": _bounce_message("err@example.com")}
+    with (
+        patch("utils.sns_verify.verify_sns_signature", return_value=True),
+        patch("db_supabase.find_one", AsyncMock(side_effect=DatabaseError(details={"original": "boom"}))),
+    ):
+        r = test_client.post(_SES_URL, json=payload)
+    # DB unavailable → 503 so SNS retries rather than dropping the bounce.
+    assert r.status_code == 503

--- a/backend/tests/test_ses_webhook.py
+++ b/backend/tests/test_ses_webhook.py
@@ -24,9 +24,10 @@ from cryptography.x509.oid import NameOID
 from fastapi.testclient import TestClient
 
 try:
-    from utils.sns_verify import _string_to_sign, is_trusted_sns_url, verify_sns_signature
+    from utils.sns_verify import _fetch_cert, _string_to_sign, is_trusted_sns_url, verify_sns_signature
 except ImportError:
     from backend.utils.sns_verify import (  # type: ignore[no-redef]
+        _fetch_cert,
         _string_to_sign,
         is_trusted_sns_url,
         verify_sns_signature,
@@ -171,6 +172,34 @@ def test_verify_signature_rejects_untrusted_cert_url():
 
     assert verify_sns_signature(payload, fetch=_fetch) is False
     assert called["n"] == 0
+
+
+def test_verify_signature_accepts_lowercase_cert_url_key():
+    key, pem = _make_cert_and_key()
+    payload = {
+        "Type": "Notification",
+        "MessageId": "m1",
+        "TopicArn": "arn:aws:sns:ca-central-1:1:ses",
+        "Message": _bounce_message("a@b.com"),
+        "Timestamp": "2026-06-15T00:00:00.000Z",
+        "SigningCertUrl": _CERT_URL,  # non-canonical lowercase-url key
+        "SignatureVersion": "1",
+    }
+    sig = key.sign(_string_to_sign(payload), padding.PKCS1v15(), hashes.SHA1())
+    payload["Signature"] = base64.b64encode(sig).decode()
+    assert verify_sns_signature(payload, fetch=lambda _u: pem) is True
+
+
+def test_fetch_cert_is_cached():
+    _fetch_cert.cache_clear()
+    url = "https://sns.ca-central-1.amazonaws.com/unique-cache-test.pem"
+    resp = MagicMock(content=b"PEMDATA")
+    with patch("httpx.get", return_value=resp) as mock_get:
+        a = _fetch_cert(url)
+        b = _fetch_cert(url)
+    assert a == b == b"PEMDATA"
+    mock_get.assert_called_once()  # second call served from cache
+    _fetch_cert.cache_clear()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/utils/email_provider.py
+++ b/backend/utils/email_provider.py
@@ -126,16 +126,17 @@ async def _try_ses(
     text: Optional[str],
     default_from: str,
     log_id: str,
-) -> bool:
-    """Attempt delivery via AWS SES. Returns True on success.
+) -> Optional[str]:
+    """Attempt delivery via AWS SES.
 
-    Returns False when SES is unconfigured (so the caller falls through to the
-    Resend guardrail) and also on a runtime failure (already logged here).
+    Returns the SES MessageId (possibly "") on success, or None when SES is
+    unconfigured (so the caller falls through to the Resend guardrail) or a
+    runtime failure occurs (already logged here).
     """
     access_key_id = (settings.get("aws_ses_access_key_id") or "").strip()
     secret_access_key = (settings.get("aws_ses_secret_access_key") or "").strip()
     if not access_key_id or not secret_access_key:
-        return False  # unconfigured — fall through to Resend
+        return None  # unconfigured — fall through to Resend
 
     region = (settings.get("aws_ses_region") or "").strip() or _DEFAULT_SES_REGION
     from_email = (settings.get("aws_ses_from_email") or "").strip() or default_from
@@ -159,7 +160,7 @@ async def _try_ses(
             subject,
             message_id,
         )
-        return True
+        return message_id or ""
     except Exception:
         # Do not swallow — SES failures must surface so the root cause is
         # fixed. We log .error and let the Resend guardrail take over.
@@ -169,7 +170,7 @@ async def _try_ses(
             subject,
             exc_info=True,
         )
-        return False
+        return None
 
 
 async def _try_resend(
@@ -181,11 +182,15 @@ async def _try_resend(
     text: Optional[str],
     default_from: str,
     log_id: str,
-) -> bool:
-    """Attempt delivery via Resend (the guardrail). Returns True on 2xx."""
+) -> Optional[str]:
+    """Attempt delivery via Resend (the guardrail).
+
+    Returns the Resend message id (possibly "") on a 2xx, or None when Resend
+    is unconfigured or the call fails (already logged here).
+    """
     resend_key = (settings.get("resend_api_key") or "").strip()
     if not resend_key:
-        return False  # unconfigured
+        return None  # unconfigured
 
     from_email = (settings.get("resend_from_email") or "").strip() or default_from
     payload: Dict[str, Any] = {
@@ -218,15 +223,18 @@ async def _try_resend(
                 subject,
                 response.status_code,
             )
-        else:
-            logger.error(
-                "[EMAIL] Resend (guardrail) returned %s log_id=%s subject=%r body=%s",
-                response.status_code,
-                log_id,
-                subject,
-                response.text[:200],
-            )
-        return ok
+            try:
+                return (response.json() or {}).get("id", "") or ""
+            except Exception:
+                return ""
+        logger.error(
+            "[EMAIL] Resend (guardrail) returned %s log_id=%s subject=%r body=%s",
+            response.status_code,
+            log_id,
+            subject,
+            response.text[:200],
+        )
+        return None
     except Exception:
         logger.error(
             "[EMAIL] Resend (guardrail) send failed log_id=%s subject=%r",
@@ -234,7 +242,68 @@ async def _try_resend(
             subject,
             exc_info=True,
         )
+        return None
+
+
+def normalize_email(email: str) -> str:
+    """Canonical form for suppression-list comparison: trimmed + lowercased.
+
+    Used by both the sender (before a suppression check) and the SES webhook
+    (before writing a suppression) so the two always agree.
+    """
+    return (email or "").strip().lower()
+
+
+async def _is_suppressed(email: str) -> bool:
+    """True if the address is on the suppression list (hard bounce/complaint).
+
+    Fail-open: if the suppression lookup itself errors we log .error and return
+    False (send anyway). Blocking a receipt on a transient DB hiccup is worse
+    than the rare extra send to a freshly-suppressed address — the SES
+    account-level suppression list is the backstop for that.
+    """
+    try:
+        try:
+            from .. import db_supabase
+        except ImportError:
+            import db_supabase  # type: ignore
+        row = await db_supabase.find_one("email_suppressions", {"email": normalize_email(email)})
+        return row is not None
+    except Exception:
+        logger.error("[EMAIL] suppression lookup failed — sending anyway", exc_info=True)
         return False
+
+
+async def _log_send(
+    *,
+    provider: str,
+    message_id: Optional[str],
+    status: str,
+    email_type: Optional[str],
+    recipient_user_id: Optional[str],
+) -> None:
+    """Best-effort append to email_send_log. Never raises (observability only).
+
+    PIPEDA: stores recipient_user_id, never the email address.
+    """
+    try:
+        try:
+            from .. import db_supabase
+        except ImportError:
+            import db_supabase  # type: ignore
+        await db_supabase.insert_one(
+            "email_send_log",
+            {
+                "provider": provider,
+                "message_id": message_id or None,
+                "status": status,
+                "email_type": email_type,
+                "recipient_user_id": recipient_user_id,
+            },
+        )
+    except Exception:
+        # A logging failure must never break email delivery.
+        logger.error("[EMAIL] email_send_log write failed status=%s provider=%s", status, provider, exc_info=True)
 
 
 async def send_transactional_email(
@@ -245,8 +314,13 @@ async def send_transactional_email(
     text: Optional[str] = None,
     default_from: str = _DEFAULT_FROM,
     log_id: str = "-",
+    email_type: Optional[str] = "transactional",
+    recipient_user_id: Optional[str] = None,
 ) -> bool:
     """Send one transactional email: AWS SES primary, Resend guardrail.
+
+    Skips addresses on the suppression list (hard bounce/complaint) and records
+    every attempt in email_send_log.
 
     Args:
         to: Recipient address (single recipient).
@@ -257,6 +331,8 @@ async def send_transactional_email(
             configured (each provider prefers its own configured sender).
         log_id: PII-safe identifier (rider_id, "safety", …) for log correlation.
             The recipient address is never logged.
+        email_type: Category recorded in email_send_log (receipt, dsar, …).
+        recipient_user_id: PIPEDA-safe user id recorded in email_send_log.
 
     Returns:
         True if either provider accepted the message, False otherwise.
@@ -268,10 +344,22 @@ async def send_transactional_email(
         logger.error("[EMAIL] send skipped log_id=%s — empty body", log_id)
         return False
 
+    # Suppression gate — never send to a hard-bounced / complained address.
+    if await _is_suppressed(to):
+        logger.warning("[EMAIL] suppressed recipient log_id=%s subject=%r — not sent", log_id, subject)
+        await _log_send(
+            provider="none",
+            message_id=None,
+            status="suppressed",
+            email_type=email_type,
+            recipient_user_id=recipient_user_id,
+        )
+        return False
+
     settings = await _load_settings()
 
     # 1. Primary: AWS SES.
-    if await _try_ses(
+    ses_id = await _try_ses(
         settings,
         to=to,
         subject=subject,
@@ -279,11 +367,19 @@ async def send_transactional_email(
         text=text,
         default_from=default_from,
         log_id=log_id,
-    ):
+    )
+    if ses_id is not None:
+        await _log_send(
+            provider="ses",
+            message_id=ses_id,
+            status="sent",
+            email_type=email_type,
+            recipient_user_id=recipient_user_id,
+        )
         return True
 
     # 2. Guardrail: Resend (fires when SES unconfigured OR SES failed).
-    if await _try_resend(
+    resend_id = await _try_resend(
         settings,
         to=to,
         subject=subject,
@@ -291,7 +387,15 @@ async def send_transactional_email(
         text=text,
         default_from=default_from,
         log_id=log_id,
-    ):
+    )
+    if resend_id is not None:
+        await _log_send(
+            provider="resend",
+            message_id=resend_id,
+            status="sent",
+            email_type=email_type,
+            recipient_user_id=recipient_user_id,
+        )
         return True
 
     # 3. Neither provider sent it.
@@ -299,5 +403,12 @@ async def send_transactional_email(
         "[EMAIL] no provider configured/succeeded log_id=%s subject=%r — not sent",
         log_id,
         subject,
+    )
+    await _log_send(
+        provider="none",
+        message_id=None,
+        status="failed",
+        email_type=email_type,
+        recipient_user_id=recipient_user_id,
     )
     return False

--- a/backend/utils/email_provider.py
+++ b/backend/utils/email_provider.py
@@ -227,12 +227,13 @@ async def _try_resend(
                 return (response.json() or {}).get("id", "") or ""
             except Exception:
                 return ""
+        # PIPEDA: never log response.text — Resend's 4xx validation errors echo
+        # the recipient address back in the body. Status code is enough to act.
         logger.error(
-            "[EMAIL] Resend (guardrail) returned %s log_id=%s subject=%r body=%s",
+            "[EMAIL] Resend (guardrail) returned %s log_id=%s subject=%r",
             response.status_code,
             log_id,
             subject,
-            response.text[:200],
         )
         return None
     except Exception:

--- a/backend/utils/email_provider.py
+++ b/backend/utils/email_provider.py
@@ -1,0 +1,278 @@
+"""
+Unified transactional-email sender for Spinr.
+
+Provider strategy
+-----------------
+AWS SES is the PRIMARY provider (materially cheaper at our volume). Resend is
+the GUARDRAIL fallback. The decision tree for every send is:
+
+    1. If SES is configured (access key id + secret + from address) → try SES.
+       • SES accepted (no exception)         → return True.
+       • SES raised                          → log .error and fall through.
+    2. If SES is unconfigured OR SES failed → try Resend (if configured).
+       • Resend 2xx                          → return True.
+       • Resend non-2xx / raised             → log .error and fall through.
+    3. Neither provider sent it              → log and return False.
+
+This means an SES outage or mis-configuration never silently drops a receipt:
+Resend catches it. When neither is configured (dev/test) we log-only, matching
+the previous behaviour of the per-call-site Resend implementations.
+
+PIPEDA: recipient email addresses are never written to logs at error/info
+level here — callers pass an already-redacted ``log_id`` (rider_id, "safety",
+etc.) for log correlation. Subjects are logged but receipt subjects only
+contain a dollar amount, no PII.
+
+boto3 is synchronous, so the SES call runs in a worker thread via
+``asyncio.to_thread`` to avoid blocking the event loop.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default SES region — Canada, for PIPEDA data-residency alignment. Overridden
+# by the aws_ses_region setting when present.
+_DEFAULT_SES_REGION = "ca-central-1"
+# Last-resort sender when neither provider has a configured from-address.
+_DEFAULT_FROM = "noreply@spinr.ca"
+
+
+async def _load_settings() -> Dict[str, Any]:
+    try:
+        from ..settings_loader import get_app_settings
+    except ImportError:
+        from settings_loader import get_app_settings  # type: ignore
+    return await get_app_settings()
+
+
+def _send_ses_sync(
+    *,
+    region: str,
+    access_key_id: str,
+    secret_access_key: str,
+    source: str,
+    to: str,
+    subject: str,
+    html: Optional[str],
+    text: Optional[str],
+) -> str:
+    """Blocking SES SendEmail. Returns the SES MessageId. Raises on failure.
+
+    Runs inside asyncio.to_thread — keep it free of awaitables.
+    """
+    import boto3
+
+    client = boto3.client(
+        "ses",
+        region_name=region,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
+
+    body: Dict[str, Any] = {}
+    if html:
+        body["Html"] = {"Data": html, "Charset": "UTF-8"}
+    if text:
+        body["Text"] = {"Data": text, "Charset": "UTF-8"}
+    if not body:
+        # SES rejects an empty body; guard so we surface a clear error.
+        raise ValueError("send_transactional_email requires html or text")
+
+    resp = client.send_email(
+        Source=source,
+        Destination={"ToAddresses": [to]},
+        Message={
+            "Subject": {"Data": subject, "Charset": "UTF-8"},
+            "Body": body,
+        },
+    )
+    return resp.get("MessageId", "")
+
+
+async def _try_ses(
+    settings: Dict[str, Any],
+    *,
+    to: str,
+    subject: str,
+    html: Optional[str],
+    text: Optional[str],
+    default_from: str,
+    log_id: str,
+) -> bool:
+    """Attempt delivery via AWS SES. Returns True on success.
+
+    Returns False when SES is unconfigured (so the caller falls through to the
+    Resend guardrail) and also on a runtime failure (already logged here).
+    """
+    access_key_id = (settings.get("aws_ses_access_key_id") or "").strip()
+    secret_access_key = (settings.get("aws_ses_secret_access_key") or "").strip()
+    if not access_key_id or not secret_access_key:
+        return False  # unconfigured — fall through to Resend
+
+    region = (settings.get("aws_ses_region") or "").strip() or _DEFAULT_SES_REGION
+    from_email = (settings.get("aws_ses_from_email") or "").strip() or default_from
+    source = f"Spinr <{from_email}>"
+
+    try:
+        message_id = await asyncio.to_thread(
+            _send_ses_sync,
+            region=region,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            source=source,
+            to=to,
+            subject=subject,
+            html=html,
+            text=text,
+        )
+        logger.info(
+            "[EMAIL] SES sent log_id=%s subject=%r message_id=%s",
+            log_id,
+            subject,
+            message_id,
+        )
+        return True
+    except Exception:
+        # Do not swallow — SES failures must surface so the root cause is
+        # fixed. We log .error and let the Resend guardrail take over.
+        logger.error(
+            "[EMAIL] SES send failed log_id=%s subject=%r — falling back to Resend",
+            log_id,
+            subject,
+            exc_info=True,
+        )
+        return False
+
+
+async def _try_resend(
+    settings: Dict[str, Any],
+    *,
+    to: str,
+    subject: str,
+    html: Optional[str],
+    text: Optional[str],
+    default_from: str,
+    log_id: str,
+) -> bool:
+    """Attempt delivery via Resend (the guardrail). Returns True on 2xx."""
+    resend_key = (settings.get("resend_api_key") or "").strip()
+    if not resend_key:
+        return False  # unconfigured
+
+    from_email = (settings.get("resend_from_email") or "").strip() or default_from
+    payload: Dict[str, Any] = {
+        "from": f"Spinr <{from_email}>",
+        "to": [to],
+        "subject": subject,
+    }
+    if html:
+        payload["html"] = html
+    if text:
+        payload["text"] = text
+
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                "https://api.resend.com/emails",
+                headers={
+                    "Authorization": f"Bearer {resend_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+        ok = response.status_code in (200, 201, 202)
+        if ok:
+            logger.info(
+                "[EMAIL] Resend (guardrail) sent log_id=%s subject=%r status=%s",
+                log_id,
+                subject,
+                response.status_code,
+            )
+        else:
+            logger.error(
+                "[EMAIL] Resend (guardrail) returned %s log_id=%s subject=%r body=%s",
+                response.status_code,
+                log_id,
+                subject,
+                response.text[:200],
+            )
+        return ok
+    except Exception:
+        logger.error(
+            "[EMAIL] Resend (guardrail) send failed log_id=%s subject=%r",
+            log_id,
+            subject,
+            exc_info=True,
+        )
+        return False
+
+
+async def send_transactional_email(
+    *,
+    to: str,
+    subject: str,
+    html: Optional[str] = None,
+    text: Optional[str] = None,
+    default_from: str = _DEFAULT_FROM,
+    log_id: str = "-",
+) -> bool:
+    """Send one transactional email: AWS SES primary, Resend guardrail.
+
+    Args:
+        to: Recipient address (single recipient).
+        subject: Email subject. For receipts this is only a dollar amount — no PII.
+        html: HTML body (optional).
+        text: Plain-text body (optional). At least one of html/text is required.
+        default_from: Sender used when the chosen provider has no from-address
+            configured (each provider prefers its own configured sender).
+        log_id: PII-safe identifier (rider_id, "safety", …) for log correlation.
+            The recipient address is never logged.
+
+    Returns:
+        True if either provider accepted the message, False otherwise.
+    """
+    if not to:
+        logger.warning("[EMAIL] send skipped log_id=%s — no recipient", log_id)
+        return False
+    if not html and not text:
+        logger.error("[EMAIL] send skipped log_id=%s — empty body", log_id)
+        return False
+
+    settings = await _load_settings()
+
+    # 1. Primary: AWS SES.
+    if await _try_ses(
+        settings,
+        to=to,
+        subject=subject,
+        html=html,
+        text=text,
+        default_from=default_from,
+        log_id=log_id,
+    ):
+        return True
+
+    # 2. Guardrail: Resend (fires when SES unconfigured OR SES failed).
+    if await _try_resend(
+        settings,
+        to=to,
+        subject=subject,
+        html=html,
+        text=text,
+        default_from=default_from,
+        log_id=log_id,
+    ):
+        return True
+
+    # 3. Neither provider sent it.
+    logger.warning(
+        "[EMAIL] no provider configured/succeeded log_id=%s subject=%r — not sent",
+        log_id,
+        subject,
+    )
+    return False

--- a/backend/utils/email_provider.py
+++ b/backend/utils/email_provider.py
@@ -59,11 +59,23 @@ def _send_ses_sync(
     html: Optional[str],
     text: Optional[str],
 ) -> str:
-    """Blocking SES SendEmail. Returns the SES MessageId. Raises on failure.
+    """Blocking SES SendRawEmail. Returns the SES MessageId. Raises on failure.
+
+    Uses SendRawEmail (not SendEmail) so the integration works with the
+    common ``AmazonSesSendingAccess`` IAM policy, which grants only
+    ``ses:SendRawEmail``. We build a MIME message ourselves: a
+    multipart/alternative when both text and html are supplied, otherwise a
+    single text or html part.
 
     Runs inside asyncio.to_thread — keep it free of awaitables.
     """
     import boto3
+
+    if not html and not text:
+        # SES rejects an empty body; guard so we surface a clear error.
+        raise ValueError("send_transactional_email requires html or text")
+
+    message = _build_mime(source=source, to=to, subject=subject, html=html, text=text)
 
     client = boto3.client(
         "ses",
@@ -72,24 +84,37 @@ def _send_ses_sync(
         aws_secret_access_key=secret_access_key,
     )
 
-    body: Dict[str, Any] = {}
-    if html:
-        body["Html"] = {"Data": html, "Charset": "UTF-8"}
-    if text:
-        body["Text"] = {"Data": text, "Charset": "UTF-8"}
-    if not body:
-        # SES rejects an empty body; guard so we surface a clear error.
-        raise ValueError("send_transactional_email requires html or text")
-
-    resp = client.send_email(
+    resp = client.send_raw_email(
         Source=source,
-        Destination={"ToAddresses": [to]},
-        Message={
-            "Subject": {"Data": subject, "Charset": "UTF-8"},
-            "Body": body,
-        },
+        Destinations=[to],
+        RawMessage={"Data": message.as_string()},
     )
     return resp.get("MessageId", "")
+
+
+def _build_mime(*, source: str, to: str, subject: str, html: Optional[str], text: Optional[str]):
+    """Build the MIME message SES SendRawEmail expects.
+
+    multipart/alternative with both parts when text+html are present (clients
+    prefer html, fall back to text); a single MIMEText otherwise.
+    """
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+
+    if html and text:
+        msg = MIMEMultipart("alternative")
+        # Plain part first — RFC 2046 says the most-preferred alternative goes last.
+        msg.attach(MIMEText(text, "plain", "utf-8"))
+        msg.attach(MIMEText(html, "html", "utf-8"))
+    elif html:
+        msg = MIMEText(html, "html", "utf-8")
+    else:
+        msg = MIMEText(text or "", "plain", "utf-8")
+
+    msg["Subject"] = subject
+    msg["From"] = source
+    msg["To"] = to
+    return msg
 
 
 async def _try_ses(

--- a/backend/utils/email_receipt.py
+++ b/backend/utils/email_receipt.py
@@ -1,6 +1,7 @@
 """
 Receipt generator for Spinr rides.
-Generates HTML receipt and sends via email (Resend when configured, logs otherwise).
+Generates HTML receipt and sends via email through utils.email_provider
+(AWS SES primary, Resend guardrail; logs only when neither is configured).
 
 Line items
 ----------
@@ -29,10 +30,8 @@ from typing import Any, Dict
 
 try:
     from .datetime_utils import parse_iso_utc
-    from .pii import redact_email
 except ImportError:
     from utils.datetime_utils import parse_iso_utc
-    from utils.pii import redact_email
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +297,12 @@ def _receipt_total(ride: dict, tip: float = 0) -> Decimal:
 
 
 async def send_receipt_email(ride: dict, rider: dict, driver: dict = None, tip: float = 0):
-    """Send receipt email. Uses Resend when configured, logs otherwise."""
+    """Send an HTML receipt email: AWS SES primary, Resend guardrail.
+
+    Delegates to utils.email_provider.send_transactional_email, which tries
+    AWS SES first and falls back to Resend when SES is unconfigured or fails.
+    Returns True if either provider accepted the message, False otherwise.
+    """
     email = rider.get("email", "")
     if not email:
         logger.warning(f"No email for rider {rider.get('id')} — skipping receipt")
@@ -307,34 +311,15 @@ async def send_receipt_email(ride: dict, rider: dict, driver: dict = None, tip: 
     html = generate_receipt_html(ride, rider, driver, tip)
     total = _receipt_total(ride, tip)
 
-    # Try Resend
     try:
-        from ..settings_loader import get_app_settings
-
-        settings = await get_app_settings()
-        resend_key = settings.get("resend_api_key", "")
-        from_email = settings.get("resend_from_email") or "receipts@spinr.ca"
-
-        if resend_key:
-            import httpx
-
-            response = await httpx.AsyncClient().post(
-                "https://api.resend.com/emails",
-                headers={"Authorization": f"Bearer {resend_key}", "Content-Type": "application/json"},
-                json={
-                    "from": f"Spinr <{from_email}>",
-                    "to": [email],
-                    "subject": f"Your Spinr ride receipt — ${total:.2f}",
-                    "html": html,
-                },
-            )
-            logger.info(f"[EMAIL] Resend receipt sent to {redact_email(email)} (status: {response.status_code})")
-            return response.status_code in (200, 201, 202)
+        from .email_provider import send_transactional_email
     except ImportError:
-        pass
-    except Exception as e:
-        logger.warning(f"[EMAIL] Resend failed: {e}")
+        from utils.email_provider import send_transactional_email  # type: ignore
 
-    # Fallback: log only (PII-safe: email + total amount redacted)
-    logger.info(f"[EMAIL] Receipt for ride {ride.get('id')} → {redact_email(email)} (Resend not configured)")
-    return False
+    return await send_transactional_email(
+        to=email,
+        subject=f"Your Spinr ride receipt — ${total:.2f}",
+        html=html,
+        default_from="receipts@spinr.ca",
+        log_id=str(rider.get("id") or ride.get("rider_id") or "-"),
+    )

--- a/backend/utils/email_receipt.py
+++ b/backend/utils/email_receipt.py
@@ -316,10 +316,13 @@ async def send_receipt_email(ride: dict, rider: dict, driver: dict = None, tip: 
     except ImportError:
         from utils.email_provider import send_transactional_email  # type: ignore
 
+    recipient_user_id = rider.get("id") or ride.get("rider_id")
     return await send_transactional_email(
         to=email,
         subject=f"Your Spinr ride receipt — ${total:.2f}",
         html=html,
         default_from="receipts@spinr.ca",
-        log_id=str(rider.get("id") or ride.get("rider_id") or "-"),
+        log_id=str(recipient_user_id or "-"),
+        email_type="receipt",
+        recipient_user_id=str(recipient_user_id) if recipient_user_id else None,
     )

--- a/backend/utils/receipt_email.py
+++ b/backend/utils/receipt_email.py
@@ -139,6 +139,8 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
             text=plain_body,
             default_from="receipts@spinr.ca",
             log_id=str(rider_id),
+            email_type="receipt",
+            recipient_user_id=str(rider_id) if rider_id and rider_id != "unknown" else None,
         )
 
         if sent:

--- a/backend/utils/receipt_email.py
+++ b/backend/utils/receipt_email.py
@@ -1,9 +1,10 @@
 """
 Send ride receipt emails with Canadian GST/PST tax line items.
 
-Uses the Resend REST API via httpx (same pattern as features.send_email and
-utils.email_receipt.send_receipt_email). Settings are loaded from the
-app_settings Supabase table via settings_loader.get_app_settings().
+Delivery goes through utils.email_provider.send_transactional_email, which
+sends via AWS SES (primary) and falls back to Resend (guardrail) when SES is
+unconfigured or fails. Provider credentials live in the app_settings Supabase
+table (loaded via settings_loader.get_app_settings()).
 
 PIPEDA: rider email address is never written to logs. Use rider_id only.
 """
@@ -120,22 +121,6 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
         return
 
     try:
-        try:
-            from ..settings_loader import get_app_settings
-        except ImportError:
-            from settings_loader import get_app_settings
-
-        settings = await get_app_settings()
-        resend_key = settings.get("resend_api_key", "")
-        from_email = settings.get("resend_from_email") or settings.get("email_from") or "receipts@spinr.ca"
-
-        if not resend_key:
-            logger.warning(
-                "[receipt_email] resend_api_key not configured — receipt not sent for rider %s",
-                rider_id,
-            )
-            return
-
         plain_body = _build_plain_text(ride, rider)
         subtotal = _d(ride.get("total_fare"))
         gst = (subtotal * _GST_RATE).quantize(_CENT, rounding=ROUND_HALF_UP)
@@ -143,24 +128,20 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
         grand_total = _d(ride.get("grand_total")) if ride.get("grand_total") is not None else subtotal + gst + pst
         subject = f"Your Spinr ride receipt — {_fmt(grand_total)} CAD"
 
-        import httpx
+        try:
+            from .email_provider import send_transactional_email
+        except ImportError:
+            from utils.email_provider import send_transactional_email  # type: ignore
 
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(
-                "https://api.resend.com/emails",
-                headers={
-                    "Authorization": f"Bearer {resend_key}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "from": f"Spinr <{from_email}>",
-                    "to": [email],
-                    "subject": subject,
-                    "text": plain_body,
-                },
-            )
+        sent = await send_transactional_email(
+            to=email,
+            subject=subject,
+            text=plain_body,
+            default_from="receipts@spinr.ca",
+            log_id=str(rider_id),
+        )
 
-        if response.status_code in (200, 201, 202):
+        if sent:
             logger.info(
                 "[receipt_email] Receipt sent successfully for rider %s (ride %s)",
                 rider_id,
@@ -168,10 +149,9 @@ async def send_ride_receipt_email(ride: dict, rider: dict) -> None:
             )
         else:
             logger.error(
-                "[receipt_email] Resend returned %s for rider %s — body: %s",
-                response.status_code,
+                "[receipt_email] No email provider sent receipt for rider %s (ride %s)",
                 rider_id,
-                response.text[:200],
+                ride.get("id"),
             )
 
     except Exception:

--- a/backend/utils/sns_verify.py
+++ b/backend/utils/sns_verify.py
@@ -12,10 +12,25 @@ addresses (a denial-of-email attack) or forge confirmations.
 """
 
 import base64
+import functools
 import logging
 from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=16)
+def _fetch_cert(cert_url: str) -> bytes:
+    """Fetch (and cache) the SNS signing certificate PEM.
+
+    AWS reuses the same per-region SigningCertURL for weeks, so caching turns
+    a burst of bounce notifications into a single outbound fetch instead of one
+    per message. Caller must have already host-validated ``cert_url``.
+    """
+    import httpx
+
+    return httpx.get(cert_url, timeout=5.0).content
+
 
 # Fields included in the SNS signature, in this order, keyed by message Type.
 # (See "Verifying the signatures of Amazon SNS messages" in the AWS docs.)
@@ -81,7 +96,12 @@ def verify_sns_signature(payload: dict, *, fetch=None) -> bool:
             the (host-validated) SigningCertURL.
     """
     try:
-        cert_url = payload.get("SigningCertURL") or payload.get("SigningCertUrl") or ""
+        cert_url = payload.get("SigningCertURL") or ""
+        if not cert_url and payload.get("SigningCertUrl"):
+            # AWS's canonical field is SigningCertURL; accept the lowercase-url
+            # variant defensively but surface it so a malformed payload is visible.
+            logger.warning("[SNS] payload used non-canonical SigningCertUrl key")
+            cert_url = payload.get("SigningCertUrl") or ""
         if not is_trusted_sns_url(cert_url):
             logger.error("[SNS] untrusted SigningCertURL host — rejecting message")
             return False
@@ -90,12 +110,7 @@ def verify_sns_signature(payload: dict, *, fetch=None) -> bool:
         message = _string_to_sign(payload)
         version = str(payload.get("SignatureVersion", "1"))
 
-        if fetch is None:
-            import httpx
-
-            pem = httpx.get(cert_url, timeout=5.0).content
-        else:
-            pem = fetch(cert_url)
+        pem = _fetch_cert(cert_url) if fetch is None else fetch(cert_url)
 
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.asymmetric import padding

--- a/backend/utils/sns_verify.py
+++ b/backend/utils/sns_verify.py
@@ -1,0 +1,112 @@
+"""Amazon SNS message signature verification.
+
+SNS delivers to our HTTPS webhook unauthenticated, so before acting on a
+message (confirming a subscription, or adding addresses to the email
+suppression list) we must prove it genuinely came from AWS. We verify the
+RSA signature against the X.509 certificate AWS publishes, *after* confirming
+the certificate URL is an `sns.<region>.amazonaws.com` HTTPS host (SSRF guard
+— never fetch an attacker-supplied URL).
+
+Without this, anyone who finds the webhook URL could suppress arbitrary
+addresses (a denial-of-email attack) or forge confirmations.
+"""
+
+import base64
+import logging
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# Fields included in the SNS signature, in this order, keyed by message Type.
+# (See "Verifying the signatures of Amazon SNS messages" in the AWS docs.)
+_SIGNED_KEYS = {
+    "Notification": ["Message", "MessageId", "Subject", "Timestamp", "TopicArn", "Type"],
+    "SubscriptionConfirmation": [
+        "Message",
+        "MessageId",
+        "SubscribeURL",
+        "Timestamp",
+        "Token",
+        "TopicArn",
+        "Type",
+    ],
+    "UnsubscribeConfirmation": [
+        "Message",
+        "MessageId",
+        "SubscribeURL",
+        "Timestamp",
+        "Token",
+        "TopicArn",
+        "Type",
+    ],
+}
+
+
+def is_trusted_sns_url(url: str) -> bool:
+    """True only for an https URL on an `sns.*.amazonaws.com` host.
+
+    Used to gate both the SigningCertURL fetch and the SubscribeURL confirm,
+    so we never issue a request to an attacker-controlled host.
+    """
+    try:
+        p = urlparse(url or "")
+    except Exception:
+        return False
+    host = (p.hostname or "").lower()
+    return p.scheme == "https" and host.startswith("sns.") and host.endswith(".amazonaws.com")
+
+
+def _string_to_sign(payload: dict) -> bytes:
+    keys = _SIGNED_KEYS.get(payload.get("Type", ""))
+    if not keys:
+        raise ValueError(f"Unsupported SNS Type: {payload.get('Type')!r}")
+    parts: list[str] = []
+    for k in keys:
+        if k == "Subject" and "Subject" not in payload:
+            continue  # Subject is optional — omit the pair entirely when absent
+        if k not in payload:
+            raise ValueError(f"SNS message missing signed field {k!r}")
+        parts.append(k)
+        parts.append(str(payload[k]))
+    return ("\n".join(parts) + "\n").encode("utf-8")
+
+
+def verify_sns_signature(payload: dict, *, fetch=None) -> bool:
+    """Return True iff ``payload`` carries a valid AWS SNS signature.
+
+    Args:
+        payload: the parsed SNS JSON body.
+        fetch: optional ``callable(url) -> pem_bytes`` for the signing
+            certificate, injected in tests. Defaults to an httpx GET against
+            the (host-validated) SigningCertURL.
+    """
+    try:
+        cert_url = payload.get("SigningCertURL") or payload.get("SigningCertUrl") or ""
+        if not is_trusted_sns_url(cert_url):
+            logger.error("[SNS] untrusted SigningCertURL host — rejecting message")
+            return False
+
+        signature = base64.b64decode(payload["Signature"])
+        message = _string_to_sign(payload)
+        version = str(payload.get("SignatureVersion", "1"))
+
+        if fetch is None:
+            import httpx
+
+            pem = httpx.get(cert_url, timeout=5.0).content
+        else:
+            pem = fetch(cert_url)
+
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import padding
+        from cryptography.x509 import load_pem_x509_certificate
+
+        cert = load_pem_x509_certificate(pem)
+        # SignatureVersion 1 uses SHA1withRSA, version 2 uses SHA256withRSA.
+        # SHA1 here is dictated by the SNS protocol, not a security choice.
+        algo = hashes.SHA256() if version == "2" else hashes.SHA1()  # noqa: S303
+        cert.public_key().verify(signature, message, padding.PKCS1v15(), algo)
+        return True
+    except Exception:
+        logger.error("[SNS] signature verification failed", exc_info=True)
+        return False


### PR DESCRIPTION
Introduce a unified transactional-email sender (utils/email_provider.py)
that sends via AWS SES (primary, cheaper) and falls back to Resend
(guardrail) when SES is unconfigured or a send fails, so a SES
outage/mis-config never silently drops a receipt.

- Migration 154 adds aws_ses_region / access_key_id / secret_access_key /
  from_email to settings (region defaults to ca-central-1 for PIPEDA data
  residency; from_email backfilled from resend_from_email).
- Admin settings model accepts the new fields; the SES secret is masked
  on GET like other credentials (access key id left visible, like the
  Twilio account SID).
- SES boto3 call runs in a worker thread; recipient addresses never logged
  (PII-safe log_id only).
- Tests cover SES-success / SES-failure-fallback / Resend-only /
  none-configured / empty-body paths.

https://claude.ai/code/session_01PyeXRZxbx5BiTWfATUfc9u

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
