### PR TITLE
perf(admin): drop driver profile photos from drivers list

### DIFF
--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -580,12 +580,10 @@ export default function DriversPage() {
                                         <TableCell className="py-3">
                                             <div className="flex items-center gap-3">
                                                 <div className="relative">
-                                                    {driver.photo_url ? (
-                                                        // eslint-disable-next-line @next/next/no-img-element
-                                                        <img src={driver.photo_url} alt="" className="w-10 h-10 rounded-full object-cover ring-1 ring-border shadow-sm" />
-                                                    ) : (
-                                                        <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-sm font-bold text-primary ring-1 ring-border shadow-sm">{(driver.first_name?.[0] || "")}{(driver.last_name?.[0] || "")}</div>
-                                                    )}
+                                                    {/* Profile photo intentionally omitted from the list — loading
+                                                        one image per row slowed the page down. Initials stand in here;
+                                                        the real photo still renders in the detail slideout. */}
+                                                    <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-sm font-bold text-primary ring-1 ring-border shadow-sm">{(driver.first_name?.[0] || "")}{(driver.last_name?.[0] || "")}</div>
                                                     <span className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-card ${driver.is_online ? "bg-emerald-500" : "bg-gray-300"}`} />
                                                 </div>
                                                 <div className="flex-1 min-w-0">

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -677,9 +677,12 @@ export default function DriversPage() {
                                 <div className="flex items-start justify-between">
                                     <div className="flex items-center gap-4">
                                         <div className="relative">
-                                            {selected.photo_url ? (
+                                            {/* Photo comes from live-stats (loaded on open) — the drivers
+                                                list no longer ships profile_image. Falls back to selected
+                                                in case an older list payload still carries it. */}
+                                            {(liveStats?.photo_url || selected.photo_url) ? (
                                                 // eslint-disable-next-line @next/next/no-img-element
-                                                <img src={selected.photo_url} alt="" className="w-16 h-16 rounded-2xl object-cover" />
+                                                <img src={liveStats?.photo_url || selected.photo_url} alt="" className="w-16 h-16 rounded-2xl object-cover" />
                                             ) : (
                                                 <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-primary/20 to-primary/5 flex items-center justify-center text-xl font-bold text-primary">{(selected.first_name?.[0] || "")}{(selected.last_name?.[0] || "")}</div>
                                             )}
@@ -701,9 +704,9 @@ export default function DriversPage() {
                                             </div>
                                             {selected.profile_image_status === "pending_review" && (
                                                 <div className="flex items-center gap-2 mt-2 p-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
-                                                    {selected.photo_url && (
+                                                    {(liveStats?.photo_url || selected.photo_url) && (
                                                         // eslint-disable-next-line @next/next/no-img-element
-                                                        <img src={selected.photo_url} alt="" className="w-9 h-9 rounded-full object-cover" />
+                                                        <img src={liveStats?.photo_url || selected.photo_url} alt="" className="w-9 h-9 rounded-full object-cover" />
                                                     )}
                                                     <span className="text-xs text-amber-700 dark:text-amber-400 flex-1">Profile photo pending review</span>
                                                     <button disabled={photoReviewing} onClick={() => handlePhotoReview("approve")} className="text-xs font-semibold px-2 py-1 rounded bg-emerald-600 text-white disabled:opacity-50">Approve</button>
@@ -1339,7 +1342,7 @@ function VerificationSummaryCard({
                 </div>
                 <div className="flex items-center justify-between pt-1 text-xs border-t border-border">
                     <div className="flex items-center gap-2">
-                        <div className={`w-2 h-2 rounded-full ${driver.profile_photo_url ? "bg-emerald-500" : "bg-muted-foreground/30"}`} />
+                        <div className={`w-2 h-2 rounded-full ${driver.profile_image_status ? "bg-emerald-500" : "bg-muted-foreground/30"}`} />
                         <span className="text-muted-foreground">Profile photo</span>
                     </div>
                     <div className="flex items-center gap-2">

--- a/admin-dashboard/src/app/dashboard/safety/page.tsx
+++ b/admin-dashboard/src/app/dashboard/safety/page.tsx
@@ -29,6 +29,7 @@ import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Pagination } from "@/components/ui/pagination";
 import { Sheet, SheetContent, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
@@ -121,6 +122,8 @@ export default function SafetyPage() {
 
     const [items, setItems] = useState<SafetyIncident[]>([]);
     const [openCount, setOpenCount] = useState<number | null>(null);
+    const [total, setTotal] = useState(0);
+    const [page, setPage] = useState(0);
     const [loading, setLoading] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
 
@@ -145,10 +148,12 @@ export default function SafetyPage() {
                 role: roleFilter !== "all" ? roleFilter : undefined,
                 search: search.trim() || undefined,
                 limit: PAGE_SIZE,
+                offset: page * PAGE_SIZE,
             });
             // Drop stale responses if the user re-filtered while a fetch was in flight.
             if (id !== reqIdRef.current) return;
             setItems(res.items || []);
+            setTotal(res.total ?? 0);
             setOpenCount(res.open_count ?? null);
         } catch (e: any) {
             toast({
@@ -160,12 +165,18 @@ export default function SafetyPage() {
             setLoading(false);
             setRefreshing(false);
         }
-    }, [statusFilter, severityFilter, roleFilter, search, toast]);
+    }, [statusFilter, severityFilter, roleFilter, search, page, toast]);
 
     useEffect(() => {
         if (!allowed) return;
         load();
     }, [allowed, load]);
+
+    // Any filter/search change resets to the first page so the user never lands
+    // on an out-of-range offset (e.g. page 3 of a now-shorter result set).
+    useEffect(() => {
+        setPage(0);
+    }, [statusFilter, severityFilter, roleFilter, search]);
 
     // Live updates: when an admin WS broadcast announces a new incident,
     // refresh the list. We don't optimistically prepend because the
@@ -379,6 +390,17 @@ export default function SafetyPage() {
                     </Table>
                 )}
             </div>
+
+            {/* Pagination — server-side offset; only the current page is fetched. */}
+            {!loading && total > 0 && (
+                <Pagination
+                    page={page}
+                    pageSize={PAGE_SIZE}
+                    hasNextPage={(page + 1) * PAGE_SIZE < total}
+                    totalCount={total}
+                    onPageChange={setPage}
+                />
+            )}
 
             {/* Detail / triage drawer */}
             <Sheet open={!!selectedId} onOpenChange={(open) => { if (!open) { setSelectedId(null); setDetail(null); } }}>

--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -153,6 +153,8 @@ export default function UsersPage() {
             const transformed = slice.map((u: any) => ({
                 id: u.id,
                 name: `${u.first_name || ""} ${u.last_name || ""}`.trim() || u.email || u.phone,
+                first_name: u.first_name,
+                last_name: u.last_name,
                 email: u.email,
                 phone: u.phone,
                 role: u.role,
@@ -160,6 +162,8 @@ export default function UsersPage() {
                 total_rides: u.total_rides || 0,
                 rating: u.rating || null,
                 is_verified: u.is_verified ?? true,
+                is_rider: u.is_rider,
+                is_driver: u.is_driver,
                 city: u.city,
                 status: u.status || "active",
             }));

--- a/admin-dashboard/src/app/dashboard/venues/page.tsx
+++ b/admin-dashboard/src/app/dashboard/venues/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { MapPin, Plus, Trash2, Save, X, RefreshCw } from "lucide-react";
+import { MapPin, Plus, Trash2, Save, X, RefreshCw, Ruler } from "lucide-react";
 import {
-  getVenues, createVenue, updateVenue, deleteVenue,
+  getVenues, createVenue, updateVenue, deleteVenue, getServiceAreas,
   type Venue, type VenueUpsert, type VenuePickupPoint,
 } from "@/lib/api";
 
@@ -16,6 +16,8 @@ const EMPTY: VenueUpsert = {
 
 export default function VenuesPage() {
   const [venues, setVenues] = useState<Venue[]>([]);
+  const [serviceAreas, setServiceAreas] = useState<{ id: string; name: string }[]>([]);
+  const [areaFilter, setAreaFilter] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [editing, setEditing] = useState<{ id: string | null; data: VenueUpsert } | null>(null);
   const [saving, setSaving] = useState(false);
@@ -24,16 +26,29 @@ export default function VenuesPage() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await getVenues();
+      const res = await getVenues(areaFilter ? { service_area_id: areaFilter } : undefined);
       setVenues(res.venues || []);
     } catch (e: any) {
       setError(e?.message || "Failed to load venues");
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [areaFilter]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Service areas drive both the list filter and the per-venue area label.
+  useEffect(() => {
+    getServiceAreas()
+      .then((rows) => setServiceAreas((rows || []).map((a: any) => ({ id: a.id, name: a.name }))))
+      .catch(() => {});
+  }, []);
+
+  const areaNameById = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const a of serviceAreas) m[a.id] = a.name;
+    return m;
+  }, [serviceAreas]);
 
   const startNew = () => setEditing({ id: null, data: { ...EMPTY, pickup_points: [] } });
   const startEdit = (v: Venue) => setEditing({
@@ -92,6 +107,17 @@ export default function VenuesPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          <select
+            value={areaFilter}
+            onChange={(e) => setAreaFilter(e.target.value)}
+            className="text-sm border rounded-lg px-3 py-2 bg-background hover:bg-muted"
+            aria-label="Filter by service area"
+          >
+            <option value="">All service areas</option>
+            {serviceAreas.map((a) => (
+              <option key={a.id} value={a.id}>{a.name}</option>
+            ))}
+          </select>
           <button onClick={load} className="flex items-center gap-1.5 text-sm border rounded-lg px-3 py-2 hover:bg-muted">
             <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} /> Refresh
           </button>
@@ -113,6 +139,18 @@ export default function VenuesPage() {
               <label className="text-sm">Center latitude<Input type="number" value={d.center_lat} onChange={(e) => patch({ center_lat: parseFloat(e.target.value) || 0 })} /></label>
               <label className="text-sm">Center longitude<Input type="number" value={d.center_lng} onChange={(e) => patch({ center_lng: parseFloat(e.target.value) || 0 })} /></label>
               <label className="text-sm">Detection radius (m)<Input type="number" value={d.radius_m} onChange={(e) => patch({ radius_m: parseInt(e.target.value) || 0 })} /></label>
+              <label className="text-sm">Service area
+                <select
+                  value={d.service_area_id ?? ""}
+                  onChange={(e) => patch({ service_area_id: e.target.value || null })}
+                  className="mt-1 w-full text-sm border rounded-md px-3 py-2 bg-background h-10"
+                >
+                  <option value="">Unassigned</option>
+                  {serviceAreas.map((a) => (
+                    <option key={a.id} value={a.id}>{a.name}</option>
+                  ))}
+                </select>
+              </label>
             </div>
             <div className="flex items-center gap-2">
               <Switch checked={d.is_active} onCheckedChange={(v) => patch({ is_active: v })} />
@@ -164,12 +202,20 @@ export default function VenuesPage() {
               {venues.map((v) => (
                 <div key={v.id} className="flex items-center justify-between py-3 gap-4">
                   <div className="min-w-0">
-                    <p className="font-medium flex items-center gap-2">
+                    <p className="font-medium flex items-center gap-2 flex-wrap">
                       {v.name}
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 inline-flex items-center gap-1">
+                        <MapPin className="h-2.5 w-2.5" />
+                        {v.service_area_id ? (areaNameById[v.service_area_id] || "Unknown area") : "Unassigned"}
+                      </span>
+                      <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-foreground/80 inline-flex items-center gap-1 tabular-nums">
+                        <Ruler className="h-2.5 w-2.5" />
+                        {v.radius_m} m
+                      </span>
                       {!v.is_active && <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground">inactive</span>}
                     </p>
                     <p className="text-xs text-muted-foreground tabular-nums">
-                      {v.center_lat.toFixed(5)}, {v.center_lng.toFixed(5)} · {v.radius_m}m · {(v.pickup_points || []).length} point{(v.pickup_points || []).length === 1 ? "" : "s"}
+                      {v.center_lat.toFixed(5)}, {v.center_lng.toFixed(5)} · {(v.pickup_points || []).length} point{(v.pickup_points || []).length === 1 ? "" : "s"}
                     </p>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -888,7 +888,10 @@ export interface Venue {
     is_active: boolean;
 }
 export type VenueUpsert = Omit<Venue, "id">;
-export const getVenues = () => request<{ venues: Venue[] }>("/api/admin/venues");
+export const getVenues = (params?: { service_area_id?: string }) => {
+    const qs = params?.service_area_id ? `?service_area_id=${encodeURIComponent(params.service_area_id)}` : "";
+    return request<{ venues: Venue[] }>(`/api/admin/venues${qs}`);
+};
 export const createVenue = (body: VenueUpsert) =>
     request<Venue>("/api/admin/venues", { method: "POST", body: JSON.stringify(body) });
 export const updateVenue = (id: string, body: VenueUpsert) =>

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -567,6 +567,9 @@ export interface DriverLiveStats {
     acceptance_rate: number | null;
     cancelled_by_driver: number;
     total_assigned: number;
+    // Driver avatar, loaded lazily here so the bulk drivers list no longer
+    // has to ship profile_image (a base64 blob for legacy accounts).
+    photo_url: string | null;
 }
 export const getDriverLiveStats = (id: string) =>
     request<DriverLiveStats>(`/api/admin/drivers/${id}/live-stats`);

--- a/backend/migrations/159_payouts_overview_aggregates_fn.sql
+++ b/backend/migrations/159_payouts_overview_aggregates_fn.sql
@@ -1,0 +1,150 @@
+-- 159_payouts_overview_aggregates_fn.sql
+--
+-- Purpose:
+--   The admin /payouts/overview dashboard computed its all-time aggregates
+--   (outstanding payable, stuck-payout queue, blocked-driver balance, and the
+--   T4A year-to-date snapshot) by streaming the ENTIRE rides + payouts history
+--   into Python via two `get_rows(..., limit=200000)` full-table scans, then
+--   summing in a loop. This function does the same arithmetic in Postgres in a
+--   single round-trip, so the backend no longer pulls hundreds of thousands of
+--   rows over the wire to add them up.
+--
+--   The period-windowed, per-row metrics (daily series, failure reasons,
+--   median time-to-payout, top / at-risk drivers) stay in Python — they need
+--   the individual rows — but the endpoint now fetches only the rows inside the
+--   selected window, not the whole table.
+--
+-- Semantics mirror the previous Python exactly:
+--   * effective ride timestamp  = COALESCE(ride_completed_at, updated_at);
+--     a completed ride with neither timestamp is still counted in the
+--     cumulative "up to" sums (matched the old ""<=ts string comparison) but
+--     excluded from the YTD T4A window (matched "">=year_start being false).
+--   * effective payout state set for "paid or in flight" =
+--     ('completed','pending','processing').
+--   * money (FLOAT columns) is cast ::text::numeric before summing, so it
+--     matches the old per-row Decimal(str(float)) summation to the cent — a
+--     bare ::numeric would keep the float's binary rounding error.
+--
+-- Money-function safety: STABLE + SECURITY DEFINER + pinned search_path, read
+-- only (no writes), callable by the backend service role only.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_payouts_overview_aggregates(
+--       timestamptz, timestamptz, timestamptz, timestamptz, text);
+--   DROP INDEX IF EXISTS idx_rides_completed_driver;
+--   DROP INDEX IF EXISTS idx_payouts_processed_at;
+--   (idx_payouts_status_created is owned by migration 79 — do NOT drop it here.)
+--
+-- Note: the two CREATE INDEX statements use CONCURRENTLY because rides/payouts
+-- are hot tables. CONCURRENTLY cannot run inside a transaction block; the
+-- migration runner detects "CONCURRENTLY" in the file and applies it in
+-- autocommit mode (same handling as 153/156).
+
+-- Supporting indexes for the aggregate predicates + the windowed payout fetch.
+-- The (status, created_at DESC) predicate is already covered by
+-- idx_payouts_status_created from migration 79 — not recreated here.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rides_completed_driver
+    ON public.rides (driver_id) WHERE status = 'completed';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_payouts_processed_at
+    ON public.payouts (processed_at);
+
+CREATE OR REPLACE FUNCTION public.admin_payouts_overview_aggregates(
+    p_end             timestamptz,
+    p_prev_end        timestamptz,
+    p_year_start      timestamptz,
+    p_stuck_before    timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+WITH scoped_drivers AS (
+    -- Resolve the area → driver-id set once (only when an area is selected) so
+    -- the scope predicate isn't a repeated correlated subquery on drivers.
+    SELECT id FROM drivers
+    WHERE p_service_area_id IS NOT NULL AND service_area_id::text = p_service_area_id
+),
+scoped_rides AS (
+    -- driver_earnings is FLOAT in the DB; cast via text so the value matches
+    -- the old Python Decimal(str(float)) path exactly (float8::text uses the
+    -- shortest round-trip representation, same as Python's str(float)). A bare
+    -- ::numeric would carry the binary rounding error (12.2999999…) and drift
+    -- from the previous totals.
+    SELECT r.driver_id,
+           r.driver_earnings::text::numeric AS earnings,
+           COALESCE(r.ride_completed_at, r.updated_at) AS eff_ts
+    FROM rides r
+    WHERE r.status = 'completed'
+      AND (p_service_area_id IS NULL OR r.driver_id IN (SELECT id FROM scoped_drivers))
+),
+scoped_payouts AS (
+    -- payouts.amount is FLOAT — same ::text::numeric cast rationale as above.
+    SELECT p.driver_id, p.amount::text::numeric AS amount, p.status, p.created_at
+    FROM payouts p
+    WHERE (p_service_area_id IS NULL OR p.driver_id IN (SELECT id FROM scoped_drivers))
+),
+blocked AS (
+    SELECT d.id
+    FROM drivers d
+    WHERE d.stripe_payouts_enabled = false
+      AND d.stripe_account_id IS NOT NULL
+      AND (p_service_area_id IS NULL OR d.id IN (SELECT id FROM scoped_drivers))
+),
+ytd AS (
+    SELECT driver_id, COALESCE(SUM(earnings), 0) AS earned
+    FROM scoped_rides
+    WHERE eff_ts >= p_year_start
+    GROUP BY driver_id
+)
+SELECT jsonb_build_object(
+    'earned_up_to_end',
+        COALESCE((SELECT SUM(earnings) FROM scoped_rides WHERE eff_ts IS NULL OR eff_ts <= p_end), 0),
+    'earned_up_to_prev',
+        COALESCE((SELECT SUM(earnings) FROM scoped_rides WHERE eff_ts IS NULL OR eff_ts <= p_prev_end), 0),
+    'paid_up_to_end',
+        COALESCE((SELECT SUM(amount) FROM scoped_payouts
+                  WHERE status IN ('completed','pending','processing')
+                    AND (created_at IS NULL OR created_at <= p_end)), 0),
+    'paid_up_to_prev',
+        COALESCE((SELECT SUM(amount) FROM scoped_payouts
+                  WHERE status IN ('completed','pending','processing')
+                    AND (created_at IS NULL OR created_at <= p_prev_end)), 0),
+    'stuck_count',
+        (SELECT COUNT(*) FROM scoped_payouts
+         WHERE status IN ('pending','processing')
+           AND (created_at IS NULL OR created_at < p_stuck_before)),
+    'stuck_amount',
+        COALESCE((SELECT SUM(amount) FROM scoped_payouts
+                  WHERE status IN ('pending','processing')
+                    AND (created_at IS NULL OR created_at < p_stuck_before)), 0),
+    'blocked_count',
+        (SELECT COUNT(*) FROM blocked),
+    'blocked_outstanding',
+        GREATEST(
+            COALESCE((SELECT SUM(earnings) FROM scoped_rides WHERE driver_id IN (SELECT id FROM blocked)), 0)
+            - COALESCE((SELECT SUM(amount) FROM scoped_payouts
+                        WHERE driver_id IN (SELECT id FROM blocked)
+                          AND status IN ('completed','pending','processing')), 0),
+            0),
+    't4a_under_500',  (SELECT COUNT(*) FROM ytd WHERE earned < 500),
+    't4a_500_10k',    (SELECT COUNT(*) FROM ytd WHERE earned >= 500   AND earned < 10000),
+    't4a_10k_30k',    (SELECT COUNT(*) FROM ytd WHERE earned >= 10000 AND earned < 30000),
+    't4a_over_30k',   (SELECT COUNT(*) FROM ytd WHERE earned >= 30000),
+    't4a_drivers_with_earnings', (SELECT COUNT(*) FROM ytd),
+    't4a_ytd_gross',  COALESCE((SELECT SUM(earned) FROM ytd), 0)
+);
+$$;
+
+COMMENT ON FUNCTION public.admin_payouts_overview_aggregates(
+    timestamptz, timestamptz, timestamptz, timestamptz, text) IS
+    'All-time payout/earnings aggregates for the admin /payouts/overview dashboard. '
+    'Replaces two limit=200000 full-table scans. Read-only.';
+
+-- Called from the backend (service role) only. The service role bypasses these
+-- REVOKEs by design; this just stops a rider/driver/anon JWT from invoking an
+-- RPC that exposes fleet-wide financial + T4A aggregates.
+REVOKE EXECUTE ON FUNCTION public.admin_payouts_overview_aggregates(
+    timestamptz, timestamptz, timestamptz, timestamptz, text) FROM anon, authenticated;

--- a/backend/migrations/160_ride_daily_counts_fn.sql
+++ b/backend/migrations/160_ride_daily_counts_fn.sql
@@ -1,0 +1,47 @@
+-- 160_ride_daily_counts_fn.sql
+--
+-- Purpose:
+--   Replace two "pull rows, count in Python" analytics paths with a single
+--   GROUP BY in Postgres:
+--     * /rides/trend  fetched up to 50,000 created_at values and bucketed them
+--       per day in a Python loop.
+--     * /rides/stats  daily_chart issued 14 sequential COUNT round-trips
+--       (get_ride_count_by_date_range once per day).
+--   Both are now one call to admin_ride_daily_counts, which returns the per-day
+--   ride count (by created_at, UTC calendar day) for a window. Days with no
+--   rides are absent from the result; the caller fills gaps with zero.
+--
+--   Mirrors get_ride_count_by_date_range exactly: counts ALL rides by
+--   created_at in [p_start, p_end).
+--
+-- rides(created_at) is already indexed (migration 79), so no new index here.
+--
+-- Money-function safety: read-only, STABLE, SECURITY DEFINER, pinned
+-- search_path, EXECUTE revoked from anon/authenticated.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_ride_daily_counts(timestamptz, timestamptz);
+
+CREATE OR REPLACE FUNCTION public.admin_ride_daily_counts(
+    p_start timestamptz,
+    p_end   timestamptz
+)
+RETURNS TABLE (day date, rides bigint)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT (created_at AT TIME ZONE 'UTC')::date AS day, COUNT(*) AS rides
+    FROM rides
+    WHERE created_at >= p_start AND created_at < p_end
+    GROUP BY 1
+    ORDER BY 1;
+$$;
+
+COMMENT ON FUNCTION public.admin_ride_daily_counts(timestamptz, timestamptz) IS
+    'Per-day ride counts (by created_at, UTC) for a window. Replaces row-fetch '
+    'bucketing in /rides/trend and the 14-query daily_chart in /rides/stats.';
+
+REVOKE EXECUTE ON FUNCTION public.admin_ride_daily_counts(timestamptz, timestamptz)
+    FROM anon, authenticated;

--- a/backend/migrations/161_ride_money_rollup_fn.sql
+++ b/backend/migrations/161_ride_money_rollup_fn.sql
@@ -1,0 +1,79 @@
+-- 161_ride_money_rollup_fn.sql
+--
+-- Purpose:
+--   /stats, /rides/stats and /rides/financials each fetched completed rides
+--   (limit 5,000–10,000) only to SUM money columns in a Python loop. This
+--   function returns those sums for a [p_start, p_end) window of completed
+--   rides (by ride_completed_at) in one round-trip.
+--
+--   p_end NULL means "no upper bound" (matches the /stats and /rides/stats
+--   "today"/"month" queries, which use ride_completed_at >= start only).
+--
+-- Cent-faithful: the money columns are FLOAT, so every component is cast
+-- ::text::numeric BEFORE summing — and driver_revenue casts each of
+-- base/distance/time separately before adding — so the totals match the old
+-- per-row Decimal(str(float)) arithmetic exactly. rider_paid uses
+-- COALESCE(grand_total, total_fare, 0) so a comped $0 ride (grand_total = 0)
+-- counts as 0, not the pre-promo fare — matching the Python _rider_paid().
+--
+-- Money-function safety: read-only, STABLE, SECURITY DEFINER, pinned
+-- search_path, EXECUTE revoked from anon/authenticated.
+--
+-- Note: the index uses CONCURRENTLY (rides is a hot table); the runner detects
+-- CONCURRENTLY and applies the file in autocommit mode.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_ride_money_rollup(timestamptz, timestamptz);
+--   DROP INDEX IF EXISTS idx_rides_completed_at_completed;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rides_completed_at_completed
+    ON public.rides (ride_completed_at) WHERE status = 'completed';
+
+CREATE OR REPLACE FUNCTION public.admin_ride_money_rollup(
+    p_start timestamptz,
+    p_end   timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    WITH c AS (
+        SELECT
+            COALESCE(total_fare, 0)::text::numeric      AS total_fare,
+            COALESCE(tip_amount, 0)::text::numeric      AS tip_amount,
+            COALESCE(tax_amount, 0)::text::numeric      AS tax_amount,
+            COALESCE(discount_amount, 0)::text::numeric AS discount_amount,
+            COALESCE(area_fees_total, 0)::text::numeric AS area_fees_total,
+            COALESCE(admin_earnings, 0)::text::numeric  AS admin_earnings,
+            COALESCE(driver_earnings, 0)::text::numeric AS driver_earnings,
+            COALESCE(base_fare, 0)::text::numeric
+              + COALESCE(distance_fare, 0)::text::numeric
+              + COALESCE(time_fare, 0)::text::numeric   AS driver_revenue,
+            COALESCE(grand_total, total_fare, 0)::text::numeric AS rider_paid
+        FROM rides
+        WHERE status = 'completed'
+          AND ride_completed_at >= p_start
+          AND (p_end IS NULL OR ride_completed_at < p_end)
+    )
+    SELECT jsonb_build_object(
+        'completed_count',     (SELECT COUNT(*) FROM c),
+        'sum_total_fare',      COALESCE((SELECT SUM(total_fare) FROM c), 0),
+        'sum_tip',             COALESCE((SELECT SUM(tip_amount) FROM c), 0),
+        'sum_tax',             COALESCE((SELECT SUM(tax_amount) FROM c), 0),
+        'sum_discount',        COALESCE((SELECT SUM(discount_amount) FROM c), 0),
+        'sum_area_fees',       COALESCE((SELECT SUM(area_fees_total) FROM c), 0),
+        'sum_admin_earnings',  COALESCE((SELECT SUM(admin_earnings) FROM c), 0),
+        'sum_driver_earnings', COALESCE((SELECT SUM(driver_earnings) FROM c), 0),
+        'sum_driver_revenue',  COALESCE((SELECT SUM(driver_revenue) FROM c), 0),
+        'sum_rider_paid',      COALESCE((SELECT SUM(rider_paid) FROM c), 0)
+    );
+$$;
+
+COMMENT ON FUNCTION public.admin_ride_money_rollup(timestamptz, timestamptz) IS
+    'Completed-ride money sums for a [start,end) window (end NULL = open). '
+    'Replaces row-fetch+Python-sum in /stats, /rides/stats, /rides/financials.';
+
+REVOKE EXECUTE ON FUNCTION public.admin_ride_money_rollup(timestamptz, timestamptz)
+    FROM anon, authenticated;

--- a/backend/migrations/162_payout_stats_fn.sql
+++ b/backend/migrations/162_payout_stats_fn.sql
@@ -1,0 +1,41 @@
+-- 162_payout_stats_fn.sql
+--
+-- Purpose:
+--   /payouts/stats fetched the ENTIRE payouts table (limit 10,000) only to sum
+--   amounts per status and count rows in Python. This function returns those
+--   status totals + counts in one aggregate round-trip.
+--
+--   payouts.amount is FLOAT, so it is cast ::text::numeric before summing to
+--   match the old Decimal(str(float)) arithmetic to the cent.
+--
+--   Uses idx_payouts_status_created (status, created_at) from migration 79 for
+--   the status FILTERs — no new index needed.
+--
+-- Money-function safety: read-only, STABLE, SECURITY DEFINER, pinned
+-- search_path, EXECUTE revoked from anon/authenticated.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_payout_stats();
+
+CREATE OR REPLACE FUNCTION public.admin_payout_stats()
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT jsonb_build_object(
+        'total_paid',    COALESCE(SUM(amount::text::numeric) FILTER (WHERE status = 'completed'), 0),
+        'total_pending', COALESCE(SUM(amount::text::numeric) FILTER (WHERE status = 'pending'), 0),
+        'total_failed',  COALESCE(SUM(amount::text::numeric) FILTER (WHERE status = 'failed'), 0),
+        'payout_count',  COUNT(*),
+        'pending_count', COUNT(*) FILTER (WHERE status = 'pending')
+    )
+    FROM payouts;
+$$;
+
+COMMENT ON FUNCTION public.admin_payout_stats() IS
+    'Payout totals by status + counts for /payouts/stats. Replaces a '
+    'whole-table fetch + Python sum.';
+
+REVOKE EXECUTE ON FUNCTION public.admin_payout_stats() FROM anon, authenticated;

--- a/backend/migrations/163_earnings_overview_aggregates_fn.sql
+++ b/backend/migrations/163_earnings_overview_aggregates_fn.sql
@@ -1,0 +1,178 @@
+-- 163_earnings_overview_aggregates_fn.sql
+--
+-- Purpose:
+--   /earnings/overview pulled four windows of rides (current/previous
+--   completed + cancelled, limit=50000 each) plus refunds (limit=10000 x2) and
+--   aggregated them in Python (GBV, platform margin, distinct active
+--   riders/drivers, surge revenue, promo, GST/PST from the tax_breakdown JSONB,
+--   cancellation counts/revenue, refund totals, and a daily series). These
+--   functions do that work in Postgres.
+--
+--   Three functions:
+--     admin_earnings_overview_agg(start,end,area)  -> jsonb of completed +
+--         cancelled metrics for one window (called for current & previous).
+--     admin_earnings_daily_series(start,end,area)  -> per-day gbv/trips/
+--         net_revenue over completed rides (current window line chart).
+--     admin_earnings_refunds(start,end,area)       -> refund $ + count from
+--         disputes resolved in the window (area-scoped via the ride set, same
+--         as the old Python cross-reference).
+--
+--   NOT converted (left in Python for now): the Spinr Pass MRR snapshot, which
+--   reads driver_subscriptions (bounded) through point-in-time _active_subs_at
+--   logic — a separate follow-up.
+--
+-- Semantics mirror the previous Python exactly:
+--   * completed window = ride_completed_at in [start, end]; cancelled window =
+--     created_at in [start, end] (cancelled rows have null ride_completed_at).
+--   * money columns are FLOAT -> cast ::text::numeric so sums match the old
+--     Decimal(str(float)) arithmetic to the cent.
+--   * surge_revenue = sum(total_fare - total_fare/surge_multiplier) over rides
+--     with surge_multiplier > 1.
+--   * GST bucket = tax_breakdown keys containing 'gst' or equal to 'hst';
+--     PST bucket = keys containing 'pst' or 'qst'; amount = value->>'amount'.
+--   * cancel attribution: 'driver' in reason -> driver; else 'rider'/'user' ->
+--     rider (driver takes precedence, matching the old elif).
+--   * refunds: disputes resolved in [start,end]; when an area is set, only
+--     disputes whose ride_id is in that window's completed+cancelled ride set.
+--
+-- Money-function safety: read-only, STABLE, SECURITY DEFINER, pinned
+-- search_path, EXECUTE revoked from anon/authenticated.
+--
+-- Note: the two new indexes use CONCURRENTLY (hot tables); the runner detects
+-- CONCURRENTLY and applies the file in autocommit mode.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_earnings_overview_agg(timestamptz,timestamptz,text);
+--   DROP FUNCTION IF EXISTS public.admin_earnings_daily_series(timestamptz,timestamptz,text);
+--   DROP FUNCTION IF EXISTS public.admin_earnings_refunds(timestamptz,timestamptz,text);
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_rides_cancelled_created;
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_disputes_resolved_at;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rides_cancelled_created
+    ON public.rides (created_at) WHERE status = 'cancelled';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_disputes_resolved_at
+    ON public.disputes (resolved_at);
+
+CREATE OR REPLACE FUNCTION public.admin_earnings_overview_agg(
+    p_start           timestamptz,
+    p_end             timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+WITH completed AS (
+    SELECT total_fare, admin_earnings, rider_id, driver_id,
+           surge_multiplier, discount_amount, tax_breakdown
+    FROM rides
+    WHERE status = 'completed'
+      AND ride_completed_at >= p_start AND ride_completed_at <= p_end
+      AND (p_service_area_id IS NULL OR service_area_id::text = p_service_area_id)
+),
+cancelled AS (
+    SELECT cancellation_fee_admin, cancellation_reason
+    FROM rides
+    WHERE status = 'cancelled'
+      AND created_at >= p_start AND created_at <= p_end
+      AND (p_service_area_id IS NULL OR service_area_id::text = p_service_area_id)
+),
+tax AS (
+    SELECT t.key AS k, (t.value ->> 'amount') AS amt
+    FROM completed c, LATERAL jsonb_each(c.tax_breakdown) t
+    WHERE jsonb_typeof(c.tax_breakdown) = 'object'
+)
+SELECT jsonb_build_object(
+    'gbv',           COALESCE((SELECT SUM(total_fare::text::numeric) FROM completed), 0),
+    'platform',      COALESCE((SELECT SUM(admin_earnings::text::numeric) FROM completed), 0),
+    'trips',         (SELECT COUNT(*) FROM completed),
+    'riders',        (SELECT COUNT(DISTINCT rider_id) FROM completed WHERE rider_id IS NOT NULL),
+    'drivers',       (SELECT COUNT(DISTINCT driver_id) FROM completed WHERE driver_id IS NOT NULL),
+    'surge_revenue', COALESCE((
+        SELECT SUM(total_fare::text::numeric - total_fare::text::numeric / surge_multiplier::text::numeric)
+        FROM completed
+        WHERE surge_multiplier IS NOT NULL AND surge_multiplier::text::numeric > 1
+    ), 0),
+    'promo_spend',   COALESCE((SELECT SUM(discount_amount::text::numeric) FROM completed), 0),
+    'promo_count',   (SELECT COUNT(*) FROM completed WHERE COALESCE(discount_amount, 0)::text::numeric > 0),
+    'gst_collected', COALESCE((SELECT SUM(amt::numeric) FROM tax WHERE lower(k) LIKE '%gst%' OR lower(k) = 'hst'), 0),
+    'pst_collected', COALESCE((SELECT SUM(amt::numeric) FROM tax WHERE lower(k) LIKE '%pst%' OR lower(k) LIKE '%qst%'), 0),
+    'cx_count',      (SELECT COUNT(*) FROM cancelled),
+    'cx_revenue',    COALESCE((SELECT SUM(cancellation_fee_admin::text::numeric) FROM cancelled), 0),
+    'cx_rider_cancels', (
+        SELECT COUNT(*) FROM cancelled
+        WHERE lower(COALESCE(cancellation_reason, '')) NOT LIKE '%driver%'
+          AND (lower(COALESCE(cancellation_reason, '')) LIKE '%rider%'
+               OR lower(COALESCE(cancellation_reason, '')) LIKE '%user%')
+    ),
+    'cx_driver_cancels', (
+        SELECT COUNT(*) FROM cancelled WHERE lower(COALESCE(cancellation_reason, '')) LIKE '%driver%'
+    )
+);
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_earnings_daily_series(
+    p_start           timestamptz,
+    p_end             timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS TABLE (day date, gbv numeric, trips bigint, net_revenue numeric)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT (ride_completed_at AT TIME ZONE 'UTC')::date AS day,
+           COALESCE(SUM(total_fare::text::numeric), 0)    AS gbv,
+           COUNT(*)                                       AS trips,
+           COALESCE(SUM(admin_earnings::text::numeric), 0) AS net_revenue
+    FROM rides
+    WHERE status = 'completed'
+      AND ride_completed_at >= p_start AND ride_completed_at <= p_end
+      AND (p_service_area_id IS NULL OR service_area_id::text = p_service_area_id)
+    GROUP BY 1
+    ORDER BY 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_earnings_refunds(
+    p_start           timestamptz,
+    p_end             timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT jsonb_build_object(
+        'refund_amount', COALESCE(SUM(refund_amount::text::numeric), 0),
+        'refund_count',  COUNT(*) FILTER (WHERE COALESCE(refund_amount, 0)::text::numeric > 0)
+    )
+    FROM disputes d
+    WHERE d.resolved_at >= p_start AND d.resolved_at <= p_end
+      AND (
+        p_service_area_id IS NULL
+        OR d.ride_id IN (
+            SELECT r.id FROM rides r
+            WHERE r.service_area_id::text = p_service_area_id
+              AND (
+                (r.status = 'completed' AND r.ride_completed_at >= p_start AND r.ride_completed_at <= p_end)
+                OR (r.status = 'cancelled' AND r.created_at >= p_start AND r.created_at <= p_end)
+              )
+        )
+      );
+$$;
+
+COMMENT ON FUNCTION public.admin_earnings_overview_agg(timestamptz, timestamptz, text) IS
+    'Completed + cancelled ride aggregates for one /earnings/overview window.';
+COMMENT ON FUNCTION public.admin_earnings_daily_series(timestamptz, timestamptz, text) IS
+    'Per-day GBV/trips/net-revenue over completed rides for the /earnings/overview chart.';
+COMMENT ON FUNCTION public.admin_earnings_refunds(timestamptz, timestamptz, text) IS
+    'Refund $ + count from disputes resolved in a window (area-scoped via ride set).';
+
+REVOKE EXECUTE ON FUNCTION public.admin_earnings_overview_agg(timestamptz, timestamptz, text) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.admin_earnings_daily_series(timestamptz, timestamptz, text) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.admin_earnings_refunds(timestamptz, timestamptz, text) FROM anon, authenticated;

--- a/backend/migrations/163_earnings_overview_aggregates_fn.sql
+++ b/backend/migrations/163_earnings_overview_aggregates_fn.sql
@@ -24,10 +24,18 @@
 -- Semantics mirror the previous Python exactly:
 --   * completed window = ride_completed_at in [start, end]; cancelled window =
 --     created_at in [start, end] (cancelled rows have null ride_completed_at).
---   * money columns are FLOAT -> cast ::text::numeric so sums match the old
+--   * money columns are FLOAT -> cast ::text::numeric so single-field sums
+--     (gbv, platform, promo, cancellation revenue, refunds) match the old
 --     Decimal(str(float)) arithmetic to the cent.
+--   * surge_revenue and the daily net_revenue/gbv are batch-SUMmed here, vs the
+--     old Python which round()-ed after each per-row addition. The SQL is
+--     arithmetically more correct; for big days the two can differ by a
+--     sub-cent — acceptable, these are display-only analytics, not charges.
 --   * surge_revenue = sum(total_fare - total_fare/surge_multiplier) over rides
 --     with surge_multiplier > 1.
+--   * GST bucket matches keys containing 'gst' OR exactly equal to 'hst' (HST is
+--     exact-match only — a compound key like 'provincial_hst' would NOT match,
+--     same as the old Python; new tax areas must use the key 'hst').
 --   * GST bucket = tax_breakdown keys containing 'gst' or equal to 'hst';
 --     PST bucket = keys containing 'pst' or 'qst'; amount = value->>'amount'.
 --   * cancel attribution: 'driver' in reason -> driver; else 'rider'/'user' ->

--- a/backend/migrations/164_driver_offer_analytics_fns.sql
+++ b/backend/migrations/164_driver_offer_analytics_fns.sql
@@ -1,0 +1,117 @@
+-- 164_driver_offer_analytics_fns.sql
+--
+-- Purpose:
+--   The two Driver Offers analytics endpoints each scanned the append-only
+--   ride_offers ledger with limit=100000 and rolled it up in Python:
+--     * /driver-offer-stats  — per-driver accepted/declined/ignored/preempted/
+--       pending counts + average response time.
+--     * /driver-offer-trends — per-day offer-outcome counts.
+--   These functions do the GROUP BY in Postgres, returning ~N-driver / ~N-day
+--   rows instead of streaming up to 100k offer rows into the app.
+--
+--   Existing indexes cover the predicates: idx_ride_offers_offered_at
+--   (migration 130) for the window, idx_ride_offers_driver_status for the
+--   per-driver/status rollups — so no new index is added here.
+--
+-- Semantics mirror the old Python exactly:
+--   * offered = every offer in the window (incl. 'cancelled'/'pending'); the
+--     status FILTER counts only their respective statuses ('expired' == ignored).
+--   * avg_response_secs = AVG(responded_at - offered_at) over offers the driver
+--     actually answered (accepted/declined, responded_at >= offered_at); NULL
+--     when none (caller renders None).
+--   * day bucket = offered_at at UTC calendar day.
+--   * area scope = driver_id in drivers with that service_area_id; for trends,
+--     a driver_id filter takes precedence and ignores the area (matches old).
+--
+-- Function safety: read-only, STABLE, SECURITY DEFINER, pinned search_path,
+-- EXECUTE revoked from anon/authenticated. (Counts only — no money.)
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_driver_offer_stats(timestamptz, text);
+--   DROP FUNCTION IF EXISTS public.admin_driver_offer_trends(timestamptz, text, text);
+
+CREATE OR REPLACE FUNCTION public.admin_driver_offer_stats(
+    p_start           timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS TABLE (
+    driver_id         text,
+    offered           bigint,
+    accepted          bigint,
+    declined          bigint,
+    ignored           bigint,
+    preempted         bigint,
+    pending           bigint,
+    avg_response_secs numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT
+        o.driver_id,
+        COUNT(*)                                          AS offered,
+        COUNT(*) FILTER (WHERE o.status = 'accepted')     AS accepted,
+        COUNT(*) FILTER (WHERE o.status = 'declined')     AS declined,
+        COUNT(*) FILTER (WHERE o.status = 'expired')      AS ignored,
+        COUNT(*) FILTER (WHERE o.status = 'preempted')    AS preempted,
+        COUNT(*) FILTER (WHERE o.status = 'pending')      AS pending,
+        AVG(EXTRACT(EPOCH FROM (o.responded_at - o.offered_at)))
+            FILTER (WHERE o.status IN ('accepted', 'declined')
+                      AND o.responded_at IS NOT NULL
+                      AND o.responded_at >= o.offered_at)  AS avg_response_secs
+    FROM ride_offers o
+    WHERE o.offered_at >= p_start
+      AND o.driver_id IS NOT NULL
+      AND (
+        p_service_area_id IS NULL
+        OR o.driver_id IN (SELECT d.id FROM drivers d WHERE d.service_area_id::text = p_service_area_id)
+      )
+    GROUP BY o.driver_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_driver_offer_trends(
+    p_start           timestamptz,
+    p_driver_id       text DEFAULT NULL,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS TABLE (
+    day       date,
+    offered   bigint,
+    accepted  bigint,
+    declined  bigint,
+    ignored   bigint,
+    preempted bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT
+        (o.offered_at AT TIME ZONE 'UTC')::date           AS day,
+        COUNT(*)                                          AS offered,
+        COUNT(*) FILTER (WHERE o.status = 'accepted')     AS accepted,
+        COUNT(*) FILTER (WHERE o.status = 'declined')     AS declined,
+        COUNT(*) FILTER (WHERE o.status = 'expired')      AS ignored,
+        COUNT(*) FILTER (WHERE o.status = 'preempted')    AS preempted
+    FROM ride_offers o
+    WHERE o.offered_at >= p_start
+      AND (p_driver_id IS NULL OR o.driver_id = p_driver_id)
+      AND (
+        p_driver_id IS NOT NULL
+        OR p_service_area_id IS NULL
+        OR o.driver_id IN (SELECT d.id FROM drivers d WHERE d.service_area_id::text = p_service_area_id)
+      )
+    GROUP BY 1
+    ORDER BY 1;
+$$;
+
+COMMENT ON FUNCTION public.admin_driver_offer_stats(timestamptz, text) IS
+    'Per-driver ride_offers rollup for /driver-offer-stats. Replaces a 100k-row scan.';
+COMMENT ON FUNCTION public.admin_driver_offer_trends(timestamptz, text, text) IS
+    'Per-day ride_offers outcome counts for /driver-offer-trends. Replaces a 100k-row scan.';
+
+REVOKE EXECUTE ON FUNCTION public.admin_driver_offer_stats(timestamptz, text) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.admin_driver_offer_trends(timestamptz, text, text) FROM anon, authenticated;

--- a/backend/migrations/165_analytics_count_fns.sql
+++ b/backend/migrations/165_analytics_count_fns.sql
@@ -1,0 +1,129 @@
+-- 165_analytics_count_fns.sql
+--
+-- Purpose:
+--   Two more admin analytics endpoints aggregated rows in Python:
+--     * /driver-acceptance — fetched up to 10,000 rides and rolled per-driver
+--       completed/cancelled-by-driver counts.
+--     * /cancellation-breakdown — fetched up to 5,000 cancelled rides and
+--       classified reasons / party / hour in Python.
+--   These functions do the grouping in Postgres. Counts only — no money.
+--
+--   Existing indexes cover the predicates: idx_rides_driver_created
+--   (driver_id, created_at) for acceptance; rides(created_at) + the cancelled
+--   partial index idx_rides_cancelled_created (migration 163) for the
+--   cancellation window — so no new index here.
+--
+-- Semantics mirror the old Python exactly:
+--   * acceptance: over rides with created_at >= p_start (optionally area-scoped
+--     via drivers); per driver_id: total = COUNT(*), completed = status
+--     'completed', cancelled_by_driver = status 'cancelled' AND reason ILIKE
+--     '%driver%'. Drivers with no rides in window simply don't appear (caller
+--     defaults them to zero from its own driver list).
+--   * cancellation reason classification uses the SAME priority chain as the
+--     old Python (no-driver -> rider -> driver -> timeout/expired -> scheduled
+--     -> other; empty -> unspecified) and the same party attribution; the hour
+--     bucket is the UTC hour of COALESCE(cancelled_at, updated_at, created_at).
+--
+-- Function safety: read-only, STABLE, SECURITY DEFINER, pinned search_path,
+-- EXECUTE revoked from anon/authenticated.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_driver_acceptance_rates(timestamptz, text);
+--   DROP FUNCTION IF EXISTS public.admin_cancellation_breakdown(timestamptz, text);
+
+CREATE OR REPLACE FUNCTION public.admin_driver_acceptance_rates(
+    p_start           timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS TABLE (
+    driver_id           text,
+    total_rides         bigint,
+    completed           bigint,
+    cancelled_by_driver bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    SELECT
+        r.driver_id,
+        COUNT(*)                                       AS total_rides,
+        COUNT(*) FILTER (WHERE r.status = 'completed') AS completed,
+        COUNT(*) FILTER (
+            WHERE r.status = 'cancelled' AND lower(r.cancellation_reason) LIKE '%driver%'
+        )                                              AS cancelled_by_driver
+    FROM rides r
+    WHERE r.created_at >= p_start
+      AND r.driver_id IS NOT NULL
+      AND (
+        p_service_area_id IS NULL
+        OR r.driver_id IN (SELECT d.id FROM drivers d WHERE d.service_area_id::text = p_service_area_id)
+      )
+    GROUP BY r.driver_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.admin_cancellation_breakdown(
+    p_start           timestamptz,
+    p_service_area_id text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    WITH c AS (
+        SELECT
+            CASE
+                WHEN cancellation_reason IS NULL OR cancellation_reason = '' THEN 'unspecified'
+                WHEN lower(cancellation_reason) LIKE '%no nearby drivers%'
+                  OR lower(cancellation_reason) LIKE '%no driver%' THEN 'no_drivers_available'
+                WHEN lower(cancellation_reason) LIKE '%rider%' THEN 'rider_cancelled'
+                WHEN lower(cancellation_reason) LIKE '%driver%' THEN 'driver_cancelled'
+                WHEN lower(cancellation_reason) LIKE '%timeout%'
+                  OR lower(cancellation_reason) LIKE '%expired%' THEN 'search_timeout'
+                WHEN lower(cancellation_reason) LIKE '%scheduled%' THEN 'scheduled_cancelled'
+                ELSE 'other'
+            END AS reason,
+            CASE
+                WHEN cancellation_reason IS NULL OR cancellation_reason = '' THEN 'unknown'
+                WHEN lower(cancellation_reason) LIKE '%no nearby drivers%'
+                  OR lower(cancellation_reason) LIKE '%no driver%' THEN 'unknown'
+                WHEN lower(cancellation_reason) LIKE '%rider%' THEN 'rider'
+                WHEN lower(cancellation_reason) LIKE '%driver%' THEN 'driver'
+                WHEN lower(cancellation_reason) LIKE '%timeout%'
+                  OR lower(cancellation_reason) LIKE '%expired%' THEN 'unknown'
+                WHEN lower(cancellation_reason) LIKE '%scheduled%' THEN 'rider'
+                ELSE 'unknown'
+            END AS party,
+            EXTRACT(HOUR FROM (COALESCE(cancelled_at, updated_at, created_at) AT TIME ZONE 'UTC'))::int AS hr
+        FROM rides
+        WHERE status = 'cancelled'
+          AND created_at >= p_start
+          AND (p_service_area_id IS NULL OR service_area_id::text = p_service_area_id)
+    )
+    SELECT jsonb_build_object(
+        'total', (SELECT COUNT(*) FROM c),
+        'reasons', (
+            SELECT COALESCE(jsonb_agg(jsonb_build_object('reason', reason, 'count', cnt) ORDER BY cnt DESC), '[]'::jsonb)
+            FROM (SELECT reason, COUNT(*) AS cnt FROM c GROUP BY reason) r
+        ),
+        'by_party', (
+            SELECT COALESCE(jsonb_agg(jsonb_build_object('party', party, 'count', cnt) ORDER BY cnt DESC), '[]'::jsonb)
+            FROM (SELECT party, COUNT(*) AS cnt FROM c GROUP BY party) p
+        ),
+        'hourly', (
+            SELECT COALESCE(jsonb_object_agg(hr::text, cnt), '{}'::jsonb)
+            FROM (SELECT hr, COUNT(*) AS cnt FROM c WHERE hr IS NOT NULL GROUP BY hr) h
+        )
+    );
+$$;
+
+COMMENT ON FUNCTION public.admin_driver_acceptance_rates(timestamptz, text) IS
+    'Per-driver total/completed/cancelled-by-driver ride counts for /driver-acceptance.';
+COMMENT ON FUNCTION public.admin_cancellation_breakdown(timestamptz, text) IS
+    'Cancellation reason/party/hour breakdown for /cancellation-breakdown.';
+
+REVOKE EXECUTE ON FUNCTION public.admin_driver_acceptance_rates(timestamptz, text) FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.admin_cancellation_breakdown(timestamptz, text) FROM anon, authenticated;

--- a/backend/migrations/166_analytics_overview_fn.sql
+++ b/backend/migrations/166_analytics_overview_fn.sql
@@ -1,0 +1,71 @@
+-- 166_analytics_overview_fn.sql
+--
+-- Purpose:
+--   /analytics/overview fetched up to 10,000 rides for the window and computed
+--   status counts, completed-ride revenue/tips, a daily by-status chart, and
+--   peak hours in Python. This function returns all of that from one aggregate
+--   round-trip. (The endpoint caches the result 5 min, so this runs on cache
+--   miss only — but it removes the last row-fetch-and-sum analytics path.)
+--
+--   rides(created_at) is already indexed (migration 79) — no new index.
+--
+-- Semantics mirror the old Python exactly:
+--   * status buckets: completed / cancelled / in_progress (in_progress,
+--     driver_arrived, driver_accepted) / searching / scheduled (is_scheduled).
+--   * revenue/tips: SUM over completed rides only; FLOAT cast ::text::numeric
+--     to match the old Decimal(str(float)).
+--   * daily/hourly bucketed by created_at UTC day / hour.
+--
+-- Function safety: read-only, STABLE, SECURITY DEFINER, pinned search_path,
+-- EXECUTE revoked from anon/authenticated.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS public.admin_analytics_overview(timestamptz);
+
+CREATE OR REPLACE FUNCTION public.admin_analytics_overview(
+    p_start timestamptz
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+    WITH p AS (
+        SELECT status, is_scheduled, total_fare, tip_amount,
+               (created_at AT TIME ZONE 'UTC')::date              AS d,
+               EXTRACT(HOUR FROM (created_at AT TIME ZONE 'UTC'))::int AS hr
+        FROM rides
+        WHERE created_at >= p_start
+    )
+    SELECT jsonb_build_object(
+        'total',       (SELECT COUNT(*) FROM p),
+        'completed',   (SELECT COUNT(*) FROM p WHERE status = 'completed'),
+        'cancelled',   (SELECT COUNT(*) FROM p WHERE status = 'cancelled'),
+        'in_progress', (SELECT COUNT(*) FROM p WHERE status IN ('in_progress', 'driver_arrived', 'driver_accepted')),
+        'searching',   (SELECT COUNT(*) FROM p WHERE status = 'searching'),
+        'scheduled',   (SELECT COUNT(*) FROM p WHERE is_scheduled),
+        'total_revenue', COALESCE((SELECT SUM(total_fare::text::numeric) FROM p WHERE status = 'completed'), 0),
+        'total_tips',    COALESCE((SELECT SUM(tip_amount::text::numeric) FROM p WHERE status = 'completed'), 0),
+        'daily', (
+            SELECT COALESCE(jsonb_object_agg(d::text, obj), '{}'::jsonb)
+            FROM (
+                SELECT d, jsonb_build_object(
+                    'completed', COUNT(*) FILTER (WHERE status = 'completed'),
+                    'cancelled', COUNT(*) FILTER (WHERE status = 'cancelled'),
+                    'total', COUNT(*)
+                ) AS obj
+                FROM p WHERE d IS NOT NULL GROUP BY d
+            ) x
+        ),
+        'hourly', (
+            SELECT COALESCE(jsonb_object_agg(hr::text, cnt), '{}'::jsonb)
+            FROM (SELECT hr, COUNT(*) AS cnt FROM p WHERE hr IS NOT NULL GROUP BY hr) y
+        )
+    );
+$$;
+
+COMMENT ON FUNCTION public.admin_analytics_overview(timestamptz) IS
+    'Status counts + completed revenue/tips + daily/hourly buckets for /analytics/overview.';
+
+REVOKE EXECUTE ON FUNCTION public.admin_analytics_overview(timestamptz) FROM anon, authenticated;

--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -4,7 +4,6 @@ Provides aggregated operational intelligence for the admin dashboard.
 """
 
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Optional
@@ -247,64 +246,50 @@ async def get_analytics_overview(
 
     start_date = _parse_date_range(date_range)
 
+    # Status counts, completed revenue/tips, and the daily/hourly buckets are
+    # aggregated in Postgres (admin_analytics_overview) instead of fetching up to
+    # 10,000 rides and summing in Python.
     try:
-        period_rides = await db.get_rows(
-            "rides",
-            {"created_at": {"$gte": start_date.isoformat()}},
-            limit=10000,
-            order="created_at",
-        )
+        ov = await db.rpc("admin_analytics_overview", {"p_start": start_date.isoformat()})
     except Exception as e:
-        logger.error(f"Failed to fetch rides: {e}", exc_info=True)
+        logger.error(f"Failed to aggregate rides for overview: {e}", exc_info=True)
         from fastapi import HTTPException as _HTTPException
 
         raise _HTTPException(status_code=503, detail="Analytics data unavailable — database error") from e
 
-    total = len(period_rides)
-    completed = sum(1 for r in period_rides if r.get("status") == "completed")
-    cancelled = sum(1 for r in period_rides if r.get("status") == "cancelled")
-    in_progress = sum(
-        1 for r in period_rides if r.get("status") in ("in_progress", "driver_arrived", "driver_accepted")
-    )
-    searching = sum(1 for r in period_rides if r.get("status") == "searching")
-    scheduled = sum(1 for r in period_rides if r.get("is_scheduled"))
+    ov = ov[0] if isinstance(ov, list) and ov else ov
+    if not isinstance(ov, dict):
+        ov = {}
+
+    total = int(ov.get("total") or 0)
+    completed = int(ov.get("completed") or 0)
+    cancelled = int(ov.get("cancelled") or 0)
+    in_progress = int(ov.get("in_progress") or 0)
+    searching = int(ov.get("searching") or 0)
+    scheduled = int(ov.get("scheduled") or 0)
 
     completion_rate = round(completed / total * 100, 1) if total > 0 else 0
     cancellation_rate = round(cancelled / total * 100, 1) if total > 0 else 0
 
-    total_revenue = float(
-        sum(Decimal(str(r.get("total_fare") or 0)) for r in period_rides if r.get("status") == "completed")
-    )
-    total_tips = float(
-        sum(Decimal(str(r.get("tip_amount") or 0)) for r in period_rides if r.get("status") == "completed")
-    )
+    total_revenue = float(Decimal(str(ov.get("total_revenue") or 0)))
+    total_tips = float(Decimal(str(ov.get("total_tips") or 0)))
     avg_fare = round(total_revenue / completed, 2) if completed > 0 else 0
 
-    # Daily ride counts for chart
-    daily = defaultdict(lambda: {"completed": 0, "cancelled": 0, "total": 0})
-    for r in period_rides:
-        date_str = (r.get("created_at") or "")[:10]
-        if date_str:
-            daily[date_str]["total"] += 1
-            if r.get("status") == "completed":
-                daily[date_str]["completed"] += 1
-            elif r.get("status") == "cancelled":
-                daily[date_str]["cancelled"] += 1
+    # Daily ride counts for chart (date -> {completed, cancelled, total}).
+    daily_map = ov.get("daily") or {}
+    daily_chart = [
+        {
+            "date": date,
+            "completed": int((counts or {}).get("completed") or 0),
+            "cancelled": int((counts or {}).get("cancelled") or 0),
+            "total": int((counts or {}).get("total") or 0),
+        }
+        for date, counts in sorted(daily_map.items())
+    ]
 
-    daily_chart = [{"date": date, **counts} for date, counts in sorted(daily.items())]
-
-    # Peak hours
-    hourly = defaultdict(int)
-    for r in period_rides:
-        created = r.get("created_at", "")
-        if isinstance(created, str) and len(created) >= 13:
-            try:
-                hour = int(created[11:13])
-                hourly[hour] += 1
-            except (ValueError, IndexError):
-                pass
-
-    peak_hours = sorted(hourly.items(), key=lambda x: x[1], reverse=True)[:5]
+    # Peak hours — top 5 by ride count.
+    hourly_map = ov.get("hourly") or {}
+    peak_hours = sorted(((int(h), int(c or 0)) for h, c in hourly_map.items()), key=lambda x: x[1], reverse=True)[:5]
 
     result = {
         "date_range": date_range,

--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -40,17 +40,6 @@ def _parse_date_range(date_range: str) -> datetime:
     return now - delta
 
 
-def _parse_iso(value) -> Optional[datetime]:
-    """Best-effort parse of an ISO-8601 timestamp string to an aware datetime."""
-    if not value or not isinstance(value, str):
-        return None
-    try:
-        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-
-
 async def _fetch_rows_in_chunks(table: str, ids: list, chunk_size: int = 200) -> list:
     """Fetch rows by id in bounded `IN (...)` batches.
 
@@ -486,58 +475,38 @@ async def get_driver_offer_stats(
     """
     start_date = _parse_date_range(date_range)
 
+    # Per-driver rollup is done in Postgres (admin_driver_offer_stats) over the
+    # append-only ride_offers ledger, instead of streaming up to 100k offer rows
+    # into Python. Area scoping is applied inside the function.
     try:
-        offers = await db.get_rows(
-            "ride_offers",
-            {"offered_at": {"$gte": start_date.isoformat()}},
-            limit=100000,
+        rows = await db.rpc(
+            "admin_driver_offer_stats",
+            {"p_start": start_date.isoformat(), "p_service_area_id": service_area_id},
         )
     except Exception as e:
         logger.error(
-            f"Failed to fetch ride_offers for offer stats: {e}",
+            f"Failed to aggregate ride_offers for offer stats: {e}",
             exc_info=True,
             extra={"domain": "admin"},
         )
         raise HTTPException(status_code=503, detail="analytics_unavailable") from e
 
-    # Roll up per driver.
-    by_driver: dict = defaultdict(
-        lambda: {
-            "offered": 0,
-            "accepted": 0,
-            "declined": 0,
-            "ignored": 0,
-            "preempted": 0,
-            "pending": 0,
-            "_response_secs": [],
-        }
-    )
-    for o in offers:
-        did = o.get("driver_id")
+    by_driver: dict = {}
+    for r in rows or []:
+        did = r.get("driver_id")
         if not did:
             continue
-        agg = by_driver[did]
-        agg["offered"] += 1
-        status = o.get("status")
-        if status == "accepted":
-            agg["accepted"] += 1
-        elif status == "declined":
-            agg["declined"] += 1
-        elif status == "expired":
-            # Genuine timeout — the driver received the offer and never responded.
-            agg["ignored"] += 1
-        elif status == "preempted":
-            # Another driver accepted first — NOT an ignore; tracked separately
-            # and excluded from the decided-rate denominators below.
-            agg["preempted"] += 1
-        elif status == "pending":
-            agg["pending"] += 1
-        # Response latency for the offers the driver actually answered.
-        if status in ("accepted", "declined"):
-            offered_at = _parse_iso(o.get("offered_at"))
-            responded_at = _parse_iso(o.get("responded_at"))
-            if offered_at and responded_at and responded_at >= offered_at:
-                agg["_response_secs"].append((responded_at - offered_at).total_seconds())
+        by_driver[did] = {
+            "offered": int(r.get("offered") or 0),
+            "accepted": int(r.get("accepted") or 0),
+            "declined": int(r.get("declined") or 0),
+            "ignored": int(r.get("ignored") or 0),
+            "preempted": int(r.get("preempted") or 0),
+            "pending": int(r.get("pending") or 0),
+            "avg_response_secs": (
+                round(float(r["avg_response_secs"]), 1) if r.get("avg_response_secs") is not None else None
+            ),
+        }
 
     driver_ids = list(by_driver.keys())
     drivers_list: list = []
@@ -584,7 +553,6 @@ async def get_driver_offer_stats(
             if user
             else (driver.get("name") if driver else None)
         ) or did[:12]
-        response_secs = agg.pop("_response_secs")
         result.append(
             {
                 "driver_id": did,
@@ -598,7 +566,7 @@ async def get_driver_offer_stats(
                 "accept_rate": round(agg["accepted"] / decided * 100, 1) if decided else 0.0,
                 "decline_rate": round(agg["declined"] / decided * 100, 1) if decided else 0.0,
                 "ignore_rate": round(agg["ignored"] / decided * 100, 1) if decided else 0.0,
-                "avg_response_seconds": (round(sum(response_secs) / len(response_secs), 1) if response_secs else None),
+                "avg_response_seconds": agg["avg_response_secs"],
                 "rating": driver.get("rating") if driver else None,
                 "is_online": driver.get("is_online", False) if driver else False,
             }
@@ -639,51 +607,37 @@ async def get_driver_offer_trends(
     """
     start_date = _parse_date_range(date_range)
 
-    filters: dict = {"offered_at": {"$gte": start_date.isoformat()}}
-    if driver_id:
-        filters["driver_id"] = driver_id
+    # Per-day bucketing done in Postgres (admin_driver_offer_trends) instead of
+    # scanning up to 100k offer rows. A driver_id filter takes precedence; else
+    # an optional service-area scope is applied inside the function.
     try:
-        offers = await db.get_rows("ride_offers", filters, limit=100000)
+        rows = await db.rpc(
+            "admin_driver_offer_trends",
+            {
+                "p_start": start_date.isoformat(),
+                "p_driver_id": driver_id,
+                "p_service_area_id": service_area_id,
+            },
+        )
     except Exception as e:
         logger.error(
-            f"Failed to fetch ride_offers for offer trends: {e}",
+            f"Failed to aggregate ride_offers for offer trends: {e}",
             exc_info=True,
             extra={"domain": "admin"},
         )
         raise HTTPException(status_code=503, detail="analytics_unavailable") from e
 
-    # Scope to a service area by intersecting with that area's drivers.
-    if service_area_id and not driver_id:
-        try:
-            area_drivers = await db.get_rows("drivers", {"service_area_id": service_area_id}, limit=10000)
-        except Exception as e:
-            logger.error(
-                f"Failed to fetch area drivers for offer trends: {e}",
-                exc_info=True,
-                extra={"domain": "admin"},
-            )
-            raise HTTPException(status_code=503, detail="analytics_unavailable") from e
-        area_ids = {d["id"] for d in area_drivers if d.get("id")}
-        offers = [o for o in offers if o.get("driver_id") in area_ids]
-
-    daily: dict = defaultdict(lambda: {"offered": 0, "accepted": 0, "declined": 0, "ignored": 0, "preempted": 0})
-    for o in offers:
-        day = (o.get("offered_at") or "")[:10]
-        if not day:
-            continue
-        b = daily[day]
-        b["offered"] += 1
-        status = o.get("status")
-        if status == "accepted":
-            b["accepted"] += 1
-        elif status == "declined":
-            b["declined"] += 1
-        elif status == "expired":
-            b["ignored"] += 1
-        elif status == "preempted":
-            b["preempted"] += 1
-
-    daily_chart = [{"date": d, **counts} for d, counts in sorted(daily.items())]
+    daily_chart = [
+        {
+            "date": str(r.get("day")),
+            "offered": int(r.get("offered") or 0),
+            "accepted": int(r.get("accepted") or 0),
+            "declined": int(r.get("declined") or 0),
+            "ignored": int(r.get("ignored") or 0),
+            "preempted": int(r.get("preempted") or 0),
+        }
+        for r in (rows or [])
+    ]
     return {
         "date_range": date_range,
         "driver_id": driver_id,

--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -209,7 +209,11 @@ async def get_driver_acceptance_rates(
     users_list: list = []
     if user_ids:
         try:
-            users_list = await db.get_rows("users", {"id": {"$in": user_ids}}, limit=len(user_ids))
+            # Only the driver's display name is read from these rows — project
+            # the name columns so we don't pull base64 profile_image blobs.
+            users_list = await db.get_rows(
+                "users", {"id": {"$in": user_ids}}, columns="id,first_name,last_name", limit=len(user_ids)
+            )
         except Exception as e:
             logger.error(
                 f"Failed to fetch users for acceptance stats: {e}",

--- a/backend/routes/admin/analytics.py
+++ b/backend/routes/admin/analytics.py
@@ -4,7 +4,7 @@ Provides aggregated operational intelligence for the admin dashboard.
 """
 
 import logging
-from collections import Counter, defaultdict
+from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Optional
@@ -67,79 +67,43 @@ async def get_cancellation_breakdown(
     """Aggregated cancellation reason breakdown by date range and optionally service area."""
     start_date = _parse_date_range(date_range)
 
+    # Reason / party / hour classification is done in Postgres
+    # (admin_cancellation_breakdown) instead of fetching up to 5,000 cancelled
+    # rides and bucketing in Python.
     try:
-        filters: dict = {
-            "status": "cancelled",
-            "created_at": {"$gte": start_date.isoformat()},
-        }
-        if service_area_id:
-            filters["service_area_id"] = service_area_id
-        filtered = await db.get_rows("rides", filters, limit=5000, order="created_at")
+        bd = await db.rpc(
+            "admin_cancellation_breakdown",
+            {"p_start": start_date.isoformat(), "p_service_area_id": service_area_id},
+        )
     except Exception as e:
-        logger.error(f"Failed to fetch cancelled rides: {e}", exc_info=True)
+        logger.error(f"Failed to aggregate cancelled rides: {e}", exc_info=True)
         from fastapi import HTTPException as _HTTPException
 
         raise _HTTPException(status_code=503, detail="Analytics data unavailable — database error") from e
 
-    # Categorize cancellation reasons
-    reason_counter = Counter()
-    cancelled_by_counter = Counter()
-    hourly_cancellations = defaultdict(int)
+    bd = bd[0] if isinstance(bd, list) and bd else bd
+    if not isinstance(bd, dict):
+        bd = {}
 
-    for r in filtered:
-        raw_reason = r.get("cancellation_reason", "")
-        cancelled_by = "unknown"
-
-        if not raw_reason:
-            reason = "unspecified"
-        elif "no nearby drivers" in raw_reason.lower() or "no driver" in raw_reason.lower():
-            reason = "no_drivers_available"
-        elif "rider" in raw_reason.lower() or "cancelled by rider" in raw_reason.lower():
-            reason = "rider_cancelled"
-            cancelled_by = "rider"
-        elif "driver" in raw_reason.lower():
-            reason = "driver_cancelled"
-            cancelled_by = "driver"
-        elif "timeout" in raw_reason.lower() or "expired" in raw_reason.lower():
-            reason = "search_timeout"
-        elif "scheduled" in raw_reason.lower():
-            reason = "scheduled_cancelled"
-            cancelled_by = "rider"
-        else:
-            reason = "other"
-
-        reason_counter[reason] += 1
-        cancelled_by_counter[cancelled_by] += 1
-
-        # Hourly distribution
-        created = r.get("cancelled_at") or r.get("updated_at") or r.get("created_at", "")
-        if isinstance(created, str) and len(created) >= 13:
-            try:
-                hour = int(created[11:13])
-                hourly_cancellations[hour] += 1
-            except (ValueError, IndexError):
-                pass
-
-    total = len(filtered)
+    total = int(bd.get("total") or 0)
     reasons = [
         {
-            "reason": reason,
-            "count": count,
-            "pct": round(count / total * 100, 1) if total > 0 else 0,
+            "reason": row.get("reason"),
+            "count": int(row.get("count") or 0),
+            "pct": round(int(row.get("count") or 0) / total * 100, 1) if total > 0 else 0,
         }
-        for reason, count in reason_counter.most_common()
+        for row in (bd.get("reasons") or [])
     ]
-
     by_party = [
         {
-            "party": party,
-            "count": count,
-            "pct": round(count / total * 100, 1) if total > 0 else 0,
+            "party": row.get("party"),
+            "count": int(row.get("count") or 0),
+            "pct": round(int(row.get("count") or 0) / total * 100, 1) if total > 0 else 0,
         }
-        for party, count in cancelled_by_counter.most_common()
+        for row in (bd.get("by_party") or [])
     ]
-
-    hourly = [{"hour": h, "count": hourly_cancellations.get(h, 0)} for h in range(24)]
+    hourly_map = bd.get("hourly") or {}
+    hourly = [{"hour": h, "count": int(hourly_map.get(str(h), 0) or 0)} for h in range(24)]
 
     return {
         "total_cancellations": total,
@@ -175,25 +139,28 @@ async def get_driver_acceptance_rates(
     driver_ids = [d["id"] for d in drivers]
     user_ids = [d["user_id"] for d in drivers if d.get("user_id")]
 
-    # Batch-fetch all rides and users in 2 queries instead of 2N (F-48).
-    all_rides: list = []
+    # Per-driver ride counts are aggregated in Postgres (admin_driver_acceptance_rates)
+    # over the window instead of fetching up to 10,000 rides and rolling up in
+    # Python. Drivers with no rides in the window simply aren't returned; we
+    # default them to zero from the `drivers` list below.
+    acc_by_driver: dict = {}
     if driver_ids:
         try:
-            all_rides = await db.get_rows(
-                "rides",
-                {
-                    "driver_id": {"$in": driver_ids},
-                    "created_at": {"$gte": start_date.isoformat()},
-                },
-                limit=10000,
+            acc_rows = await db.rpc(
+                "admin_driver_acceptance_rates",
+                {"p_start": start_date.isoformat(), "p_service_area_id": service_area_id},
             )
         except Exception as e:
             logger.error(
-                f"Failed to fetch rides for acceptance stats: {e}",
+                f"Failed to aggregate rides for acceptance stats: {e}",
                 exc_info=True,
                 extra={"domain": "admin"},
             )
             raise HTTPException(status_code=503, detail="analytics_unavailable") from e
+        for r in acc_rows or []:
+            did = r.get("driver_id")
+            if did:
+                acc_by_driver[did] = r
 
     users_list: list = []
     if user_ids:
@@ -211,25 +178,15 @@ async def get_driver_acceptance_rates(
             )
             raise HTTPException(status_code=503, detail="analytics_unavailable") from e
 
-    rides_by_driver: dict = {}
-    for r in all_rides:
-        did = r.get("driver_id")
-        if did:
-            rides_by_driver.setdefault(did, []).append(r)
-
     users_map = {u["id"]: u for u in users_list if u.get("id")}
 
     result = []
     for driver in drivers:
         driver_id = driver["id"]
-        period_rides = rides_by_driver.get(driver_id, [])
-        total_assigned = len(period_rides)
-        completed = sum(1 for r in period_rides if r.get("status") == "completed")
-        cancelled_by_driver = sum(
-            1
-            for r in period_rides
-            if r.get("status") == "cancelled" and "driver" in (r.get("cancellation_reason") or "").lower()
-        )
+        agg = acc_by_driver.get(driver_id) or {}
+        total_assigned = int(agg.get("total_rides") or 0)
+        completed = int(agg.get("completed") or 0)
+        cancelled_by_driver = int(agg.get("cancelled_by_driver") or 0)
 
         acceptance_rate = round((completed / total_assigned * 100), 1) if total_assigned > 0 else 0
         cancellation_rate = round((cancelled_by_driver / total_assigned * 100), 1) if total_assigned > 0 else 0

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -210,25 +210,33 @@ async def admin_get_drivers(
     deduped.sort(key=lambda r: r.get("created_at") or "", reverse=True)
 
     user_ids = list({d.get("user_id") for d in deduped if d.get("user_id")})
+    # Project only the columns the list renders. users.profile_image is
+    # deliberately excluded: for accounts predating the `profile-photos` storage
+    # bucket it holds a full base64 data URI, so pulling N of them into a bulk
+    # list response bloated the payload (and shipped a face photo — PII — in a
+    # list endpoint). The avatar now loads lazily from the per-driver live-stats
+    # endpoint when the detail slideout opens. profile_image_status is kept so
+    # the status badges and "Pending photos" tab keep working.
     users_list = (
-        await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)) if user_ids else []
+        await db_supabase.get_rows(
+            "users",
+            {"id": {"$in": user_ids}},
+            columns="id,first_name,last_name,email,phone,profile_image_status",
+            limit=max(len(user_ids), 1),
+        )
+        if user_ids
+        else []
     )
     users_map = {u["id"]: u for u in users_list if u.get("id")}
     out = []
     for d in deduped:
         u = users_map.get(d.get("user_id"))
-        # Driver avatar lives on the user row (users.profile_image); the drivers
-        # table has no photo column. Expose it as photo_url (canonical) +
-        # profile_photo_url (the key the existing UI presence-dot reads).
-        _img = u.get("profile_image") if u else None
         out.append(
             {
                 **d,
                 "name": _user_display_name(u) or d.get("name"),
                 "email": u.get("email") if u else None,
                 "phone": u.get("phone") if u else d.get("phone"),
-                "photo_url": _img,
-                "profile_photo_url": _img,
                 "profile_image_status": (u.get("profile_image_status") if u else None),
             }
         )
@@ -463,9 +471,7 @@ async def admin_get_driver_stats(
             "total_earnings": total_earnings_sum,
             "avg_rating": avg_rating,
             # Drivers whose profile photo is awaiting admin approval.
-            "pending_photos": sum(
-                1 for u in users_map.values() if u.get("profile_image_status") == "pending_review"
-            ),
+            "pending_photos": sum(1 for u in users_map.values() if u.get("profile_image_status") == "pending_review"),
         },
         "area_stats": list(area_stats.values()),
         "charts": {
@@ -1474,6 +1480,16 @@ async def admin_get_driver_live_stats(driver_id: str):
         1 for r in rides if r.get("status") == "cancelled" and "driver" in (r.get("cancellation_reason") or "").lower()
     )
 
+    # The detail slideout reads the driver's avatar from here rather than the
+    # bulk drivers list, which no longer ships profile_image (see
+    # admin_get_drivers). One targeted lookup on open keeps the heavy
+    # base64/URL blob off the list payload while still showing the photo.
+    photo_url = None
+    drv = await db_supabase.get_driver_by_id(driver_id)
+    if drv and drv.get("user_id"):
+        user = await db_supabase.get_user_by_id(drv["user_id"])
+        photo_url = (user or {}).get("profile_image")
+
     return {
         "total_rides": completed_count,
         "total_earnings": total_earnings,
@@ -1481,6 +1497,7 @@ async def admin_get_driver_live_stats(driver_id: str):
         "acceptance_rate": acceptance_rate,
         "cancelled_by_driver": cancelled_by_driver,
         "total_assigned": total_assigned,
+        "photo_url": photo_url,
     }
 
 

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -168,7 +168,9 @@ async def admin_get_drivers(
                     {"last_name": {"$regex": re.escape(term), "$options": "i"}},
                 ]
             }
-            matching_users = await db_supabase.get_rows("users", user_filters, limit=100)
+            # Only the matched ids feed the driver $or filter below — project
+            # id so the name search doesn't pull base64 profile_image rows.
+            matching_users = await db_supabase.get_rows("users", user_filters, columns="id", limit=100)
             matching_uids = [u["id"] for u in matching_users if u.get("id")]
 
             # Match driver rows by phone/plate directly OR by user_id from user search above.

--- a/backend/routes/admin/faqs.py
+++ b/backend/routes/admin/faqs.py
@@ -133,18 +133,20 @@ async def admin_send_notification(request: Request, notification: NotificationRe
     if user_id:
         await db_supabase.insert_one("notifications", notification_doc)
         logger.info(f"Notification sent to user {user_id}: {title}")
+    # Broadcasts only need the user id for the push fan-out — project it so we
+    # don't pull up to 10k base64 profile_image blobs out of the DB.
     elif audience == "all":
-        all_users = await db.get_rows("users", {}, limit=10000)
+        all_users = await db.get_rows("users", {}, columns="id", limit=10000)
         for u in all_users or []:
             await send_push_notification(u["id"], title, body)
         logger.info(f"Broadcast notification to all users: {title}")
     elif audience == "riders":
-        riders = await db.get_rows("users", {"is_rider": True}, limit=10000)
+        riders = await db.get_rows("users", {"is_rider": True}, columns="id", limit=10000)
         for u in riders or []:
             await send_push_notification(u["id"], title, body)
         logger.info(f"Broadcast notification to all riders: {title}")
     elif audience == "drivers":
-        drivers = await db.get_rows("users", {"is_driver": True}, limit=10000)
+        drivers = await db.get_rows("users", {"is_driver": True}, columns="id", limit=10000)
         for u in drivers or []:
             await send_push_notification(u["id"], title, body)
         logger.info(f"Broadcast notification to all drivers: {title}")

--- a/backend/routes/admin/messaging.py
+++ b/backend/routes/admin/messaging.py
@@ -135,14 +135,17 @@ async def admin_send_cloud_message(
 
     target_users: list = []
     if not is_scheduled:
+        # Only the id is needed for fan-out (_fan_out_push reads u["id"]). Project
+        # it explicitly so a broadcast doesn't drag up to 10k base64 profile_image
+        # blobs out of the DB and into memory.
         if audience in ("particular_customer", "particular_driver"):
             target_users = [{"id": uid} for uid in particular_ids]
         elif audience == "customers":
-            target_users = await db.get_rows("users", {"is_rider": True}, limit=10000)
+            target_users = await db.get_rows("users", {"is_rider": True}, columns="id", limit=10000)
         elif audience == "drivers":
-            target_users = await db.get_rows("users", {"is_driver": True}, limit=10000)
+            target_users = await db.get_rows("users", {"is_driver": True}, columns="id", limit=10000)
         elif audience == "all":
-            target_users = await db.get_rows("users", {}, limit=10000)
+            target_users = await db.get_rows("users", {}, columns="id", limit=10000)
 
     doc = {
         "id": str(uuid.uuid4()),

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1786,141 +1786,73 @@ async def admin_get_earnings_overview(
     # Pull current + previous window in two queries. Bounded by completed-only
     # so cancellation rows don't inflate GBV.
     # ── Rides — completed (the GBV / trips / net rev numerator) ──────────
-    base_filter: Dict[str, Any] = {"status": "completed"}
-    if service_area_id:
-        base_filter["service_area_id"] = service_area_id
+    # ── Window aggregates via SQL ────────────────────────────────────────
+    # Completed + cancelled ride metrics for the current and previous windows,
+    # and refund totals, are aggregated in Postgres (admin_earnings_overview_agg
+    # / admin_earnings_refunds) instead of pulling four 50k ride windows + two
+    # 10k dispute windows into Python.
+    import asyncio  # noqa: PLC0415
 
-    current_rides = await db_supabase.get_rows(
-        "rides",
-        {**base_filter, "ride_completed_at": {"$gte": start.isoformat(), "$lte": end.isoformat()}},
-        limit=50000,
-    )
-    previous_rides = await db_supabase.get_rows(
-        "rides",
-        {**base_filter, "ride_completed_at": {"$gte": prev_start.isoformat(), "$lte": prev_end.isoformat()}},
-        limit=50000,
-    )
-
-    # ── Rides — cancelled (cancellation rate denominator + fee revenue) ──
-    # Cancelled rides have null ride_completed_at, so filter on created_at
-    # for the window. Same service-area scoping as completed rides above.
-    cancelled_filter: Dict[str, Any] = {"status": "cancelled"}
-    if service_area_id:
-        cancelled_filter["service_area_id"] = service_area_id
-    current_cancelled = await db_supabase.get_rows(
-        "rides",
-        {**cancelled_filter, "created_at": {"$gte": start.isoformat(), "$lte": end.isoformat()}},
-        limit=50000,
-    )
-    previous_cancelled = await db_supabase.get_rows(
-        "rides",
-        {**cancelled_filter, "created_at": {"$gte": prev_start.isoformat(), "$lte": prev_end.isoformat()}},
-        limit=50000,
+    current_agg, previous_agg, current_ref, previous_ref = await asyncio.gather(
+        db_supabase.rpc(
+            "admin_earnings_overview_agg",
+            {"p_start": start.isoformat(), "p_end": end.isoformat(), "p_service_area_id": service_area_id},
+        ),
+        db_supabase.rpc(
+            "admin_earnings_overview_agg",
+            {"p_start": prev_start.isoformat(), "p_end": prev_end.isoformat(), "p_service_area_id": service_area_id},
+        ),
+        db_supabase.rpc(
+            "admin_earnings_refunds",
+            {"p_start": start.isoformat(), "p_end": end.isoformat(), "p_service_area_id": service_area_id},
+        ),
+        db_supabase.rpc(
+            "admin_earnings_refunds",
+            {"p_start": prev_start.isoformat(), "p_end": prev_end.isoformat(), "p_service_area_id": service_area_id},
+        ),
     )
 
-    # ── Disputes / refunds (resolved within window) ──────────────────────
-    # Refunds are persisted on `disputes.refund_amount` — service area
-    # isn't on the dispute row, so when a service-area filter is set we
-    # narrow to disputes whose ride_id is in the current ride set.
-    refunded_filter: Dict[str, Any] = {
-        "resolved_at": {"$gte": start.isoformat(), "$lte": end.isoformat()},
-    }
-    refunded_filter_prev: Dict[str, Any] = {
-        "resolved_at": {"$gte": prev_start.isoformat(), "$lte": prev_end.isoformat()},
-    }
-    current_refunds = await db_supabase.get_rows("disputes", refunded_filter, limit=10000)
-    previous_refunds = await db_supabase.get_rows("disputes", refunded_filter_prev, limit=10000)
-    if service_area_id:
-        # Cross-reference against the ride set; cheaper than a join.
-        current_ride_ids = {r.get("id") for r in current_rides + current_cancelled}
-        previous_ride_ids = {r.get("id") for r in previous_rides + previous_cancelled}
-        current_refunds = [d for d in current_refunds if d.get("ride_id") in current_ride_ids]
-        previous_refunds = [d for d in previous_refunds if d.get("ride_id") in previous_ride_ids]
+    def _obj(res: Any) -> Dict[str, Any]:
+        row = res[0] if isinstance(res, list) and res else res
+        return row if isinstance(row, dict) else {}
 
-    def _agg(rides: list) -> Dict[str, Any]:
-        gbv = sum((Decimal(str(r.get("total_fare") or 0)) for r in rides), Decimal("0"))
-        platform = sum((Decimal(str(r.get("admin_earnings") or 0)) for r in rides), Decimal("0"))
-        rider_ids = {r.get("rider_id") for r in rides if r.get("rider_id")}
-        driver_ids = {r.get("driver_id") for r in rides if r.get("driver_id")}
-        # Surge revenue: portion of total_fare attributable to the
-        # surge multiplier. base = total / surge_mult → surge = total -
-        # base. Only counts rides where surge actually applied (>1.0).
-        surge_rev = Decimal("0")
-        for r in rides:
-            mult = Decimal(str(r.get("surge_multiplier") or 1.0))
-            if mult > 1:
-                fare = Decimal(str(r.get("total_fare") or 0))
-                surge_rev += fare - (fare / mult)
-        # Promo spend: discount_amount on completed rides — what we
-        # gave away to acquire/retain the ride.
-        promo = sum((Decimal(str(r.get("discount_amount") or 0)) for r in rides), Decimal("0"))
-        promo_count = sum(1 for r in rides if Decimal(str(r.get("discount_amount") or 0)) > 0)
-        # Tax decomposition from rides.tax_breakdown JSONB — defensive
-        # because tax_name keys vary by service area config.
-        gst = Decimal("0")
-        pst = Decimal("0")
-        for r in rides:
-            breakdown = r.get("tax_breakdown") or {}
-            if isinstance(breakdown, dict):
-                for tax_name, info in breakdown.items():
-                    amount = Decimal("0")
-                    if isinstance(info, dict):
-                        amount = Decimal(str(info.get("amount") or 0))
-                    name_l = str(tax_name).lower()
-                    if "gst" in name_l or name_l == "hst":
-                        gst += amount
-                    elif "pst" in name_l or "qst" in name_l:
-                        pst += amount
-        return {
-            "gbv": float(gbv),
-            "platform": float(platform),
-            "trips": len(rides),
-            "riders": len(rider_ids),
-            "drivers": len(driver_ids),
-            "surge_revenue": float(surge_rev),
-            "promo_spend": float(promo),
-            "promo_count": promo_count,
-            "gst_collected": float(gst),
-            "pst_collected": float(pst),
+    def _f(d: Dict[str, Any], k: str) -> float:
+        return float(Decimal(str(d.get(k) or 0)))
+
+    def _i(d: Dict[str, Any], k: str) -> int:
+        return int(d.get(k) or 0)
+
+    def _win(res: Any) -> tuple[Dict[str, Any], Dict[str, Any]]:
+        a = _obj(res)
+        completed = {
+            "gbv": _f(a, "gbv"),
+            "platform": _f(a, "platform"),
+            "trips": _i(a, "trips"),
+            "riders": _i(a, "riders"),
+            "drivers": _i(a, "drivers"),
+            "surge_revenue": _f(a, "surge_revenue"),
+            "promo_spend": _f(a, "promo_spend"),
+            "promo_count": _i(a, "promo_count"),
+            "gst_collected": _f(a, "gst_collected"),
+            "pst_collected": _f(a, "pst_collected"),
         }
-
-    def _agg_cancelled(rides: list) -> Dict[str, Any]:
-        """Cancellation-only aggregator. cancellation_fee_admin is the
-        platform's share of the cancel fee — that's the revenue side."""
-        cancel_revenue = sum(
-            (Decimal(str(r.get("cancellation_fee_admin") or 0)) for r in rides),
-            Decimal("0"),
-        )
-        # Rider vs driver vs system cancel breakdown — pulled from the
-        # cancellation_reason text field with a simple keyword match.
-        # Same convention the admin analytics page already uses.
-        rider_cancels = 0
-        driver_cancels = 0
-        for r in rides:
-            reason = (r.get("cancellation_reason") or "").lower()
-            if "driver" in reason:
-                driver_cancels += 1
-            elif "rider" in reason or "user" in reason:
-                rider_cancels += 1
-        return {
-            "count": len(rides),
-            "revenue": float(cancel_revenue),
-            "rider_cancels": rider_cancels,
-            "driver_cancels": driver_cancels,
+        cancelled = {
+            "count": _i(a, "cx_count"),
+            "revenue": _f(a, "cx_revenue"),
+            "rider_cancels": _i(a, "cx_rider_cancels"),
+            "driver_cancels": _i(a, "cx_driver_cancels"),
         }
+        return completed, cancelled
 
-    cur = _agg(current_rides)
-    prev = _agg(previous_rides)
-    cur_cx = _agg_cancelled(current_cancelled)
-    prev_cx = _agg_cancelled(previous_cancelled)
+    cur, cur_cx = _win(current_agg)
+    prev, prev_cx = _win(previous_agg)
 
-    # Refund $ in window — disputes resolved during the period with a
-    # non-zero refund_amount. We don't distinguish full vs partial here;
-    # any payout to the rider counts as refund leakage.
-    cur_refund_amt = float(sum((Decimal(str(d.get("refund_amount") or 0)) for d in current_refunds), Decimal("0")))
-    prev_refund_amt = float(sum((Decimal(str(d.get("refund_amount") or 0)) for d in previous_refunds), Decimal("0")))
-    cur_refund_count = sum(1 for d in current_refunds if Decimal(str(d.get("refund_amount") or 0)) > 0)
-    prev_refund_count = sum(1 for d in previous_refunds if Decimal(str(d.get("refund_amount") or 0)) > 0)
+    cur_ref_obj = _obj(current_ref)
+    prev_ref_obj = _obj(previous_ref)
+    cur_refund_amt = _f(cur_ref_obj, "refund_amount")
+    prev_refund_amt = _f(prev_ref_obj, "refund_amount")
+    cur_refund_count = _i(cur_ref_obj, "refund_count")
+    prev_refund_count = _i(prev_ref_obj, "refund_count")
 
     # Cancellation rate: cancelled / (completed + cancelled). Same
     # formula the ops cancellation-rate KPI uses across the codebase.
@@ -1957,22 +1889,25 @@ async def admin_get_earnings_overview(
     prev_avg_fare = round(prev["gbv"] / prev["trips"], 2) if prev["trips"] > 0 else 0.0
 
     # ── Daily series for the line chart ───────────────────────────────────
+    # Per-day GBV/trips/net-revenue grouped in Postgres; gaps filled with zero.
+    series_rows = await db_supabase.rpc(
+        "admin_earnings_daily_series",
+        {"p_start": start.isoformat(), "p_end": end.isoformat(), "p_service_area_id": service_area_id},
+    )
+    by_day = {str(r.get("day")): r for r in (series_rows or [])}
     daily: Dict[str, Dict[str, Any]] = {}
     cursor = start.date()
     end_date = end.date()
     while cursor <= end_date:
-        daily[cursor.isoformat()] = {"date": cursor.isoformat(), "gbv": 0.0, "trips": 0, "net_revenue": 0.0}
+        key = cursor.isoformat()
+        sr = by_day.get(key) or {}
+        daily[key] = {
+            "date": key,
+            "gbv": round(float(Decimal(str(sr.get("gbv") or 0))), 2),
+            "trips": int(sr.get("trips") or 0),
+            "net_revenue": round(float(Decimal(str(sr.get("net_revenue") or 0))), 2),
+        }
         cursor += timedelta(days=1)
-    for r in current_rides:
-        completed = r.get("ride_completed_at") or r.get("created_at") or ""
-        day = completed[:10]
-        if day in daily:
-            daily[day]["gbv"] = round(daily[day]["gbv"] + float(Decimal(str(r.get("total_fare") or 0))), 2)
-            daily[day]["trips"] += 1
-            daily[day]["net_revenue"] = round(
-                daily[day]["net_revenue"] + float(Decimal(str(r.get("admin_earnings") or 0))),
-                2,
-            )
     daily_series = list(daily.values())
 
     return {

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -2127,8 +2127,17 @@ async def admin_export_drivers(
 
     drivers = await db_supabase.get_rows("drivers", order="created_at", desc=True, limit=limit)
     user_ids = list({d.get("user_id") for d in drivers if d.get("user_id")})
+    # Export rows only carry name/email/phone from the user row — project those
+    # so the export doesn't read base64 profile_image for every driver.
     users_list = (
-        await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=max(len(user_ids), 1)) if user_ids else []
+        await db_supabase.get_rows(
+            "users",
+            {"id": {"$in": user_ids}},
+            columns="id,first_name,last_name,email,phone",
+            limit=max(len(user_ids), 1),
+        )
+        if user_ids
+        else []
     )
     users_map = {u["id"]: u for u in users_list if u.get("id")}
     out = []

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -955,7 +955,9 @@ async def admin_get_stats():
     today_start = now_utc.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
     month_start = now_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0).isoformat()
 
-    # Parallelise all independent DB calls (F-49: previously 11 sequential round-trips).
+    # Parallelise all independent DB calls (F-49: previously 11 sequential
+    # round-trips). The two money rollups (today + month) are aggregated in
+    # Postgres now instead of fetching up to 5,000 completed rides each.
     (
         total_drivers,
         online_drivers,
@@ -966,8 +968,8 @@ async def admin_get_stats():
         total_users,
         rides_today,
         pending_applications,
-        completed_today,
-        completed_month,
+        today_money,
+        month_money,
     ) = await asyncio.gather(
         db_supabase.count_documents("drivers", {}),
         db_supabase.count_documents("drivers", {"is_online": True}),
@@ -990,26 +992,24 @@ async def admin_get_stats():
         db_supabase.count_documents("users", {}),
         db_supabase.count_documents("rides", {"created_at": {"$gte": today_start}}),
         db_supabase.count_documents("drivers", {"is_verified": False}),
-        db_supabase.get_rows(
-            "rides",
-            {"status": "completed", "ride_completed_at": {"$gte": today_start}},
-            limit=5000,
-        ),
-        db_supabase.get_rows(
-            "rides",
-            {"status": "completed", "ride_completed_at": {"$gte": month_start}},
-            limit=5000,
-        ),
+        db_supabase.rpc("admin_ride_money_rollup", {"p_start": today_start, "p_end": None}),
+        db_supabase.rpc("admin_ride_money_rollup", {"p_start": month_start, "p_end": None}),
     )
 
-    revenue_today = float(sum(Decimal(str(r.get("total_fare") or 0)) for r in (completed_today or [])))
-    revenue_month = float(sum(Decimal(str(r.get("total_fare") or 0)) for r in completed_month))
+    def _rollup_dec(rollup: Any, key: str) -> Decimal:
+        row = rollup[0] if isinstance(rollup, list) and rollup else rollup
+        if not isinstance(row, dict):
+            return Decimal("0")
+        return Decimal(str(row.get(key) or 0))
+
+    revenue_today = float(_rollup_dec(today_money, "sum_total_fare"))
+    revenue_month = float(_rollup_dec(month_money, "sum_total_fare"))
     # Earnings + tip totals are aggregated over completed rides in the
     # current month; upstream's stats API never wired these up so we compute
     # them here rather than returning stale zeroes.
-    total_driver_earnings = float(sum(Decimal(str(r.get("driver_earnings") or 0)) for r in completed_month))
-    total_admin_earnings = float(sum(Decimal(str(r.get("admin_earnings") or 0)) for r in completed_month))
-    total_tips = float(sum(Decimal(str(r.get("tip_amount") or 0)) for r in completed_month))
+    total_driver_earnings = float(_rollup_dec(month_money, "sum_driver_earnings"))
+    total_admin_earnings = float(_rollup_dec(month_money, "sum_admin_earnings"))
+    total_tips = float(_rollup_dec(month_money, "sum_tip"))
     return {
         # Fields the dashboard page expects
         "total_rides": total_rides,
@@ -1053,23 +1053,24 @@ async def admin_get_ride_stats():
     this_week_count = await db_supabase.get_ride_count_by_date_range(week_start.isoformat(), week_end.isoformat())
     this_month_count = await db_supabase.get_ride_count_by_date_range(month_start.isoformat(), next_month.isoformat())
 
-    # Revenue stats from completed rides
-    completed_today = await db_supabase.get_rows(
-        "rides",
-        {"status": "completed", "ride_completed_at": {"$gte": today_start.isoformat()}},
-        limit=10000,
+    # Revenue stats from completed rides — aggregated in Postgres (today +
+    # month) instead of fetching up to 10,000 rides per window and summing.
+    today_money = await db_supabase.rpc(
+        "admin_ride_money_rollup", {"p_start": today_start.isoformat(), "p_end": None}
     )
-    total_revenue = float(sum(Decimal(str(r.get("total_fare") or 0)) for r in completed_today))
-    total_tips = float(sum(Decimal(str(r.get("tip_amount") or 0)) for r in completed_today))
-    completed_count = len(completed_today)
+    month_money = await db_supabase.rpc(
+        "admin_ride_money_rollup", {"p_start": month_start.isoformat(), "p_end": None}
+    )
 
-    # Monthly completed rides for revenue
-    completed_month = await db_supabase.get_rows(
-        "rides",
-        {"status": "completed", "ride_completed_at": {"$gte": month_start.isoformat()}},
-        limit=10000,
-    )
-    month_revenue = float(sum(Decimal(str(r.get("total_fare") or 0)) for r in completed_month))
+    def _rollup(rollup: Any) -> Dict[str, Any]:
+        row = rollup[0] if isinstance(rollup, list) and rollup else rollup
+        return row if isinstance(row, dict) else {}
+
+    today_row = _rollup(today_money)
+    total_revenue = float(Decimal(str(today_row.get("sum_total_fare") or 0)))
+    total_tips = float(Decimal(str(today_row.get("sum_tip") or 0)))
+    completed_count = int(today_row.get("completed_count") or 0)
+    month_revenue = float(Decimal(str(_rollup(month_money).get("sum_total_fare") or 0)))
 
     # Daily chart data for last 14 days — one grouped query instead of 14
     # sequential COUNT round-trips.
@@ -1173,39 +1174,28 @@ async def admin_get_ride_financials(
 
     rides_count = await db_supabase.get_ride_count_by_date_range(start.isoformat(), end.isoformat())
 
-    completed = await db_supabase.get_rows(
-        "rides",
-        {"status": "completed", "ride_completed_at": {"$gte": start.isoformat(), "$lt": end.isoformat()}},
-        limit=10000,
+    # Completed-ride money is summed in Postgres (admin_ride_money_rollup) over
+    # the [start, end) window instead of fetching up to 10,000 rides and summing
+    # in Python. rider_paid uses COALESCE(grand_total, total_fare, 0) inside the
+    # function so a comped $0 ride isn't counted at full fare.
+    money = await db_supabase.rpc(
+        "admin_ride_money_rollup", {"p_start": start.isoformat(), "p_end": end.isoformat()}
     )
+    money_row = money[0] if isinstance(money, list) and money else money
+    if not isinstance(money_row, dict):
+        money_row = {}
 
-    def _s(rows, key):
-        return float(sum(Decimal(str(r.get(key) or 0)) for r in rows))
+    def _m(key: str) -> float:
+        return float(Decimal(str(money_row.get(key) or 0)))
 
-    def _rider_paid(r):
-        # A free-ride promo persists grand_total = 0 (intentional) while
-        # total_fare keeps the pre-promo subtotal. Use an explicit None check so
-        # comped $0 rides aren't counted at full fare.
-        gt = r.get("grand_total")
-        if gt is None:
-            gt = r.get("total_fare")
-        return Decimal(str(gt or 0))
-
-    rider_paid = float(sum(_rider_paid(r) for r in completed))
-    gross_fare = _s(completed, "total_fare")
-    driver_revenue = float(
-        sum(
-            Decimal(str(r.get("base_fare") or 0))
-            + Decimal(str(r.get("distance_fare") or 0))
-            + Decimal(str(r.get("time_fare") or 0))
-            for r in completed
-        )
-    )
-    tips = _s(completed, "tip_amount")
-    gst_collected = _s(completed, "tax_amount")
-    promo_applied = _s(completed, "discount_amount")
-    area_fees = _s(completed, "area_fees_total")
-    booking_airport = _s(completed, "admin_earnings")
+    rider_paid = _m("sum_rider_paid")
+    gross_fare = _m("sum_total_fare")
+    driver_revenue = _m("sum_driver_revenue")
+    tips = _m("sum_tip")
+    gst_collected = _m("sum_tax")
+    promo_applied = _m("sum_discount")
+    area_fees = _m("sum_area_fees")
+    booking_airport = _m("sum_admin_earnings")
 
     # Incentives paid out in the window (platform-funded; ride_incentive_claims
     # is append-only, keyed by claimed_at).
@@ -1229,7 +1219,7 @@ async def admin_get_ride_financials(
         "period": period,
         "label": label,
         "rides_count": rides_count,
-        "completed_count": len(completed),
+        "completed_count": int(money_row.get("completed_count") or 0),
         "rider_paid": round(rider_paid, 2),
         "gross_fare": round(gross_fare, 2),
         "driver_revenue": round(driver_revenue, 2),

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1055,12 +1055,8 @@ async def admin_get_ride_stats():
 
     # Revenue stats from completed rides — aggregated in Postgres (today +
     # month) instead of fetching up to 10,000 rides per window and summing.
-    today_money = await db_supabase.rpc(
-        "admin_ride_money_rollup", {"p_start": today_start.isoformat(), "p_end": None}
-    )
-    month_money = await db_supabase.rpc(
-        "admin_ride_money_rollup", {"p_start": month_start.isoformat(), "p_end": None}
-    )
+    today_money = await db_supabase.rpc("admin_ride_money_rollup", {"p_start": today_start.isoformat(), "p_end": None})
+    month_money = await db_supabase.rpc("admin_ride_money_rollup", {"p_start": month_start.isoformat(), "p_end": None})
 
     def _rollup(rollup: Any) -> Dict[str, Any]:
         row = rollup[0] if isinstance(rollup, list) and rollup else rollup
@@ -1178,9 +1174,7 @@ async def admin_get_ride_financials(
     # the [start, end) window instead of fetching up to 10,000 rides and summing
     # in Python. rider_paid uses COALESCE(grand_total, total_fare, 0) inside the
     # function so a comped $0 ride isn't counted at full fare.
-    money = await db_supabase.rpc(
-        "admin_ride_money_rollup", {"p_start": start.isoformat(), "p_end": end.isoformat()}
-    )
+    money = await db_supabase.rpc("admin_ride_money_rollup", {"p_start": start.isoformat(), "p_end": end.isoformat()})
     money_row = money[0] if isinstance(money, list) and money else money
     if not isinstance(money_row, dict):
         money_row = {}
@@ -1570,26 +1564,19 @@ async def admin_get_earnings(period: str = Query("month")):
     else:  # month
         start_date = now - timedelta(days=30)
 
-    start_date_str = start_date.isoformat()
-
-    # Get completed rides since start_date
-    completed_rides = await db_supabase.get_rows(
-        "rides",
-        {"status": "completed", "ride_completed_at": {"$gte": start_date_str}},
-        limit=10000,
-    )
-
-    # Calculate totals
-    total_revenue = float(sum(Decimal(str(r.get("total_fare") or 0)) for r in completed_rides))
-    driver_earnings = float(sum(Decimal(str(r.get("driver_earnings") or 0)) for r in completed_rides))
-    platform_fees = float(sum(Decimal(str(r.get("admin_earnings") or 0)) for r in completed_rides))
+    # Totals aggregated in Postgres (admin_ride_money_rollup) over completed
+    # rides since start_date, instead of fetching up to 10,000 rides and summing.
+    rollup = await db_supabase.rpc("admin_ride_money_rollup", {"p_start": start_date.isoformat(), "p_end": None})
+    row = rollup[0] if isinstance(rollup, list) and rollup else rollup
+    if not isinstance(row, dict):
+        row = {}
 
     return {
         "period": period,
-        "total_revenue": total_revenue,
-        "total_rides": len(completed_rides),
-        "driver_earnings": driver_earnings,
-        "platform_fees": platform_fees,
+        "total_revenue": float(Decimal(str(row.get("sum_total_fare") or 0))),
+        "total_rides": int(row.get("completed_count") or 0),
+        "driver_earnings": float(Decimal(str(row.get("sum_driver_earnings") or 0))),
+        "platform_fees": float(Decimal(str(row.get("sum_admin_earnings") or 0))),
     }
 
 
@@ -2843,18 +2830,21 @@ async def admin_close_payout_period(
 async def admin_get_payout_stats():
     """Get payout stats: total paid, pending, failed."""
     try:
-        all_payouts = await db.get_rows("payouts", {}, limit=10000)
+        stats = await db.rpc("admin_payout_stats", {})
     except Exception:
-        all_payouts = []
+        logger.error("payout stats query failed", exc_info=True)
+        stats = None
+    row = stats[0] if isinstance(stats, list) and stats else stats
+    if not isinstance(row, dict):
+        row = {}
 
-    total_paid = float(sum(Decimal(str(p.get("amount", 0))) for p in all_payouts if p.get("status") == "completed"))
-    total_pending = float(sum(Decimal(str(p.get("amount", 0))) for p in all_payouts if p.get("status") == "pending"))
-    total_failed = float(sum(Decimal(str(p.get("amount", 0))) for p in all_payouts if p.get("status") == "failed"))
+    def _d(key: str) -> float:
+        return round(float(Decimal(str(row.get(key) or 0))), 2)
 
     return {
-        "total_paid": round(total_paid, 2),
-        "total_pending": round(total_pending, 2),
-        "total_failed": round(total_failed, 2),
-        "payout_count": len(all_payouts),
-        "pending_count": sum(1 for p in all_payouts if p.get("status") == "pending"),
+        "total_paid": _d("total_paid"),
+        "total_pending": _d("total_pending"),
+        "total_failed": _d("total_failed"),
+        "payout_count": int(row.get("payout_count") or 0),
+        "pending_count": int(row.get("pending_count") or 0),
     }

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1071,18 +1071,22 @@ async def admin_get_ride_stats():
     )
     month_revenue = float(sum(Decimal(str(r.get("total_fare") or 0)) for r in completed_month))
 
-    # Daily chart data for last 14 days
-    daily_chart = []
-    for i in range(13, -1, -1):
-        day_start = today_start - timedelta(days=i)
-        day_end = day_start + timedelta(days=1)
-        count = await db_supabase.get_ride_count_by_date_range(day_start.isoformat(), day_end.isoformat())
-        daily_chart.append(
-            {
-                "date": day_start.strftime("%b %d"),
-                "rides": count,
-            }
-        )
+    # Daily chart data for last 14 days — one grouped query instead of 14
+    # sequential COUNT round-trips.
+    chart_start = today_start - timedelta(days=13)
+    chart_end = today_start + timedelta(days=1)
+    count_rows = await db_supabase.rpc(
+        "admin_ride_daily_counts",
+        {"p_start": chart_start.isoformat(), "p_end": chart_end.isoformat()},
+    )
+    chart_buckets: Dict[str, int] = {str(r.get("day")): int(r.get("rides") or 0) for r in (count_rows or [])}
+    daily_chart = [
+        {
+            "date": (chart_start + timedelta(days=i)).strftime("%b %d"),
+            "rides": chart_buckets.get((chart_start + timedelta(days=i)).strftime("%Y-%m-%d"), 0),
+        }
+        for i in range(14)
+    ]
 
     return {
         "today_count": today_count,
@@ -1107,32 +1111,19 @@ async def admin_get_ride_trend(
 ):
     """Daily ride counts for the trend chart.
 
-    Single DB round-trip: fetches only the created_at column for rides in the
-    window, then buckets in Python. Replaces the 14-sequential-query pattern
-    in /rides/stats daily_chart.
+    One grouped query in Postgres (admin_ride_daily_counts) instead of fetching
+    every created_at in the window and bucketing in Python.
     """
     now = datetime.now(timezone.utc)
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     window_start = today_start - timedelta(days=days - 1)
+    window_end = today_start + timedelta(days=1)  # through end of today
 
-    rows = await db_supabase.get_rows(
-        "rides",
-        {"created_at": {"$gte": window_start.isoformat()}},
-        columns="created_at",
-        limit=50000,
+    count_rows = await db_supabase.rpc(
+        "admin_ride_daily_counts",
+        {"p_start": window_start.isoformat(), "p_end": window_end.isoformat()},
     )
-
-    buckets: Dict[str, int] = {}
-    for i in range(days):
-        d = (window_start + timedelta(days=i)).strftime("%Y-%m-%d")
-        buckets[d] = 0
-    for r in rows:
-        ca = r.get("created_at")
-        if not ca:
-            continue
-        day_key = ca[:10]
-        if day_key in buckets:
-            buckets[day_key] += 1
+    buckets: Dict[str, int] = {str(r.get("day")): int(r.get("rides") or 0) for r in (count_rows or [])}
 
     daily_chart = [
         {

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -2234,59 +2234,44 @@ async def admin_get_payouts_overview(
     def _in_scope(row: Dict[str, Any]) -> bool:
         return driver_id_filter is None or row.get("driver_id") in driver_id_filter
 
-    # ── Outstanding payable balance ──────────────────────────────────────
-    # Lifetime sum of driver_earnings on completed rides minus payouts
-    # that have either completed or are mid-flight. NOT scoped to the
-    # period — this is a "right now" snapshot. Showing PoP delta against
-    # "same number of days ago" so the operator can see whether the
-    # backlog is growing or shrinking.
-    def _sum(rows: list, key: str) -> Decimal:
-        return sum((Decimal(str(r.get(key) or 0)) for r in rows if _in_scope(r)), Decimal("0"))
-
-    all_completed_rides = await db_supabase.get_rows("rides", {"status": "completed"}, limit=200000)
-    all_payouts = await db_supabase.get_rows("payouts", {}, limit=200000)
-
-    earned_total = _sum(all_completed_rides, "driver_earnings")
-    paid_or_in_flight = sum(
-        (
-            Decimal(str(p.get("amount") or 0))
-            for p in all_payouts
-            if _in_scope(p) and p.get("status") in ("completed", "pending", "processing")
-        ),
-        Decimal("0"),
+    # ── Cumulative aggregates via SQL (one round-trip) ───────────────────
+    # Outstanding payable, the stuck/blocked queues, and the T4A YTD snapshot
+    # are all-time aggregates. They used to require streaming the whole rides +
+    # payouts history into Python (two limit=200000 scans); now Postgres sums
+    # them for us. Money is summed as NUMERIC server-side to stay cent-faithful.
+    year_start_iso = datetime(now.year, 1, 1, tzinfo=timezone.utc).isoformat()
+    stuck_before_iso = (now - timedelta(hours=48)).isoformat()
+    agg_rows = await db_supabase.rpc(
+        "admin_payouts_overview_aggregates",
+        {
+            "p_end": end.isoformat(),
+            "p_prev_end": prev_end.isoformat(),
+            "p_year_start": year_start_iso,
+            "p_stuck_before": stuck_before_iso,
+            "p_service_area_id": service_area_id,
+        },
     )
-    outstanding_now = max(earned_total - paid_or_in_flight, Decimal("0"))  # noqa: F841
+    agg = agg_rows[0] if isinstance(agg_rows, list) and agg_rows else agg_rows
+    if not isinstance(agg, dict):
+        agg = {}
 
-    # Same calculation snapshot at prev_end so we can show delta.
-    end_iso = end.isoformat()
-    prev_end_iso = prev_end.isoformat()
+    def _agg_dec(key: str) -> Decimal:
+        return Decimal(str(agg.get(key) or 0))
 
-    def _completed_up_to(rows: list, ts: str) -> Decimal:
-        return sum(
-            (
-                Decimal(str(r.get("driver_earnings") or 0))
-                for r in rows
-                if _in_scope(r) and (r.get("ride_completed_at") or r.get("updated_at") or "") <= ts
-            ),
-            Decimal("0"),
-        )
+    outstanding_now_calc = max(_agg_dec("earned_up_to_end") - _agg_dec("paid_up_to_end"), Decimal("0"))
+    outstanding_prev = max(_agg_dec("earned_up_to_prev") - _agg_dec("paid_up_to_prev"), Decimal("0"))
 
-    def _paid_up_to(rows: list, ts: str) -> Decimal:
-        return sum(
-            (
-                Decimal(str(p.get("amount") or 0))
-                for p in rows
-                if _in_scope(p)
-                and p.get("status") in ("completed", "pending", "processing")
-                and (p.get("created_at") or "") <= ts
-            ),
-            Decimal("0"),
-        )
-
-    outstanding_now_calc = _completed_up_to(all_completed_rides, end_iso) - _paid_up_to(all_payouts, end_iso)
-    outstanding_prev = _completed_up_to(all_completed_rides, prev_end_iso) - _paid_up_to(all_payouts, prev_end_iso)
-    outstanding_now_calc = max(outstanding_now_calc, Decimal("0"))
-    outstanding_prev = max(outstanding_prev, Decimal("0"))
+    # ── Period-windowed payouts ──────────────────────────────────────────
+    # The per-row metrics below only look at the current + previous windows, so
+    # fetch just that slice rather than the entire payouts table. A payout's
+    # effective timestamp is processed_at when present else created_at, so a row
+    # qualifies if either is at/after the earliest window bound (prev_start).
+    window_lo = prev_start.isoformat()
+    all_payouts = await db_supabase.get_rows(
+        "payouts",
+        {"$or": [{"created_at": {"$gte": window_lo}}, {"processed_at": {"$gte": window_lo}}]},
+        limit=200000,
+    )
 
     # ── Period-windowed payout metrics ───────────────────────────────────
     def _in_window(p: Dict[str, Any], lo: datetime, hi: datetime) -> bool:
@@ -2400,46 +2385,19 @@ async def admin_get_payouts_overview(
         key=lambda x: (-x["count"], -x["amount"]),
     )[:8]
 
-    # Stuck pending payouts — anything still pending more than 48h after
-    # creation. These are the manual-intervention queue: Stripe webhook
-    # didn't return or the rebalance is held up. NOT period-scoped —
-    # this is a "right now" signal regardless of the selected window.
-    stuck_threshold = (now - timedelta(hours=48)).isoformat()
-    stuck_rows = [
-        p
-        for p in all_payouts
-        if _in_scope(p)
-        and p.get("status") in ("pending", "processing")
-        and (p.get("created_at") or "") < stuck_threshold
-    ]
+    # Stuck pending payouts — pending/processing more than 48h after creation
+    # (manual-intervention queue). All-time signal, computed in SQL above.
     stuck_over_48h = {
-        "count": len(stuck_rows),
-        "amount": round(float(sum((Decimal(str(p.get("amount") or 0)) for p in stuck_rows), Decimal("0"))), 2),
+        "count": int(agg.get("stuck_count") or 0),
+        "amount": round(float(_agg_dec("stuck_amount")), 2),
     }
 
-    # Blocked drivers — Stripe Connect KYC mirror says payouts are
-    # disabled. Uses the partial index from migration 92. Outstanding
-    # balance for these drivers is the operational "we can't pay
-    # them yet" number.
-    blocked_drivers_rows = await db_supabase.get_rows(
-        "drivers",
-        {"stripe_payouts_enabled": False, "stripe_account_id": {"$ne": None}},
-        limit=500,
-    )
-    if driver_id_filter is not None:
-        blocked_drivers_rows = [d for d in blocked_drivers_rows if d.get("id") in driver_id_filter]
-    blocked_driver_ids = {d.get("id") for d in blocked_drivers_rows if d.get("id")}
-    blocked_outstanding = Decimal("0")
-    if blocked_driver_ids:
-        for r in all_completed_rides:
-            if r.get("driver_id") in blocked_driver_ids:
-                blocked_outstanding += Decimal(str(r.get("driver_earnings") or 0))
-        for p in all_payouts:
-            if p.get("driver_id") in blocked_driver_ids and p.get("status") in ("completed", "pending", "processing"):
-                blocked_outstanding -= Decimal(str(p.get("amount") or 0))
+    # Blocked drivers — Stripe Connect KYC mirror says payouts are disabled.
+    # Their count + the outstanding "we can't pay them yet" balance are
+    # all-time aggregates, computed in SQL above (scoped to the selected area).
     blocked_drivers = {
-        "count": len(blocked_driver_ids),
-        "outstanding_balance": round(float(max(blocked_outstanding, Decimal("0"))), 2),
+        "count": int(agg.get("blocked_count") or 0),
+        "outstanding_balance": round(float(_agg_dec("blocked_outstanding")), 2),
     }
 
     # Top earning drivers in window — sum of completed payout amounts
@@ -2506,41 +2464,16 @@ async def admin_get_payouts_overview(
     )[:10]
 
     # ── Pass 4: T4A snapshot ─────────────────────────────────────────────
-    # CRA T4A threshold for self-employed contractor reporting in Canada
-    # is $500 to the same payee in a tax year. The GST/HST mandatory
-    # registration threshold is $30,000 — that's the more operationally
-    # interesting line because it's when a driver MUST register their
-    # GST account. Bucket per driver against both numbers.
-    year_start = datetime(now.year, 1, 1, tzinfo=timezone.utc).isoformat()
-    ytd_completed = [
-        r
-        for r in all_completed_rides
-        if _in_scope(r) and (r.get("ride_completed_at") or r.get("updated_at") or "") >= year_start
-    ]
-    ytd_earnings_by_driver: Dict[str, Decimal] = {}
-    for r in ytd_completed:
-        did = r.get("driver_id")
-        if not did:
-            continue
-        ytd_earnings_by_driver[did] = ytd_earnings_by_driver.get(did, Decimal("0")) + Decimal(
-            str(r.get("driver_earnings") or 0)
-        )
-
+    # CRA T4A threshold for self-employed contractor reporting in Canada is
+    # $500 to the same payee in a tax year; the GST/HST mandatory registration
+    # threshold is $30,000. Per-driver YTD earnings are bucketed against both
+    # in SQL above (the bucketing is a GROUP BY, not a per-row Python loop).
     t4a_buckets = {
-        "under_500": 0,  # below T4A reporting threshold (CRA $500)
-        "from_500_to_10k": 0,  # T4A required, GST registration not required
-        "from_10k_to_30k": 0,  # T4A required, GST elective
-        "over_30k": 0,  # T4A required, GST registration MANDATORY
+        "under_500": int(agg.get("t4a_under_500") or 0),  # below T4A reporting threshold (CRA $500)
+        "from_500_to_10k": int(agg.get("t4a_500_10k") or 0),  # T4A required, GST registration not required
+        "from_10k_to_30k": int(agg.get("t4a_10k_30k") or 0),  # T4A required, GST elective
+        "over_30k": int(agg.get("t4a_over_30k") or 0),  # T4A required, GST registration MANDATORY
     }
-    for amt in ytd_earnings_by_driver.values():
-        if amt < Decimal("500"):
-            t4a_buckets["under_500"] += 1
-        elif amt < Decimal("10000"):
-            t4a_buckets["from_500_to_10k"] += 1
-        elif amt < Decimal("30000"):
-            t4a_buckets["from_10k_to_30k"] += 1
-        else:
-            t4a_buckets["over_30k"] += 1
 
     # Period locks — derived from audit_log entries written by
     # admin_close_payout_period. Surface the most recent N so the UI
@@ -2602,11 +2535,11 @@ async def admin_get_payouts_overview(
         # Pass 4 — compliance.
         "t4a_snapshot": {
             "tax_year": now.year,
-            "drivers_with_earnings": len(ytd_earnings_by_driver),
+            "drivers_with_earnings": int(agg.get("t4a_drivers_with_earnings") or 0),
             "buckets": t4a_buckets,
             # Sum of YTD driver_earnings — the gross-side of the T4A
             # generation pipeline, not what's been paid out.
-            "ytd_gross_earnings": round(float(sum(ytd_earnings_by_driver.values(), Decimal("0"))), 2),
+            "ytd_gross_earnings": round(float(_agg_dec("t4a_ytd_gross")), 2),
         },
         "period_locks": period_locks,
     }

--- a/backend/routes/admin/safety.py
+++ b/backend/routes/admin/safety.py
@@ -100,7 +100,14 @@ async def admin_list_safety_incidents(
     reporter_ids = list({r.get("reported_by_user_id") for r in page if r.get("reported_by_user_id")})
     _drivers_map, users_map = await _batch_fetch_drivers_and_users([], [])
     if reporter_ids:
-        users_list = await db_supabase.get_rows("users", {"id": {"$in": reporter_ids}}, limit=len(reporter_ids))
+        # Only the reporter's display name is used — project the columns
+        # _user_display_name reads so base64 profile_image stays out of the read.
+        users_list = await db_supabase.get_rows(
+            "users",
+            {"id": {"$in": reporter_ids}},
+            columns="id,first_name,last_name,email,phone",
+            limit=len(reporter_ids),
+        )
         users_map = {u["id"]: u for u in users_list if u.get("id")}
 
     enriched: List[Dict[str, Any]] = []

--- a/backend/routes/admin/safety.py
+++ b/backend/routes/admin/safety.py
@@ -41,6 +41,11 @@ router = APIRouter(prefix="/safety", tags=["Admin · Safety"])
 # default scope when no explicit status filter is passed.
 _OPEN_STATUSES = ("open", "in_progress")
 
+# Columns the queue table actually renders. Project these instead of SELECT *
+# so the list query only pulls what the page needs; the single-incident detail
+# endpoint returns the full row for the triage drawer.
+_LIST_COLUMNS = "id,reported_by_user_id,role,category,status,severity,ride_id,assigned_to_admin_id,reported_at"
+
 
 @router.get("/incidents")
 async def admin_list_safety_incidents(
@@ -77,24 +82,28 @@ async def admin_list_safety_incidents(
         filters["category"] = category
     if ride_id:
         filters["ride_id"] = ride_id
+    if search and search.strip():
+        # Push search into the DB filter (case-insensitive substring on
+        # description) so it matches across the whole result set, not just the
+        # rows that happened to land on the current page.
+        filters["description"] = {"$regex": re.escape(search.strip()), "$options": "i"}
 
     try:
-        rows = await db_supabase.get_rows(
+        # Fetch exactly one page via the DB's native offset — project only the
+        # columns the queue renders. (Previously this fetched limit+offset rows
+        # and sliced in Python, so deeper pages read ever-larger result sets.)
+        page = await db_supabase.get_rows(
             "safety_incidents",
             filters,
+            columns=_LIST_COLUMNS,
             order="reported_at",
             desc=True,
-            limit=limit + offset,
+            limit=limit,
+            offset=offset,
         )
     except Exception:
         logger.error("safety_incidents list query failed", exc_info=True)
         raise HTTPException(status_code=503, detail="Could not load safety queue.") from None
-
-    page = rows[offset : offset + limit]
-
-    if search:
-        needle = search.strip().lower()
-        page = [r for r in page if needle in (r.get("description") or "").lower()]
 
     # Batch-fetch reporter names so the queue table doesn't have to N+1.
     reporter_ids = list({r.get("reported_by_user_id") for r in page if r.get("reported_by_user_id")})
@@ -120,21 +129,25 @@ async def admin_list_safety_incidents(
             }
         )
 
-    # Open count is useful for the sidebar badge and headline stat —
-    # cheap because we only query in the open status set.
+    # Total rows matching the current filters — drives the pagination control.
+    # Exact COUNT, never a row fetch.
     try:
-        open_rows = await db_supabase.get_rows(
-            "safety_incidents",
-            {"status": {"$in": list(_OPEN_STATUSES)}},
-            limit=1000,
-        )
-        open_count = len(open_rows)
+        total = await db_supabase.count_documents("safety_incidents", filters)
+    except Exception:
+        logger.error("safety_incidents count query failed", exc_info=True)
+        total = offset + len(page)
+
+    # Open count for the sidebar badge / headline stat — a COUNT over the open
+    # status set, independent of the current filters (previously this fetched up
+    # to 1000 full rows just to len() them).
+    try:
+        open_count = await db_supabase.count_documents("safety_incidents", {"status": {"$in": list(_OPEN_STATUSES)}})
     except Exception:
         open_count = None
 
     return {
         "items": enriched,
-        "total": len(rows),
+        "total": total,
         "offset": offset,
         "limit": limit,
         "open_count": open_count,

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -18,6 +18,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Columns the admin Users list / search / export actually render. We project
+# explicitly to keep users.profile_image OUT of these bulk reads: for accounts
+# created before the `profile-photos` storage bucket, profile_image holds a full
+# base64 data URI, so `SELECT *` shipped ~one image blob per row — that's the
+# multi-MB payload (and the slow DB read on the 1000-row export). The Users page
+# never displays an avatar, so the column is pure dead weight here. The single-
+# user detail endpoint (admin_get_user_details) still selects everything.
+_USER_LIST_COLUMNS = (
+    "id,first_name,last_name,email,phone,role,created_at,total_rides,rating,is_verified,city,status,is_rider,is_driver"
+)
+
 
 class UserStatusRequest(BaseModel):
     status: Literal["active", "suspended", "banned"]
@@ -69,7 +80,15 @@ async def admin_get_users(
                 {"first_name": {"$regex": re.escape(term), "$options": "i"}},
                 {"last_name": {"$regex": re.escape(term), "$options": "i"}},
             ]
-    users = await db_supabase.get_rows("users", filters, order="created_at", desc=True, limit=limit, offset=offset)
+    users = await db_supabase.get_rows(
+        "users",
+        filters,
+        columns=_USER_LIST_COLUMNS,
+        order="created_at",
+        desc=True,
+        limit=limit,
+        offset=offset,
+    )
     return users
 
 
@@ -233,6 +252,7 @@ async def admin_export_users(
     users = await db_supabase.get_rows(
         "users",
         {"role": {"$ne": "admin"}},
+        columns=_USER_LIST_COLUMNS,
         order="created_at",
         desc=True,
         limit=limit,

--- a/backend/routes/admin/venues.py
+++ b/backend/routes/admin/venues.py
@@ -44,9 +44,17 @@ class VenueRequest(BaseModel):
 
 
 @router.get("")
-async def list_venues(admin: dict = Depends(get_admin_user)):
+async def list_venues(
+    service_area_id: Optional[str] = None,
+    admin: dict = Depends(get_admin_user),
+):
+    # Filter server-side when an area is selected so we only fetch the venues
+    # that belong to it rather than the whole table.
+    filters: dict = {}
+    if service_area_id:
+        filters["service_area_id"] = service_area_id
     try:
-        rows = await db_supabase.get_rows(_TABLE, {}, order="created_at", desc=True, limit=2000)
+        rows = await db_supabase.get_rows(_TABLE, filters, order="created_at", desc=True, limit=2000)
     except Exception as e:
         logger.error(f"Failed to list venues: {e}", exc_info=True, extra={"domain": "admin"})
         raise HTTPException(status_code=503, detail="venues_unavailable") from e

--- a/backend/routes/disputes.py
+++ b/backend/routes/disputes.py
@@ -159,7 +159,15 @@ async def admin_get_disputes(
     # user_phone intentionally omitted from response — P1-9 (PIPEDA: no PII in bulk list).
     user_ids = list({d["user_id"] for d in disputes if d.get("user_id")})
     ride_ids = list({d["ride_id"] for d in disputes if d.get("ride_id")})
-    users = await db_supabase.get_rows("users", {"id": {"$in": user_ids}}, limit=len(user_ids)) if user_ids else []
+    # Only first/last name are surfaced (user_phone is intentionally omitted —
+    # P1-9). Project name columns to keep base64 profile_image out of the read.
+    users = (
+        await db_supabase.get_rows(
+            "users", {"id": {"$in": user_ids}}, columns="id,first_name,last_name", limit=len(user_ids)
+        )
+        if user_ids
+        else []
+    )
     rides = await db_supabase.get_rows("rides", {"id": {"$in": ride_ids}}, limit=len(ride_ids)) if ride_ids else []
     users_by_id = {u["id"]: u for u in (users or [])}
     rides_by_id = {r["id"]: r for r in (rides or [])}

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4486,7 +4486,11 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
     referral_code = driver.get("referral_code", f"DRIVER{driver['id'][:8].upper()}")
 
     # Find users who used this referral code
-    referred_users_cursor = db_supabase.get_rows("users", {"referral_code_used": referral_code}, limit=100)
+    # Only the id is used below (to look up each referred user's driver row),
+    # so project it and keep base64 profile_image out of the read.
+    referred_users_cursor = db_supabase.get_rows(
+        "users", {"referral_code_used": referral_code}, columns="id", limit=100
+    )
     referred_users = (
         await referred_users_cursor.to_list(100)
         if hasattr(referred_users_cursor, "to_list")

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4584,7 +4584,11 @@ async def get_referred_drivers(
     referral_code = driver.get("referral_code", f"DRIVER{driver['id'][:8].upper()}")
 
     # Find users who used this referral code and became drivers
-    referred_users_cursor = db_supabase.get_rows("users", {"referral_code_used": referral_code}, limit=100)
+    # Each referred user contributes name + email to the response — project
+    # those columns and keep base64 profile_image out of the read.
+    referred_users_cursor = db_supabase.get_rows(
+        "users", {"referral_code_used": referral_code}, columns="id,first_name,last_name,email", limit=100
+    )
     referred_users = (
         await referred_users_cursor.to_list(100)
         if hasattr(referred_users_cursor, "to_list")

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -357,6 +357,43 @@ class TestAdminSendReceipt:
             resp = client.post("/api/admin/rides/ride-1/send-receipt")
         assert resp.status_code == 422
 
+
+# ---------------------------------------------------------------------------
+# Spinr Pass subscription stats (regression: _money() used ROUND_HALF_UP
+# without importing it, so /subscription-stats 500'd on every call with a
+# NameError — the earnings "Spinr Pass" tab showed "Failed to load stats").
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSubscriptionStats:
+    def test_subscription_stats_empty_ok(self, client):
+        # Even with no data the daily-chart loop calls _money(), so an
+        # empty-data request exercises the formerly-broken path. Must be 200.
+        with patch("db_supabase.get_rows", new_callable=AsyncMock, return_value=[]):
+            resp = client.get("/api/admin/subscription-stats")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["stats"]["total_subscribers"] == 0
+        assert body["stats"]["total_revenue"] == 0
+        assert body["stats"]["active_mrr"] == 0
+
+    def test_subscription_stats_money_rounding(self, client):
+        # A paid subscription + a ledger payment must round to 2dp and surface
+        # in the totals (exercises _money on real amounts, not just zero).
+        async def _rows(table, *args, **kwargs):
+            if table == "driver_subscriptions":
+                return [{"driver_id": "d1", "plan_id": "p1", "status": "active", "price": "19.99", "payment_status": "paid"}]
+            if table == "subscription_payments":
+                return [{"id": "pay1", "driver_id": "d1", "plan_id": "p1", "amount": "19.999", "created_at": "2999-01-01T00:00:00"}]
+            return []
+
+        with patch("db_supabase.get_rows", new_callable=AsyncMock, side_effect=_rows):
+            resp = client.get("/api/admin/subscription-stats")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["stats"]["active_mrr"] == 19.99
+        assert body["stats"]["total_revenue"] == 20.0
+
     def test_send_receipt_happy_path(self, client):
         with (
             patch("db_supabase.get_ride", new_callable=AsyncMock, return_value=_FAKE_RIDE),

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -75,7 +75,8 @@ async def _alert_admins_payment_exhausted(ride: dict) -> None:
         logger.error(f"Admin WS broadcast failed for exhausted payment ride {ride_id}: {exc}")
 
     try:
-        admin_users = await db.get_rows("users", {"role": "admin"}, limit=50)
+        # Only the admin id is needed to target the push — project it.
+        admin_users = await db.get_rows("users", {"role": "admin"}, columns="id", limit=50)
         for admin in admin_users:
             try:
                 await send_push_notification(


### PR DESCRIPTION
Each row in the drivers table fired a network request for the driver's
profile photo, slowing the page load. Show the initials avatar in the
list instead; the full photo still renders in the detail slideout.

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
