### PR TITLE
Claude/rider card payment failure kqdoe0

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from decimal import Decimal
 from typing import Optional
 
 import bcrypt
@@ -136,6 +137,13 @@ class Settings(BaseSettings):
 
     # Fare cache TTL (PERF-001)
     FARE_CACHE_TTL_SECONDS: int = 300  # 5-minute cache per lat/lng grid cell
+
+    # Card pre-authorization buffer (PAY pre-auth). At booking we place a manual-
+    # capture hold of (estimated_fare + this buffer) on the rider's card/Apple Pay
+    # so a post-trip tip can be captured on the SAME PaymentIntent (one Stripe fee)
+    # and a dead card is caught BEFORE dispatch. Tunable via env without redeploy;
+    # money value so it is a Decimal, never a float. Applies to card source only.
+    RIDE_AUTH_BUFFER_CAD: Decimal = Decimal("10.00")
 
     # Public tracking page base URL — used when generating shareable trip links.
     # Customer links are clean: "{TRACKING_BASE_URL}/{token}". The tracking

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -205,6 +205,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to import pre-auth capture sweeper: {e}", exc_info=True)
 
+    # Driver claim reaper — releases drivers claimed by dispatch whose offer
+    # insert never landed (crash/restart), recovering orphaned is_available
+    # flags so supply isn't silently eroded. Every 60 seconds.
+    try:
+        from utils.driver_claim_reaper import driver_claim_reaper_loop
+
+        _spawn("driver_claim_reaper (60s)", driver_claim_reaper_loop)
+    except Exception as e:
+        logger.error(f"Failed to import driver claim reaper: {e}", exc_info=True)
+
     # Document expiry alerts — notifies drivers about expiring docs every 12h
     try:
         from utils.document_expiry import document_expiry_loop

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -196,6 +196,15 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to import payment retry service: {e}", exc_info=True)
 
+    # Pre-auth capture sweeper — captures booking-time card holds whose tip
+    # window has elapsed, so a hold never lapses uncaptured. Every 5 minutes.
+    try:
+        from utils.preauth_capture import preauth_capture_loop
+
+        _spawn("preauth_capture (5min)", preauth_capture_loop)
+    except Exception as e:
+        logger.error(f"Failed to import pre-auth capture sweeper: {e}", exc_info=True)
+
     # Document expiry alerts — notifies drivers about expiring docs every 12h
     try:
         from utils.document_expiry import document_expiry_loop

