### PR TITLE
fix(driver-app): resolve ride-offer notification small icon + add ren…

### DIFF
--- a/driver-app/services/notifeeService.ts
+++ b/driver-app/services/notifeeService.ts
@@ -42,6 +42,16 @@ const RIDE_OFFER_NOTIFICATION_ID = 'ride-offer-current';
 const RIDE_OFFER_CATEGORY_ID = 'ride-offer';
 const DEFAULT_RIDE_OFFER_TIMEOUT_MS = 15_000;
 
+// Android REJECTS a notification whose small icon can't be resolved — it does
+// NOT fall back to the app icon. 'ic_launcher' is the one drawable Expo
+// generates into every Android build (Notifee resolves the name against both
+// mipmap and drawable), so it's the only small-icon name guaranteed to exist.
+// The previous 'ic_notification' was never produced by any config plugin, so
+// every displayNotification() threw and ride offers silently failed to appear.
+// (Swap in a dedicated monochrome glyph later via the expo-notifications
+// plugin — that's cosmetic; this is what makes the offer render at all.)
+const RIDE_OFFER_SMALL_ICON = 'ic_launcher';
+
 export const NOTIFEE_RIDE_OFFER_CHANNEL_ID = RIDE_OFFER_CHANNEL_ID;
 export const NOTIFEE_RIDE_OFFER_NOTIFICATION_ID = RIDE_OFFER_NOTIFICATION_ID;
 
@@ -220,7 +230,7 @@ export async function displayRideOfferNotification(
         type: 'new_ride_assignment',
     };
 
-    await notifee.displayNotification({
+    const request = {
         id: RIDE_OFFER_NOTIFICATION_ID,
         title,
         body,
@@ -232,7 +242,7 @@ export async function displayRideOfferNotification(
             visibility: AndroidVisibility.PUBLIC,
             color: AndroidColor.GREEN,
             colorized: true,
-            smallIcon: 'ic_notification', // fallback to app icon if missing
+            smallIcon: RIDE_OFFER_SMALL_ICON,
             largeIcon: undefined,
             ongoing: true,
             autoCancel: false,
@@ -278,7 +288,51 @@ export async function displayRideOfferNotification(
                 list: true,
             },
         },
-    });
+    };
+
+    try {
+        await notifee.displayNotification(request);
+    } catch (e) {
+        // Guardrail: a single unresolved resource (small icon, custom sound,
+        // BIG_TEXT style, full-screen intent) makes Android reject the WHOLE
+        // notification — the driver would see nothing and miss the fare. Never
+        // let that happen silently. Log loudly, then retry with a minimal,
+        // dependency-free notification that still carries Accept/Decline so the
+        // offer stays actionable. Channel sound (set at channel creation) still
+        // rings; we just drop the per-notification overrides that can throw.
+        console.error(
+            '[Notifee] rich ride-offer render failed — falling back to a basic notification:',
+            e,
+        );
+        try {
+            await notifee.displayNotification({
+                id: RIDE_OFFER_NOTIFICATION_ID,
+                title,
+                body,
+                data: dataPayload,
+                android: {
+                    channelId: silent ? RIDE_OFFER_SILENT_CHANNEL_ID : RIDE_OFFER_CHANNEL_ID,
+                    importance: AndroidImportance.HIGH,
+                    smallIcon: RIDE_OFFER_SMALL_ICON,
+                    pressAction: { id: 'default', launchActivity: 'default' },
+                    actions: [
+                        { title: 'APPROVE', pressAction: { id: 'accept', launchActivity: 'default' } },
+                        { title: 'Decline', pressAction: { id: 'decline' } },
+                    ],
+                    timeoutAfter: timeoutMs,
+                },
+                ios: {
+                    categoryId: RIDE_OFFER_CATEGORY_ID,
+                    interruptionLevel: 'timeSensitive',
+                },
+            });
+        } catch (e2) {
+            // Both renders failed — surface it; the WS in-app panel is the only
+            // remaining channel and the backend offer-timeout still protects the
+            // driver's miss streak.
+            console.error('[Notifee] basic ride-offer render also failed:', e2);
+        }
+    }
     scheduleRideOfferDismiss(timeoutMs);
 }
 


### PR DESCRIPTION
…der guardrail

Root cause of "ride offer never appears outside the app": Notifee's displayNotification() was given smallIcon 'ic_notification', a drawable that no config plugin generates (expo-notifications isn't in the plugins array and there is no committed android/ dir). Android REJECTS a notification whose small icon can't be resolved — it does not fall back to the app icon — so every render threw and the catch in backgroundMessaging.ts logged "displayRideOfferNotification failed". FCM was arriving fine (dispatch=True on the backend); the offer just never rendered, foreground or background.

Fix:
  * point smallIcon at 'ic_launcher', the one drawable Expo generates into every Android build (Notifee resolves the name against mipmap + drawable), so it is guaranteed to resolve.
  * add a guardrail: wrap displayNotification so a single unresolved resource (icon, custom sound, BIG_TEXT style, full-screen intent) can never drop the whole offer. On throw we log loudly (console.error, not a silent swallow) and retry with a minimal notification that still carries Accept/Decline, so the offer stays actionable. The channel-level sound still rings.

This is a JS-only change (no native code), so it can ship via `eas update` to any build that already carries the Notifee native module + bundled sound (runtimeVersion 2.1.0); a full rebuild also works.

https://claude.ai/code/session_019Syvw3Zi7tQjxYuhCr2WJ7

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
