### PR TITLE
feat(backend): admin debug-ride-offer endpoint to diagnose driver push

### DIFF
--- a/backend/routes/notifications.py
+++ b/backend/routes/notifications.py
@@ -2,9 +2,10 @@
 notifications.py – In-app notification system for Spinr.
 """
 
+import json
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -52,6 +53,14 @@ class TestPushRequest(BaseModel):
     user_id: Optional[str] = None  # None → send to the admin's own account
     title: str = "Spinr test push"
     body: str = "If you can see this, push notifications are wired up correctly."
+
+
+class DebugRideOfferRequest(BaseModel):
+    user_id: str  # target driver's user id — debugging a specific device
+    pickup_address: str = "Test pickup — 8th St E, Saskatoon"
+    dropoff_address: str = "Test dropoff — Stonebridge, Saskatoon"
+    fare: float = 12.50
+    countdown_seconds: int = 30
 
 
 def _mask_token(token: Optional[str]) -> Optional[str]:
@@ -108,6 +117,142 @@ async def admin_send_test_push(body: TestPushRequest, admin: dict = Depends(get_
         "token_on_file": bool(token),
         "token_preview": _mask_token(token),
         "platform_hint": platform_hint,
+    }
+
+
+def _stringify_fcm(payload: Dict[str, Any]) -> Dict[str, str]:
+    """Coerce a dispatch payload into FCM's string-only data map.
+
+    Mirrors the stringification the live ride-offer path applies in
+    routes/rides.py: dicts/lists become JSON, scalars become str, None → "".
+    """
+    return {
+        k: json.dumps(v) if isinstance(v, (dict, list)) else (str(v) if v is not None else "")
+        for k, v in payload.items()
+    }
+
+
+@api_router.post("/debug-ride-offer")
+async def admin_debug_ride_offer(body: DebugRideOfferRequest, admin: dict = Depends(get_admin_user)):
+    """Simulate a real ride-offer push end-to-end against a driver's device.
+
+    Unlike /test-push (a plain notification on the generic ``fcm_token``), this
+    reproduces the EXACT path a live ride offer takes:
+
+      * reads the driver-specific token (``users.fcm_token_driver`` → falls
+        back to ``fcm_token``), the same column dispatch reads via
+        ``target_app="driver"``;
+      * sends a data-only ``new_ride_assignment`` FCM message at
+        ``priority="dispatch"`` so the driver app's headless handler + Notifee
+        render the full-screen offer with the ride-offer sound, and iOS gets
+        the ``ride_offer.caf`` APNs alert;
+      * returns which token column was used, masked previews of all three
+        token columns, and whether Firebase accepted the send.
+
+    Use when a driver reports "no offer push / no sound". The response isolates
+    the failure stage:
+      * ``no_driver_token`` → the driver app never registered a token (token
+        problem, not a build problem);
+      * ``success=true`` but device shows nothing → the installed binary lacks
+        the merged native code (needs an EAS rebuild — OTA can't ship native
+        changes) or OS notifications are disabled;
+      * ``success=false`` → Firebase rejected the send (stale token purged, or
+        FIREBASE_SERVICE_ACCOUNT_JSON misconfigured — check server logs).
+
+    No real ride is dispatched; the synthetic ``ride_id`` is a ``debug-`` value,
+    so Accept/Decline from the device resolve to a harmless 404.
+    """
+    user = await db.find_one("users", {"id": body.user_id})
+    if not user:
+        raise HTTPException(status_code=404, detail=f"User {body.user_id} not found")
+
+    driver_token = user.get("fcm_token_driver")
+    rider_token = user.get("fcm_token_rider")
+    generic_token = user.get("fcm_token")
+
+    # Mirror send_push_notification(target_app="driver") token selection so the
+    # response reports the exact column the dispatch send will read.
+    used_token = driver_token or generic_token
+    used_column = "fcm_token_driver" if driver_token else ("fcm_token" if generic_token else None)
+
+    token_previews = {
+        "fcm_token_driver": _mask_token(driver_token),
+        "fcm_token_rider": _mask_token(rider_token),
+        "fcm_token": _mask_token(generic_token),
+    }
+
+    if not used_token:
+        return {
+            "success": False,
+            "reason": "no_driver_token",
+            "detail": (
+                "No fcm_token_driver or fcm_token on file. The driver app has "
+                "not registered a push token for this account. Re-open the "
+                "driver app, grant the notification permission, and confirm "
+                "POST /notifications/register-token ran with client_type=driver."
+            ),
+            "target_user_id": body.user_id,
+            "tokens": token_previews,
+            "is_online": user.get("is_online"),
+            "is_driver": user.get("is_driver"),
+        }
+
+    routing = "expo" if used_token.startswith(("ExponentPushToken", "ExpoPushToken")) else "fcm"
+
+    ride_id = f"debug-{uuid.uuid4().hex[:12]}"
+    now = datetime.now(timezone.utc)
+    offer_expires_at = (now + timedelta(seconds=body.countdown_seconds)).isoformat()
+
+    # Minimal but realistic dispatch payload — same shape/keys the live offer
+    # uses in routes/rides.py (spatial fields are excluded there too).
+    offer_payload = {
+        "type": "new_ride_assignment",
+        "ride_id": ride_id,
+        "booking_id": ride_id,
+        "pickup_address": body.pickup_address,
+        "dropoff_address": body.dropoff_address,
+        "pickup_lat": 52.1332,
+        "pickup_lng": -106.6700,
+        "dropoff_lat": 52.1100,
+        "dropoff_lng": -106.6300,
+        "fare": body.fare,
+        "distance_km": 4.2,
+        "duration_minutes": 11,
+        "rider_name": "Debug Rider",
+        "requires_wav": False,
+        "countdown_seconds": body.countdown_seconds,
+        "offer_expires_at": offer_expires_at,
+        "deeplink": "/driver/",
+    }
+    fcm_data = _stringify_fcm(offer_payload)
+
+    earnings_label = f"${body.fare:.2f}"
+    delivered = await send_push_notification(
+        body.user_id,
+        f"{earnings_label} ride offer",
+        f"Booking {ride_id} • {body.pickup_address} → {body.dropoff_address}",
+        fcm_data,
+        priority="dispatch",
+        target_app="driver",
+    )
+
+    return {
+        "success": bool(delivered),
+        "target_user_id": body.user_id,
+        "token_column_used": used_column,
+        "routing": routing,
+        "ride_id": ride_id,
+        "tokens": token_previews,
+        "is_online": user.get("is_online"),
+        "is_driver": user.get("is_driver"),
+        "note": (
+            "success=true means Firebase accepted the message for delivery. If "
+            "the device still shows no offer or plays no sound, the installed "
+            "binary lacks the merged native code (rebuild via EAS — an OTA "
+            "update cannot ship native changes) or OS notifications are off. A "
+            "data-only dispatch renders only through the app's Notifee handler, "
+            "so an outdated build shows nothing even on a successful send."
+        ),
     }
 
 

--- a/backend/tests/test_p3_push_notifications.py
+++ b/backend/tests/test_p3_push_notifications.py
@@ -593,3 +593,114 @@ class TestDispatchPushIsImmediate:
                 )
 
         assert enqueued == [], "normal pushes must not be enqueued for retry"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /notifications/debug-ride-offer — admin tool that reproduces the exact
+# dispatch path against a driver's device (token column, data-only payload,
+# priority=dispatch) without dispatching a real ride.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestDebugRideOffer:
+    """Pins admin_debug_ride_offer.
+
+    Code under test: backend/routes/notifications.py::admin_debug_ride_offer.
+    """
+
+    async def _run(self, user_row, send_result=True):
+        from backend.routes.notifications import DebugRideOfferRequest, admin_debug_ride_offer
+
+        captured: dict = {}
+
+        async def _send(user_id, title, body, data=None, priority="normal", target_app=None):
+            captured.update(
+                user_id=user_id,
+                title=title,
+                body=body,
+                data=data,
+                priority=priority,
+                target_app=target_app,
+            )
+            return send_result
+
+        with (
+            patch("backend.routes.notifications.db.find_one", AsyncMock(return_value=user_row)),
+            patch("backend.routes.notifications.send_push_notification", AsyncMock(side_effect=_send)),
+        ):
+            result = await admin_debug_ride_offer(
+                body=DebugRideOfferRequest(user_id=USER_ID),
+                admin={"id": "admin-1"},
+            )
+
+        return result, captured
+
+    async def test_uses_driver_token_column_and_dispatch_path(self):
+        """A registered driver token routes through target_app='driver' with a
+        data-only new_ride_assignment payload at priority='dispatch'."""
+        user_row = {
+            "id": USER_ID,
+            "fcm_token_driver": "android-fcm-driver-token-1234567890",
+            "fcm_token": "legacy-generic-token",
+            "is_online": True,
+            "is_driver": True,
+        }
+
+        result, captured = await self._run(user_row, send_result=True)
+
+        assert result["success"] is True
+        assert result["token_column_used"] == "fcm_token_driver"
+        assert result["routing"] == "fcm"
+        assert captured["priority"] == "dispatch"
+        assert captured["target_app"] == "driver"
+        assert captured["data"]["type"] == "new_ride_assignment"
+        assert captured["data"]["ride_id"].startswith("debug-")
+        # FCM data must be string-only (no raw floats/bools/None).
+        assert all(isinstance(v, str) for v in captured["data"].values())
+
+    async def test_falls_back_to_generic_token_when_no_driver_token(self):
+        user_row = {
+            "id": USER_ID,
+            "fcm_token": "legacy-generic-token-abc",
+        }
+
+        result, captured = await self._run(user_row, send_result=True)
+
+        assert result["success"] is True
+        assert result["token_column_used"] == "fcm_token"
+        assert captured["target_app"] == "driver"
+
+    async def test_no_token_short_circuits_without_send(self):
+        """No driver/generic token → diagnostic response, no push attempted."""
+        user_row = {"id": USER_ID, "is_online": False, "is_driver": True}
+
+        result, captured = await self._run(user_row)
+
+        assert result["success"] is False
+        assert result["reason"] == "no_driver_token"
+        assert captured == {}, "must not attempt a send when no token is on file"
+
+    async def test_tokens_are_masked_never_raw(self):
+        """The response must never echo a raw, device-routable token."""
+        raw = "android-fcm-driver-token-1234567890"
+        user_row = {"id": USER_ID, "fcm_token_driver": raw}
+
+        result, _ = await self._run(user_row)
+
+        assert result["tokens"]["fcm_token_driver"] != raw
+        assert "..." in result["tokens"]["fcm_token_driver"]
+
+    async def test_user_not_found_raises_404(self):
+        from fastapi import HTTPException
+
+        from backend.routes.notifications import DebugRideOfferRequest, admin_debug_ride_offer
+
+        with patch("backend.routes.notifications.db.find_one", AsyncMock(return_value=None)):
+            with pytest.raises(HTTPException) as exc:
+                await admin_debug_ride_offer(
+                    body=DebugRideOfferRequest(user_id="ghost"),
+                    admin={"id": "admin-1"},
+                )
+
+        assert exc.value.status_code == 404


### PR DESCRIPTION
Adds POST /notifications/debug-ride-offer (admin-gated) that reproduces the exact path a live ride offer takes against a specific driver's device:

  * reads users.fcm_token_driver (falls back to fcm_token), the same column dispatch uses via target_app="driver"
  * sends a data-only `new_ride_assignment` FCM message at priority="dispatch" so the driver app's headless handler + Notifee render the full-screen offer with the ride-offer sound (iOS gets the ride_offer.caf APNs alert)
  * returns which token column was used, masked previews of all three token columns, routing (expo/fcm), and whether Firebase accepted the send

This isolates the failure stage for "no offer push / no sound" reports: no_driver_token (token never registered) vs success=true-but-silent (stale binary missing native code / OS notifications off) vs success=false (Firebase rejected the send). No real ride is dispatched — the ride_id is a synthetic `debug-` value, so device Accept/Decline resolve to a harmless 404.

Tokens are masked in the response (never echoed raw). Adds regression tests covering token-column selection, generic-token fallback, no-token short-circuit, masking, and the 404 path.

https://claude.ai/code/session_019Syvw3Zi7tQjxYuhCr2WJ7

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