--- a/backend/dependencies/__init__.py
+++ b/backend/dependencies/__init__.py
@@ -292,7 +292,11 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(s
     except Exception as e:
         # Never log the signing secret, even partially — it's a credential.
         logger.error(f"JWT verification failed: {e}")
-        raise HTTPException(status_code=401, detail=f"Invalid token: {str(e)}") from e
+        # Static client message (C4): interpolating the PyJWT reason lets an
+        # attacker fingerprint which claim failed (alg/aud/exp/sig). The real
+        # cause is in the server log above; the client only learns the token is
+        # invalid — matching every other auth path.
+        raise HTTPException(status_code=401, detail="Invalid token") from e
 
     # Full admin verification (aud, JTI revocation, staff active/version/idle) is
     # delegated to _verify_admin_payload — the WS path calls the same function so

--- a/backend/migrations/156_ride_preauth_columns.sql
+++ b/backend/migrations/156_ride_preauth_columns.sql
@@ -1,0 +1,83 @@
+-- 156_ride_preauth_columns.sql
+--
+-- Buffered pre-authorization support for card-paid rides.
+--
+-- Spinr historically had NO pre-authorization: the card was charged (immediate
+-- off_session capture) only at trip completion, so a dead/declined card was
+-- never discovered until AFTER the driver had completed the trip — an unpaid
+-- ride the 0%-commission driver effectively eats. This migration adds the two
+-- columns the new flow needs to (a) hold an authorization at booking time for
+-- the estimated fare + a fixed buffer (RIDE_AUTH_BUFFER, $10), and (b) capture
+-- fare + tip in a SINGLE transaction once the tip window closes, avoiding the
+-- duplicate Stripe per-transaction fee on a separately-charged tip.
+--
+-- The held Stripe PaymentIntent id reuses the EXISTING rides.payment_intent_id
+-- column — a manual-capture PI created at authorization is the same PI that is
+-- later captured at settlement, so no new id column is needed. We add:
+--
+--   • authorized_amount  numeric(12,2) — the dollar amount actually HELD on the
+--     card (estimated fare + buffer, OR fare-only when the buffered auth was
+--     declined for insufficient funds and we fell back). Lets settlement know
+--     the ceiling it can capture without a second charge.
+--
+--   • auth_status text — lifecycle of the hold, one of:
+--       'authorized'       buffered hold placed (fare + buffer)
+--       'fare_only'        buffered hold declined; fell back to fare-only hold
+--       'captured'         hold captured at settlement (terminal)
+--       'released'         hold canceled (ride cancelled pre-trip / expired)
+--     NULL  → no pre-auth on this ride (wallet/corporate, or a scheduled ride
+--             not yet dispatched). Settlement falls back to the create-charge
+--             path for these, so the column is nullable and unconstrained-NULL.
+--
+-- Money columns are numeric(12,2) — never float — consistent with the rest of
+-- the rides fare columns; all writes go through the Decimal helpers in
+-- backend (_d/_round) before hitting this table.
+--
+-- Index: the tip-window sweeper (a replay-safe background loop) polls for rides
+-- still holding an uncaptured authorization past the tip window, i.e.
+-- WHERE auth_status IN ('authorized','fare_only'). A partial index on the open
+-- states keeps that scan cheap and excludes the terminal-state majority.
+--
+-- RLS: no new table — rides already has RLS enabled with its existing policies.
+-- Adding nullable columns inherits that policy set; no policy change needed.
+--
+-- Forward-compatible (rides is a HOT table — every dispatch, location, and
+-- settlement write touches it, so every step here avoids a long write-blocking
+-- lock):
+--   • ADD COLUMN ... (nullable, no default) is metadata-only, no table rewrite.
+--   • The CHECK constraint is added NOT VALID then VALIDATE'd separately, so the
+--     full-table validation runs under SHARE UPDATE EXCLUSIVE (concurrent writes
+--     keep flowing) instead of the ACCESS EXCLUSIVE a plain ADD CONSTRAINT takes.
+--   • The partial index is built CONCURRENTLY (no SHARE lock on rides). The
+--     runner (backend/scripts/migrate.py) detects "CONCURRENTLY" and applies the
+--     whole file in autocommit, executing each statement individually.
+-- New code writes the columns, old code ignores them, and existing rides keep
+-- NULL (no pre-auth) which the settlement path already handles.
+--
+-- Rollback:
+--   DROP INDEX CONCURRENTLY IF EXISTS public.idx_rides_open_authorization;
+--   ALTER TABLE public.rides DROP CONSTRAINT IF EXISTS rides_auth_status_check;
+--   ALTER TABLE public.rides DROP COLUMN IF EXISTS auth_status;
+--   ALTER TABLE public.rides DROP COLUMN IF EXISTS authorized_amount;
+
+ALTER TABLE public.rides
+    ADD COLUMN IF NOT EXISTS authorized_amount numeric(12, 2),
+    ADD COLUMN IF NOT EXISTS auth_status text;
+
+-- Guard the enum-ish domain at the DB layer so a bad write surfaces loudly
+-- instead of silently corrupting settlement logic. NULL is allowed (no pre-auth).
+-- NOT VALID skips the blocking validation scan at ADD time; VALIDATE then checks
+-- existing rows (all NULL today, so it passes) under a non-blocking lock.
+ALTER TABLE public.rides
+    DROP CONSTRAINT IF EXISTS rides_auth_status_check;
+ALTER TABLE public.rides
+    ADD CONSTRAINT rides_auth_status_check
+    CHECK (auth_status IS NULL OR auth_status IN ('authorized', 'fare_only', 'captured', 'released'))
+    NOT VALID;
+ALTER TABLE public.rides
+    VALIDATE CONSTRAINT rides_auth_status_check;
+
+-- Partial index for the tip-window capture sweeper: only the open holds.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rides_open_authorization
+    ON public.rides (auth_status)
+    WHERE auth_status IN ('authorized', 'fare_only');

--- a/backend/migrations/157_driver_availability_claimed_at.sql
+++ b/backend/migrations/157_driver_availability_claimed_at.sql
@@ -1,0 +1,44 @@
+-- 157_driver_availability_claimed_at.sql
+--
+-- Orphaned driver-claim recovery (C3).
+--
+-- Dispatch claims a driver by atomically flipping is_available=false
+-- (claim_driver_atomic) and only THEN inserts the ride_offers row + schedules
+-- the in-process offer-timeout task. If the process crashes/restarts in that
+-- window, the driver is left is_available=false with no offer row and no
+-- timeout handler — silently dropped from dispatch (is_available ⇒ is_online
+-- recovery contract violated, match-rate erodes with no obvious cause). The
+-- stuck-ride sweeper recovers the ride, not the orphaned driver flag.
+--
+-- This adds a DEDICATED claim timestamp so a reaper loop can release such
+-- orphans WITHOUT racing the sub-second claim→offer-insert window:
+--
+--   • availability_claimed_at timestamptz — set to now() by claim_driver_atomic
+--     when it claims a driver; cleared (NULL) by set_driver_available(True) on
+--     release. A reaper releases drivers that are is_online=true,
+--     is_available=false, claimed > N seconds ago, AND have no pending offer and
+--     no active ride. A dedicated column (NOT updated_at) is used precisely
+--     because heartbeats/location writes bump updated_at and would mask the age.
+--
+-- Index: the reaper fetches drivers is_online=true, is_available=false (then
+-- sieves the claim age in code). The partial index predicate matches THAT query
+-- exactly so Postgres actually uses it, and indexes availability_claimed_at for
+-- ordered access; the available majority is excluded.
+--
+-- RLS: no new table — drivers already has RLS; a nullable column inherits it.
+--
+-- Forward-compatible (drivers is a hot table): ADD COLUMN is metadata-only (no
+-- rewrite), and the partial index is built CONCURRENTLY (the runner detects
+-- CONCURRENTLY and applies the file in autocommit). Old code ignores the column;
+-- new code sets it. Existing rows keep NULL (never reaped — conservative).
+--
+-- Rollback:
+--   DROP INDEX CONCURRENTLY IF EXISTS public.idx_drivers_orphan_claim;
+--   ALTER TABLE public.drivers DROP COLUMN IF EXISTS availability_claimed_at;
+
+ALTER TABLE public.drivers
+    ADD COLUMN IF NOT EXISTS availability_claimed_at timestamptz;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_drivers_orphan_claim
+    ON public.drivers (availability_claimed_at)
+    WHERE is_online = true AND is_available = false;

--- a/backend/repositories/_base.py
+++ b/backend/repositories/_base.py
@@ -432,6 +432,17 @@ def _postgrest_pattern(value: str) -> str:
     return str(value).replace("*", r"\*").replace(",", r"\,").replace("(", r"\(").replace(")", r"\)")
 
 
+def _escape_like(value: str) -> str:
+    r"""Escape SQL LIKE/ILIKE wildcards in user input (C6).
+
+    Without this, a user-supplied ``%`` or ``_`` in a $regex search acts as a
+    wildcard (over-match) and ``%`` allows a cheap ReDoS-style scan. Escape the
+    escape char first, then the two wildcards. Postgres LIKE treats ``\`` as the
+    default ESCAPE, so ``\%`` / ``\_`` match a literal percent / underscore.
+    """
+    return str(value).replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+
+
 def _unwrap_enum(v: Any) -> Any:
     """Return the .value of Enum instances so PostgREST sees plain strings."""
     return v.value if isinstance(v, _Enum) else v
@@ -500,7 +511,9 @@ def _apply_filters(q, filters: Optional[Dict[str, Any]]):
             elif "$nin" in v and isinstance(v["$nin"], (list, tuple)):
                 q = q.not_.in_(k, [_unwrap_enum(x) for x in v["$nin"]])
             elif "$regex" in v:
-                pattern = f"%{v['$regex']}%"
+                # Escape LIKE wildcards in user input so `%`/`_` can't over-match
+                # or be used as a cheap scan vector (C6).
+                pattern = f"%{_escape_like(v['$regex'])}%"
                 if v.get("$options") == "i":
                     q = q.ilike(k, pattern)
                 else:

--- a/backend/repositories/driver_repo.py
+++ b/backend/repositories/driver_repo.py
@@ -146,6 +146,10 @@ async def set_driver_available(driver_id: str, available: bool = True, total_rid
 
     def _update():
         payload: Dict[str, Any] = {"is_available": available}
+        # C3: releasing the driver clears the claim stamp so the reaper won't
+        # consider them orphaned. (Claiming sets it; releasing unsets it.)
+        if available:
+            payload["availability_claimed_at"] = None
 
         # Enforce the invariant is_available ⇒ is_online. is_online is
         # driver-toggled, so we must NOT flip it on here; instead, when asked
@@ -233,7 +237,15 @@ async def claim_driver_atomic(driver_id: str) -> bool:
     def _claim():
         res = (
             supabase.table("drivers")
-            .update({"is_available": False})
+            # C3: stamp a dedicated claim time so the orphan-claim reaper can
+            # release this driver if the offer-insert never lands (crash/restart)
+            # without racing the sub-second claim→insert window. Cleared on release.
+            .update(
+                {
+                    "is_available": False,
+                    "availability_claimed_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
             .eq("id", driver_id)
             .eq("is_available", True)
             .execute()

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -389,6 +389,46 @@ async def confirm_payment(
                         status_code=403,
                         detail="Not authorized to confirm payment for this ride",
                     )
+
+                # SECURITY (C1): ownership alone is insufficient — a rider owns
+                # many PaymentIntents. Bind the PI to THIS ride and verify it
+                # actually covers the owed total, or a rider could confirm a
+                # cheap / other-ride intent against an expensive ride and underpay.
+                pi_ride_id = (intent.metadata or {}).get("ride_id")
+                if pi_ride_id and pi_ride_id != ride_id:
+                    logger.error(
+                        "[confirm][security] PI %s metadata ride_id=%s != ride %s",
+                        payment_intent_id,
+                        pi_ride_id,
+                        ride_id,
+                    )
+                    raise HTTPException(status_code=403, detail="Payment does not match this ride")
+
+                # Only a genuinely succeeded charge can mark a ride paid, and only
+                # when the captured amount covers the authoritative owed total
+                # (grand_total). amount_received is 0 until the PI succeeds.
+                if intent.status == "succeeded":
+                    _grand = _ride.get("grand_total")
+                    if _grand is None:
+                        _grand = _ride.get("total_fare", 0)
+                    owed_cents = int((_q2(_grand) * 100).to_integral_value())
+                    received = int(getattr(intent, "amount_received", 0) or 0)
+                    if received < owed_cents:
+                        logger.error(
+                            "[confirm][security] underpay ride=%s pi=%s received=%d owed=%d",
+                            ride_id,
+                            payment_intent_id,
+                            received,
+                            owed_cents,
+                        )
+                        raise HTTPException(
+                            status_code=402,
+                            detail={
+                                "code": "AMOUNT_MISMATCH",
+                                "message": "Payment amount does not cover the fare.",
+                            },
+                        )
+
                 await db_supabase.update_ride(
                     ride_id,
                     {

--- a/backend/routes/payments.py
+++ b/backend/routes/payments.py
@@ -559,8 +559,11 @@ async def get_cards(request: Request = None, current_user: dict = Depends(get_cu
             for m in methods.data
         ]
     except Exception as e:
+        # C7: do NOT mask a Stripe outage as "no cards" — that's the log-and-
+        # continue-on-payment-error anti-pattern CLAUDE.md forbids, and it makes
+        # a rider think their saved card vanished. Surface 502 so the client retries.
         logger.error(f"Get cards error: {e}", exc_info=True)
-        return []
+        raise HTTPException(status_code=502, detail="Could not load your saved cards. Please try again.") from e
 
 
 class AddCardRequest(BaseModel):
@@ -739,9 +742,13 @@ async def set_default_card(
     request: Request = None,
     current_user: dict = Depends(get_current_user),
 ):
-    """Set card as default. Updates both our DB and Stripe customer."""
-    await db_supabase.update_one("users", {"id": current_user["id"]}, {"default_payment_method": card_id})
+    """Set card as default. Updates both our DB and Stripe customer.
 
+    C7: Stripe is updated FIRST; the DB default is only written once Stripe
+    accepts it, so a Stripe failure can't leave our DB pointing at a default the
+    payment processor doesn't know about. On Stripe error we surface 502 (not a
+    silent success) so the client retries.
+    """
     settings = await get_app_settings()
     stripe_secret = settings.get("stripe_secret_key", "")
     if stripe_secret:
@@ -756,6 +763,9 @@ async def set_default_card(
                 )
         except Exception as e:
             logger.error(f"Stripe set default failed for card {card_id}: {e}", exc_info=True)
+            raise HTTPException(status_code=502, detail="Could not update your default card. Please try again.") from e
+
+    await db_supabase.update_one("users", {"id": current_user["id"]}, {"default_payment_method": card_id})
 
     import asyncio
 
@@ -778,7 +788,13 @@ async def delete_card(
     request: Request = None,
     current_user: dict = Depends(get_current_user),
 ):
-    """Detach card from Stripe and clear default if needed."""
+    """Detach card from Stripe and clear default if needed.
+
+    C7: the Stripe detach must SUCCEED before we mutate our DB. Previously a
+    failed detach was logged-and-ignored, then the DB default was cleared anyway
+    — leaving the card live in Stripe but gone from the UI. Now a failed detach
+    raises 502 and the DB is left untouched.
+    """
     settings = await get_app_settings()
     stripe_secret = settings.get("stripe_secret_key", "")
     if stripe_secret:
@@ -786,6 +802,7 @@ async def delete_card(
             stripe.PaymentMethod.detach(card_id, api_key=stripe_secret)
         except Exception as e:
             logger.error(f"Stripe detach failed for card {card_id}: {e}", exc_info=True)
+            raise HTTPException(status_code=502, detail="Could not remove your card. Please try again.") from e
 
     user = await db_supabase.get_user_by_id(current_user["id"])
     if user and user.get("default_payment_method") == card_id:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -152,9 +152,11 @@ try:
         settle_corporate,
         settle_wallet,
     )
+    from ..utils.stripe_charge import authorize_ride
 except ImportError:
     from services.cancellation_service import calculate_cancellation_fee, pay_driver_cancellation_fee  # type: ignore
     from services.payment_service import send_ride_receipt, settle_card, settle_corporate, settle_wallet  # type: ignore
+    from utils.stripe_charge import authorize_ride  # type: ignore
 
 db = db_supabase  # legacy alias
 
@@ -1766,6 +1768,125 @@ async def ride_search_timeout(r_id: str, timeout_seconds: int = 300):
         logger.error(f"Ride timeout handler error for {r_id}: {e}", exc_info=True)
 
 
+# Decline codes where re-authorizing at a LOWER amount (fare without the buffer)
+# can still succeed — the card is fundable, the buffer just tipped a thin balance
+# over. Any other decline (lost/stolen/generic) is the card itself being bad, so
+# a smaller hold won't help and we block instead of retrying.
+_RETRYABLE_AT_LOWER_AMOUNT = frozenset({"insufficient_funds"})
+
+
+async def _preauthorize_ride_card(
+    *,
+    ride_id: str,
+    rider_id: str,
+    grand_total: Decimal,
+    stripe_customer_id: Optional[str],
+    payment_method_id: Optional[str],
+) -> dict:
+    """Place a buffered card hold at booking; return ride fields to persist.
+
+    Holds ``grand_total + RIDE_AUTH_BUFFER_CAD`` via a manual-capture
+    PaymentIntent so a post-trip tip can later be captured on the SAME intent
+    (one Stripe fee) and a dead card is surfaced BEFORE a driver is dispatched.
+    The held PaymentIntent id reuses the existing ``payment_intent_id`` column.
+
+    Returns a (possibly empty) dict merged into ``ride_data``:
+        {"payment_intent_id", "authorized_amount", "auth_status"} on a hold,
+        {} when no hold was placed (ride proceeds on the post-trip settlement
+        path exactly as it does today).
+
+    Raises ``HTTPException(402)`` in EXACTLY ONE case — the card genuinely
+    cannot pay (both the buffered hold AND the fare-only fallback were
+    declined). Every other non-success degrades to "no hold, proceed":
+      - ``requires_action`` (SCA/3DS at booking) — handled by the dedicated
+        SCA-at-booking flow later; for now fall back to post-trip settlement.
+      - ``failed`` (Stripe ops error) — never block a rider over our outage.
+      - ``unconfigured`` (dev/test, no Stripe key) — proceed.
+      - missing customer / payment method — proceed (post-trip settlement
+        still validates a card is on file before dispatch in create_ride).
+    The buffer must never block a ride the rider could otherwise take.
+    """
+    if not stripe_customer_id or not payment_method_id:
+        # No saved card to hold against — leave settlement to the post-trip path.
+        return {}
+
+    buffer = _round(_d(_settings.RIDE_AUTH_BUFFER_CAD))
+    hold_amount = _round(_d(grand_total) + buffer)
+    _ride_stub = {"id": ride_id, "payment_method": "card"}
+
+    outcome = await authorize_ride(
+        ride=_ride_stub,
+        rider_id=rider_id,
+        amount=hold_amount,
+        payment_method_id=payment_method_id,
+        stripe_customer_id=stripe_customer_id,
+    )
+
+    if outcome.status == "authorized":
+        return {
+            "payment_intent_id": outcome.payment_intent_id,
+            "authorized_amount": _f(hold_amount),
+            "auth_status": "authorized",
+        }
+
+    if outcome.status == "declined":
+        if outcome.decline_code in _RETRYABLE_AT_LOWER_AMOUNT:
+            # Buffer tipped a thin balance over — retry holding the fare only so
+            # a rider who can afford the ride still rides (loses single-fee tips).
+            fare_outcome = await authorize_ride(
+                ride=_ride_stub,
+                rider_id=rider_id,
+                amount=_round(_d(grand_total)),
+                payment_method_id=payment_method_id,
+                stripe_customer_id=stripe_customer_id,
+            )
+            if fare_outcome.status == "authorized":
+                logger.info(
+                    "[preauth] buffered hold declined (insufficient_funds); fare-only hold placed for ride=%s",
+                    ride_id,
+                )
+                return {
+                    "payment_intent_id": fare_outcome.payment_intent_id,
+                    "authorized_amount": _f(_round(_d(grand_total))),
+                    "auth_status": "fare_only",
+                }
+            if fare_outcome.status == "declined":
+                logger.info("[preauth] fare-only hold also declined for ride=%s — blocking", ride_id)
+                raise HTTPException(
+                    status_code=402,
+                    detail={
+                        "code": "CARD_DECLINED",
+                        "message": ("Your card was declined. Please update your payment method and try booking again."),
+                        "decline_code": fare_outcome.decline_code,
+                    },
+                )
+            # fare-only hit SCA / ops / unconfigured — degrade to no hold.
+            return {}
+
+        # Hard decline (lost/stolen/generic) — a smaller hold won't help.
+        logger.info(
+            "[preauth] hard card decline (code=%s) for ride=%s — blocking",
+            outcome.decline_code,
+            ride_id,
+        )
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "code": "CARD_DECLINED",
+                "message": ("Your card was declined. Please update your payment method and try booking again."),
+                "decline_code": outcome.decline_code,
+            },
+        )
+
+    # requires_action / failed / unconfigured — proceed without a hold; the
+    # post-trip settlement path (and its retry loop) remains the safety net.
+    if outcome.status == "requires_action":
+        logger.info("[preauth] card requires SCA at booking for ride=%s — deferring to post-trip settlement", ride_id)
+    elif outcome.status == "failed":
+        logger.error("[preauth] authorization ops error for ride=%s: %s", ride_id, outcome.error_message)
+    return {}
+
+
 @api_router.post("")
 @ride_request_limit
 @idempotent_endpoint(scope="ride_create")
@@ -2272,6 +2393,25 @@ async def create_ride(
         # 6. Tag ride as corporate
         ride_data["corporate_account_id"] = _corp_company_id
         ride_data["payment_method"] = "company_allowance"
+
+    # ── Card pre-authorization (buffered hold) ────────────────────────────────
+    # For an immediate CARD ride, place a manual-capture hold of
+    # (grand_total + RIDE_AUTH_BUFFER_CAD) BEFORE the ride is inserted/dispatched.
+    # This catches a dead card up front (a true decline raises 402 here, before a
+    # driver is disturbed) and reserves headroom so a post-trip tip captures on
+    # the same PaymentIntent. Skipped for wallet/corporate (different settlement)
+    # and for scheduled rides (authorized at dispatch time — see scheduled_rides).
+    # Any non-decline failure degrades to "no hold" and the existing post-trip
+    # settlement path; the buffer never blocks a ride the rider could take.
+    if ride_data.get("payment_method") == "card" and not _is_deferred_schedule:
+        _auth_fields = await _preauthorize_ride_card(
+            ride_id=ride_data["id"],
+            rider_id=current_user["id"],
+            grand_total=_d(grand_total),
+            stripe_customer_id=(rider_row or {}).get("stripe_customer_id"),
+            payment_method_id=body.payment_method_id,
+        )
+        ride_data.update(_auth_fields)
 
     # ``insert_ride`` returns the row Supabase just wrote — use it directly
     # instead of a follow-up ``get_ride`` round-trip. Fall back to the

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1775,6 +1775,25 @@ async def ride_search_timeout(r_id: str, timeout_seconds: int = 300):
 _RETRYABLE_AT_LOWER_AMOUNT = frozenset({"insufficient_funds"})
 
 
+def _card_declined_result(decline_code: Optional[str], block_on_decline: bool) -> dict:
+    """Terminal decline of a pre-auth hold. At interactive booking
+    (``block_on_decline=True``) raise 402 so the rider fixes their card before a
+    driver is disturbed. At scheduled dispatch (``block_on_decline=False``) the
+    rider is not present, so degrade to no hold and let post-trip settlement +
+    the retry/unpaid-block safety net handle it — never strand a scheduled ride.
+    """
+    if not block_on_decline:
+        return {}
+    raise HTTPException(
+        status_code=402,
+        detail={
+            "code": "CARD_DECLINED",
+            "message": "Your card was declined. Please update your payment method and try booking again.",
+            "decline_code": decline_code,
+        },
+    )
+
+
 async def _preauthorize_ride_card(
     *,
     ride_id: str,
@@ -1782,6 +1801,7 @@ async def _preauthorize_ride_card(
     grand_total: Decimal,
     stripe_customer_id: Optional[str],
     payment_method_id: Optional[str],
+    block_on_decline: bool = True,
 ) -> dict:
     """Place a buffered card hold at booking; return ride fields to persist.
 
@@ -1795,9 +1815,11 @@ async def _preauthorize_ride_card(
         {} when no hold was placed (ride proceeds on the post-trip settlement
         path exactly as it does today).
 
-    Raises ``HTTPException(402)`` in EXACTLY ONE case — the card genuinely
-    cannot pay (both the buffered hold AND the fare-only fallback were
-    declined). Every other non-success degrades to "no hold, proceed":
+    Raises ``HTTPException(402)`` when ``block_on_decline`` (the default, for
+    interactive booking) and the card genuinely cannot pay (both the buffered
+    hold AND the fare-only fallback declined). With ``block_on_decline=False``
+    (scheduled dispatch, rider not present) a decline returns {} instead of
+    raising. Every other non-success degrades to "no hold, proceed":
       - ``requires_action`` (SCA/3DS at booking) — handled by the dedicated
         SCA-at-booking flow later; for now fall back to post-trip settlement.
       - ``failed`` (Stripe ops error) — never block a rider over our outage.
@@ -1851,32 +1873,14 @@ async def _preauthorize_ride_card(
                     "auth_status": "fare_only",
                 }
             if fare_outcome.status == "declined":
-                logger.info("[preauth] fare-only hold also declined for ride=%s — blocking", ride_id)
-                raise HTTPException(
-                    status_code=402,
-                    detail={
-                        "code": "CARD_DECLINED",
-                        "message": ("Your card was declined. Please update your payment method and try booking again."),
-                        "decline_code": fare_outcome.decline_code,
-                    },
-                )
+                logger.info("[preauth] fare-only hold also declined for ride=%s", ride_id)
+                return _card_declined_result(fare_outcome.decline_code, block_on_decline)
             # fare-only hit SCA / ops / unconfigured — degrade to no hold.
             return {}
 
         # Hard decline (lost/stolen/generic) — a smaller hold won't help.
-        logger.info(
-            "[preauth] hard card decline (code=%s) for ride=%s — blocking",
-            outcome.decline_code,
-            ride_id,
-        )
-        raise HTTPException(
-            status_code=402,
-            detail={
-                "code": "CARD_DECLINED",
-                "message": ("Your card was declined. Please update your payment method and try booking again."),
-                "decline_code": outcome.decline_code,
-            },
-        )
+        logger.info("[preauth] hard card decline (code=%s) for ride=%s", outcome.decline_code, ride_id)
+        return _card_declined_result(outcome.decline_code, block_on_decline)
 
     # requires_action / failed / unconfigured — proceed without a hold; the
     # post-trip settlement path (and its retry loop) remains the safety net.

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3,6 +3,8 @@ import json
 import secrets
 import time as _time_mod
 import uuid
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from datetime import datetime, timedelta, timezone
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import List, Optional
@@ -152,11 +154,11 @@ try:
         settle_corporate,
         settle_wallet,
     )
-    from ..utils.stripe_charge import authorize_ride
+    from ..utils.stripe_charge import authorize_ride, verify_authorization
 except ImportError:
     from services.cancellation_service import calculate_cancellation_fee, pay_driver_cancellation_fee  # type: ignore
     from services.payment_service import send_ride_receipt, settle_card, settle_corporate, settle_wallet  # type: ignore
-    from utils.stripe_charge import authorize_ride  # type: ignore
+    from utils.stripe_charge import authorize_ride, verify_authorization  # type: ignore
 
 db = db_supabase  # legacy alias
 
@@ -1775,7 +1777,23 @@ async def ride_search_timeout(r_id: str, timeout_seconds: int = 300):
 _RETRYABLE_AT_LOWER_AMOUNT = frozenset({"insufficient_funds"})
 
 
-def _card_declined_result(decline_code: Optional[str], block_on_decline: bool) -> dict:
+@dataclass
+class _PreauthOutcome:
+    """Result of a booking-time card pre-authorization attempt.
+
+    ``fields`` are merged into ``ride_data`` (empty when no hold was placed).
+    ``requires_action`` signals the rider-app must complete an on-device SCA /
+    Apple Pay confirm for ``client_secret`` and then re-book passing
+    ``payment_intent_id`` back as ``preauthorized_payment_intent_id``.
+    """
+
+    fields: dict = dataclass_field(default_factory=dict)
+    requires_action: bool = False
+    client_secret: Optional[str] = None
+    payment_intent_id: Optional[str] = None
+
+
+def _card_declined_result(decline_code: Optional[str], block_on_decline: bool) -> _PreauthOutcome:
     """Terminal decline of a pre-auth hold. At interactive booking
     (``block_on_decline=True``) raise 402 so the rider fixes their card before a
     driver is disturbed. At scheduled dispatch (``block_on_decline=False``) the
@@ -1783,7 +1801,7 @@ def _card_declined_result(decline_code: Optional[str], block_on_decline: bool) -
     the retry/unpaid-block safety net handle it — never strand a scheduled ride.
     """
     if not block_on_decline:
-        return {}
+        return _PreauthOutcome()
     raise HTTPException(
         status_code=402,
         detail={
@@ -1794,6 +1812,39 @@ def _card_declined_result(decline_code: Optional[str], block_on_decline: bool) -
     )
 
 
+async def _attach_preauthorized_hold(
+    *,
+    ride_id: str,
+    payment_intent_id: str,
+) -> dict:
+    """Verify a PaymentIntent the rider-app already confirmed on-device (SCA /
+    Apple Pay two-step) and return the ride fields to persist. A failed/abandoned
+    authentication raises 402 so the rider re-tries — we never attach an
+    unconfirmed hold, and we re-read the PI from Stripe rather than trusting the
+    client. ``authorized_amount`` is taken from Stripe (the true held amount)."""
+    outcome = await verify_authorization(ride_id=ride_id, payment_intent_id=payment_intent_id)
+    if outcome.status == "authorized":
+        return {
+            "payment_intent_id": outcome.payment_intent_id,
+            "authorized_amount": _f(outcome.charged_amount),
+            "auth_status": "authorized",
+        }
+    if outcome.status == "declined":
+        logger.info("[preauth] on-device auth not completed for ride=%s pi=%s", ride_id, payment_intent_id)
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "code": "CARD_DECLINED",
+                "message": "Card authentication wasn't completed. Please try booking again.",
+            },
+        )
+    # unconfigured (dev) / failed (ops) — degrade to no hold; post-trip settles.
+    logger.error(
+        "[preauth] verify hold failed for ride=%s pi=%s: %s", ride_id, payment_intent_id, outcome.error_message
+    )
+    return {}
+
+
 async def _preauthorize_ride_card(
     *,
     ride_id: str,
@@ -1802,35 +1853,27 @@ async def _preauthorize_ride_card(
     stripe_customer_id: Optional[str],
     payment_method_id: Optional[str],
     block_on_decline: bool = True,
-) -> dict:
-    """Place a buffered card hold at booking; return ride fields to persist.
+) -> _PreauthOutcome:
+    """Place a buffered card hold at booking; return a ``_PreauthOutcome``.
 
     Holds ``grand_total + RIDE_AUTH_BUFFER_CAD`` via a manual-capture
     PaymentIntent so a post-trip tip can later be captured on the SAME intent
     (one Stripe fee) and a dead card is surfaced BEFORE a driver is dispatched.
     The held PaymentIntent id reuses the existing ``payment_intent_id`` column.
 
-    Returns a (possibly empty) dict merged into ``ride_data``:
-        {"payment_intent_id", "authorized_amount", "auth_status"} on a hold,
-        {} when no hold was placed (ride proceeds on the post-trip settlement
-        path exactly as it does today).
-
-    Raises ``HTTPException(402)`` when ``block_on_decline`` (the default, for
-    interactive booking) and the card genuinely cannot pay (both the buffered
-    hold AND the fare-only fallback declined). With ``block_on_decline=False``
-    (scheduled dispatch, rider not present) a decline returns {} instead of
-    raising. Every other non-success degrades to "no hold, proceed":
-      - ``requires_action`` (SCA/3DS at booking) — handled by the dedicated
-        SCA-at-booking flow later; for now fall back to post-trip settlement.
-      - ``failed`` (Stripe ops error) — never block a rider over our outage.
-      - ``unconfigured`` (dev/test, no Stripe key) — proceed.
-      - missing customer / payment method — proceed (post-trip settlement
-        still validates a card is on file before dispatch in create_ride).
-    The buffer must never block a ride the rider could otherwise take.
+    Outcomes:
+      - hold placed → ``fields`` populated (authorized / fare_only).
+      - ``requires_action`` → ``requires_action=True`` with client_secret +
+        payment_intent_id so the caller drives the on-device SCA / Apple Pay
+        two-step (interactive booking only).
+      - genuine decline → raises 402 when ``block_on_decline`` (interactive
+        booking); returns empty when not (scheduled dispatch — never strand it).
+      - ``failed`` / ``unconfigured`` / no card on file → empty fields, ride
+        proceeds on the post-trip settlement path.
     """
     if not stripe_customer_id or not payment_method_id:
         # No saved card to hold against — leave settlement to the post-trip path.
-        return {}
+        return _PreauthOutcome()
 
     buffer = _round(_d(_settings.RIDE_AUTH_BUFFER_CAD))
     hold_amount = _round(_d(grand_total) + buffer)
@@ -1845,11 +1888,27 @@ async def _preauthorize_ride_card(
     )
 
     if outcome.status == "authorized":
-        return {
-            "payment_intent_id": outcome.payment_intent_id,
-            "authorized_amount": _f(hold_amount),
-            "auth_status": "authorized",
-        }
+        return _PreauthOutcome(
+            fields={
+                "payment_intent_id": outcome.payment_intent_id,
+                "authorized_amount": _f(hold_amount),
+                "auth_status": "authorized",
+            }
+        )
+
+    if outcome.status == "requires_action":
+        # 3DS / Apple Pay biometric needed — hand the client_secret to the app to
+        # confirm on-device, then re-book passing the PI back. Scheduled dispatch
+        # (block_on_decline=False) can't drive an on-device sheet → degrade.
+        if not block_on_decline:
+            logger.info("[preauth] SCA needed at scheduled dispatch for ride=%s — degrading to post-trip", ride_id)
+            return _PreauthOutcome()
+        logger.info("[preauth] card requires SCA at booking for ride=%s — returning client_secret", ride_id)
+        return _PreauthOutcome(
+            requires_action=True,
+            client_secret=outcome.client_secret,
+            payment_intent_id=outcome.payment_intent_id,
+        )
 
     if outcome.status == "declined":
         if outcome.decline_code in _RETRYABLE_AT_LOWER_AMOUNT:
@@ -1867,28 +1926,36 @@ async def _preauthorize_ride_card(
                     "[preauth] buffered hold declined (insufficient_funds); fare-only hold placed for ride=%s",
                     ride_id,
                 )
-                return {
-                    "payment_intent_id": fare_outcome.payment_intent_id,
-                    "authorized_amount": _f(_round(_d(grand_total))),
-                    "auth_status": "fare_only",
-                }
+                return _PreauthOutcome(
+                    fields={
+                        "payment_intent_id": fare_outcome.payment_intent_id,
+                        "authorized_amount": _f(_round(_d(grand_total))),
+                        "auth_status": "fare_only",
+                    }
+                )
+            if fare_outcome.status == "requires_action":
+                if not block_on_decline:
+                    return _PreauthOutcome()
+                return _PreauthOutcome(
+                    requires_action=True,
+                    client_secret=fare_outcome.client_secret,
+                    payment_intent_id=fare_outcome.payment_intent_id,
+                )
             if fare_outcome.status == "declined":
                 logger.info("[preauth] fare-only hold also declined for ride=%s", ride_id)
                 return _card_declined_result(fare_outcome.decline_code, block_on_decline)
-            # fare-only hit SCA / ops / unconfigured — degrade to no hold.
-            return {}
+            # fare-only hit ops / unconfigured — degrade to no hold.
+            return _PreauthOutcome()
 
         # Hard decline (lost/stolen/generic) — a smaller hold won't help.
         logger.info("[preauth] hard card decline (code=%s) for ride=%s", outcome.decline_code, ride_id)
         return _card_declined_result(outcome.decline_code, block_on_decline)
 
-    # requires_action / failed / unconfigured — proceed without a hold; the
-    # post-trip settlement path (and its retry loop) remains the safety net.
-    if outcome.status == "requires_action":
-        logger.info("[preauth] card requires SCA at booking for ride=%s — deferring to post-trip settlement", ride_id)
-    elif outcome.status == "failed":
+    # failed (Stripe ops) / unconfigured — proceed without a hold; the post-trip
+    # settlement path (and its retry loop) remains the safety net.
+    if outcome.status == "failed":
         logger.error("[preauth] authorization ops error for ride=%s: %s", ride_id, outcome.error_message)
-    return {}
+    return _PreauthOutcome()
 
 
 @api_router.post("")
@@ -2408,14 +2475,38 @@ async def create_ride(
     # Any non-decline failure degrades to "no hold" and the existing post-trip
     # settlement path; the buffer never blocks a ride the rider could take.
     if ride_data.get("payment_method") == "card" and not _is_deferred_schedule:
-        _auth_fields = await _preauthorize_ride_card(
-            ride_id=ride_data["id"],
-            rider_id=current_user["id"],
-            grand_total=_d(grand_total),
-            stripe_customer_id=(rider_row or {}).get("stripe_customer_id"),
-            payment_method_id=body.payment_method_id,
-        )
-        ride_data.update(_auth_fields)
+        if body.preauthorized_payment_intent_id:
+            # SCA two-step, second leg: the app already confirmed this hold
+            # on-device (3DS / Apple Pay). Verify with Stripe and attach it —
+            # do NOT authorize again (that would place a second hold).
+            ride_data.update(
+                await _attach_preauthorized_hold(
+                    ride_id=ride_data["id"],
+                    payment_intent_id=body.preauthorized_payment_intent_id,
+                )
+            )
+        else:
+            _preauth = await _preauthorize_ride_card(
+                ride_id=ride_data["id"],
+                rider_id=current_user["id"],
+                grand_total=_d(grand_total),
+                stripe_customer_id=(rider_row or {}).get("stripe_customer_id"),
+                payment_method_id=body.payment_method_id,
+            )
+            if _preauth.requires_action:
+                # SCA two-step, first leg: the hold needs an on-device confirm.
+                # Do NOT create the ride yet — hand the client_secret back; the
+                # app runs the Stripe sheet, then re-books with
+                # preauthorized_payment_intent_id set. Keeps the ride state
+                # machine clean: no ride exists until the hold is real.
+                return {
+                    "requires_action": True,
+                    "payment_authorization": {
+                        "client_secret": _preauth.client_secret,
+                        "payment_intent_id": _preauth.payment_intent_id,
+                    },
+                }
+            ride_data.update(_preauth.fields)
 
     # ``insert_ride`` returns the row Supabase just wrote — use it directly
     # instead of a follow-up ``get_ride`` round-trip. Fall back to the

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1830,6 +1830,16 @@ async def _attach_preauthorized_hold(
     least the ride fare, and (c) not already be attached to another ride — so a
     client cannot attach someone else's hold, replay a cheaper one, or reuse a PI
     across rides."""
+    # Fail CLOSED: ownership is verified against the rider's Stripe customer, so
+    # we cannot attach a client-supplied PI when we have no customer to check it
+    # against (e.g. a crafted work_profile card request). Reject rather than skip.
+    if not stripe_customer_id:
+        logger.error("[preauth][security] no Stripe customer to verify PI ownership for ride=%s", ride_id)
+        raise HTTPException(
+            status_code=402,
+            detail={"code": "CARD_DECLINED", "message": "No payment method on file. Please add a card first."},
+        )
+
     # (c) Reuse guard: a PI already on another ride must not be re-attached.
     try:
         existing = await db_supabase.get_rows(
@@ -1839,6 +1849,8 @@ async def _attach_preauthorized_hold(
             columns="id",
         )
     except Exception as e:
+        # Fail OPEN here is acceptable: ownership + amount are still enforced
+        # against Stripe below, so a degraded reuse-lookup can't bypass security.
         logger.error("[preauth] PI-reuse lookup failed for ride=%s pi=%s: %s", ride_id, payment_intent_id, e)
         existing = []
     if existing and existing[0].get("id") != ride_id:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1815,14 +1815,49 @@ def _card_declined_result(decline_code: Optional[str], block_on_decline: bool) -
 async def _attach_preauthorized_hold(
     *,
     ride_id: str,
+    rider_id: str,
     payment_intent_id: str,
+    stripe_customer_id: Optional[str],
+    min_amount: Decimal,
 ) -> dict:
     """Verify a PaymentIntent the rider-app already confirmed on-device (SCA /
     Apple Pay two-step) and return the ride fields to persist. A failed/abandoned
     authentication raises 402 so the rider re-tries — we never attach an
     unconfirmed hold, and we re-read the PI from Stripe rather than trusting the
-    client. ``authorized_amount`` is taken from Stripe (the true held amount)."""
-    outcome = await verify_authorization(ride_id=ride_id, payment_intent_id=payment_intent_id)
+    client. ``authorized_amount`` is taken from Stripe (the true held amount).
+
+    SECURITY: the PI must (a) belong to this rider's Stripe customer, (b) hold at
+    least the ride fare, and (c) not already be attached to another ride — so a
+    client cannot attach someone else's hold, replay a cheaper one, or reuse a PI
+    across rides."""
+    # (c) Reuse guard: a PI already on another ride must not be re-attached.
+    try:
+        existing = await db_supabase.get_rows(
+            "rides",
+            {"payment_intent_id": payment_intent_id},
+            limit=1,
+            columns="id",
+        )
+    except Exception as e:
+        logger.error("[preauth] PI-reuse lookup failed for ride=%s pi=%s: %s", ride_id, payment_intent_id, e)
+        existing = []
+    if existing and existing[0].get("id") != ride_id:
+        logger.error("[preauth][security] PI already attached to ride=%s (declining)", existing[0].get("id"))
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "code": "CARD_DECLINED",
+                "message": "This authorization can't be reused. Please try booking again.",
+            },
+        )
+
+    min_cents = int((_round(_d(min_amount)) * Decimal("100")).to_integral_value(rounding=ROUND_HALF_UP))
+    outcome = await verify_authorization(
+        ride_id=ride_id,
+        payment_intent_id=payment_intent_id,
+        expected_customer_id=stripe_customer_id,
+        min_amount_cents=min_cents,
+    )
     if outcome.status == "authorized":
         return {
             "payment_intent_id": outcome.payment_intent_id,
@@ -2482,7 +2517,10 @@ async def create_ride(
             ride_data.update(
                 await _attach_preauthorized_hold(
                     ride_id=ride_data["id"],
+                    rider_id=current_user["id"],
                     payment_intent_id=body.preauthorized_payment_intent_id,
+                    stripe_customer_id=(rider_row or {}).get("stripe_customer_id"),
+                    min_amount=_d(grand_total),
                 )
             )
         else:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -17,6 +17,7 @@ except ImportError:
     from utils.money import cents_to_dollars
     from utils.rate_limiter import default_limiter
 import asyncio
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -81,6 +82,39 @@ def _invoice_period_end_iso(invoice: dict) -> str | None:
     return None
 
 
+def _event_to_plain_dict(event):
+    """Normalize a verified Stripe webhook Event to a plain, recursively-plain dict.
+
+    stripe-python v15 Events are NOT dict subclasses and lack ``.get()`` /
+    ``.to_dict_recursive()`` — calling either AttributeError'd and 500'd every
+    webhook. ``_to_dict_recursive()`` yields plain nested dicts on v15. Test
+    fixtures and legacy StripeObjects are already dicts. Last resort: a JSON
+    round-trip via ``str()`` (a StripeObject's ``__str__`` is JSON).
+    """
+    if isinstance(event, dict):
+        return event
+    # Only the v15 Event needs conversion. Detect it precisely: accessing ``.get``
+    # on a v15 Event raises AttributeError (via __getattr__), whereas a dict-like
+    # object or a configured test mock exposes a usable ``.get`` — leave those
+    # untouched so we don't transform an object that already works.
+    try:
+        getter = event.get
+    except AttributeError:
+        getter = None
+    if callable(getter):
+        return event
+    fn = getattr(event, "_to_dict_recursive", None) or getattr(event, "to_dict_recursive", None)
+    if callable(fn):
+        try:
+            return fn()
+        except Exception:  # pragma: no cover — fall through to JSON
+            pass
+    try:
+        return json.loads(str(event))
+    except Exception:  # pragma: no cover — last-ditch shallow dict
+        return dict(event)
+
+
 @api_router.post("/stripe")
 async def stripe_webhook(request: Request):
     """Handle Stripe webhook events for server-side payment confirmation."""
@@ -134,6 +168,12 @@ async def stripe_webhook(request: Request):
         logger.error(f"Stripe webhook signature verification failed: {last_sig_error}")
         raise HTTPException(status_code=400, detail="Invalid signature") from last_sig_error
 
+    # stripe-python v15: the returned Event is NOT a dict subclass — it has no
+    # ``.get()`` or ``.to_dict_recursive()`` (both raise AttributeError via
+    # __getattr__, which 500'd every webhook). Normalize it to a plain,
+    # recursively-plain dict for all field access + jsonb storage.
+    event = _event_to_plain_dict(event)
+
     event_id = event.get("id", "")
     event_type = event.get("type", "")
     data_object = event.get("data", {}).get("object", {})
@@ -148,14 +188,9 @@ async def stripe_webhook(request: Request):
     # Stripe retries every event (network blip, >20s handler, any non-2xx)
     # so we MUST treat a replay of the same event.id as a no-op. The
     # stripe_events table (migration 22) has event_id as PRIMARY KEY;
-    # claim_stripe_event returns False on a unique-violation replay.
-    # Stripe objects are dict subclasses but nested values (e.g. data.object)
-    # remain as StripeObject instances. to_dict_recursive() flattens the whole
-    # tree into plain dicts so it can be stored in jsonb without surprises.
-    try:
-        event_payload = event.to_dict_recursive()  # type: ignore[attr-defined]
-    except AttributeError:
-        event_payload = dict(event)
+    # claim_stripe_event returns False on a unique-violation replay. event is
+    # already a plain (json.loads) dict, safe to store directly in jsonb.
+    event_payload = event
 
     try:
         is_new = await claim_stripe_event(event_id, event_type, event_payload)
@@ -1105,7 +1140,9 @@ async def _suppress_address(email: str, *, reason: str, detail, message_id) -> N
         logger.warning("[SES] address suppressed reason=%s message_id=%s", reason, message_id or "-")
     except DuplicateRecordError:
         # Concurrent redelivery already inserted it — idempotent success.
-        logger.info("[SES] suppression already present (insert race) reason=%s message_id=%s", reason, message_id or "-")
+        logger.info(
+            "[SES] suppression already present (insert race) reason=%s message_id=%s", reason, message_id or "-"
+        )
     except DatabaseError as e:
         logger.error(
             "[SES] suppression write failed reason=%s: %s",

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -160,7 +160,20 @@ async def stripe_webhook(request: Request):
     try:
         is_new = await claim_stripe_event(event_id, event_type, event_payload)
     except Exception as e:
-        logger.error(f"Failed to persist stripe event {event_id}: {e}")
+        # Surface the REAL cause: for DatabaseError, str(e) is only
+        # "Database operation failed" — the underlying Postgres error (e.g.
+        # "relation stripe_events does not exist") lives in details["original"].
+        # Without this the webhook just logs a generic message and the root cause
+        # (missing table / RLS / schema drift) stays invisible.
+        _orig = e.details.get("original") if isinstance(e, DatabaseError) else None
+        logger.error(
+            "Failed to persist stripe event %s (type=%s): %s | original=%s",
+            event_id,
+            event_type,
+            e,
+            _orig,
+            exc_info=True,
+        )
         # Let Stripe retry — 5xx keeps the event in their queue.
         raise HTTPException(status_code=500, detail="Event persistence failed") from e
 

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -402,6 +402,11 @@ class CreateRideRequest(BaseModel):
     # the confirmed fare can't bait-and-switch from the estimate.
     estimate_token: Optional[str] = None
     payment_method_id: Optional[str] = None
+    # SCA two-step: a manual-capture PaymentIntent the rider-app already confirmed
+    # on-device (3DS / Apple Pay biometric) after a prior create_ride returned
+    # requires_action. When present, create_ride verifies + attaches this hold
+    # instead of authorizing afresh — so the SCA challenge completes at BOOKING.
+    preauthorized_payment_intent_id: Optional[str] = None
     work_profile: Optional[bool] = None
     promo_code: Optional[str] = None
     requires_wav: bool = False

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -18,13 +18,13 @@ try:
     from ..services import corporate_allowance_service, corporate_wallet_service
     from ..services.corporate_policy_service import evaluate_policy
     from ..socket_manager import manager
-    from ..utils.stripe_charge import charge_ride
+    from ..utils.stripe_charge import capture_ride, charge_ride
 except ImportError:
     import db_supabase  # type: ignore
     from services import corporate_allowance_service, corporate_wallet_service  # type: ignore
     from services.corporate_policy_service import evaluate_policy  # type: ignore
     from socket_manager import manager  # type: ignore
-    from utils.stripe_charge import charge_ride  # type: ignore
+    from utils.stripe_charge import capture_ride, charge_ride  # type: ignore
 
 try:
     from ..features import send_push_notification
@@ -376,6 +376,163 @@ async def settle_corporate(
 # ── Card (Stripe) settlement ─────────────────────────────────────────
 
 
+async def _settle_against_hold(
+    ride: dict,
+    ride_id: str,
+    rider_id: str,
+    total_charge: Decimal,
+    tip_amount: Decimal,
+    *,
+    held_pi: str,
+    authorized: Decimal,
+    stripe_customer_id: Optional[str],
+    payment_method_id: Optional[str],
+) -> Optional[PaymentResult]:
+    """Capture a booking-time hold for (fare + tip) in a single Stripe fee.
+
+    Captures ``min(total_charge, authorized)`` against the manual-capture
+    PaymentIntent placed at booking. When the tip pushes the total OVER the
+    authorized hold (a tip beyond the buffer), the overflow is charged on a
+    fresh PaymentIntent — Stripe forbids capturing more than was authorized.
+
+    Returns:
+        PaymentResult — terminal outcome (captured-and-paid, or capture
+            declined by the issuer).
+        ``None`` — the hold is unusable (expired / amount_too_large / Stripe
+            ops error); the caller falls back to a fresh full charge.
+    """
+    capture_amount = _round(min(total_charge, authorized))
+    cap = await capture_ride(ride_id=ride_id, payment_intent_id=held_pi, amount=capture_amount)
+
+    if cap.status == "failed":
+        # Hold lapsed or otherwise uncapturable — re-drive via a fresh charge so
+        # the rider is still settled. error (not warning): a dropped hold is a
+        # payment-path anomaly we must surface, per CLAUDE.md. No exc_info — we
+        # are not inside an except block; the Stripe message is in error_message.
+        logger.error(
+            "[PAYMENT] capture of hold pi=%s failed for ride %s (%s) — falling back to fresh charge",
+            held_pi,
+            ride_id,
+            cap.error_message,
+        )
+        return None
+
+    if cap.status == "declined":
+        await db_supabase.update_ride(
+            ride_id,
+            {
+                "payment_status": "failed",
+                "payment_intent_id": held_pi,
+                "auth_status": "released",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        return PaymentResult(
+            success=False,
+            error_code="card_declined",
+            decline_code=cap.decline_code,
+            error=cap.error_message or "Your card was declined.",
+            status_code=402,
+            extra={"suggested_action": "change_card"},
+        )
+
+    if cap.status == "unconfigured":
+        # DEV/TEST ONLY: reached only when stripe_secret_key is unset. Production
+        # fails fast on a missing Stripe key at startup (core/config), so this
+        # branch is unreachable in prod and intentionally writes no
+        # financial_events row — mirroring the existing fresh-charge
+        # `unconfigured` branch below, which also marks paid without a ledger
+        # entry so dev flows don't wedge when Stripe isn't wired up.
+        logger.error("Stripe unconfigured — marking ride %s paid (held) without real capture", ride_id)
+        await db_supabase.update_ride(
+            ride_id,
+            {
+                "payment_status": "paid",
+                "auth_status": "captured",
+                "tip_amount": _f(tip_amount),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        return PaymentResult(success=True, charged_amount=_money_str(total_charge))
+
+    # cap.status == "captured" — the hold is now real money.
+    remainder = _round(total_charge - capture_amount)
+    tip_collected = _round(tip_amount)
+    extra_charged = Decimal("0")
+    if remainder > 0:
+        # Tip exceeded the buffer; charge the overflow on a fresh PaymentIntent.
+        over = await charge_ride(
+            ride=ride,
+            total_amount=remainder,
+            rider_id=rider_id,
+            payment_method_id=payment_method_id,
+            stripe_customer_id=stripe_customer_id,
+        )
+        if over.status == "succeeded":
+            extra_charged = remainder
+        else:
+            # Fare + within-buffer tip are captured; only the EXCESS tip failed.
+            # Settle what we actually collected rather than stranding a paid
+            # ride. Log loudly — never silently drop the shortfall.
+            fare = _round(total_charge - _round(tip_amount))
+            tip_collected = _round(authorized - fare)
+            if tip_collected < 0:
+                tip_collected = Decimal("0")
+            logger.error(
+                "[PAYMENT] over-buffer tip charge failed for ride %s (%s); captured %s, "
+                "tip collected %s, excess %s uncollected",
+                ride_id,
+                over.error_message,
+                _money_str(capture_amount),
+                _money_str(tip_collected),
+                _money_str(remainder),
+            )
+
+    settled_amount = _round(capture_amount + extra_charged)
+    await record_payment_event(
+        ride_id=ride_id,
+        user_id=rider_id,
+        amount_cents=int(_round(settled_amount * Decimal("100"))),
+        payment_intent_id=cap.payment_intent_id,
+        ride=ride,
+        tip_amount=tip_collected,
+    )
+    try:
+        await db_supabase.update_ride(
+            ride_id,
+            {
+                "payment_status": "paid",
+                "payment_intent_id": cap.payment_intent_id,
+                "auth_status": "captured",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+                **_tip_ride_update(ride, tip_collected),
+            },
+        )
+    except Exception as db_err:
+        logger.error(
+            "[PAYMENT] Capture %s succeeded but ride %s DB update failed — "
+            "ride stuck in 'processing'; financial_events written for recovery. err=%s",
+            cap.payment_intent_id,
+            ride_id,
+            db_err,
+            exc_info=True,
+        )
+        return PaymentResult(
+            success=False,
+            error="Payment was captured but confirmation failed. Do not retry — our team has been notified.",
+            status_code=503,
+        )
+    await manager.send_personal_message(
+        {
+            "type": "payment_completed",
+            "ride_id": ride_id,
+            "charged_amount": _money_str(settled_amount),
+        },
+        f"rider_{rider_id}",
+    )
+    return PaymentResult(success=True, charged_amount=_money_str(settled_amount))
+
+
 async def settle_card(
     ride: dict,
     ride_id: str,
@@ -383,10 +540,41 @@ async def settle_card(
     total_charge: Decimal,
     tip_amount: Decimal,
 ) -> PaymentResult:
-    """Charge rider's card via Stripe."""
+    """Charge rider's card via Stripe.
+
+    Prefers capturing a booking-time pre-authorization hold (one Stripe fee,
+    lets a within-buffer tip ride on the same PaymentIntent). Falls back to a
+    fresh charge when there is no usable hold or the hold could not be captured.
+    """
     rider_user = await db_supabase.get_user_by_id(rider_id)
     stripe_customer_id = (rider_user or {}).get("stripe_customer_id")
     payment_method_id = ride.get("payment_method_id") or (rider_user or {}).get("default_payment_method")
+
+    # Settle against a pre-authorized hold when one is open. ``auth_status``
+    # distinguishes a manual-capture hold from a prior 3DS auto-capture PI that
+    # also lives in ``payment_intent_id`` — only the former is captured here.
+    held_pi = ride.get("payment_intent_id")
+    auth_status = (ride.get("auth_status") or "").lower()
+    authorized = _round(_d(ride.get("authorized_amount") or 0))
+    # Default fresh-charge confirm target: a stored PI is only reused for the
+    # 3DS-retry case (no open hold). After an unusable hold we must NOT reconfirm
+    # the dead hold PI — pass None so charge_ride creates a fresh PaymentIntent.
+    confirm_pi = held_pi
+    if held_pi and auth_status in ("authorized", "fare_only") and authorized > 0:
+        held_result = await _settle_against_hold(
+            ride,
+            ride_id,
+            rider_id,
+            total_charge,
+            tip_amount,
+            held_pi=held_pi,
+            authorized=authorized,
+            stripe_customer_id=stripe_customer_id,
+            payment_method_id=payment_method_id,
+        )
+        if held_result is not None:
+            return held_result
+        confirm_pi = None  # hold unusable → fresh charge, not a reconfirm
 
     if not payment_method_id:
         await db_supabase.update_ride(ride_id, {"payment_status": "pending"})
@@ -404,7 +592,7 @@ async def settle_card(
         rider_id=rider_id,
         payment_method_id=payment_method_id,
         stripe_customer_id=stripe_customer_id,
-        payment_intent_id=ride.get("payment_intent_id"),
+        payment_intent_id=confirm_pi,
     )
 
     if outcome.status == "succeeded":

--- a/backend/tests/routes/test_payments.py
+++ b/backend/tests/routes/test_payments.py
@@ -144,3 +144,115 @@ async def test_create_intent_non_owner_gets_403_not_500():
             )
 
     assert exc_info.value.status_code == 403
+
+
+# ── C1: confirm must bind the PI to this ride and verify amount ──────────────
+
+_RIDE_BASIS = {"id": _RIDE_ID, "rider_id": _OWNER_ID, "payment_status": "pending", "grand_total": "30.00"}
+
+
+def _patch_confirm_env(metadata, *, status="succeeded", amount_received=3000):
+    from unittest.mock import MagicMock
+
+    intent = MagicMock()
+    intent.metadata = metadata
+    intent.status = status
+    intent.amount_received = amount_received
+    stripe_mock = MagicMock()
+    stripe_mock.PaymentIntent.retrieve.return_value = intent
+    return stripe_mock
+
+
+@pytest.mark.anyio
+async def test_confirm_rejects_pi_for_different_ride():
+    """C1: a PaymentIntent whose metadata.ride_id is a DIFFERENT ride is rejected
+    (owning the PI + the ride is not enough)."""
+    from fastapi import HTTPException
+
+    from backend.routes.payments import ConfirmPaymentRequest, confirm_payment
+
+    stripe_mock = _patch_confirm_env({"user_id": _OWNER_ID, "ride_id": "ride-OTHER"})
+    with (
+        patch("backend.routes.payments.db_supabase") as mock_db,
+        patch(
+            "backend.routes.payments.get_app_settings",
+            new_callable=AsyncMock,
+            return_value={"stripe_secret_key": "sk_test"},
+        ),
+        patch("backend.routes.payments.stripe", stripe_mock),
+    ):
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_BASIS)
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=True)
+        mock_db.update_ride = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc:
+            await confirm_payment(
+                body=ConfirmPaymentRequest(**{"payment_intent_id": "pi_x", "ride_id": _RIDE_ID}),
+                request=None,
+                current_user=_OWNER_USER,
+            )
+    assert exc.value.status_code == 403
+    mock_db.update_ride.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_confirm_rejects_underpayment():
+    """C1: a succeeded PI whose amount_received is below the owed total (a cheap
+    intent confirmed against an expensive ride) is rejected with 402."""
+    from fastapi import HTTPException
+
+    from backend.routes.payments import ConfirmPaymentRequest, confirm_payment
+
+    stripe_mock = _patch_confirm_env({"user_id": _OWNER_ID, "ride_id": _RIDE_ID}, amount_received=1000)
+    with (
+        patch("backend.routes.payments.db_supabase") as mock_db,
+        patch(
+            "backend.routes.payments.get_app_settings",
+            new_callable=AsyncMock,
+            return_value={"stripe_secret_key": "sk_test"},
+        ),
+        patch("backend.routes.payments.stripe", stripe_mock),
+    ):
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_BASIS)
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=True)
+        mock_db.update_ride = AsyncMock()
+
+        with pytest.raises(HTTPException) as exc:
+            await confirm_payment(
+                body=ConfirmPaymentRequest(**{"payment_intent_id": "pi_x", "ride_id": _RIDE_ID}),
+                request=None,
+                current_user=_OWNER_USER,
+            )
+    assert exc.value.status_code == 402
+    assert exc.value.detail["code"] == "AMOUNT_MISMATCH"
+    mock_db.update_ride.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_confirm_marks_paid_when_bound_and_sufficient():
+    """C1: matching ride_id + sufficient amount → the ride is settled."""
+    from backend.routes.payments import ConfirmPaymentRequest, confirm_payment
+
+    stripe_mock = _patch_confirm_env({"user_id": _OWNER_ID, "ride_id": _RIDE_ID}, amount_received=3000)
+    with (
+        patch("backend.routes.payments.db_supabase") as mock_db,
+        patch(
+            "backend.routes.payments.get_app_settings",
+            new_callable=AsyncMock,
+            return_value={"stripe_secret_key": "sk_test"},
+        ),
+        patch("backend.routes.payments.stripe", stripe_mock),
+    ):
+        mock_db.get_ride = AsyncMock(return_value=_RIDE_BASIS)
+        mock_db.claim_ride_payment_processing = AsyncMock(return_value=True)
+        mock_db.update_ride = AsyncMock()
+
+        result = await confirm_payment(
+            body=ConfirmPaymentRequest(**{"payment_intent_id": "pi_x", "ride_id": _RIDE_ID}),
+            request=None,
+            current_user=_OWNER_USER,
+        )
+    assert result["status"] == "succeeded"
+    mock_db.update_ride.assert_awaited_once()
+    written = mock_db.update_ride.call_args[0][1]
+    assert written["payment_status"] == "succeeded"

--- a/backend/tests/test_base_like_escape.py
+++ b/backend/tests/test_base_like_escape.py
@@ -1,0 +1,48 @@
+"""C6: LIKE/ILIKE wildcard escaping in the repository $regex filter path.
+
+A user-supplied `%` or `_` in a $regex search must be escaped so it matches
+literally (no over-match / cheap scan), matching the $or sibling's escaping.
+"""
+
+from __future__ import annotations
+
+
+class _FakeQuery:
+    """Records the last like/ilike call and returns itself for chaining."""
+
+    def __init__(self):
+        self.like_calls = []
+        self.ilike_calls = []
+
+    def like(self, col, pattern):
+        self.like_calls.append((col, pattern))
+        return self
+
+    def ilike(self, col, pattern):
+        self.ilike_calls.append((col, pattern))
+        return self
+
+
+def test_escape_like_escapes_wildcards_and_escape_char():
+    from backend.repositories._base import _escape_like
+
+    # backslash first, then % and _
+    assert _escape_like("50%_off") == r"50\%\_off"
+    assert _escape_like(r"a\b") == r"a\\b"
+    assert _escape_like("plain") == "plain"
+
+
+def test_regex_filter_wraps_escaped_pattern_for_like():
+    from backend.repositories._base import _apply_filters
+
+    q = _FakeQuery()
+    _apply_filters(q, {"name": {"$regex": "100%_match"}})
+    assert q.like_calls == [("name", r"%100\%\_match%")]
+
+
+def test_regex_filter_case_insensitive_uses_ilike_escaped():
+    from backend.repositories._base import _apply_filters
+
+    q = _FakeQuery()
+    _apply_filters(q, {"name": {"$regex": "a_b", "$options": "i"}})
+    assert q.ilike_calls == [("name", r"%a\_b%")]

--- a/backend/tests/test_coverage_payments.py
+++ b/backend/tests/test_coverage_payments.py
@@ -503,7 +503,11 @@ async def test_get_cards_with_stripe():
 
 
 @pytest.mark.anyio
-async def test_get_cards_stripe_error_returns_empty():
+async def test_get_cards_stripe_error_raises_502():
+    """C7: a Stripe outage must NOT masquerade as an empty card list — it raises
+    502 so the client retries instead of thinking the saved card vanished."""
+    from fastapi import HTTPException
+
     from backend.routes.payments import get_cards
 
     with (
@@ -516,9 +520,10 @@ async def test_get_cards_stripe_error_returns_empty():
     ):
         mock_db.get_user_by_id = AsyncMock(return_value=_USER)
 
-        result = await get_cards(current_user=_USER)
+        with pytest.raises(HTTPException) as exc:
+            await get_cards(current_user=_USER)
 
-    assert result == []
+    assert exc.value.status_code == 502
 
 
 # ── add_card (stripe path) ─────────────────────────────────────────────────────
@@ -868,8 +873,11 @@ async def test_add_card_invalid_json():
 
 
 @pytest.mark.anyio
-async def test_set_default_card_stripe_error_logged_not_raised():
-    """Stripe failure on set_default_card is logged but does not raise — DB update still ran."""
+async def test_set_default_card_stripe_error_raises_502_and_skips_db():
+    """C7: Stripe is the source of truth — a failed Customer.modify raises 502 and
+    must NOT write the DB default (no DB↔Stripe divergence)."""
+    from fastapi import HTTPException
+
     from backend.routes.payments import set_default_card
 
     with (
@@ -883,15 +891,19 @@ async def test_set_default_card_stripe_error_logged_not_raised():
         mock_db.update_one = AsyncMock()
         mock_db.get_user_by_id = AsyncMock(return_value={**_USER, "stripe_customer_id": "cus_existing"})
 
-        result = await set_default_card(card_id="pm_001", current_user=_USER)
+        with pytest.raises(HTTPException) as exc:
+            await set_default_card(card_id="pm_001", current_user=_USER)
 
-    # Should still succeed despite stripe error
-    assert result["success"] is True
+    assert exc.value.status_code == 502
+    mock_db.update_one.assert_not_awaited()  # DB default not written on Stripe failure
 
 
 @pytest.mark.anyio
-async def test_delete_card_stripe_error_logged_not_raised():
-    """Stripe detach failure is logged but does not raise — DB cleanup still runs."""
+async def test_delete_card_stripe_error_raises_502_and_keeps_db():
+    """C7: a failed detach raises 502 and leaves the DB untouched — the card must
+    not vanish from the UI while still live in Stripe."""
+    from fastapi import HTTPException
+
     from backend.routes.payments import delete_card
 
     with (
@@ -905,6 +917,8 @@ async def test_delete_card_stripe_error_logged_not_raised():
         mock_db.get_user_by_id = AsyncMock(return_value={**_USER, "default_payment_method": "pm_001"})
         mock_db.update_one = AsyncMock()
 
-        result = await delete_card(card_id="pm_001", current_user=_USER)
+        with pytest.raises(HTTPException) as exc:
+            await delete_card(card_id="pm_001", current_user=_USER)
 
-    assert result["success"] is True
+    assert exc.value.status_code == 502
+    mock_db.update_one.assert_not_awaited()  # default not cleared when detach failed

--- a/backend/tests/test_driver_claim_reaper.py
+++ b/backend/tests/test_driver_claim_reaper.py
@@ -1,0 +1,114 @@
+"""Tests for the orphaned driver-claim reaper (C3).
+
+A driver claimed by dispatch (is_available=false) whose offer-insert never
+landed (crash) must be released; a legitimately busy driver (pending offer or
+active ride) or a recently-claimed one must NOT be.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _driver(minutes_ago=5, claimed=True):
+    stamp = None
+    if claimed:
+        stamp = (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat()
+    return {
+        "id": "drv_1",
+        "user_id": "u_1",
+        "is_online": True,
+        "is_available": False,
+        "availability_claimed_at": stamp,
+    }
+
+
+def _patches(*, drivers, pending_offer=False, active_ride=False, release_ok=True):
+    P = "backend.utils.driver_claim_reaper."
+
+    async def _get_rows(table, flt, **kw):
+        if table == "drivers":
+            return drivers
+        if table == "ride_offers":
+            return [{"id": "o1"}] if pending_offer else []
+        if table == "rides":
+            return [{"id": "r1"}] if active_ride else []
+        return []
+
+    release_mock = AsyncMock(return_value={"is_available": True} if release_ok else {"is_available": False})
+    return [
+        patch(P + "db.get_rows", AsyncMock(side_effect=_get_rows)),
+        patch(P + "set_driver_available", release_mock),
+    ], release_mock
+
+
+@pytest.mark.asyncio
+class TestReapTick:
+    async def test_orphan_is_released(self):
+        from contextlib import ExitStack
+
+        from backend.utils.driver_claim_reaper import _reap_tick
+
+        patches, release = _patches(drivers=[_driver(minutes_ago=5)])
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _reap_tick()
+
+        release.assert_called_once_with("drv_1", available=True)
+
+    async def test_recent_claim_not_reaped(self):
+        """Within the threshold (sub-second claim→insert window) → never touched."""
+        from contextlib import ExitStack
+
+        from backend.utils.driver_claim_reaper import _reap_tick
+
+        patches, release = _patches(drivers=[_driver(minutes_ago=0)])  # claimed seconds ago
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _reap_tick()
+
+        release.assert_not_called()
+
+    async def test_null_stamp_not_reaped(self):
+        from contextlib import ExitStack
+
+        from backend.utils.driver_claim_reaper import _reap_tick
+
+        patches, release = _patches(drivers=[_driver(claimed=False)])
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _reap_tick()
+
+        release.assert_not_called()
+
+    async def test_pending_offer_not_reaped(self):
+        from contextlib import ExitStack
+
+        from backend.utils.driver_claim_reaper import _reap_tick
+
+        patches, release = _patches(drivers=[_driver(minutes_ago=5)], pending_offer=True)
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _reap_tick()
+
+        release.assert_not_called()
+
+    async def test_active_ride_not_reaped(self):
+        from contextlib import ExitStack
+
+        from backend.utils.driver_claim_reaper import _reap_tick
+
+        patches, release = _patches(drivers=[_driver(minutes_ago=5)], active_ride=True)
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _reap_tick()
+
+        release.assert_not_called()

--- a/backend/tests/test_preauth_capture.py
+++ b/backend/tests/test_preauth_capture.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for the pre-authorization capture sweeper
+backend/utils/preauth_capture.py.
+
+Pins the subtask-5 behavior: after the tip window elapses, a completed card
+ride with an open hold is atomically claimed and settled via settle_card
+(which captures the hold). Covered:
+  - tip window still open  → skipped, no claim
+  - window elapsed         → atomic claim then settle_card called
+  - lost claim race        → settle_card NOT called
+  - settlement success     → receipt sent
+  - settlement failure     → handed to retry loop (no raise)
+
+db, settle_card, send_ride_receipt are patched on the module's bound names.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _ride(minutes_ago=60, auth_status="authorized"):
+    completed = (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).isoformat()
+    return {
+        "id": "ride_sw_1",
+        "rider_id": "rider_sw_1",
+        "payment_method": "card",
+        "payment_method_id": "pm_sw",
+        "payment_status": "pending",
+        "auth_status": auth_status,
+        "authorized_amount": "35.00",
+        "payment_intent_id": "pi_hold",
+        "total_fare": "25.00",
+        "grand_total": "25.00",
+        "tip_amount": "0",
+        "ride_completed_at": completed,
+    }
+
+
+def _result(success=True, **kw):
+    from backend.services.payment_service import PaymentResult
+
+    return PaymentResult(success=success, **kw)
+
+
+def _patches(*, rows, claim=None, settle=None):
+    P = "backend.utils.preauth_capture."
+    settle_mock = AsyncMock(return_value=settle if settle is not None else _result())
+    claim_mock = AsyncMock(return_value=claim)
+    return (
+        [
+            patch(P + "db.get_rows", AsyncMock(return_value=rows)),
+            patch(P + "db.update_one", claim_mock),
+            patch(P + "settle_card", settle_mock),
+            patch(P + "send_ride_receipt", AsyncMock(return_value=True)),
+        ],
+        settle_mock,
+        claim_mock,
+    )
+
+
+@pytest.mark.asyncio
+class TestCaptureTick:
+    async def test_window_open_skips_without_claim(self):
+        from contextlib import ExitStack
+
+        from backend.utils.preauth_capture import _capture_tick
+
+        patches, settle, claim = _patches(rows=[_ride(minutes_ago=5)], claim={"id": "ride_sw_1"})
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _capture_tick()
+
+        claim.assert_not_called()  # tip window still open
+        settle.assert_not_called()
+
+    async def test_window_elapsed_claims_then_settles(self):
+        from contextlib import ExitStack
+
+        from backend.utils.preauth_capture import _capture_tick
+
+        patches, settle, claim = _patches(rows=[_ride(minutes_ago=60)], claim={"id": "ride_sw_1"})
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _capture_tick()
+
+        claim.assert_called_once()
+        # claim asserts pending + auth_status, sets processing
+        claim_filter = claim.call_args.args[1]
+        assert claim_filter["payment_status"] == "pending"
+        assert claim_filter["auth_status"] == "authorized"
+        settle.assert_called_once()
+        # settle_card called with total_charge = grand_total + tip (25 + 0)
+        assert settle.call_args.args[3] == Decimal("25.00")
+
+    async def test_lost_claim_race_does_not_settle(self):
+        from contextlib import ExitStack
+
+        from backend.utils.preauth_capture import _capture_tick
+
+        patches, settle, claim = _patches(rows=[_ride(minutes_ago=60)], claim=None)  # lost race
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _capture_tick()
+
+        claim.assert_called_once()
+        settle.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestCaptureOne:
+    async def test_success_sends_receipt(self):
+        from contextlib import ExitStack
+
+        from backend.utils.preauth_capture import _capture_one
+
+        patches, settle, _ = _patches(rows=[], settle=_result(success=True, charged_amount="25.00"))
+        receipt = AsyncMock(return_value=True)
+        with ExitStack() as st:
+            for p in patches[:3]:
+                st.enter_context(p)
+            st.enter_context(patch("backend.utils.preauth_capture.send_ride_receipt", receipt))
+            await _capture_one(_ride())
+
+        settle.assert_called_once()
+        receipt.assert_called_once()
+
+    async def test_failure_no_raise_no_receipt(self):
+        from contextlib import ExitStack
+
+        from backend.utils.preauth_capture import _capture_one
+
+        patches, settle, _ = _patches(rows=[], settle=_result(success=False, error_code="card_declined"))
+        receipt = AsyncMock(return_value=True)
+        with ExitStack() as st:
+            for p in patches[:3]:
+                st.enter_context(p)
+            st.enter_context(patch("backend.utils.preauth_capture.send_ride_receipt", receipt))
+            await _capture_one(_ride())  # must not raise
+
+        settle.assert_called_once()
+        receipt.assert_not_called()
+
+    async def test_settle_raises_is_swallowed(self):
+        from contextlib import ExitStack
+
+        from backend.utils.preauth_capture import _capture_one
+
+        with ExitStack() as st:
+            st.enter_context(
+                patch("backend.utils.preauth_capture.settle_card", AsyncMock(side_effect=RuntimeError("boom")))
+            )
+            st.enter_context(patch("backend.utils.preauth_capture.send_ride_receipt", AsyncMock()))
+            await _capture_one(_ride())  # must not raise

--- a/backend/tests/test_ride_preauth.py
+++ b/backend/tests/test_ride_preauth.py
@@ -346,3 +346,39 @@ class TestVerifyAuthorization:
         ):
             outcome = await verify_authorization(ride_id="r", payment_intent_id="pi_e")
         assert outcome.status == "failed"
+
+    async def test_customer_mismatch_is_declined(self):
+        """SECURITY: a PI owned by a different Stripe customer must not attach."""
+        from backend.utils.stripe_charge import verify_authorization
+
+        intent = MagicMock(id="pi_o", status="requires_capture", amount=3500, customer="cus_OTHER")
+        stripe_patch, _ = _patch_stripe(retrieve_return=intent)
+        with _patch_settings(), stripe_patch:
+            outcome = await verify_authorization(ride_id="r", payment_intent_id="pi_o", expected_customer_id="cus_MINE")
+        assert outcome.status == "declined"
+        assert "account" in (outcome.error_message or "").lower()
+
+    async def test_amount_too_small_is_declined(self):
+        """SECURITY: a hold smaller than the fare (replayed cheaper booking) is declined."""
+        from backend.utils.stripe_charge import verify_authorization
+
+        intent = MagicMock(id="pi_s", status="requires_capture", amount=1000, customer="cus_MINE")
+        stripe_patch, _ = _patch_stripe(retrieve_return=intent)
+        with _patch_settings(), stripe_patch:
+            outcome = await verify_authorization(
+                ride_id="r", payment_intent_id="pi_s", expected_customer_id="cus_MINE", min_amount_cents=2500
+            )
+        assert outcome.status == "declined"
+        assert "insufficient" in (outcome.error_message or "").lower()
+
+    async def test_owner_and_amount_ok_is_authorized(self):
+        from backend.utils.stripe_charge import verify_authorization
+
+        intent = MagicMock(id="pi_ok", status="requires_capture", amount=3500, customer="cus_MINE")
+        stripe_patch, _ = _patch_stripe(retrieve_return=intent)
+        with _patch_settings(), stripe_patch:
+            outcome = await verify_authorization(
+                ride_id="r", payment_intent_id="pi_ok", expected_customer_id="cus_MINE", min_amount_cents=2500
+            )
+        assert outcome.status == "authorized"
+        assert outcome.charged_amount == Decimal("35.00")

--- a/backend/tests/test_ride_preauth.py
+++ b/backend/tests/test_ride_preauth.py
@@ -43,12 +43,14 @@ def _patch_settings(secret: str = "sk_test_xxx"):
     )
 
 
-def _patch_stripe(create_return=None, capture_return=None):
+def _patch_stripe(create_return=None, capture_return=None, retrieve_return=None):
     mock_stripe = MagicMock()
     if create_return is not None:
         mock_stripe.PaymentIntent.create.return_value = create_return
     if capture_return is not None:
         mock_stripe.PaymentIntent.capture.return_value = capture_return
+    if retrieve_return is not None:
+        mock_stripe.PaymentIntent.retrieve.return_value = retrieve_return
     return patch("backend.utils.stripe_charge.stripe", mock_stripe), mock_stripe
 
 
@@ -279,3 +281,68 @@ class TestCapture:
 
         assert outcome.status == "declined"
         assert outcome.decline_code == "issuer_not_available"
+
+
+# --------------------------------------------------------------------------- #
+# verify_authorization (SCA two-step: confirm an on-device-authed hold)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+class TestVerifyAuthorization:
+    async def test_requires_capture_is_authorized(self):
+        """The PI the app confirmed on-device landed in requires_capture →
+        hold is real; charged_amount comes from Stripe's cents."""
+        from backend.utils.stripe_charge import verify_authorization
+
+        intent = MagicMock(id="pi_sca", status="requires_capture", amount=3500)
+        stripe_patch, _ = _patch_stripe(retrieve_return=intent)
+
+        with _patch_settings(), stripe_patch:
+            outcome = await verify_authorization(ride_id="r", payment_intent_id="pi_sca")
+
+        assert outcome.status == "authorized"
+        assert outcome.payment_intent_id == "pi_sca"
+        assert outcome.charged_amount == Decimal("35.00")
+
+    async def test_succeeded_treated_as_authorized(self):
+        """Already captured (e.g. duplicate) → authorized so the caller attaches
+        it; settlement's idempotent capture is a no-op, never a double charge."""
+        from backend.utils.stripe_charge import verify_authorization
+
+        intent = MagicMock(id="pi_s", status="succeeded", amount=2500)
+        stripe_patch, _ = _patch_stripe(retrieve_return=intent)
+        with _patch_settings(), stripe_patch:
+            outcome = await verify_authorization(ride_id="r", payment_intent_id="pi_s")
+        assert outcome.status == "authorized"
+        assert outcome.charged_amount == Decimal("25.00")
+
+    async def test_unconfirmed_pi_is_declined(self):
+        """Rider abandoned/failed the SCA sheet → PI still needs action/method."""
+        from backend.utils.stripe_charge import verify_authorization
+
+        intent = MagicMock(id="pi_x", status="requires_payment_method", amount=3500)
+        stripe_patch, _ = _patch_stripe(retrieve_return=intent)
+        with _patch_settings(), stripe_patch:
+            outcome = await verify_authorization(ride_id="r", payment_intent_id="pi_x")
+        assert outcome.status == "declined"
+
+    async def test_missing_pi_returns_failed(self):
+        from backend.utils.stripe_charge import verify_authorization
+
+        outcome = await verify_authorization(ride_id="r", payment_intent_id="")
+        assert outcome.status == "failed"
+
+    async def test_stripe_error_returns_failed(self):
+        from backend.utils.stripe_charge import verify_authorization
+
+        class _FakeStripeError(Exception):
+            pass
+
+        mock_stripe = MagicMock()
+        mock_stripe.PaymentIntent.retrieve.side_effect = _FakeStripeError("api_error")
+        with (
+            _patch_settings(),
+            patch("backend.utils.stripe_charge.stripe", mock_stripe),
+            patch("backend.utils.stripe_charge._StripeBaseError", _FakeStripeError),
+        ):
+            outcome = await verify_authorization(ride_id="r", payment_intent_id="pi_e")
+        assert outcome.status == "failed"

--- a/backend/tests/test_ride_preauth.py
+++ b/backend/tests/test_ride_preauth.py
@@ -1,0 +1,281 @@
+"""
+Unit tests for the buffered pre-authorization helpers in
+backend/utils/stripe_charge.py — ``authorize_ride`` and ``capture_ride``.
+
+These two functions implement the front-of-ride hold + single-capture model:
+
+    authorize_ride  → at booking, place a manual-capture hold for
+                      (estimated fare + RIDE_AUTH_BUFFER). Surfaces a dead card
+                      BEFORE dispatch; a "declined" outcome lets the caller fall
+                      back to a fare-only hold.
+    capture_ride    → at settlement, capture (fare + tip) against that hold in a
+                      single transaction, so a tip rides on the same PaymentIntent
+                      (one Stripe fee). Capture > authorization is rejected by
+                      Stripe, hence tip-over-buffer is charged separately.
+
+Mirrors test_stripe_charge.py: stripe + settings are patched on the bound names
+in the module, so no real Stripe network or package is required.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_AUTH_KW = dict(
+    ride={"id": "ride_pa_1", "payment_method": "card"},
+    rider_id="rider_pa_1",
+    amount=Decimal("35.00"),  # estimated fare 25.00 + 10.00 buffer
+    stripe_customer_id="cus_pa",
+    payment_method_id="pm_pa",
+)
+
+
+def _patch_settings(secret: str = "sk_test_xxx"):
+    async def _settings():
+        return {"stripe_secret_key": secret}
+
+    return patch(
+        "backend.utils.stripe_charge.get_app_settings",
+        AsyncMock(side_effect=_settings),
+    )
+
+
+def _patch_stripe(create_return=None, capture_return=None):
+    mock_stripe = MagicMock()
+    if create_return is not None:
+        mock_stripe.PaymentIntent.create.return_value = create_return
+    if capture_return is not None:
+        mock_stripe.PaymentIntent.capture.return_value = capture_return
+    return patch("backend.utils.stripe_charge.stripe", mock_stripe), mock_stripe
+
+
+# --------------------------------------------------------------------------- #
+# authorize_ride
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+class TestAuthorize:
+    async def test_zero_amount_is_noop_authorized(self):
+        from backend.utils.stripe_charge import authorize_ride
+
+        outcome = await authorize_ride(ride={"id": "r"}, rider_id="u", amount=0)
+        assert outcome.status == "authorized"
+        assert outcome.charged_amount == Decimal("0.00")
+        assert outcome.payment_intent_id is None
+
+    async def test_unconfigured_when_no_secret(self):
+        from backend.utils.stripe_charge import authorize_ride
+
+        stripe_patch, _ = _patch_stripe()
+        with _patch_settings(secret=""), stripe_patch:
+            outcome = await authorize_ride(**_AUTH_KW)
+        assert outcome.status == "unconfigured"
+
+    async def test_no_customer_returns_failed(self):
+        from backend.utils.stripe_charge import authorize_ride
+
+        stripe_patch, _ = _patch_stripe()
+        with _patch_settings(), stripe_patch:
+            outcome = await authorize_ride(**{**_AUTH_KW, "stripe_customer_id": None})
+        assert outcome.status == "failed"
+        assert "Stripe customer" in (outcome.error_message or "")
+
+    async def test_requires_capture_returns_authorized(self):
+        """The happy path: Stripe holds funds and reports requires_capture.
+        No money has moved yet; charged_amount carries the held amount."""
+        from backend.utils.stripe_charge import authorize_ride
+
+        intent = MagicMock(id="pi_hold_1", status="requires_capture", client_secret=None)
+        stripe_patch, mock_stripe = _patch_stripe(create_return=intent)
+
+        with _patch_settings(), stripe_patch:
+            outcome = await authorize_ride(**_AUTH_KW)
+
+        assert outcome.status == "authorized"
+        assert outcome.payment_intent_id == "pi_hold_1"
+        assert outcome.charged_amount == Decimal("35.00")
+
+        kwargs = mock_stripe.PaymentIntent.create.call_args.kwargs
+        assert kwargs["amount"] == 3500  # cents, HALF_UP
+        assert kwargs["currency"] == "cad"
+        assert kwargs["capture_method"] == "manual"  # HOLD, not charge
+        assert kwargs["confirm"] is True
+        assert kwargs["off_session"] is False  # rider present at booking
+        assert kwargs["metadata"]["source"] == "ride_booking_authorization"
+        assert kwargs["metadata"]["authorized_amount"] == "35.00"
+        # amount-pinned idempotency key: a re-auth at a revised estimate gets a
+        # fresh key; an identical double-tap dedupes to the same hold.
+        assert kwargs["idempotency_key"] == "ride-auth-ride_pa_1-3500"
+
+    async def test_requires_action_returns_client_secret(self):
+        """Apple Pay / 3DS at booking — hand the client_secret back so the
+        rider-app runs the biometric / SCA sheet."""
+        from backend.utils.stripe_charge import authorize_ride
+
+        intent = MagicMock(id="pi_ra", status="requires_action", client_secret="pi_ra_secret")
+        stripe_patch, _ = _patch_stripe(create_return=intent)
+
+        with _patch_settings(), stripe_patch:
+            outcome = await authorize_ride(**_AUTH_KW)
+
+        assert outcome.status == "requires_action"
+        assert outcome.client_secret == "pi_ra_secret"
+
+    async def test_insufficient_funds_returns_declined(self):
+        """A declined buffered hold is the signal the caller uses to fall back
+        to a fare-only authorization — decline_code must be propagated."""
+        from backend.utils.stripe_charge import authorize_ride
+
+        class _FakeErrObj:
+            code = "card_declined"
+            decline_code = "insufficient_funds"
+            message = "Your card has insufficient funds."
+
+        class _FakeCardError(Exception):
+            def __init__(self):
+                super().__init__("Your card has insufficient funds.")
+                self.error = _FakeErrObj()
+
+        mock_stripe = MagicMock()
+        mock_stripe.PaymentIntent.create.side_effect = _FakeCardError()
+
+        with (
+            _patch_settings(),
+            patch("backend.utils.stripe_charge.stripe", mock_stripe),
+            patch("backend.utils.stripe_charge._StripeCardError", _FakeCardError),
+        ):
+            outcome = await authorize_ride(**_AUTH_KW)
+
+        assert outcome.status == "declined"
+        assert outcome.decline_code == "insufficient_funds"
+
+    async def test_requires_payment_method_treated_as_declined(self):
+        from backend.utils.stripe_charge import authorize_ride
+
+        intent = MagicMock(id="pi_rpm", status="requires_payment_method", client_secret=None)
+        stripe_patch, _ = _patch_stripe(create_return=intent)
+
+        with _patch_settings(), stripe_patch:
+            outcome = await authorize_ride(**_AUTH_KW)
+
+        assert outcome.status == "declined"
+
+    async def test_non_card_error_returns_failed(self):
+        from backend.utils.stripe_charge import authorize_ride
+
+        class _FakeStripeError(Exception):
+            pass
+
+        class _NeverMatches(Exception):
+            pass
+
+        mock_stripe = MagicMock()
+        mock_stripe.PaymentIntent.create.side_effect = _FakeStripeError("rate_limit_error")
+
+        with (
+            _patch_settings(),
+            patch("backend.utils.stripe_charge.stripe", mock_stripe),
+            patch("backend.utils.stripe_charge._StripeCardError", _NeverMatches),
+            patch("backend.utils.stripe_charge._StripeBaseError", _FakeStripeError),
+        ):
+            outcome = await authorize_ride(**_AUTH_KW)
+
+        assert outcome.status == "failed"
+
+
+# --------------------------------------------------------------------------- #
+# capture_ride
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+class TestCapture:
+    async def test_zero_amount_is_noop_captured(self):
+        from backend.utils.stripe_charge import capture_ride
+
+        outcome = await capture_ride(ride_id="r", payment_intent_id="pi_x", amount=0)
+        assert outcome.status == "captured"
+
+    async def test_missing_pi_returns_failed(self):
+        from backend.utils.stripe_charge import capture_ride
+
+        outcome = await capture_ride(ride_id="r", payment_intent_id="", amount=Decimal("10"))
+        assert outcome.status == "failed"
+        assert "capture" in (outcome.error_message or "").lower()
+
+    async def test_capture_succeeds(self):
+        """Fare 25.00 + tip 5.00 captured against the 35.00 hold in one go."""
+        from backend.utils.stripe_charge import capture_ride
+
+        intent = MagicMock(id="pi_hold_1", status="succeeded")
+        stripe_patch, mock_stripe = _patch_stripe(capture_return=intent)
+
+        with _patch_settings(), stripe_patch:
+            outcome = await capture_ride(
+                ride_id="ride_pa_1",
+                payment_intent_id="pi_hold_1",
+                amount=Decimal("30.00"),
+            )
+
+        assert outcome.status == "captured"
+        assert outcome.payment_intent_id == "pi_hold_1"
+        assert outcome.charged_amount == Decimal("30.00")
+
+        kwargs = mock_stripe.PaymentIntent.capture.call_args.kwargs
+        assert kwargs["amount_to_capture"] == 3000  # cents
+        assert kwargs["idempotency_key"] == "ride-capture-ride_pa_1-3000"
+
+    async def test_expired_hold_returns_failed_for_fresh_charge_fallback(self):
+        """A non-card Stripe error at capture (expired hold, amount_too_large)
+        is 'failed' — the caller re-drives via a fresh charge_ride, NOT a
+        rider-facing decline."""
+        from backend.utils.stripe_charge import capture_ride
+
+        class _FakeStripeError(Exception):
+            pass
+
+        class _NeverMatches(Exception):
+            pass
+
+        mock_stripe = MagicMock()
+        mock_stripe.PaymentIntent.capture.side_effect = _FakeStripeError(
+            "This PaymentIntent could not be captured because it has expired."
+        )
+
+        with (
+            _patch_settings(),
+            patch("backend.utils.stripe_charge.stripe", mock_stripe),
+            patch("backend.utils.stripe_charge._StripeCardError", _NeverMatches),
+            patch("backend.utils.stripe_charge._StripeBaseError", _FakeStripeError),
+        ):
+            outcome = await capture_ride(ride_id="ride_pa_1", payment_intent_id="pi_hold_1", amount=Decimal("30.00"))
+
+        assert outcome.status == "failed"
+        assert "expired" in (outcome.error_message or "").lower()
+
+    async def test_capture_decline_propagates_code(self):
+        """Rare: issuer reverses the hold and Stripe raises CardError at capture."""
+        from backend.utils.stripe_charge import capture_ride
+
+        class _FakeErrObj:
+            code = "card_declined"
+            decline_code = "issuer_not_available"
+            message = "The card issuer could not be reached."
+
+        class _FakeCardError(Exception):
+            def __init__(self):
+                super().__init__("The card issuer could not be reached.")
+                self.error = _FakeErrObj()
+
+        mock_stripe = MagicMock()
+        mock_stripe.PaymentIntent.capture.side_effect = _FakeCardError()
+
+        with (
+            _patch_settings(),
+            patch("backend.utils.stripe_charge.stripe", mock_stripe),
+            patch("backend.utils.stripe_charge._StripeCardError", _FakeCardError),
+        ):
+            outcome = await capture_ride(ride_id="ride_pa_1", payment_intent_id="pi_hold_1", amount=Decimal("30.00"))
+
+        assert outcome.status == "declined"
+        assert outcome.decline_code == "issuer_not_available"

--- a/backend/tests/test_ride_preauth_booking.py
+++ b/backend/tests/test_ride_preauth_booking.py
@@ -50,13 +50,14 @@ class TestPreauthorizeRideCard:
         from backend.routes.rides import _preauthorize_ride_card
 
         with _patch_authorize(_outcome(status="authorized", payment_intent_id="pi_hold")) as auth:
-            fields = await _preauthorize_ride_card(**_BASE)
+            result = await _preauthorize_ride_card(**_BASE)
 
-        assert fields == {
+        assert result.fields == {
             "payment_intent_id": "pi_hold",
             "authorized_amount": 35.0,  # 25.00 fare + 10.00 buffer
             "auth_status": "authorized",
         }
+        assert result.requires_action is False
         # Buffered amount actually requested
         assert auth.call_args.kwargs["amount"] == Decimal("35.00")
 
@@ -67,9 +68,9 @@ class TestPreauthorizeRideCard:
             _outcome(status="declined", decline_code="insufficient_funds"),
             _outcome(status="authorized", payment_intent_id="pi_fare_only"),
         ) as auth:
-            fields = await _preauthorize_ride_card(**_BASE)
+            result = await _preauthorize_ride_card(**_BASE)
 
-        assert fields == {
+        assert result.fields == {
             "payment_intent_id": "pi_fare_only",
             "authorized_amount": 25.0,  # fare only, no buffer
             "auth_status": "fare_only",
@@ -103,12 +104,26 @@ class TestPreauthorizeRideCard:
         assert ei.value.status_code == 402
         assert auth.call_count == 1  # no fallback retry on a hard decline
 
-    async def test_requires_action_degrades_to_no_hold(self):
+    async def test_requires_action_surfaces_client_secret_at_booking(self):
+        """SCA / Apple Pay at booking: surface requires_action + client_secret so
+        the app confirms on-device, then re-books with the PI."""
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="requires_action", client_secret="cs", payment_intent_id="pi_sca")):
+            result = await _preauthorize_ride_card(**_BASE)
+        assert result.requires_action is True
+        assert result.client_secret == "cs"
+        assert result.payment_intent_id == "pi_sca"
+        assert result.fields == {}
+
+    async def test_requires_action_degrades_when_not_blocking(self):
+        """Scheduled dispatch can't drive an on-device sheet → degrade to no hold."""
         from backend.routes.rides import _preauthorize_ride_card
 
         with _patch_authorize(_outcome(status="requires_action", client_secret="cs")):
-            fields = await _preauthorize_ride_card(**_BASE)
-        assert fields == {}
+            result = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
+        assert result.requires_action is False
+        assert result.fields == {}
 
     async def test_block_on_decline_false_hard_decline_returns_empty(self):
         """Scheduled dispatch (rider absent): a hard decline must NOT raise —
@@ -116,8 +131,8 @@ class TestPreauthorizeRideCard:
         from backend.routes.rides import _preauthorize_ride_card
 
         with _patch_authorize(_outcome(status="declined", decline_code="lost_card")):
-            fields = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
-        assert fields == {}
+            result = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
+        assert result.fields == {}
 
     async def test_block_on_decline_false_both_declined_returns_empty(self):
         from backend.routes.rides import _preauthorize_ride_card
@@ -126,27 +141,62 @@ class TestPreauthorizeRideCard:
             _outcome(status="declined", decline_code="insufficient_funds"),
             _outcome(status="declined", decline_code="insufficient_funds"),
         ):
-            fields = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
-        assert fields == {}
+            result = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
+        assert result.fields == {}
 
     async def test_ops_failure_degrades_to_no_hold(self):
         from backend.routes.rides import _preauthorize_ride_card
 
         with _patch_authorize(_outcome(status="failed", error_message="rate_limit")):
-            fields = await _preauthorize_ride_card(**_BASE)
-        assert fields == {}
+            result = await _preauthorize_ride_card(**_BASE)
+        assert result.fields == {}
 
     async def test_unconfigured_degrades_to_no_hold(self):
         from backend.routes.rides import _preauthorize_ride_card
 
         with _patch_authorize(_outcome(status="unconfigured")):
-            fields = await _preauthorize_ride_card(**_BASE)
-        assert fields == {}
+            result = await _preauthorize_ride_card(**_BASE)
+        assert result.fields == {}
 
     async def test_no_card_on_file_skips_stripe_entirely(self):
         from backend.routes.rides import _preauthorize_ride_card
 
         with _patch_authorize() as auth:  # would raise StopIteration if called
-            fields = await _preauthorize_ride_card(**{**_BASE, "payment_method_id": None})
-        assert fields == {}
+            result = await _preauthorize_ride_card(**{**_BASE, "payment_method_id": None})
+        assert result.fields == {}
         auth.assert_not_called()
+
+
+def _patch_verify(outcome):
+    return patch("backend.routes.rides.verify_authorization", AsyncMock(return_value=outcome))
+
+
+@pytest.mark.asyncio
+class TestAttachPreauthorizedHold:
+    async def test_authorized_attaches_amount_from_stripe(self):
+        from backend.routes.rides import _attach_preauthorized_hold
+
+        with _patch_verify(_outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))):
+            fields = await _attach_preauthorized_hold(ride_id="r", payment_intent_id="pi_sca")
+
+        assert fields == {
+            "payment_intent_id": "pi_sca",
+            "authorized_amount": 35.0,
+            "auth_status": "authorized",
+        }
+
+    async def test_declined_raises_402(self):
+        from backend.routes.rides import _attach_preauthorized_hold
+
+        with _patch_verify(_outcome(status="declined")):
+            with pytest.raises(HTTPException) as ei:
+                await _attach_preauthorized_hold(ride_id="r", payment_intent_id="pi_x")
+        assert ei.value.status_code == 402
+        assert ei.value.detail["code"] == "CARD_DECLINED"
+
+    async def test_failed_degrades_to_no_hold(self):
+        from backend.routes.rides import _attach_preauthorized_hold
+
+        with _patch_verify(_outcome(status="failed", error_message="ops")):
+            fields = await _attach_preauthorized_hold(ride_id="r", payment_intent_id="pi_x")
+        assert fields == {}

--- a/backend/tests/test_ride_preauth_booking.py
+++ b/backend/tests/test_ride_preauth_booking.py
@@ -110,6 +110,25 @@ class TestPreauthorizeRideCard:
             fields = await _preauthorize_ride_card(**_BASE)
         assert fields == {}
 
+    async def test_block_on_decline_false_hard_decline_returns_empty(self):
+        """Scheduled dispatch (rider absent): a hard decline must NOT raise —
+        it degrades to no hold so the scheduled ride is never stranded."""
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="declined", decline_code="lost_card")):
+            fields = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
+        assert fields == {}
+
+    async def test_block_on_decline_false_both_declined_returns_empty(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(
+            _outcome(status="declined", decline_code="insufficient_funds"),
+            _outcome(status="declined", decline_code="insufficient_funds"),
+        ):
+            fields = await _preauthorize_ride_card(**_BASE, block_on_decline=False)
+        assert fields == {}
+
     async def test_ops_failure_degrades_to_no_hold(self):
         from backend.routes.rides import _preauthorize_ride_card
 

--- a/backend/tests/test_ride_preauth_booking.py
+++ b/backend/tests/test_ride_preauth_booking.py
@@ -192,9 +192,10 @@ class TestAttachPreauthorizedHold:
         from backend.routes.rides import _attach_preauthorized_hold
 
         out = _outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))
+        patches = _patch_verify(out)
         with ExitStack() as st:
-            verify = st.enter_context(_patch_verify(out)[0])
-            st.enter_context(_patch_verify(out)[1])
+            verify = st.enter_context(patches[0])
+            st.enter_context(patches[1])
             fields = await _attach_preauthorized_hold(**_ATTACH_KW)
 
         assert fields == {
@@ -205,6 +206,33 @@ class TestAttachPreauthorizedHold:
         # ownership + amount checks are threaded to verify_authorization
         assert verify.call_args.kwargs["expected_customer_id"] == "cus_book"
         assert verify.call_args.kwargs["min_amount_cents"] == 2500
+
+    async def test_same_ride_reattach_is_allowed(self):
+        """Idempotent retry: a PI already on THIS ride re-attaches, not blocks."""
+        from contextlib import ExitStack
+
+        from backend.routes.rides import _attach_preauthorized_hold
+
+        out = _outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))
+        with ExitStack() as st:
+            for p in _patch_verify(out, existing_rows=[{"id": _ATTACH_KW["ride_id"]}]):
+                st.enter_context(p)
+            fields = await _attach_preauthorized_hold(**_ATTACH_KW)
+        assert fields["auth_status"] == "authorized"
+
+    async def test_no_stripe_customer_blocks(self):
+        """SECURITY: without a customer to verify ownership against, reject (fail closed)."""
+        from contextlib import ExitStack
+
+        from backend.routes.rides import _attach_preauthorized_hold
+
+        out = _outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))
+        with ExitStack() as st:
+            for p in _patch_verify(out):
+                st.enter_context(p)
+            with pytest.raises(HTTPException) as ei:
+                await _attach_preauthorized_hold(**{**_ATTACH_KW, "stripe_customer_id": None})
+        assert ei.value.status_code == 402
 
     async def test_declined_raises_402(self):
         from contextlib import ExitStack

--- a/backend/tests/test_ride_preauth_booking.py
+++ b/backend/tests/test_ride_preauth_booking.py
@@ -1,0 +1,133 @@
+"""
+Unit tests for the booking-time card pre-authorization helper
+backend/routes/rides.py::_preauthorize_ride_card.
+
+The helper places a buffered manual-capture hold (grand_total +
+RIDE_AUTH_BUFFER_CAD) at booking and decides, per Stripe outcome, whether to:
+  - persist the hold (authorized / fare_only),
+  - block the booking with 402 (genuine decline), or
+  - degrade to "no hold, proceed" (SCA, ops error, unconfigured, no card).
+
+`authorize_ride` is patched on the bound name in routes.rides so no Stripe is
+touched. ChargeOutcome is the real dataclass.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_BASE = dict(
+    ride_id="ride_book_1",
+    rider_id="rider_book_1",
+    grand_total=Decimal("25.00"),
+    stripe_customer_id="cus_book",
+    payment_method_id="pm_book",
+)
+
+
+def _outcome(**kw):
+    from backend.utils.stripe_charge import ChargeOutcome
+
+    return ChargeOutcome(**kw)
+
+
+def _patch_authorize(*returns):
+    """Patch routes.rides.authorize_ride with a sequence of ChargeOutcomes
+    (one per call — buffered hold, then optional fare-only retry)."""
+    return patch(
+        "backend.routes.rides.authorize_ride",
+        AsyncMock(side_effect=list(returns)),
+    )
+
+
+@pytest.mark.asyncio
+class TestPreauthorizeRideCard:
+    async def test_authorized_persists_hold_with_buffer(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="authorized", payment_intent_id="pi_hold")) as auth:
+            fields = await _preauthorize_ride_card(**_BASE)
+
+        assert fields == {
+            "payment_intent_id": "pi_hold",
+            "authorized_amount": 35.0,  # 25.00 fare + 10.00 buffer
+            "auth_status": "authorized",
+        }
+        # Buffered amount actually requested
+        assert auth.call_args.kwargs["amount"] == Decimal("35.00")
+
+    async def test_insufficient_funds_falls_back_to_fare_only(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(
+            _outcome(status="declined", decline_code="insufficient_funds"),
+            _outcome(status="authorized", payment_intent_id="pi_fare_only"),
+        ) as auth:
+            fields = await _preauthorize_ride_card(**_BASE)
+
+        assert fields == {
+            "payment_intent_id": "pi_fare_only",
+            "authorized_amount": 25.0,  # fare only, no buffer
+            "auth_status": "fare_only",
+        }
+        # Second call held the fare only
+        assert auth.call_count == 2
+        assert auth.call_args_list[1].kwargs["amount"] == Decimal("25.00")
+
+    async def test_both_declined_blocks_with_402(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(
+            _outcome(status="declined", decline_code="insufficient_funds"),
+            _outcome(status="declined", decline_code="insufficient_funds"),
+        ):
+            with pytest.raises(HTTPException) as ei:
+                await _preauthorize_ride_card(**_BASE)
+
+        assert ei.value.status_code == 402
+        assert ei.value.detail["code"] == "CARD_DECLINED"
+
+    async def test_hard_decline_blocks_without_retry(self):
+        """lost_card etc. — a smaller hold won't help, so block immediately
+        (exactly one authorize call, no fare-only retry)."""
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="declined", decline_code="lost_card")) as auth:
+            with pytest.raises(HTTPException) as ei:
+                await _preauthorize_ride_card(**_BASE)
+
+        assert ei.value.status_code == 402
+        assert auth.call_count == 1  # no fallback retry on a hard decline
+
+    async def test_requires_action_degrades_to_no_hold(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="requires_action", client_secret="cs")):
+            fields = await _preauthorize_ride_card(**_BASE)
+        assert fields == {}
+
+    async def test_ops_failure_degrades_to_no_hold(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="failed", error_message="rate_limit")):
+            fields = await _preauthorize_ride_card(**_BASE)
+        assert fields == {}
+
+    async def test_unconfigured_degrades_to_no_hold(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize(_outcome(status="unconfigured")):
+            fields = await _preauthorize_ride_card(**_BASE)
+        assert fields == {}
+
+    async def test_no_card_on_file_skips_stripe_entirely(self):
+        from backend.routes.rides import _preauthorize_ride_card
+
+        with _patch_authorize() as auth:  # would raise StopIteration if called
+            fields = await _preauthorize_ride_card(**{**_BASE, "payment_method_id": None})
+        assert fields == {}
+        auth.assert_not_called()

--- a/backend/tests/test_ride_preauth_booking.py
+++ b/backend/tests/test_ride_preauth_booking.py
@@ -167,36 +167,79 @@ class TestPreauthorizeRideCard:
         auth.assert_not_called()
 
 
-def _patch_verify(outcome):
-    return patch("backend.routes.rides.verify_authorization", AsyncMock(return_value=outcome))
+def _patch_verify(outcome, *, existing_rows=None):
+    """Patch verify_authorization and the PI-reuse lookup (db_supabase.get_rows)."""
+    return [
+        patch("backend.routes.rides.verify_authorization", AsyncMock(return_value=outcome)),
+        patch("backend.routes.rides.db_supabase.get_rows", AsyncMock(return_value=existing_rows or [])),
+    ]
+
+
+_ATTACH_KW = dict(
+    ride_id="r",
+    rider_id="rider_book_1",
+    payment_intent_id="pi_sca",
+    stripe_customer_id="cus_book",
+    min_amount=Decimal("25.00"),
+)
 
 
 @pytest.mark.asyncio
 class TestAttachPreauthorizedHold:
     async def test_authorized_attaches_amount_from_stripe(self):
+        from contextlib import ExitStack
+
         from backend.routes.rides import _attach_preauthorized_hold
 
-        with _patch_verify(_outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))):
-            fields = await _attach_preauthorized_hold(ride_id="r", payment_intent_id="pi_sca")
+        out = _outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))
+        with ExitStack() as st:
+            verify = st.enter_context(_patch_verify(out)[0])
+            st.enter_context(_patch_verify(out)[1])
+            fields = await _attach_preauthorized_hold(**_ATTACH_KW)
 
         assert fields == {
             "payment_intent_id": "pi_sca",
             "authorized_amount": 35.0,
             "auth_status": "authorized",
         }
+        # ownership + amount checks are threaded to verify_authorization
+        assert verify.call_args.kwargs["expected_customer_id"] == "cus_book"
+        assert verify.call_args.kwargs["min_amount_cents"] == 2500
 
     async def test_declined_raises_402(self):
+        from contextlib import ExitStack
+
         from backend.routes.rides import _attach_preauthorized_hold
 
-        with _patch_verify(_outcome(status="declined")):
+        with ExitStack() as st:
+            for p in _patch_verify(_outcome(status="declined")):
+                st.enter_context(p)
             with pytest.raises(HTTPException) as ei:
-                await _attach_preauthorized_hold(ride_id="r", payment_intent_id="pi_x")
+                await _attach_preauthorized_hold(**_ATTACH_KW)
         assert ei.value.status_code == 402
         assert ei.value.detail["code"] == "CARD_DECLINED"
 
     async def test_failed_degrades_to_no_hold(self):
+        from contextlib import ExitStack
+
         from backend.routes.rides import _attach_preauthorized_hold
 
-        with _patch_verify(_outcome(status="failed", error_message="ops")):
-            fields = await _attach_preauthorized_hold(ride_id="r", payment_intent_id="pi_x")
+        with ExitStack() as st:
+            for p in _patch_verify(_outcome(status="failed", error_message="ops")):
+                st.enter_context(p)
+            fields = await _attach_preauthorized_hold(**_ATTACH_KW)
         assert fields == {}
+
+    async def test_pi_already_attached_to_other_ride_blocks(self):
+        """SECURITY: a PI already on a DIFFERENT ride can't be re-attached."""
+        from contextlib import ExitStack
+
+        from backend.routes.rides import _attach_preauthorized_hold
+
+        out = _outcome(status="authorized", payment_intent_id="pi_sca", charged_amount=Decimal("35.00"))
+        with ExitStack() as st:
+            for p in _patch_verify(out, existing_rows=[{"id": "some_other_ride"}]):
+                st.enter_context(p)
+            with pytest.raises(HTTPException) as ei:
+                await _attach_preauthorized_hold(**_ATTACH_KW)
+        assert ei.value.status_code == 402

--- a/backend/tests/test_scheduled_preauth.py
+++ b/backend/tests/test_scheduled_preauth.py
@@ -58,7 +58,7 @@ class TestScheduledDispatchPreauth:
 
         from backend.utils.scheduled_rides import _dispatch_scheduled_ride
 
-        fields = {"payment_intent_id": "pi_hold", "authorized_amount": 40.0, "auth_status": "authorized"}
+        fields = {"payment_intent_id": "pi_hold", "authorized_amount": "40.00", "auth_status": "authorized"}
         # update_one calls: [0]=claim (returns the claimed ride), [1]=persist hold
         patches, update_mock, preauth_mock = _dispatch_patches(
             preauth_fields=fields,

--- a/backend/tests/test_scheduled_preauth.py
+++ b/backend/tests/test_scheduled_preauth.py
@@ -1,0 +1,101 @@
+"""
+Integration test for dispatch-time pre-authorization of scheduled rides
+(backend/utils/scheduled_rides.py::_dispatch_scheduled_ride).
+
+A scheduled ride may be booked days out — beyond Stripe's ~7-day auth lifetime —
+so the card hold is placed when the ride goes live, not at booking. This pins:
+  - a card scheduled ride calls _preauthorize_ride_card(block_on_decline=False)
+    at dispatch and persists the returned hold fields
+  - a decline at dispatch does NOT raise (ride still dispatches)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _claimed_card_ride():
+    return {
+        "id": "ride_sched_1",
+        "rider_id": "rider_sched_1",
+        "payment_method": "card",
+        "payment_method_id": "pm_sched",
+        "grand_total": "30.00",
+        "total_fare": "30.00",
+        "auth_status": None,
+        "dropoff_address": "Somewhere",
+    }
+
+
+def _dispatch_patches(*, preauth_fields, update_returns):
+    """Patch the full dependency surface of _dispatch_scheduled_ride."""
+    S = "backend.utils.scheduled_rides."
+    update_mock = AsyncMock(side_effect=update_returns)
+    preauth_mock = AsyncMock(return_value=preauth_fields)
+    return (
+        [
+            patch(S + "db.update_one", update_mock),
+            patch(S + "db.get_user_by_id", AsyncMock(return_value={"stripe_customer_id": "cus_sched"})),
+            patch(S + "manager.broadcast_ride_status", AsyncMock()),
+            patch(S + "manager.broadcast_to_admins", AsyncMock()),
+            patch(S + "send_push_notification", AsyncMock()),
+            patch("backend.routes.rides._preauthorize_ride_card", preauth_mock),
+            patch("backend.routes.rides.match_driver_to_ride", AsyncMock()),
+            patch("backend.routes.rides.ride_search_timeout", AsyncMock()),
+            patch("backend.routes.admin.monitoring.build_monitoring_ride", lambda *a, **k: {}),
+        ],
+        update_mock,
+        preauth_mock,
+    )
+
+
+@pytest.mark.asyncio
+class TestScheduledDispatchPreauth:
+    async def test_card_ride_authorizes_at_dispatch_and_persists(self):
+        from contextlib import ExitStack
+
+        from backend.utils.scheduled_rides import _dispatch_scheduled_ride
+
+        fields = {"payment_intent_id": "pi_hold", "authorized_amount": 40.0, "auth_status": "authorized"}
+        # update_one calls: [0]=claim (returns the claimed ride), [1]=persist hold
+        patches, update_mock, preauth_mock = _dispatch_patches(
+            preauth_fields=fields,
+            update_returns=[_claimed_card_ride(), {"id": "ride_sched_1"}],
+        )
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            await _dispatch_scheduled_ride({"id": "ride_sched_1", "rider_id": "rider_sched_1"})
+
+        # pre-auth invoked with block_on_decline=False (rider not present)
+        preauth_mock.assert_called_once()
+        assert preauth_mock.call_args.kwargs["block_on_decline"] is False
+        # hold fields persisted via a second update_one carrying $set
+        assert update_mock.call_count == 2
+        persisted = update_mock.call_args_list[1].args[2]["$set"]
+        assert persisted["auth_status"] == "authorized"
+        assert persisted["payment_intent_id"] == "pi_hold"
+
+    async def test_decline_at_dispatch_does_not_persist_or_raise(self):
+        from contextlib import ExitStack
+
+        from backend.utils.scheduled_rides import _dispatch_scheduled_ride
+
+        # preauth returns {} (declined, degraded) → no persist update_one call
+        patches, update_mock, preauth_mock = _dispatch_patches(
+            preauth_fields={},
+            update_returns=[_claimed_card_ride()],
+        )
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            # Must not raise even though the card "declined"
+            await _dispatch_scheduled_ride({"id": "ride_sched_1", "rider_id": "rider_sched_1"})
+
+        preauth_mock.assert_called_once()
+        # only the claim update_one fired; no hold persisted
+        assert update_mock.call_count == 1

--- a/backend/tests/test_scheduled_preauth.py
+++ b/backend/tests/test_scheduled_preauth.py
@@ -31,9 +31,11 @@ def _claimed_card_ride():
 
 def _dispatch_patches(*, preauth_fields, update_returns):
     """Patch the full dependency surface of _dispatch_scheduled_ride."""
+    from backend.routes.rides import _PreauthOutcome
+
     S = "backend.utils.scheduled_rides."
     update_mock = AsyncMock(side_effect=update_returns)
-    preauth_mock = AsyncMock(return_value=preauth_fields)
+    preauth_mock = AsyncMock(return_value=_PreauthOutcome(fields=preauth_fields))
     return (
         [
             patch(S + "db.update_one", update_mock),

--- a/backend/tests/test_settle_card_capture.py
+++ b/backend/tests/test_settle_card_capture.py
@@ -1,0 +1,221 @@
+"""
+Unit tests for the capture-against-hold settlement path in
+backend/services/payment_service.py::settle_card / _settle_against_hold.
+
+These pin the subtask-4 behavior: when a ride carries a booking-time
+pre-authorization hold (auth_status in authorized/fare_only), settlement
+CAPTURES that PaymentIntent for (fare + tip) in one Stripe fee instead of
+creating a fresh charge. Covered branches:
+
+  - within-buffer tip → single capture, paid, auth_status=captured
+  - tip over buffer    → capture the hold + fresh charge for the overflow
+  - over-buffer overflow charge fails → settle captured portion, log, paid
+  - capture declined (issuer reversal) → failed + 402
+  - capture failed (expired hold)      → fall back to a fresh full charge
+  - no hold present                    → unchanged fresh-charge path
+
+capture_ride / charge_ride are patched on the payment_service bound names.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+RIDE_ID = "ride_cap_1"
+RIDER_ID = "rider_cap_1"
+
+
+def _outcome(**kw):
+    from backend.utils.stripe_charge import ChargeOutcome
+
+    return ChargeOutcome(**kw)
+
+
+def _held_ride(auth_status="authorized", authorized_amount="35.00", pi="pi_hold"):
+    return {
+        "id": RIDE_ID,
+        "rider_id": RIDER_ID,
+        "payment_method": "card",
+        "payment_intent_id": pi,
+        "auth_status": auth_status,
+        "authorized_amount": authorized_amount,
+        "total_fare": "25.00",
+        "driver_earnings": "20.00",
+        "tip_amount": "0",
+    }
+
+
+def _common_patches(*, capture=None, charge=None):
+    """Patch DB writes, ledger, socket, push, and the Stripe helpers.
+    Returns (patches, updates) where updates captures every update_ride patch."""
+    updates = []
+
+    async def _capture_update(ride_id, patch):
+        updates.append(patch)
+        return {"modified_count": 1}
+
+    ps = "backend.services.payment_service."
+    patches = [
+        patch(
+            ps + "db_supabase.get_user_by_id",
+            AsyncMock(return_value={"stripe_customer_id": "cus_X", "default_payment_method": "pm_X"}),
+        ),
+        patch(ps + "db_supabase.update_ride", AsyncMock(side_effect=_capture_update)),
+        patch(ps + "db_supabase.insert_one", AsyncMock(return_value=None)),
+        patch(ps + "record_payment_event", AsyncMock(return_value=None)),
+        patch(ps + "manager.send_personal_message", AsyncMock(return_value=None)),
+        patch(ps + "send_push_notification", AsyncMock(return_value=None)),
+    ]
+    if capture is not None:
+        patches.append(
+            patch(ps + "capture_ride", AsyncMock(side_effect=capture if isinstance(capture, list) else [capture]))
+        )
+    if charge is not None:
+        patches.append(
+            patch(ps + "charge_ride", AsyncMock(side_effect=charge if isinstance(charge, list) else [charge]))
+        )
+    return patches, updates
+
+
+def _last(updates, key):
+    for u in reversed(updates):
+        if key in u:
+            return u[key]
+    return None
+
+
+@pytest.mark.asyncio
+class TestCaptureWithinBuffer:
+    async def test_within_buffer_tip_single_capture(self):
+        """Fare 25 + tip 5 = 30 ≤ 35 hold → one capture, no fresh charge."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        cap = _outcome(status="captured", payment_intent_id="pi_hold", charged_amount=Decimal("30.00"))
+        patches, updates = _common_patches(capture=cap, charge=_outcome(status="failed"))
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            result = await settle_card(_held_ride(), RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"))
+
+        assert result.success is True
+        assert result.charged_amount == "30.00"
+        assert _last(updates, "payment_status") == "paid"
+        assert _last(updates, "auth_status") == "captured"
+        assert _last(updates, "payment_intent_id") == "pi_hold"
+
+
+@pytest.mark.asyncio
+class TestCaptureOverBuffer:
+    async def test_tip_over_buffer_captures_hold_plus_fresh_charge(self):
+        """Fare 25 + tip 20 = 45 > 35 hold → capture 35 + charge 10 overflow."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        cap = _outcome(status="captured", payment_intent_id="pi_hold", charged_amount=Decimal("35.00"))
+        over = _outcome(status="succeeded", payment_intent_id="pi_over", charged_amount=Decimal("10.00"))
+        patches, updates = _common_patches(capture=cap, charge=over)
+
+        with ExitStack() as st:
+            ctxs = [st.enter_context(p) for p in patches]
+            # capture_ride is the 2nd-to-last patch, charge_ride the last
+            charge_mock = ctxs[-1]
+            result = await settle_card(_held_ride(), RIDE_ID, RIDER_ID, Decimal("45.00"), Decimal("20.00"))
+
+        assert result.success is True
+        assert result.charged_amount == "45.00"  # 35 captured + 10 overflow
+        # overflow charge was for the remainder only
+        assert charge_mock.call_args.kwargs["total_amount"] == Decimal("10.00")
+        assert _last(updates, "payment_status") == "paid"
+
+    async def test_over_buffer_overflow_charge_fails_settles_captured_portion(self):
+        """Overflow charge declines → fare+buffer captured, excess tip dropped,
+        ride still marked paid (not stranded)."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        cap = _outcome(status="captured", payment_intent_id="pi_hold", charged_amount=Decimal("35.00"))
+        over = _outcome(status="declined", decline_code="insufficient_funds")
+        patches, updates = _common_patches(capture=cap, charge=over)
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            result = await settle_card(_held_ride(), RIDE_ID, RIDER_ID, Decimal("45.00"), Decimal("20.00"))
+
+        assert result.success is True
+        assert result.charged_amount == "35.00"  # only the captured hold
+        assert _last(updates, "payment_status") == "paid"
+
+
+@pytest.mark.asyncio
+class TestCaptureFailureModes:
+    async def test_capture_declined_marks_failed_402(self):
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        cap = _outcome(status="declined", decline_code="issuer_not_available")
+        patches, updates = _common_patches(capture=cap)
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            result = await settle_card(_held_ride(), RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"))
+
+        assert result.success is False
+        assert result.status_code == 402
+        assert result.error_code == "card_declined"
+        assert _last(updates, "payment_status") == "failed"
+
+    async def test_expired_hold_falls_back_to_fresh_charge(self):
+        """capture 'failed' (expired) → settle_card creates a fresh full charge,
+        and must NOT reconfirm the dead hold PI (payment_intent_id=None)."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        cap = _outcome(status="failed", error_message="PaymentIntent expired")
+        fresh = _outcome(status="succeeded", payment_intent_id="pi_fresh", charged_amount=Decimal("30.00"))
+        patches, updates = _common_patches(capture=cap, charge=fresh)
+
+        with ExitStack() as st:
+            ctxs = [st.enter_context(p) for p in patches]
+            charge_mock = ctxs[-1]
+            result = await settle_card(_held_ride(), RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"))
+
+        assert result.success is True
+        assert result.charged_amount == "30.00"
+        # fresh charge, not a reconfirm of the dead hold
+        assert charge_mock.call_args.kwargs["payment_intent_id"] is None
+
+
+@pytest.mark.asyncio
+class TestNoHoldUnchanged:
+    async def test_no_hold_uses_fresh_charge_path(self):
+        """A ride with no auth_status hold settles via charge_ride exactly as
+        before; capture_ride is never called."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        ride = _held_ride(auth_status=None, authorized_amount=0, pi=None)
+        fresh = _outcome(status="succeeded", payment_intent_id="pi_fresh", charged_amount=Decimal("30.00"))
+        cap_mock = AsyncMock()
+        patches, updates = _common_patches(charge=fresh)
+        patches.append(patch("backend.services.payment_service.capture_ride", cap_mock))
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            result = await settle_card(ride, RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"))
+
+        assert result.success is True
+        cap_mock.assert_not_called()

--- a/backend/tests/test_stripe_reconcile.py
+++ b/backend/tests/test_stripe_reconcile.py
@@ -45,11 +45,20 @@ def _ride(
     ride_id: str = "ride1",
     pi_id: str = "pi_abc",
     fare: str = "25.00",
+    grand_total: str = "25.00",
+    tip_amount: str = "0.00",
+    authorized_amount: str | None = None,
 ) -> dict:
     return {
         "id": ride_id,
         "payment_intent_id": pi_id,
+        # C2: reconcile compares against grand_total + tip (the authoritative
+        # charge), not the fare-side subtotal. `fare` is retained only so legacy
+        # callers don't break; the reconcile no longer reads it.
         "fare": fare,
+        "grand_total": grand_total,
+        "tip_amount": tip_amount,
+        "authorized_amount": authorized_amount,
         "status": "completed",
         "payment_status": "paid",
         "completed_at": _ts_yesterday(),
@@ -295,7 +304,7 @@ async def test_failed_stripe_pi_not_flagged_as_orphan():
 @pytest.mark.asyncio
 async def test_clean_run_writes_zero_discrepancies():
     """Matched ride + succeeded PI with correct amount → zero discrepancies in audit log."""
-    ride = _ride(fare="10.50")
+    ride = _ride(grand_total="10.50")
     pi = _pi(status="succeeded", amount_received=1050)
     db_mock = AsyncMock()
     db_mock.get_rows.return_value = [ride]
@@ -630,3 +639,81 @@ async def test_reconcile_payouts_skips_recent_and_terminal():
         result = await sr._reconcile_payouts()
 
     assert result == []
+
+
+# ── C2 regression: authoritative basis (grand_total + tip), underpay-only ────
+
+
+@pytest.mark.asyncio
+async def test_amount_basis_includes_fees_tax_and_tip():
+    """C2: expected = grand_total + tip (not the fare subtotal). A PI that paid
+    only the fare while grand_total includes fees/GST/PST + tip is UNDERPAYMENT."""
+    ride = _ride(grand_total="30.00", tip_amount="5.00")  # expect 3500
+    pi = _pi(status="succeeded", amount_received=2500)  # paid only the fare
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    mismatch = next(d for d in audit_detail["discrepancy_detail"] if d["type"] == "DB_PAID_AMOUNT_MISMATCH")
+    assert mismatch["db_cents"] == 3500
+    assert mismatch["stripe_cents"] == 2500
+
+
+@pytest.mark.asyncio
+async def test_overpayment_is_not_flagged():
+    """C2: only UNDERPAYMENT is a revenue risk. Stripe amount >= expected → clean
+    (no false positive, unlike the old strict != check)."""
+    ride = _ride(grand_total="25.00")
+    pi = _pi(status="succeeded", amount_received=2600)  # 1.00 over
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert all(d["type"] != "DB_PAID_AMOUNT_MISMATCH" for d in audit_detail["discrepancy_detail"])
+
+
+@pytest.mark.asyncio
+async def test_over_buffer_tip_capped_at_authorized_amount():
+    """C2 + pre-auth: when tip exceeds the hold, only authorized_amount is
+    captured on THIS PI (overflow is a separate PI), so expected is capped and
+    the primary PI is not falsely flagged."""
+    ride = _ride(grand_total="25.00", tip_amount="20.00", authorized_amount="35.00")  # cap 3500
+    pi = _pi(status="succeeded", amount_received=3500)
+    db_mock = AsyncMock()
+    db_mock.get_rows.return_value = [ride]
+    db_mock.insert_one.return_value = {"id": "log1"}
+    stripe_mock = _make_stripe_mock([pi])
+
+    with (
+        patch("utils.stripe_reconcile.get_app_settings", AsyncMock(return_value={"stripe_secret_key": "sk_test"})),
+        patch("utils.stripe_reconcile.db_supabase", db_mock),
+        patch.dict(sys.modules, {"stripe": stripe_mock}),
+    ):
+        from utils.stripe_reconcile import _run_reconciliation_tick
+
+        await _run_reconciliation_tick()
+
+    audit_detail = db_mock.insert_one.call_args[0][1]["details"]
+    assert all(d["type"] != "DB_PAID_AMOUNT_MISMATCH" for d in audit_detail["discrepancy_detail"])

--- a/backend/tests/test_webhook_stripe_v15.py
+++ b/backend/tests/test_webhook_stripe_v15.py
@@ -1,0 +1,61 @@
+"""Regression test for the stripe-python v15 webhook AttributeError.
+
+In stripe==15.1.0 the Event returned by Webhook.construct_event is NOT a dict
+subclass: ``event.get(...)`` and ``event.to_dict_recursive()`` raise
+``AttributeError: get`` via __getattr__, which 500'd every webhook delivery
+(all event types, table stayed at 0 rows). _event_to_plain_dict normalizes the
+Event to a plain dict so field access + jsonb storage work again.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_real_stripe_v15_event_is_normalized():
+    """A real stripe v15 Event (no .get, has _to_dict_recursive) → plain dict."""
+    stripe = pytest.importorskip("stripe")
+    from backend.routes.webhooks import _event_to_plain_dict
+
+    raw = {
+        "id": "evt_1",
+        "type": "payment_intent.succeeded",
+        "data": {"object": {"id": "pi_1", "metadata": {"k": "v"}}},
+    }
+    event = stripe.Event.construct_from(raw, "sk_test")
+
+    # Sanity: this is exactly the shape that crashed production.
+    assert not isinstance(event, dict)
+    with pytest.raises(AttributeError):
+        event.get("id")
+
+    out = _event_to_plain_dict(event)
+    assert isinstance(out, dict)
+    assert out["id"] == "evt_1"
+    assert out["type"] == "payment_intent.succeeded"
+    # Nested objects must be plain dicts too (for jsonb storage + .get access).
+    assert out["data"]["object"]["metadata"]["k"] == "v"
+    assert isinstance(out["data"]["object"], dict)
+    # And the normalized event supports .get() (the call that was crashing).
+    assert out.get("type") == "payment_intent.succeeded"
+
+
+def test_plain_dict_passthrough():
+    from backend.routes.webhooks import _event_to_plain_dict
+
+    d = {"id": "evt_2", "type": "charge.succeeded", "data": {"object": {}}}
+    assert _event_to_plain_dict(d) is d
+
+
+def test_configured_mock_with_get_is_not_transformed():
+    """A test mock that already exposes a working .get must be returned as-is
+    (so existing webhook tests keep working)."""
+    from backend.routes.webhooks import _event_to_plain_dict
+
+    m = MagicMock()
+    m.get.side_effect = lambda k, default=None: {"id": "evt_3", "type": "t"}.get(k, default)
+    out = _event_to_plain_dict(m)
+    assert out is m
+    assert out.get("id") == "evt_3"

--- a/backend/tests/test_webhook_stripe_v15.py
+++ b/backend/tests/test_webhook_stripe_v15.py
@@ -9,7 +9,8 @@ Event to a plain dict so field access + jsonb storage work again.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -59,3 +60,42 @@ def test_configured_mock_with_get_is_not_transformed():
     out = _event_to_plain_dict(m)
     assert out is m
     assert out.get("id") == "evt_3"
+
+
+def test_handler_processes_real_stripe_event_end_to_end():
+    """CI GUARD: drive a REAL stripe.Event (from the installed library) through
+    the actual stripe_webhook handler. If a future stripe version bump changes
+    the Event API so the webhook can't read/normalize it, this fails in CI
+    instead of 500'ing every webhook in production (as stripe v15 did)."""
+    stripe = pytest.importorskip("stripe")
+    from backend.routes import webhooks as wh
+
+    raw = {"id": "evt_ci_1", "type": "balance.available", "data": {"object": {"id": "ba_1"}}}
+    real_event = stripe.Event.construct_from(raw, "sk_test")
+    # Sanity: the not-a-dict, no-.get shape the handler must survive.
+    assert not isinstance(real_event, dict)
+
+    async def _settings():
+        return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+    req = MagicMock()
+    req.body = AsyncMock(return_value=b'{"id":"evt_ci_1"}')
+    req.headers = {"stripe-signature": "sig"}
+
+    claim = AsyncMock(return_value=True)
+    with (
+        patch("backend.routes.webhooks.get_app_settings", _settings),
+        patch.object(stripe.Webhook, "construct_event", return_value=real_event),
+        patch("backend.routes.webhooks.claim_stripe_event", claim),
+        patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+    ):
+        result = asyncio.run(wh.stripe_webhook(request=req))
+
+    # Processed without AttributeError (the v15 crash) and acknowledged.
+    assert result["received"] is True
+    # Event was normalized to a PLAIN dict before persistence, and id/type were
+    # read via .get() (the exact calls that crashed on a raw v15 Event).
+    event_id_arg, event_type_arg, payload_arg = claim.call_args.args[:3]
+    assert event_id_arg == "evt_ci_1"
+    assert event_type_arg == "balance.available"
+    assert isinstance(payload_arg, dict) and payload_arg["id"] == "evt_ci_1"

--- a/backend/utils/driver_claim_reaper.py
+++ b/backend/utils/driver_claim_reaper.py
@@ -1,0 +1,139 @@
+"""Orphaned driver-claim reaper (C3).
+
+Dispatch claims a driver (is_available=false via claim_driver_atomic) and only
+then inserts the ride_offers row + schedules the offer-timeout task. A crash or
+restart in that window leaves the driver is_available=false with no offer and no
+timeout handler — silently dropped from dispatch. The stuck-ride sweeper
+recovers the ride, not the driver flag.
+
+This loop releases such orphans: a driver that is online, unavailable, was
+claimed more than RECLAIM_THRESHOLD_SECONDS ago, and has NEITHER a pending offer
+NOR an active ride. The age threshold (well past the ~15s offer window) plus the
+dedicated availability_claimed_at stamp (which heartbeats never bump) guarantee
+we never race a legitimate in-flight claim.
+
+Replay-safety (CLAUDE.md, Background loops):
+  - Redis leader lock (best-effort throttle).
+  - The release (set_driver_available True) is idempotent and clamps to
+    is_online, so a double-release across replicas is harmless.
+  - A driver with a pending offer or active ride is skipped, so a legitimately
+    busy driver is never reaped.
+"""
+
+import asyncio
+import logging
+import os
+import random
+import socket
+from datetime import datetime, timedelta, timezone
+
+try:
+    from ..db import db
+    from ..repositories.driver_repo import set_driver_available
+    from .datetime_utils import parse_iso_utc
+    from .redis_client import redis_set_nx
+except ImportError:
+    from db import db  # type: ignore
+    from repositories.driver_repo import set_driver_available  # type: ignore
+    from utils.datetime_utils import parse_iso_utc  # type: ignore
+    from utils.redis_client import redis_set_nx  # type: ignore
+
+try:
+    from .loop_monitor import record_heartbeat as _record_heartbeat
+except ImportError:  # pragma: no cover
+
+    def _record_heartbeat(name: str) -> None:  # type: ignore[misc]
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+RECLAIM_THRESHOLD_SECONDS = 90  # well past the ~15s offer window
+REAP_INTERVAL_SECONDS = 60
+_LOOP_NAME = "driver_claim_reaper (60s)"
+_ACTIVE_RIDE_STATUSES = ["driver_assigned", "driver_accepted", "driver_arrived", "in_progress"]
+
+
+def _pod_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+async def _has_pending_offer(driver_id: str) -> bool:
+    rows = await db.get_rows(
+        "ride_offers",
+        {"driver_id": driver_id, "status": "pending"},
+        limit=1,
+        columns="id",
+    )
+    return bool(rows)
+
+
+async def _has_active_ride(driver_id: str) -> bool:
+    rows = await db.get_rows(
+        "rides",
+        {"driver_id": driver_id, "status": {"$in": _ACTIVE_RIDE_STATUSES}},
+        limit=1,
+        columns="id",
+    )
+    return bool(rows)
+
+
+async def _reap_tick() -> None:
+    """Find and release drivers whose dispatch claim never produced an offer."""
+    try:
+        drivers = await db.get_rows(
+            "drivers",
+            {"is_online": True, "is_available": False},
+            limit=200,
+            columns="id,user_id,is_online,is_available,availability_claimed_at",
+        )
+    except Exception as e:
+        logger.error("[claim-reaper] failed to fetch candidate drivers: %s", e, exc_info=True)
+        return
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=RECLAIM_THRESHOLD_SECONDS)
+
+    for driver in drivers:
+        claimed_at = parse_iso_utc(driver.get("availability_claimed_at"))
+        # No stamp, or claimed too recently → not a confirmed orphan (a NULL
+        # stamp means the unavailability didn't come from a dispatch claim).
+        if claimed_at is None or claimed_at > cutoff:
+            continue
+
+        driver_id = driver["id"]
+        # Legitimately busy? Pending offer or active ride → leave alone.
+        if await _has_pending_offer(driver_id) or await _has_active_ride(driver_id):
+            continue
+
+        try:
+            released = await set_driver_available(driver_id, available=True)
+        except Exception as e:
+            logger.error("[claim-reaper] release failed for driver %s: %s", driver_id, e, exc_info=True)
+            continue
+        if isinstance(released, dict) and released.get("is_available"):
+            logger.warning(
+                "[claim-reaper] released orphaned claim for driver %s (claimed %s, no offer/ride)",
+                driver_id,
+                driver.get("availability_claimed_at"),
+            )
+
+
+async def driver_claim_reaper_loop() -> None:
+    """Background loop: release orphaned driver claims every interval."""
+    logger.info(
+        f"Driver claim reaper started (interval={REAP_INTERVAL_SECONDS}s, threshold={RECLAIM_THRESHOLD_SECONDS}s)"
+    )
+    while True:
+        lock_ttl = int(REAP_INTERVAL_SECONDS * 2)
+        if not await redis_set_nx("spinr:driver:claim_reaper:lock", _pod_id(), lock_ttl):
+            _record_heartbeat(_LOOP_NAME)
+            await asyncio.sleep(REAP_INTERVAL_SECONDS)
+            continue
+        try:
+            await _reap_tick()
+        except Exception as e:
+            logger.error(f"Driver claim reaper loop error: {e}", exc_info=True)
+        _record_heartbeat(_LOOP_NAME)
+        delta = REAP_INTERVAL_SECONDS * 0.1
+        await asyncio.sleep(REAP_INTERVAL_SECONDS + random.uniform(-delta, delta))

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -376,10 +376,15 @@ async def payment_retry_loop():
     """Background loop that retries failed payments every RETRY_INTERVAL_SECONDS."""
     logger.info(f"Payment retry service started (interval={RETRY_INTERVAL_SECONDS}s)")
     while True:
-        # Single-replica enforcement: only the pod that claims the lock runs
-        # the retry; others sleep the full interval. Prevents N simultaneous
-        # Stripe retries on multi-replica deploys. TTL is 1.5× interval so
-        # the lock expires cleanly before the next tick's election.
+        # Best-effort throttle (C5): when a real Redis backs redis_set_nx, only
+        # one pod runs a tick, avoiding N simultaneous Stripe-retry scans. But
+        # the in-process fallback (REDIS_URL unset) gives every replica its own
+        # dict, so SET NX returns True everywhere and this is NOT mutual
+        # exclusion. That is acceptable because it is NOT the correctness guard:
+        # double-charge is prevented by the atomic DB claim (payment_status →
+        # 'retrying') + the Stripe idempotency key (see module docstring). The
+        # lock only reduces redundant work; it is never relied on for safety.
+        # TTL is 1.5× interval so a real lock expires before the next election.
         lock_ttl = int(RETRY_INTERVAL_SECONDS * 1.5)
         if not await redis_set_nx("spinr:payment:retry:lock", _pod_id(), lock_ttl):
             _record_heartbeat("payment_retry (5min)")

--- a/backend/utils/preauth_capture.py
+++ b/backend/utils/preauth_capture.py
@@ -12,9 +12,12 @@ triggered themselves.
 
 Replay-safety contract (CLAUDE.md, Background loops):
   Runs on every replica. Two replays must not double-capture. Three layers:
-    1. Redis leader lock (SET NX) — only one pod runs a tick.
+    1. Redis leader lock (SET NX) — normally one pod runs a tick; this is a
+       best-effort throttle, not a guarantee. When Redis is unavailable the
+       in-process fallback lets every replica run, so it is NOT the safety net.
     2. Atomic DB claim — flip payment_status 'pending' → 'processing' asserting
        auth_status unchanged; only the replica whose UPDATE returns a row acts.
+       This is the real double-capture guard and holds even with Redis down.
     3. Stripe idempotency_key on capture (ride-capture-{ride_id}-{cents}) — even
        if two replicas both win a claim race, Stripe dedupes the capture.
 
@@ -159,7 +162,10 @@ async def preauth_capture_loop() -> None:
         f"Pre-auth capture sweeper started (interval={CAPTURE_INTERVAL_SECONDS}s, window={TIP_WINDOW_MINUTES}m)"
     )
     while True:
-        lock_ttl = int(CAPTURE_INTERVAL_SECONDS * 1.5)
+        # TTL = 2× interval so the lock outlives a slow tick (50 rides × Stripe
+        # latency) even after the +10% sleep jitter; the atomic DB claim is the
+        # real double-capture guard if a second replica ever races in.
+        lock_ttl = int(CAPTURE_INTERVAL_SECONDS * 2)
         if not await redis_set_nx("spinr:preauth:capture:lock", _pod_id(), lock_ttl):
             _record_heartbeat(_LOOP_NAME)
             await asyncio.sleep(CAPTURE_INTERVAL_SECONDS)

--- a/backend/utils/preauth_capture.py
+++ b/backend/utils/preauth_capture.py
@@ -1,0 +1,174 @@
+"""Pre-authorization capture sweeper.
+
+Captures booking-time card holds whose tip window has elapsed.
+
+When a rider completes a trip but never finishes the in-app settlement (never
+opens the rate/tip screen), the manual-capture hold placed at booking would sit
+uncaptured until Stripe expires it (~7 days) — at which point the money is gone
+and the 0%-commission driver eats the fare. This loop closes that gap: a short
+tip window after completion, then a single capture of (fare + any recorded tip)
+against the held PaymentIntent — the same single-fee path the rider would have
+triggered themselves.
+
+Replay-safety contract (CLAUDE.md, Background loops):
+  Runs on every replica. Two replays must not double-capture. Three layers:
+    1. Redis leader lock (SET NX) — only one pod runs a tick.
+    2. Atomic DB claim — flip payment_status 'pending' → 'processing' asserting
+       auth_status unchanged; only the replica whose UPDATE returns a row acts.
+    3. Stripe idempotency_key on capture (ride-capture-{ride_id}-{cents}) — even
+       if two replicas both win a claim race, Stripe dedupes the capture.
+
+Settlement itself is delegated to services.payment_service.settle_card, which
+already knows how to capture an open hold (and how to fall back to a fresh
+charge if the hold is unusable), so this loop holds no payment logic of its own.
+"""
+
+import asyncio
+import logging
+import os
+import random
+import socket
+from datetime import datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+
+try:
+    from ..db import db
+    from ..services.payment_service import send_ride_receipt, settle_card
+    from .datetime_utils import parse_iso_utc
+    from .redis_client import redis_set_nx
+except ImportError:
+    from db import db  # type: ignore
+    from services.payment_service import send_ride_receipt, settle_card  # type: ignore
+    from utils.datetime_utils import parse_iso_utc  # type: ignore
+    from utils.redis_client import redis_set_nx  # type: ignore
+
+try:
+    from .loop_monitor import record_heartbeat as _record_heartbeat
+except ImportError:  # pragma: no cover
+
+    def _record_heartbeat(name: str) -> None:  # type: ignore[misc]
+        pass
+
+
+logger = logging.getLogger(__name__)
+
+# Minutes to wait after completion before auto-capturing a hold. Gives the rider
+# time to add a tip on the rating screen so it captures on the same PaymentIntent.
+# Well inside Stripe's ~7-day authorization lifetime.
+TIP_WINDOW_MINUTES = 20
+CAPTURE_INTERVAL_SECONDS = 300  # 5 minutes
+_LOOP_NAME = "preauth_capture (5min)"
+
+
+def _d(v) -> Decimal:
+    return Decimal(str(v)) if v is not None else Decimal("0")
+
+
+def _round(v: Decimal) -> Decimal:
+    return v.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _pod_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+async def _capture_one(ride: dict) -> None:
+    """Settle a single claimed ride by capturing its hold. Never raises."""
+    ride_id = ride["id"]
+    rider_id = ride.get("rider_id")
+    grand = ride.get("grand_total")
+    if grand is None:
+        grand = ride.get("total_fare") or 0
+    tip = _round(_d(ride.get("tip_amount") or 0))
+    total_charge = _round(_d(grand) + tip)
+
+    try:
+        result = await settle_card(ride, ride_id, rider_id, total_charge, tip)
+    except Exception as e:
+        # settle_card normally writes 'paid'/'failed' itself; if it raised before
+        # any write the ride stays 'processing' and the payment_retry loop
+        # reconciles it after 30 min. Surface loudly — payment path error.
+        logger.error("[preauth-capture] settle_card raised for ride %s: %s", ride_id, e, exc_info=True)
+        return
+
+    if result.success:
+        try:
+            await send_ride_receipt(ride, rider_id, tip)
+        except Exception as exc:
+            logger.error("[preauth-capture] receipt send failed for ride %s: %s", ride_id, exc)
+        logger.info("[preauth-capture] auto-captured hold for ride %s ($%s)", ride_id, total_charge)
+    else:
+        # Capture declined / hold unusable → settle_card has set payment_status
+        # to 'failed'; the payment_retry loop will re-drive it. Info, not error:
+        # this is the expected handoff, not a swallowed failure.
+        logger.info(
+            "[preauth-capture] settlement for ride %s did not complete (%s) — handed to retry loop",
+            ride_id,
+            result.error_code or result.error,
+        )
+
+
+async def _capture_tick() -> None:
+    """Find completed card rides with an open hold past the tip window and
+    capture them. One atomic claim per ride guards against double-capture."""
+    try:
+        rides = await db.get_rows(
+            "rides",
+            {
+                "status": "completed",
+                "payment_status": "pending",
+                "auth_status": {"$in": ["authorized", "fare_only"]},
+            },
+            limit=50,
+            order="ride_completed_at",
+            columns=(
+                "id,rider_id,driver_id,payment_method,payment_method_id,payment_status,"
+                "auth_status,authorized_amount,payment_intent_id,total_fare,grand_total,"
+                "tip_amount,driver_earnings,ride_completed_at,updated_at"
+            ),
+        )
+    except Exception as e:
+        logger.error("[preauth-capture] failed to fetch candidate rides: %s", e, exc_info=True)
+        return
+
+    now = datetime.now(timezone.utc)
+    window_seconds = TIP_WINDOW_MINUTES * 60
+
+    for ride in rides:
+        completed_at = parse_iso_utc(ride.get("ride_completed_at") or ride.get("updated_at"))
+        if completed_at is not None and (now - completed_at).total_seconds() < window_seconds:
+            continue  # tip window still open — let the rider tip first
+
+        auth_status = ride.get("auth_status")
+        # Atomic claim: only the replica that flips pending → processing (while
+        # auth_status is still the value we read) proceeds; others get None.
+        claimed = await db.update_one(
+            "rides",
+            {"id": ride["id"], "payment_status": "pending", "auth_status": auth_status},
+            {"$set": {"payment_status": "processing", "updated_at": now.isoformat()}},
+        )
+        if claimed is None:
+            continue
+
+        await _capture_one(ride)
+
+
+async def preauth_capture_loop() -> None:
+    """Background loop: capture expiring pre-auth holds every interval."""
+    logger.info(
+        f"Pre-auth capture sweeper started (interval={CAPTURE_INTERVAL_SECONDS}s, window={TIP_WINDOW_MINUTES}m)"
+    )
+    while True:
+        lock_ttl = int(CAPTURE_INTERVAL_SECONDS * 1.5)
+        if not await redis_set_nx("spinr:preauth:capture:lock", _pod_id(), lock_ttl):
+            _record_heartbeat(_LOOP_NAME)
+            await asyncio.sleep(CAPTURE_INTERVAL_SECONDS)
+            continue
+        try:
+            await _capture_tick()
+        except Exception as e:
+            logger.error(f"Pre-auth capture loop error: {e}", exc_info=True)
+        _record_heartbeat(_LOOP_NAME)
+        # ±10% jitter so replicas don't tick in lockstep.
+        delta = CAPTURE_INTERVAL_SECONDS * 0.1
+        await asyncio.sleep(CAPTURE_INTERVAL_SECONDS + random.uniform(-delta, delta))

--- a/backend/utils/scheduled_rides.py
+++ b/backend/utils/scheduled_rides.py
@@ -138,7 +138,7 @@ async def _dispatch_scheduled_ride(ride: dict):
                 _grand = claimed.get("grand_total")
                 if _grand is None:
                     _grand = claimed.get("total_fare") or 0
-                _auth_fields = await _preauthorize_ride_card(
+                _preauth = await _preauthorize_ride_card(
                     ride_id=ride_id,
                     rider_id=rider_id,
                     grand_total=_Decimal(str(_grand)),
@@ -146,8 +146,8 @@ async def _dispatch_scheduled_ride(ride: dict):
                     payment_method_id=claimed.get("payment_method_id"),
                     block_on_decline=False,
                 )
-                if _auth_fields:
-                    await db.update_one("rides", {"id": ride_id}, {"$set": _auth_fields})
+                if _preauth.fields:
+                    await db.update_one("rides", {"id": ride_id}, {"$set": _preauth.fields})
         except Exception as _auth_err:
             # Never let a pre-auth hiccup block dispatch; post-trip settlement
             # remains the safety net. Surface loudly — it's a payment path.

--- a/backend/utils/scheduled_rides.py
+++ b/backend/utils/scheduled_rides.py
@@ -107,8 +107,7 @@ async def _dispatch_scheduled_ride(ride: dict):
             msg = str(claim_exc).lower()
             if "rides_one_active_per_rider" in msg or "23505" in msg or "duplicate" in msg or "unique" in msg:
                 logger.warning(
-                    "scheduled dispatch deferred: rider has an active ride; "
-                    f"ride {ride_id} stays 'scheduled' for retry"
+                    f"scheduled dispatch deferred: rider has an active ride; ride {ride_id} stays 'scheduled' for retry"
                 )
                 await _notify_schedule_delayed(ride_id, rider_id, ride)
                 return
@@ -119,6 +118,45 @@ async def _dispatch_scheduled_ride(ride: dict):
             return
 
         logger.info(f"Dispatched scheduled ride {ride_id}: scheduled → searching")
+
+        # Pre-authorize the card hold NOW (at dispatch), not at booking: a
+        # scheduled ride may be booked days out, beyond Stripe's ~7-day auth
+        # lifetime, so the hold is placed when the ride actually goes live.
+        # Card source only, and only if no hold exists yet. The rider isn't
+        # present, so a decline must NOT strand the ride (block_on_decline=False)
+        # — it degrades to post-trip settlement like any un-held ride.
+        try:
+            if claimed.get("payment_method") == "card" and not claimed.get("auth_status"):
+                from decimal import Decimal as _Decimal
+
+                try:
+                    from ..routes.rides import _preauthorize_ride_card
+                except ImportError:
+                    from routes.rides import _preauthorize_ride_card  # type: ignore
+
+                _rider_row = await db.get_user_by_id(rider_id) if rider_id else None
+                _grand = claimed.get("grand_total")
+                if _grand is None:
+                    _grand = claimed.get("total_fare") or 0
+                _auth_fields = await _preauthorize_ride_card(
+                    ride_id=ride_id,
+                    rider_id=rider_id,
+                    grand_total=_Decimal(str(_grand)),
+                    stripe_customer_id=(_rider_row or {}).get("stripe_customer_id"),
+                    payment_method_id=claimed.get("payment_method_id"),
+                    block_on_decline=False,
+                )
+                if _auth_fields:
+                    await db.update_one("rides", {"id": ride_id}, {"$set": _auth_fields})
+        except Exception as _auth_err:
+            # Never let a pre-auth hiccup block dispatch; post-trip settlement
+            # remains the safety net. Surface loudly — it's a payment path.
+            logger.error(
+                "scheduled dispatch: pre-auth at dispatch failed for %s: %s",
+                ride_id,
+                _auth_err,
+                exc_info=True,
+            )
 
         # Mandatory state-change WS event (rider + admins). Drives the rider
         # app's status update and patches any admin dashboard that already has

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -426,6 +426,77 @@ async def authorize_ride(
     )
 
 
+async def verify_authorization(
+    *,
+    ride_id: str,
+    payment_intent_id: str,
+) -> ChargeOutcome:
+    """Verify an on-device-confirmed authorization hold (SCA two-step at booking).
+
+    After ``authorize_ride`` returns ``requires_action`` and the rider-app runs
+    the Stripe confirm sheet (3DS / Apple Pay biometric), the PaymentIntent
+    should land in ``requires_capture``. This re-reads it from Stripe to confirm
+    the hold is real before create_ride attaches it — we never trust the client's
+    word that authentication succeeded.
+
+    ``ChargeOutcome.status``:
+        "authorized"    PI is requires_capture — hold confirmed; charged_amount
+                        carries the held amount (dollars, from Stripe cents)
+        "declined"      authentication failed / PI needs a payment method again
+        "failed"        Stripe ops error / unexpected PI status
+        "unconfigured"  Stripe not installed/configured (dev/test)
+
+    Never raises — callers switch on ``outcome.status``.
+    """
+    if not payment_intent_id:
+        return ChargeOutcome(status="failed", error_message="No PaymentIntent to verify")
+
+    secret = await _resolve_stripe_secret(ride_id)
+    if secret is None:
+        return ChargeOutcome(status="unconfigured", error_message="Payment processing is not configured")
+
+    try:
+        intent = stripe.PaymentIntent.retrieve(payment_intent_id, api_key=secret)
+    except _StripeBaseError as e:
+        logger.error("Stripe error verifying auth ride=%s pi=%s: %s", ride_id, payment_intent_id, e)
+        return ChargeOutcome(status="failed", payment_intent_id=payment_intent_id, error_message=str(e))
+    except Exception as e:  # pragma: no cover — defence-in-depth
+        logger.exception("Unexpected error verifying auth ride=%s: %s", ride_id, e)
+        return ChargeOutcome(status="failed", payment_intent_id=payment_intent_id, error_message=str(e))
+
+    status = getattr(intent, "status", "") or ""
+    pi_id = getattr(intent, "id", None) or payment_intent_id
+    if status == "requires_capture":
+        amount_cents = getattr(intent, "amount", 0) or 0
+        return ChargeOutcome(
+            status="authorized",
+            payment_intent_id=pi_id,
+            charged_amount=to_decimal(Decimal(int(amount_cents)) / Decimal("100")),
+        )
+    if status in ("requires_action", "requires_source_action", "requires_payment_method", "requires_confirmation"):
+        # Authentication not completed (rider abandoned the sheet, or it failed).
+        return ChargeOutcome(
+            status="declined",
+            payment_intent_id=pi_id,
+            error_message=f"Authorization not completed (PI status: {status})",
+        )
+    if status == "succeeded":
+        # Already captured — treat as authorized so the caller attaches it and
+        # settlement's idempotent capture is a no-op rather than a double charge.
+        return ChargeOutcome(
+            status="authorized",
+            payment_intent_id=pi_id,
+            charged_amount=to_decimal(Decimal(int(getattr(intent, "amount", 0) or 0)) / Decimal("100")),
+        )
+
+    logger.error("Unexpected verify PI status=%s for ride=%s pi=%s", status, ride_id, pi_id)
+    return ChargeOutcome(
+        status="failed",
+        payment_intent_id=pi_id,
+        error_message=f"Unexpected PaymentIntent status: {status}",
+    )
+
+
 async def capture_ride(
     *,
     ride_id: str,

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -58,10 +58,10 @@ from typing import Any, Dict, Optional, Union
 
 try:
     from ..settings_loader import get_app_settings
-    from .money import dollars_to_cents
+    from .money import dollars_to_cents, to_decimal
 except ImportError:
     from settings_loader import get_app_settings
-    from utils.money import dollars_to_cents
+    from utils.money import dollars_to_cents, to_decimal
 
 try:
     import stripe
@@ -284,4 +284,220 @@ async def charge_ride(
         status="failed",
         payment_intent_id=pi_id,
         error_message=f"Unhandled PaymentIntent status: {status}",
+    )
+
+
+async def _resolve_stripe_secret(ride_id: str) -> Optional[str]:
+    """Shared secret lookup for the authorize/capture helpers.
+
+    Returns the configured ``stripe_secret_key`` or ``None`` when Stripe is not
+    wired up (dev/test). Callers map ``None`` → ``unconfigured`` so the system
+    doesn't wedge when Stripe isn't configured yet.
+    """
+    if stripe is None:
+        logger.error("stripe package not installed; cannot reach Stripe")
+        return None
+    settings = await get_app_settings()
+    secret = settings.get("stripe_secret_key", "") or ""
+    if not secret:
+        logger.error("stripe_secret_key not configured; ride=%s", ride_id)
+        return None
+    return secret
+
+
+async def authorize_ride(
+    *,
+    ride: Dict[str, Any],
+    rider_id: str,
+    amount: Union[Decimal, int],
+    payment_method_id: Optional[str] = None,
+    stripe_customer_id: Optional[str] = None,
+    off_session: bool = False,
+) -> ChargeOutcome:
+    """Place a manual-capture authorization HOLD on the rider's card at booking.
+
+    This is the front-of-ride counterpart to ``charge_ride``: instead of
+    capturing immediately, it creates a PaymentIntent with
+    ``capture_method="manual"`` so the funds are *held* (estimated fare +
+    buffer) without moving money. The hold is captured later, once at
+    settlement, by ``capture_ride`` — letting a post-trip tip ride on the SAME
+    PaymentIntent (one Stripe fee) and surfacing a dead card BEFORE dispatch.
+
+    ``off_session`` defaults to ``False`` because authorization happens while
+    the rider is present at booking (Apple Pay / 3DS can prompt live). A
+    ``requires_action`` outcome hands the client_secret back so the rider-app
+    runs the SCA / biometric sheet and re-confirms.
+
+    ``ChargeOutcome.status`` for this path:
+        "authorized"       hold placed (Stripe PI status ``requires_capture``);
+                           ``charged_amount`` carries the held amount
+        "requires_action"  SCA / 3DS challenge; return client_secret to app
+        "declined"         card declined (insufficient_funds, card_declined, …);
+                           caller may retry at a smaller amount (fare-only)
+        "failed"           non-decline Stripe/ops error
+        "unconfigured"     Stripe not installed/configured (dev/test)
+
+    Never raises — callers switch on ``outcome.status``.
+    """
+    if amount <= 0:
+        # Nothing to hold. Treat as a no-op success so booking proceeds; the
+        # settlement path handles a genuinely $0 ride without a Stripe round-trip.
+        return ChargeOutcome(status="authorized", charged_amount=Decimal("0.00"))
+
+    secret = await _resolve_stripe_secret(ride.get("id") or "")
+    if secret is None:
+        return ChargeOutcome(status="unconfigured", error_message="Payment processing is not configured")
+    if not stripe_customer_id:
+        return ChargeOutcome(status="failed", error_message="No Stripe customer on file for rider")
+    if not payment_method_id:
+        return ChargeOutcome(status="failed", error_message="No default payment method on file")
+
+    ride_id = ride.get("id") or ""
+    amount_cents = dollars_to_cents(amount)
+    # Amount is part of the key so a re-auth at a different hold (e.g. a revised
+    # fare estimate) gets a fresh key instead of an IdempotencyError; identical
+    # retries (double-tap / dropped response) dedupe to the original hold.
+    idempotency_key = f"ride-auth-{ride_id}-{amount_cents}"
+
+    params: Dict[str, Any] = {
+        "amount": amount_cents,
+        "currency": CURRENCY,
+        "customer": stripe_customer_id,
+        "payment_method": payment_method_id,
+        "capture_method": "manual",
+        "confirm": True,
+        "off_session": off_session,
+        "metadata": {
+            "ride_id": ride_id,
+            "rider_id": rider_id,
+            "authorized_amount": str(to_decimal(amount)),
+            "payment_method_type": ride.get("payment_method") or "card",
+            "source": "ride_booking_authorization",
+        },
+    }
+
+    try:
+        intent = stripe.PaymentIntent.create(
+            **params,
+            api_key=secret,
+            idempotency_key=idempotency_key,
+        )
+    except _StripeCardError as e:
+        err = getattr(e, "error", None)
+        decline_code = getattr(err, "decline_code", None) or getattr(err, "code", None)
+        logger.info("Auth declined for ride=%s rider=%s code=%s", ride_id, rider_id, decline_code)
+        return ChargeOutcome(
+            status="declined",
+            decline_code=decline_code,
+            error_message=str(getattr(err, "message", None) or e),
+        )
+    except _StripeBaseError as e:
+        logger.error("Stripe error authorizing ride=%s rider=%s: %s", ride_id, rider_id, e)
+        return ChargeOutcome(status="failed", error_message=str(e))
+    except Exception as e:  # pragma: no cover — defence-in-depth
+        logger.exception("Unexpected error authorizing ride=%s: %s", ride_id, e)
+        return ChargeOutcome(status="failed", error_message=str(e))
+
+    status = getattr(intent, "status", "") or ""
+    pi_id = getattr(intent, "id", None)
+    client_secret = getattr(intent, "client_secret", None)
+
+    if status == "requires_capture":
+        # Hold placed successfully — funds reserved, nothing captured yet.
+        return ChargeOutcome(
+            status="authorized",
+            payment_intent_id=pi_id,
+            charged_amount=to_decimal(amount),
+        )
+    if status in ("requires_action", "requires_source_action"):
+        return ChargeOutcome(status="requires_action", payment_intent_id=pi_id, client_secret=client_secret)
+    if status in ("requires_payment_method", "requires_confirmation"):
+        return ChargeOutcome(
+            status="declined",
+            payment_intent_id=pi_id,
+            error_message=f"PaymentIntent unexpectedly in state: {status}",
+        )
+
+    logger.error("Unhandled auth PaymentIntent status=%s for ride=%s pi=%s", status, ride_id, pi_id)
+    return ChargeOutcome(
+        status="failed",
+        payment_intent_id=pi_id,
+        error_message=f"Unhandled auth PaymentIntent status: {status}",
+    )
+
+
+async def capture_ride(
+    *,
+    ride_id: str,
+    payment_intent_id: str,
+    amount: Union[Decimal, int],
+) -> ChargeOutcome:
+    """Capture a previously-authorized hold for ``amount`` (fare + tip).
+
+    Captures against the manual-capture PaymentIntent created by
+    ``authorize_ride``. ``amount`` MUST be ≤ the originally authorized hold —
+    Stripe rejects a capture larger than the authorization, which is why a tip
+    beyond the buffer is charged separately rather than folded into this call.
+
+    ``ChargeOutcome.status``:
+        "captured"      funds captured (terminal success)
+        "declined"      card declined at capture (rare — e.g. issuer reversal)
+        "failed"        hold expired / amount_too_large / Stripe-ops error;
+                        caller falls back to a fresh ``charge_ride``
+        "unconfigured"  Stripe not installed/configured (dev/test)
+
+    Never raises — callers switch on ``outcome.status``.
+    """
+    if amount <= 0:
+        return ChargeOutcome(status="captured", charged_amount=Decimal("0.00"))
+    if not payment_intent_id:
+        return ChargeOutcome(status="failed", error_message="No authorization PaymentIntent to capture")
+
+    secret = await _resolve_stripe_secret(ride_id)
+    if secret is None:
+        return ChargeOutcome(status="unconfigured", error_message="Payment processing is not configured")
+
+    amount_cents = dollars_to_cents(amount)
+    try:
+        intent = stripe.PaymentIntent.capture(
+            payment_intent_id,
+            amount_to_capture=amount_cents,
+            api_key=secret,
+            # Same PI + same captured amount must not double-capture if two
+            # replicas race past the DB claim; Stripe dedupes the identical key.
+            idempotency_key=f"ride-capture-{ride_id}-{amount_cents}",
+        )
+    except _StripeCardError as e:
+        err = getattr(e, "error", None)
+        decline_code = getattr(err, "decline_code", None) or getattr(err, "code", None)
+        logger.info("Capture declined for ride=%s pi=%s code=%s", ride_id, payment_intent_id, decline_code)
+        return ChargeOutcome(
+            status="declined",
+            payment_intent_id=payment_intent_id,
+            decline_code=decline_code,
+            error_message=str(getattr(err, "message", None) or e),
+        )
+    except _StripeBaseError as e:
+        # Hold expired, amount_too_large, already-captured, etc. Not a card
+        # decline — caller re-drives via a fresh charge_ride.
+        logger.error("Stripe error capturing ride=%s pi=%s: %s", ride_id, payment_intent_id, e)
+        return ChargeOutcome(status="failed", payment_intent_id=payment_intent_id, error_message=str(e))
+    except Exception as e:  # pragma: no cover — defence-in-depth
+        logger.exception("Unexpected error capturing ride=%s: %s", ride_id, e)
+        return ChargeOutcome(status="failed", payment_intent_id=payment_intent_id, error_message=str(e))
+
+    status = getattr(intent, "status", "") or ""
+    pi_id = getattr(intent, "id", None) or payment_intent_id
+    if status == "succeeded":
+        return ChargeOutcome(
+            status="captured",
+            payment_intent_id=pi_id,
+            charged_amount=to_decimal(amount),
+        )
+
+    logger.error("Unhandled capture PaymentIntent status=%s for ride=%s pi=%s", status, ride_id, pi_id)
+    return ChargeOutcome(
+        status="failed",
+        payment_intent_id=pi_id,
+        error_message=f"Unhandled capture PaymentIntent status: {status}",
     )

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -430,6 +430,8 @@ async def verify_authorization(
     *,
     ride_id: str,
     payment_intent_id: str,
+    expected_customer_id: Optional[str] = None,
+    min_amount_cents: Optional[int] = None,
 ) -> ChargeOutcome:
     """Verify an on-device-confirmed authorization hold (SCA two-step at booking).
 
@@ -439,10 +441,16 @@ async def verify_authorization(
     the hold is real before create_ride attaches it — we never trust the client's
     word that authentication succeeded.
 
+    SECURITY — the client supplies the PI id, so we never attach it blindly:
+      - ``expected_customer_id``: the PI's ``customer`` MUST match the requesting
+        rider's Stripe customer, else a rider could attach someone else's hold.
+      - ``min_amount_cents``: the held amount MUST cover this ride's fare, else a
+        rider could replay a smaller hold from a cancelled/cheaper booking.
+    A mismatch on either is treated as ``declined`` (logged as a security event).
+
     ``ChargeOutcome.status``:
-        "authorized"    PI is requires_capture — hold confirmed; charged_amount
-                        carries the held amount (dollars, from Stripe cents)
-        "declined"      authentication failed / PI needs a payment method again
+        "authorized"    PI is requires_capture, owned by this rider, large enough
+        "declined"      auth not completed / wrong owner / too small / wrong PM
         "failed"        Stripe ops error / unexpected PI status
         "unconfigured"  Stripe not installed/configured (dev/test)
 
@@ -466,6 +474,40 @@ async def verify_authorization(
 
     status = getattr(intent, "status", "") or ""
     pi_id = getattr(intent, "id", None) or payment_intent_id
+
+    # Ownership: the PI must belong to THIS rider's Stripe customer.
+    if expected_customer_id is not None:
+        pi_customer = getattr(intent, "customer", None)
+        if pi_customer != expected_customer_id:
+            logger.error(
+                "[preauth][security] PI customer mismatch ride=%s pi=%s (declining attach)",
+                ride_id,
+                pi_id,
+            )
+            return ChargeOutcome(
+                status="declined",
+                payment_intent_id=pi_id,
+                error_message="Authorization does not belong to this account",
+            )
+
+    # Amount: the hold must be at least the ride's fare (no replay of a smaller
+    # hold from a cancelled/cheaper booking).
+    if min_amount_cents is not None:
+        pi_amount = int(getattr(intent, "amount", 0) or 0)
+        if pi_amount < int(min_amount_cents):
+            logger.error(
+                "[preauth][security] PI amount too small ride=%s pi=%s held=%s need=%s (declining attach)",
+                ride_id,
+                pi_id,
+                pi_amount,
+                min_amount_cents,
+            )
+            return ChargeOutcome(
+                status="declined",
+                payment_intent_id=pi_id,
+                error_message="Authorization amount is insufficient for this ride",
+            )
+
     if status == "requires_capture":
         amount_cents = getattr(intent, "amount", 0) or 0
         return ChargeOutcome(

--- a/backend/utils/stripe_reconcile.py
+++ b/backend/utils/stripe_reconcile.py
@@ -36,8 +36,14 @@ import os
 import socket
 import uuid
 from datetime import date, datetime, time, timedelta, timezone
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Dict, List
+
+
+def _q2(v: Any) -> Decimal:
+    """Quantize a money value to 2dp (HALF_UP). Decimal-only — never float."""
+    return Decimal(str(v or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
 
 try:
     from utils.loop_monitor import record_heartbeat as _record_heartbeat
@@ -125,7 +131,7 @@ async def _run_reconciliation_tick() -> None:
                 {
                     "payment_status": "paid",
                 },
-                columns="id,payment_intent_id,fare,status,completed_at",
+                columns="id,payment_intent_id,grand_total,total_fare,tip_amount,authorized_amount,status,completed_at",
                 limit=2000,
             )
             or []
@@ -182,11 +188,27 @@ async def _run_reconciliation_tick() -> None:
                 pi["status"],
             )
 
-        # Amount check — Stripe amount_received is in cents; DB fare is CAD dollars
-        if ride.get("fare") is not None:
-            expected_cents = int(Decimal(str(ride["fare"])) * 100)
+        # Amount check (C2) — the authoritative charge is grand_total + tip (the
+        # SAME total /process-payment settles), NOT the fare-side subtotal. Using
+        # `fare` excluded fees/GST/PST/tip and — since rides has no `fare` column —
+        # never even ran. We compare against grand_total + tip and ONLY flag
+        # UNDERPAYMENT (actual < expected): overpayment is not a revenue risk, and
+        # a strict `!=` false-flags rounding + the buffered-preauth split where a
+        # tip beyond the hold is captured on a SEPARATE PI (so this PI legitimately
+        # holds only up to authorized_amount).
+        _grand = ride.get("grand_total")
+        if _grand is None:
+            _grand = ride.get("total_fare")
+        if _grand is not None:
+            expected = _q2(_grand) + _q2(ride.get("tip_amount") or 0)
+            # If the tip exceeded the pre-auth hold, only up to authorized_amount
+            # could be captured on THIS PI; the overflow lives on another PI.
+            _authorized = ride.get("authorized_amount")
+            if _authorized is not None and _q2(_authorized) < expected:
+                expected = _q2(_authorized)
+            expected_cents = int((expected * 100).to_integral_value())
             actual_cents = pi.get("amount_received", 0)
-            if expected_cents != actual_cents:
+            if actual_cents < expected_cents:
                 discrepancies.append(
                     {
                         "type": "DB_PAID_AMOUNT_MISMATCH",

--- a/rider-app/app/payment-confirm.tsx
+++ b/rider-app/app/payment-confirm.tsx
@@ -16,9 +16,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useRideStore } from '../store/rideStore';
+import { useStripe } from '@stripe/stripe-react-native';
 import { useWalletStore } from '../store/walletStore';
 import { useWorkProfileStore } from '../store/workProfileStore';
 import { showToast } from '../store/toastStore';
+import type { Ride, RideRequiresAction } from '../store/rideStore';
 import ConfirmSheet from '../components/ConfirmSheet';
 import api from '@shared/api/client';
 import { useTheme } from '@shared/theme/ThemeContext';
@@ -44,6 +46,7 @@ interface SavedCard {
 function PaymentConfirmScreenContent() {
   const router = useRouter();
   const { pickup, dropoff, selectedVehicle, estimates, createRide, isLoading, scheduledTime, appliedPromo } = useRideStore();
+  const { confirmPayment } = useStripe();
   const { wallet, fetchWallet } = useWalletStore();
   const [selectedPayment, setSelectedPayment] = useState('card');
   const [savedCards, setSavedCards] = useState<SavedCard[]>([]);
@@ -118,9 +121,36 @@ function PaymentConfirmScreenContent() {
     try {
       const corpId = useCorporate && selectedCorporateId ? selectedCorporateId : null;
       const pmId = selectedPayment === 'card' ? (selectedCardId ?? undefined) : undefined;
-      const ride = await createRide(selectedPayment, corpId, pmId);
-      if ((ride as any).promo_error) {
-        showToast('Promo not applied', (ride as any).promo_error, 'warning');
+      let ride = await createRide(selectedPayment, corpId, pmId);
+
+      // SCA two-step: the card hold needs an on-device 3DS / Apple Pay confirm.
+      // Run the Stripe sheet, then re-book passing the now-confirmed hold. The
+      // manual-capture PaymentIntent lands in `requires_capture` (not
+      // `succeeded`) after authentication — accept both.
+      if ((ride as RideRequiresAction).requires_action) {
+        const auth = (ride as RideRequiresAction).payment_authorization;
+        const { error: confirmError, paymentIntent } = await confirmPayment(auth.client_secret);
+        if (confirmError) {
+          showToast('Authentication needed', confirmError.message || 'Card authentication was not completed.', 'danger');
+          return;
+        }
+        const piStatus = (paymentIntent?.status || '').toString().toLowerCase();
+        if (piStatus !== 'requirescapture' && piStatus !== 'requires_capture' && piStatus !== 'succeeded') {
+          showToast('Authentication needed', 'Card authentication was not completed. Please try again.', 'danger');
+          return;
+        }
+        ride = await createRide(selectedPayment, corpId, pmId, auth.payment_intent_id);
+      }
+
+      // After the (optional) SCA step, booking must have produced a real ride.
+      if ((ride as RideRequiresAction).requires_action) {
+        showToast('Booking failed', 'Card authorization could not be completed. Please try again.', 'danger');
+        return;
+      }
+      const bookedRide = ride as Ride;
+
+      if ((bookedRide as any).promo_error) {
+        showToast('Promo not applied', (bookedRide as any).promo_error, 'warning');
       }
       Analytics.rideRequested({
         vehicle_type: selectedVehicle?.name ?? 'unknown',
@@ -131,14 +161,14 @@ function PaymentConfirmScreenContent() {
       // Schedule a local 15-min reminder if this is a scheduled ride.
       // The backend cron also fires an FCM `scheduled_ride_reminder`; this
       // local notification is a client-side fallback.
-      if (scheduledTime && ride.id) {
-        scheduleReminder(ride.id, scheduledTime).catch(() => {});
+      if (scheduledTime && bookedRide.id) {
+        scheduleReminder(bookedRide.id, scheduledTime).catch(() => {});
       }
 
       if (scheduledTime) {
         router.replace('/(tabs)');
       } else {
-        router.replace({ pathname: '/driver-arriving', params: { rideId: ride.id } } as any);
+        router.replace({ pathname: '/driver-arriving', params: { rideId: bookedRide.id } } as any);
       }
     } catch (error: any) {
       const is409 = error?.response?.status === 409 || error?.message?.includes('already active');

--- a/rider-app/app/payment-confirm.tsx
+++ b/rider-app/app/payment-confirm.tsx
@@ -443,6 +443,15 @@ function PaymentConfirmScreenContent() {
             <View style={[styles.fareDivider, { marginTop: 12 }]} />
           </>
         )}
+        {selectedPayment === 'card' && (
+          <View style={styles.holdNote}>
+            <Ionicons name="lock-closed-outline" size={15} color={colors.textDim} style={{ marginRight: 8, marginTop: 1 }} />
+            <Text style={styles.holdNoteText}>
+              A temporary hold of ${(totalFare + 10).toFixed(2)} (estimated fare + $10) is placed on your card.
+              You're only charged the final fare plus any tip you add after the ride.
+            </Text>
+          </View>
+        )}
         {scheduledTime && (
           <View style={styles.scheduledBadge}>
             <Ionicons name="calendar-outline" size={16} color={colors.primary} />
@@ -664,6 +673,22 @@ function createStyles(colors: ThemeColors, sf: (size: number) => number = (s) =>
       fontFamily: 'PlusJakartaSans_500Medium',
       color: colors.textDim,
       marginTop: 2,
+    },
+    holdNote: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      backgroundColor: '#F3F4F6',
+      borderRadius: 10,
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      marginTop: 12,
+    },
+    holdNoteText: {
+      flex: 1,
+      fontSize: sf(12),
+      lineHeight: 17,
+      fontFamily: 'PlusJakartaSans_400Regular',
+      color: colors.textDim,
     },
     paymentCheck: {
       width: 28,

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -94,6 +94,10 @@ function RideCompletedScreenContent() {
   const fare = toNum((currentRide as any)?.grand_total || currentRide?.total_fare);
   const duration = currentRide?.duration_minutes || 0;
   const distance = currentRide?.distance_km || 0;
+  // A card hold placed at booking is captured on submit — the payment method is
+  // already chosen, so we don't show a payment picker (Google Pay) at the end.
+  const hasHold =
+    (currentRide as any)?.auth_status === 'authorized' || (currentRide as any)?.auth_status === 'fare_only';
 
   useEffect(() => {
     if (rideId) fetchRide(rideId);
@@ -632,8 +636,14 @@ function RideCompletedScreenContent() {
 
       {/* Submit Button */}
       <View style={styles.bottomBar}>
-        {/* Google Pay button — Android only, card payments, not yet paid */}
-        {Platform.OS === 'android' && !alreadyPaid && currentRide?.payment_method === 'card' && (
+        {hasHold && !alreadyPaid && (
+          <Text style={styles.holdHint}>
+            Charged to the card you chose at booking. Any tip is included in the same charge.
+          </Text>
+        )}
+        {/* Google Pay button — Android card rides with NO pre-auth hold (the held
+            method is captured on submit, so no payment picker is shown then). */}
+        {Platform.OS === 'android' && !alreadyPaid && !hasHold && currentRide?.payment_method === 'card' && (
           <TouchableOpacity
             style={[styles.submitBtn, styles.googlePayBtn]}
             onPress={handleGooglePay}
@@ -1005,6 +1015,11 @@ function createStyles(colors: ThemeColors) {
     },
     googlePayBtn: {
       backgroundColor: '#3C4043', marginBottom: 10,
+    },
+    holdHint: {
+      fontSize: 12, lineHeight: 16, color: colors.textDim,
+      fontFamily: 'PlusJakartaSans_400Regular',
+      textAlign: 'center', marginBottom: 10,
     },
     submitBtnText: {
       fontSize: 16, fontFamily: 'PlusJakartaSans_700Bold', color: '#FFF',

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -104,7 +104,7 @@ interface Driver {
   heading?: number | null;
 }
 
-interface Ride {
+export interface Ride {
   id: string;
   rider_id: string;
   driver_id?: string;
@@ -163,6 +163,13 @@ interface Promo {
   [key: string]: unknown;
 }
 
+/** SCA two-step: create_ride returns this (instead of a Ride) when the card
+ *  hold needs an on-device 3DS / Apple Pay confirm before booking can proceed. */
+export interface RideRequiresAction {
+  requires_action: true;
+  payment_authorization: { client_secret: string; payment_intent_id: string };
+}
+
 export interface ChatMessage {
   id: string;
   ride_id: string;
@@ -218,7 +225,12 @@ interface RideState {
   fetchEstimates: () => Promise<void>;
   fetchNearbyDrivers: () => Promise<void>;
   selectVehicle: (vehicle: VehicleType) => void;
-  createRide: (paymentMethod: string, corporateAccountId?: string | null, paymentMethodId?: string) => Promise<Ride>;
+  createRide: (
+    paymentMethod: string,
+    corporateAccountId?: string | null,
+    paymentMethodId?: string,
+    preauthorizedPaymentIntentId?: string,
+  ) => Promise<Ride | RideRequiresAction>;
   fetchRide: (rideId: string) => Promise<void>;
   cancelRide: (reason?: string) => Promise<void>;
   simulateDriverArrival: () => Promise<void>;
@@ -553,7 +565,7 @@ export const useRideStore = create<RideState>((set, get) => ({
     }
   },
 
-  createRide: async (paymentMethod, corporateAccountId, paymentMethodId) => {
+  createRide: async (paymentMethod, corporateAccountId, paymentMethodId, preauthorizedPaymentIntentId) => {
     const { pickup, dropoff, selectedVehicle, stops, scheduledTime, estimates, requiresWav, quietMode, riderNotes, routePolyline } = get();
     if (!pickup || !dropoff || !selectedVehicle) {
       throw new Error('Missing ride details');
@@ -593,6 +605,9 @@ export const useRideStore = create<RideState>((set, get) => ({
         stops: stops,
         payment_method: paymentMethod,
         payment_method_id: paymentMethodId ?? null,
+        // SCA two-step: a hold the app already confirmed on-device after a prior
+        // create_ride returned requires_action. Backend verifies + attaches it.
+        preauthorized_payment_intent_id: preauthorizedPaymentIntentId ?? null,
         corporate_account_id: corporateAccountId || null,
         estimate_token: selectedEstimate?.estimate_token,
         requires_wav: requiresWav,
@@ -610,12 +625,20 @@ export const useRideStore = create<RideState>((set, get) => ({
 
       const userId = useAuthStore.getState().user?.id ?? 'anon';
       const idempotencyKey = `ride-${userId}-${Date.now()}`;
-      const response = await api.post<Ride>('/rides', rideData, {
+      const response = await api.post<Ride | RideRequiresAction>('/rides', rideData, {
         headers: { 'Idempotency-Key': idempotencyKey },
       });
-      set({ currentRide: response.data, isLoading: false, scheduledTime: null, requiresWav: false, quietMode: false, riderNotes: '', routePolyline: [], appliedPromo: null, _clearedRideId: null });
-      _persistRide(response.data, null);
-      return response.data;
+      // SCA two-step, first leg: the card hold needs an on-device confirm. No
+      // ride was created — surface it to the caller (it runs the Stripe sheet
+      // then re-books with the confirmed PI). Do NOT set currentRide.
+      if ((response.data as RideRequiresAction).requires_action) {
+        set({ isLoading: false });
+        return response.data as RideRequiresAction;
+      }
+      const ride = response.data as Ride;
+      set({ currentRide: ride, isLoading: false, scheduledTime: null, requiresWav: false, quietMode: false, riderNotes: '', routePolyline: [], appliedPromo: null, _clearedRideId: null });
+      _persistRide(ride, null);
+      return ride;
     } catch (error: unknown) {
       recordNonFatal(error, { store: 'rideStore', action: 'createRide' });
       set({ isLoading: false, error: isErrorLike(error) ? error.message : 'Failed to create ride' });


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
