### PR TITLE
Claude/admin driver panel perf 6e2007

### DIFF
--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -38,7 +38,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { Pagination } from "@/components/ui/pagination";
-import { Users, Search, Mail, Phone, MapPin, Star, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff } from "lucide-react";
+import { Users, Search, Mail, Phone, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff } from "lucide-react";
 import { exportToCsv } from "@/lib/export-csv";
 import { formatDate } from "@/lib/utils";
 import { getUsersPaginated, updateUserStatus, updateUserFlags, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
@@ -159,12 +159,8 @@ export default function UsersPage() {
                 phone: u.phone,
                 role: u.role,
                 created_at: u.created_at,
-                total_rides: u.total_rides || 0,
-                rating: u.rating || null,
-                is_verified: u.is_verified ?? true,
                 is_rider: u.is_rider,
                 is_driver: u.is_driver,
-                city: u.city,
                 status: u.status || "active",
             }));
             setUsers(transformed);
@@ -208,10 +204,7 @@ export default function UsersPage() {
                 { key: 'name', label: 'Name' },
                 { key: 'email', label: 'Email' },
                 { key: 'phone', label: 'Phone' },
-                { value: (u: any) => u.city || 'N/A', label: 'City' },
-                { value: (u: any) => u.total_rides || 0, label: 'Total Rides' },
-                { value: (u: any) => u.rating || 'N/A', label: 'Rating' },
-                { value: (u: any) => u.is_verified ? 'Yes' : 'No', label: 'Verified' },
+                { value: (u: any) => (u.is_rider ? 'Rider' : '') + (u.is_rider && u.is_driver ? ' / ' : '') + (u.is_driver ? 'Driver' : ''), label: 'Role' },
                 { value: (u: any) => formatDate(u.created_at), label: 'Joined Date' },
             ]);
             toast({ title: "Export complete", description: `${res.count ?? 0} users exported.` });
@@ -276,28 +269,10 @@ export default function UsersPage() {
                 <Card>
                     <CardContent className="pt-4 pb-3">
                         <div className="flex items-center gap-2">
-                            <ShieldCheck className="h-5 w-5 text-emerald-500" />
+                            <Users className="h-5 w-5 text-emerald-500" />
                             <div>
-                                <p className="text-xs text-muted-foreground">Verified (page)</p>
-                                <p className="text-2xl font-bold">{users.filter(u => u.is_verified).length}</p>
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-                <Card>
-                    <CardContent className="pt-4 pb-3">
-                        <div className="flex items-center gap-2">
-                            <Star className="h-5 w-5 text-amber-400 fill-amber-400" />
-                            <div>
-                                <p className="text-xs text-muted-foreground">Avg Rating (page)</p>
-                                <p className="text-2xl font-bold">
-                                    {(() => {
-                                        const rated = users.filter(u => u.rating != null);
-                                        return rated.length > 0
-                                            ? (rated.reduce((s, u) => s + u.rating, 0) / rated.length).toFixed(1)
-                                            : "N/A";
-                                    })()}
-                                </p>
+                                <p className="text-xs text-muted-foreground">Riders (page)</p>
+                                <p className="text-2xl font-bold">{users.filter(u => u.is_rider).length}</p>
                             </div>
                         </div>
                     </CardContent>
@@ -307,10 +282,19 @@ export default function UsersPage() {
                         <div className="flex items-center gap-2">
                             <Car className="h-5 w-5 text-violet-500" />
                             <div>
-                                <p className="text-xs text-muted-foreground">Total Rides (page)</p>
-                                <p className="text-2xl font-bold">
-                                    {users.reduce((s, u) => s + (u.total_rides || 0), 0)}
-                                </p>
+                                <p className="text-xs text-muted-foreground">Drivers (page)</p>
+                                <p className="text-2xl font-bold">{users.filter(u => u.is_driver).length}</p>
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardContent className="pt-4 pb-3">
+                        <div className="flex items-center gap-2">
+                            <ShieldCheck className="h-5 w-5 text-sky-500" />
+                            <div>
+                                <p className="text-xs text-muted-foreground">Dual-role (page)</p>
+                                <p className="text-2xl font-bold">{users.filter(u => u.is_rider && u.is_driver).length}</p>
                             </div>
                         </div>
                     </CardContent>
@@ -380,10 +364,7 @@ export default function UsersPage() {
                                     <TableRow>
                                         <TableHead>Name</TableHead>
                                         <TableHead>Contact</TableHead>
-                                        <TableHead>City</TableHead>
-                                        <TableHead>Rides</TableHead>
-                                        <TableHead>Rating</TableHead>
-                                        <TableHead>Status</TableHead>
+                                        <TableHead>Role</TableHead>
                                         <TableHead>Joined</TableHead>
                                         <TableHead className="text-right">Actions</TableHead>
                                     </TableRow>
@@ -391,7 +372,7 @@ export default function UsersPage() {
                                 <TableBody>
                                     {users.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={8} className="text-center text-muted-foreground py-12">
+                                            <TableCell colSpan={5} className="text-center text-muted-foreground py-12">
                                                 No users found.
                                             </TableCell>
                                         </TableRow>
@@ -417,33 +398,17 @@ export default function UsersPage() {
                                                     </div>
                                                 </TableCell>
                                                 <TableCell>
-                                                    <div className="flex items-center gap-1">
-                                                        <MapPin className="h-3 w-3 text-muted-foreground" />
-                                                        {user.city || "N/A"}
+                                                    <div className="flex flex-wrap items-center gap-1">
+                                                        {user.is_rider && (
+                                                            <Badge variant="secondary" className="bg-sky-500/15 text-sky-600">Rider</Badge>
+                                                        )}
+                                                        {user.is_driver && (
+                                                            <Badge variant="secondary" className="bg-violet-500/15 text-violet-600">Driver</Badge>
+                                                        )}
+                                                        {!user.is_rider && !user.is_driver && (
+                                                            <span className="text-muted-foreground">—</span>
+                                                        )}
                                                     </div>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <div className="flex items-center gap-1">
-                                                        <Car className="h-3 w-3 text-muted-foreground" />
-                                                        {user.total_rides || 0}
-                                                    </div>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <div className="flex items-center gap-1">
-                                                        <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
-                                                        {user.rating != null ? user.rating.toFixed(1) : "N/A"}
-                                                    </div>
-                                                </TableCell>
-                                                <TableCell>
-                                                    <Badge className={
-                                                        user.status === "banned" ? "bg-red-500/15 text-red-600"
-                                                        : user.status === "suspended" ? "bg-amber-500/15 text-amber-600"
-                                                        : "bg-emerald-500/15 text-emerald-600"
-                                                    }>
-                                                        {user.status === "banned" ? "Banned"
-                                                        : user.status === "suspended" ? "Suspended"
-                                                        : "Active"}
-                                                    </Badge>
                                                 </TableCell>
                                                 <TableCell className="text-xs text-muted-foreground">
                                                     {formatDate(user.created_at)}
@@ -489,9 +454,14 @@ export default function UsersPage() {
                                 </div>
                                 <div>
                                     <p className="text-lg font-semibold">{selectedUser.name}</p>
-                                    <Badge variant={selectedUser.is_verified ? "default" : "secondary"} className={selectedUser.is_verified ? "bg-emerald-500" : ""}>
-                                        {selectedUser.is_verified ? "Verified" : "Unverified"}
-                                    </Badge>
+                                    <div className="flex flex-wrap items-center gap-1 mt-0.5">
+                                        {selectedUser.is_rider && (
+                                            <Badge variant="secondary" className="bg-sky-500/15 text-sky-600">Rider</Badge>
+                                        )}
+                                        {selectedUser.is_driver && (
+                                            <Badge variant="secondary" className="bg-violet-500/15 text-violet-600">Driver</Badge>
+                                        )}
+                                    </div>
                                 </div>
                             </div>
 
@@ -510,31 +480,9 @@ export default function UsersPage() {
                                 </div>
                                 <div className="space-y-1">
                                     <Label className="text-xs text-muted-foreground flex items-center gap-1">
-                                        <MapPin className="h-3 w-3" /> City
-                                    </Label>
-                                    <p className="text-sm">{selectedUser.city || "N/A"}</p>
-                                </div>
-                                <div className="space-y-1">
-                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
                                         <Calendar className="h-3 w-3" /> Joined
                                     </Label>
                                     <p className="text-sm">{formatDate(selectedUser.created_at)}</p>
-                                </div>
-                            </div>
-
-                            <div className="border-t pt-4">
-                                <div className="grid grid-cols-2 gap-4">
-                                    <div className="rounded-lg bg-muted/50 p-3 text-center">
-                                        <p className="text-xs text-muted-foreground">Total Rides</p>
-                                        <p className="text-2xl font-bold">{selectedUser.total_rides || 0}</p>
-                                    </div>
-                                    <div className="rounded-lg bg-muted/50 p-3 text-center">
-                                        <p className="text-xs text-muted-foreground">Rating</p>
-                                        <p className="text-2xl font-bold flex items-center justify-center gap-1">
-                                            <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
-                                            {selectedUser.rating != null ? selectedUser.rating.toFixed(1) : "N/A"}
-                                        </p>
-                                    </div>
                                 </div>
                             </div>
 

--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import {
     Table,
@@ -66,6 +67,9 @@ export default function UsersPage() {
     const [showPii, setShowPii] = useState(false);
 
     const [pendingStatusChange, setPendingStatusChange] = useState<{ id: string; status: "suspended" | "banned"; name: string } | null>(null);
+    // Moderation note (required) + optional suspension length (days; "" = indefinite).
+    const [moderationReason, setModerationReason] = useState("");
+    const [moderationDays, setModerationDays] = useState<string>("");
     const [pendingWalletAction, setPendingWalletAction] = useState<{ action: "credit" | "debit"; amount: number; reason: string } | null>(null);
 
     // Wallet state for the user-details dialog
@@ -162,6 +166,8 @@ export default function UsersPage() {
                 is_rider: u.is_rider,
                 is_driver: u.is_driver,
                 status: u.status || "active",
+                status_reason: u.status_reason ?? null,
+                suspended_until: u.suspended_until ?? null,
             }));
             setUsers(transformed);
         } catch (err: any) {
@@ -365,6 +371,7 @@ export default function UsersPage() {
                                         <TableHead>Name</TableHead>
                                         <TableHead>Contact</TableHead>
                                         <TableHead>Role</TableHead>
+                                        <TableHead>Status</TableHead>
                                         <TableHead>Joined</TableHead>
                                         <TableHead className="text-right">Actions</TableHead>
                                     </TableRow>
@@ -372,7 +379,7 @@ export default function UsersPage() {
                                 <TableBody>
                                     {users.length === 0 ? (
                                         <TableRow>
-                                            <TableCell colSpan={5} className="text-center text-muted-foreground py-12">
+                                            <TableCell colSpan={6} className="text-center text-muted-foreground py-12">
                                                 No users found.
                                             </TableCell>
                                         </TableRow>
@@ -409,6 +416,17 @@ export default function UsersPage() {
                                                             <span className="text-muted-foreground">—</span>
                                                         )}
                                                     </div>
+                                                </TableCell>
+                                                <TableCell>
+                                                    <Badge className={
+                                                        user.status === "banned" ? "bg-red-500/15 text-red-600"
+                                                        : user.status === "suspended" ? "bg-amber-500/15 text-amber-600"
+                                                        : "bg-emerald-500/15 text-emerald-600"
+                                                    }>
+                                                        {user.status === "banned" ? "Banned"
+                                                        : user.status === "suspended" ? "Suspended"
+                                                        : "Active"}
+                                                    </Badge>
                                                 </TableCell>
                                                 <TableCell className="text-xs text-muted-foreground">
                                                     {formatDate(user.created_at)}
@@ -500,6 +518,20 @@ export default function UsersPage() {
                                         : "Active"}
                                     </Badge>
                                 </div>
+                                {selectedUser.status !== "active" && (selectedUser.status_reason || selectedUser.suspended_until) && (
+                                    <div className="mb-3 rounded-md bg-muted/50 p-2 text-xs space-y-0.5">
+                                        {selectedUser.status_reason && (
+                                            <p><span className="text-muted-foreground">Reason: </span>{selectedUser.status_reason}</p>
+                                        )}
+                                        {selectedUser.status === "suspended" && (
+                                            <p className="text-muted-foreground">
+                                                {selectedUser.suspended_until
+                                                    ? `Auto-lifts ${formatDate(selectedUser.suspended_until)}`
+                                                    : "Indefinite — until reactivated"}
+                                            </p>
+                                        )}
+                                    </div>
+                                )}
                                 <div className="flex gap-2">
                                     {selectedUser.status !== "active" && (
                                         <Button
@@ -774,7 +806,7 @@ export default function UsersPage() {
                 </AlertDialogContent>
             </AlertDialog>
 
-            <AlertDialog open={!!pendingStatusChange} onOpenChange={(open) => !open && setPendingStatusChange(null)}>
+            <AlertDialog open={!!pendingStatusChange} onOpenChange={(open) => { if (!open) { setPendingStatusChange(null); setModerationReason(""); setModerationDays(""); } }}>
                 <AlertDialogContent>
                     <AlertDialogHeader>
                         <AlertDialogTitle>
@@ -782,22 +814,70 @@ export default function UsersPage() {
                         </AlertDialogTitle>
                         <AlertDialogDescription>
                             {pendingStatusChange?.status === "banned"
-                                ? `${pendingStatusChange?.name} will be permanently banned and unable to book rides or log in.`
-                                : `${pendingStatusChange?.name} will be suspended and unable to book rides until reactivated.`}
+                                ? `${pendingStatusChange?.name} will be deactivated and unable to book rides until an admin reactivates the account.`
+                                : `${pendingStatusChange?.name} will be unable to book rides for the chosen period.`}
                         </AlertDialogDescription>
                     </AlertDialogHeader>
+
+                    <div className="space-y-3 py-1">
+                        <div className="space-y-1.5">
+                            <Label className="text-xs">Reason <span className="text-red-500">*</span></Label>
+                            <div className="flex flex-wrap gap-1.5">
+                                {["Payment / chargeback", "Safety report", "Policy violation", "Fraud / abuse"].map((r) => (
+                                    <button
+                                        key={r}
+                                        type="button"
+                                        onClick={() => setModerationReason(r)}
+                                        className="text-[11px] rounded-full border px-2 py-0.5 hover:bg-muted"
+                                    >
+                                        {r}
+                                    </button>
+                                ))}
+                            </div>
+                            <Textarea
+                                value={moderationReason}
+                                onChange={(e) => setModerationReason(e.target.value)}
+                                placeholder="Shown to the rider and recorded in the audit log."
+                                className="min-h-[72px] text-sm"
+                            />
+                        </div>
+                        {pendingStatusChange?.status === "suspended" && (
+                            <div className="space-y-1.5">
+                                <Label className="text-xs">Duration</Label>
+                                <Select value={moderationDays || "0"} onValueChange={(v) => setModerationDays(v === "0" ? "" : v)}>
+                                    <SelectTrigger className="h-9 text-sm"><SelectValue /></SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="0">Indefinite (until reactivated)</SelectItem>
+                                        <SelectItem value="1">24 hours</SelectItem>
+                                        <SelectItem value="7">7 days</SelectItem>
+                                        <SelectItem value="30">30 days</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        )}
+                    </div>
+
                     <AlertDialogFooter>
                         <AlertDialogCancel>Cancel</AlertDialogCancel>
                         <AlertDialogAction
                             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                            onClick={async () => {
+                            disabled={!moderationReason.trim() || statusUpdating === pendingStatusChange?.id}
+                            onClick={async (e) => {
                                 if (!pendingStatusChange) return;
-                                setStatusUpdating(pendingStatusChange.id);
+                                if (!moderationReason.trim()) { e.preventDefault(); return; }
+                                const change = pendingStatusChange;
+                                const reason = moderationReason.trim();
+                                const suspended_until =
+                                    change.status === "suspended" && moderationDays
+                                        ? new Date(Date.now() + Number(moderationDays) * 86400000).toISOString()
+                                        : undefined;
+                                setStatusUpdating(change.id);
                                 try {
-                                    await updateUserStatus(pendingStatusChange.id, { status: pendingStatusChange.status });
-                                    setSelectedUser((prev: any) => prev ? { ...prev, status: pendingStatusChange.status } : prev);
-                                    setUsers(prev => prev.map(u => u.id === pendingStatusChange.id ? { ...u, status: pendingStatusChange.status } : u));
-                                    toast({ title: `User ${pendingStatusChange.status === "banned" ? "banned" : "suspended"}` });
+                                    await updateUserStatus(change.id, { status: change.status, reason, suspended_until });
+                                    const patch = { status: change.status, status_reason: reason, suspended_until: suspended_until ?? null };
+                                    setSelectedUser((prev: any) => prev ? { ...prev, ...patch } : prev);
+                                    setUsers(prev => prev.map(u => u.id === change.id ? { ...u, ...patch } : u));
+                                    toast({ title: `User ${change.status === "banned" ? "banned" : "suspended"}` });
                                 } catch (err: any) {
                                     console.error('[UsersPage] Failed to update user status:', err);
                                     toast({ title: "Failed to update user status", description: err?.message, variant: "destructive" });
@@ -805,6 +885,8 @@ export default function UsersPage() {
                                     setStatusUpdating(null);
                                 }
                                 setPendingStatusChange(null);
+                                setModerationReason("");
+                                setModerationDays("");
                             }}
                         >
                             {pendingStatusChange?.status === "banned" ? "Ban user" : "Suspend user"}

--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -42,7 +42,7 @@ import { Pagination } from "@/components/ui/pagination";
 import { Users, Search, Mail, Phone, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff } from "lucide-react";
 import { exportToCsv } from "@/lib/export-csv";
 import { formatDate } from "@/lib/utils";
-import { getUsersPaginated, updateUserStatus, updateUserFlags, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
+import { getUsersPaginated, getUserDetails, updateUserStatus, updateUserFlags, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
 import { maskEmail, maskPhone } from "@/lib/pii";
 import { useRequireModule } from "@/hooks/useRequireModule";
 import { useToast } from "@/components/ui/use-toast";
@@ -59,6 +59,9 @@ export default function UsersPage() {
     const [statusUpdating, setStatusUpdating] = useState<string | null>(null);
     const [roleFilter, setRoleFilter] = useState<"all" | "rider" | "driver" | "both">("all");
     const [selectedUser, setSelectedUser] = useState<any>(null);
+    // Real lifetime ride count for the open user — the list row has no count
+    // (it's not a users column); the detail endpoint computes it on demand.
+    const [detailRides, setDetailRides] = useState<number | null>(null);
     const [page, setPage] = useState(0);
     const [hasNextPage, setHasNextPage] = useState(false);
     const [stats, setStats] = useState<{ total_users: number; total_drivers: number } | null>(null);
@@ -185,6 +188,19 @@ export default function UsersPage() {
     useEffect(() => {
         getStats().then((s) => setStats(s)).catch(() => setStats(null));
     }, []);
+
+    // Fetch the open user's real lifetime ride count (detail endpoint computes
+    // it from the rides table). Guarded against races when switching users.
+    useEffect(() => {
+        if (!selectedUser?.id) { setDetailRides(null); return; }
+        const id = selectedUser.id;
+        let active = true;
+        setDetailRides(null);
+        getUserDetails(id)
+            .then((d) => { if (active) setDetailRides(d?.total_rides ?? 0); })
+            .catch(() => {});
+        return () => { active = false; };
+    }, [selectedUser?.id]);
 
     // Reset to page 0 when filters change (debounce search).
     useEffect(() => {
@@ -421,10 +437,12 @@ export default function UsersPage() {
                                                     <Badge className={
                                                         user.status === "banned" ? "bg-red-500/15 text-red-600"
                                                         : user.status === "suspended" ? "bg-amber-500/15 text-amber-600"
+                                                        : user.status === "pending_deletion" ? "bg-orange-500/15 text-orange-600"
                                                         : "bg-emerald-500/15 text-emerald-600"
                                                     }>
                                                         {user.status === "banned" ? "Banned"
                                                         : user.status === "suspended" ? "Suspended"
+                                                        : user.status === "pending_deletion" ? "Pending deletion"
                                                         : "Active"}
                                                     </Badge>
                                                 </TableCell>
@@ -502,6 +520,12 @@ export default function UsersPage() {
                                     </Label>
                                     <p className="text-sm">{formatDate(selectedUser.created_at)}</p>
                                 </div>
+                                <div className="space-y-1">
+                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                        <Car className="h-3 w-3" /> Total rides
+                                    </Label>
+                                    <p className="text-sm">{detailRides == null ? "…" : detailRides.toLocaleString()}</p>
+                                </div>
                             </div>
 
                             {/* Status Management */}
@@ -511,10 +535,12 @@ export default function UsersPage() {
                                     <Badge className={
                                         selectedUser.status === "banned" ? "bg-red-500/15 text-red-600"
                                         : selectedUser.status === "suspended" ? "bg-amber-500/15 text-amber-600"
+                                        : selectedUser.status === "pending_deletion" ? "bg-orange-500/15 text-orange-600"
                                         : "bg-emerald-500/15 text-emerald-600"
                                     }>
                                         {selectedUser.status === "banned" ? "Banned"
                                         : selectedUser.status === "suspended" ? "Suspended"
+                                        : selectedUser.status === "pending_deletion" ? "Pending deletion"
                                         : "Active"}
                                     </Badge>
                                 </div>

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -347,6 +347,16 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to import stuck ride sweeper: {e}", exc_info=True)
 
+    # Auto-reactivation of expired temporary rider suspensions — flips status
+    # back to active once suspended_until passes so the admin list isn't stale.
+    # Atomic conditional update keeps it replay-safe across replicas.
+    try:
+        from utils.suspension_reactivation import suspension_reactivation_loop
+
+        _spawn("suspension_reactivation (10min)", suspension_reactivation_loop)
+    except Exception as e:
+        logger.error(f"Failed to import suspension reactivation loop: {e}", exc_info=True)
+
     # Push notification retry loop — re-attempts FCM/Expo deliveries for
     # dispatch and safety priority pushes that failed on first attempt.
     # Uses exponential back-off (60 s × 2^attempt) up to _MAX_ATTEMPTS=5.

--- a/backend/migrations/167_users_account_status.sql
+++ b/backend/migrations/167_users_account_status.sql
@@ -1,0 +1,59 @@
+-- 167_users_account_status.sql
+--
+-- Purpose:
+--   Add the rider account-moderation columns the app already expects but that
+--   were never created. routes/rides.py blocks booking for status in
+--   ('banned','suspended') and routes/admin/users.py writes `status` +
+--   `updated_at` — but `users` had no such columns, so the admin suspend/ban
+--   call 503'd (42703) and the booking gate silently treated everyone as
+--   'active'. This adds:
+--     status            active | suspended | banned | pending_deletion
+--     status_reason     why the account was suspended/banned (moderation note)
+--     status_changed_at when status last changed
+--     status_changed_by admin id that made the change
+--     suspended_until   optional auto-lift time for a *temporary* suspension
+--     updated_at        generic row-touched timestamp (also written elsewhere)
+--
+--   'pending_deletion' is included in the CHECK because the PIPEDA DSAR flow
+--   (routes/users.py DELETE /account, migration 66) sets it.
+--
+--   ADD COLUMN ... DEFAULT 'active' is a metadata-only change on PG11+ (no table
+--   rewrite); the CHECK is added NOT VALID then VALIDATE'd so it never blocks
+--   writes; the status index is partial + CONCURRENTLY (users is hot). The
+--   runner detects CONCURRENTLY and applies the file in autocommit mode.
+--
+-- RLS: users already has RLS; adding columns does not change it. The service
+-- role (backend) bypasses RLS; only the backend mutates status.
+--
+-- Rollback:
+--   ALTER TABLE users
+--     DROP COLUMN IF EXISTS status, DROP COLUMN IF EXISTS status_reason,
+--     DROP COLUMN IF EXISTS status_changed_at, DROP COLUMN IF EXISTS status_changed_by,
+--     DROP COLUMN IF EXISTS suspended_until, DROP COLUMN IF EXISTS updated_at;
+--   DROP INDEX IF EXISTS idx_users_status;
+--   (constraint users_status_check is dropped with the status column.)
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS status            TEXT NOT NULL DEFAULT 'active',
+    ADD COLUMN IF NOT EXISTS status_reason     TEXT,
+    ADD COLUMN IF NOT EXISTS status_changed_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS status_changed_by TEXT,
+    ADD COLUMN IF NOT EXISTS suspended_until   TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS updated_at        TIMESTAMPTZ;
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_status_check;
+ALTER TABLE users
+    ADD CONSTRAINT users_status_check
+    CHECK (status IN ('active', 'suspended', 'banned', 'pending_deletion')) NOT VALID;
+ALTER TABLE users VALIDATE CONSTRAINT users_status_check;
+
+-- Admin "suspended / banned" queue filter — partial index keeps it tiny.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_status
+    ON users (status) WHERE status <> 'active';
+
+COMMENT ON COLUMN users.status IS
+    'Account moderation state: active | suspended | banned | pending_deletion.';
+COMMENT ON COLUMN users.suspended_until IS
+    'For a temporary suspension: when it auto-lifts. NULL = indefinite (admin must reactivate).';
+
+NOTIFY pgrst, 'reload schema';

--- a/backend/migrations/168_users_updated_at_trigger.sql
+++ b/backend/migrations/168_users_updated_at_trigger.sql
@@ -1,0 +1,47 @@
+-- 168_users_updated_at_trigger.sql
+--
+-- Purpose:
+--   migration 167 added users.updated_at but it was nullable with no default
+--   and is only written by the admin endpoints — so legacy rows are NULL and
+--   non-admin writes (profile/phone updates in routes/users.py) never touch it,
+--   making `updated_at` an unreliable freshness signal (migration-reviewer W2).
+--
+--   This makes updated_at universal:
+--     1. DEFAULT now() so every new row gets a value.
+--     2. A BEFORE UPDATE trigger sets updated_at = now() on every row change,
+--        regardless of which code path made it.
+--     3. Backfill existing NULLs to created_at.
+--
+--   No CONCURRENTLY here, so the whole file runs in one transaction (atomic).
+--   The backfill is a single UPDATE over NULL rows only; at Spinr's user scale
+--   this is fast. If the users table is ever very large, run the backfill
+--   out-of-band in batches before applying the rest.
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_users_set_updated_at ON users;
+--   DROP FUNCTION IF EXISTS public.set_users_updated_at();
+--   ALTER TABLE users ALTER COLUMN updated_at DROP DEFAULT;
+
+ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT now();
+
+UPDATE users SET updated_at = COALESCE(created_at, now()) WHERE updated_at IS NULL;
+
+CREATE OR REPLACE FUNCTION public.set_users_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_users_set_updated_at ON users;
+CREATE TRIGGER trg_users_set_updated_at
+    BEFORE UPDATE ON users
+    FOR EACH ROW
+    EXECUTE FUNCTION public.set_users_updated_at();
+
+COMMENT ON FUNCTION public.set_users_updated_at() IS
+    'BEFORE UPDATE trigger fn: stamps users.updated_at = now() on every row change.';

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -30,11 +30,17 @@ router = APIRouter()
 # client-side. They must NOT be listed here — projecting a non-existent column
 # makes Postgres raise 42703 ("column does not exist") and the endpoint 503s.
 # The single-user detail endpoint (admin_get_user_details) still selects *.
-_USER_LIST_COLUMNS = "id,first_name,last_name,email,phone,role,created_at,is_rider,is_driver"
+_USER_LIST_COLUMNS = "id,first_name,last_name,email,phone,role,created_at,is_rider,is_driver,status,suspended_until"
 
 
 class UserStatusRequest(BaseModel):
     status: Literal["active", "suspended", "banned"]
+    # Moderation note — required when suspending or banning so the action is
+    # auditable (and shown back to the rider). Ignored when reactivating.
+    reason: Optional[str] = None
+    # Optional auto-lift time for a *temporary* suspension (ISO-8601). Omit for
+    # an indefinite suspension (admin must reactivate). Only used for 'suspended'.
+    suspended_until: Optional[str] = None
 
 
 # ---------- Users (riders) ----------
@@ -129,19 +135,54 @@ async def admin_get_user_details(user_id: str):
 
 @router.put("/users/{user_id}/status")
 async def admin_update_user_status(user_id: str, status_data: UserStatusRequest, admin: dict = Depends(get_admin_user)):
-    """Update user status (e.g., suspend, activate)."""
+    """Suspend, ban, or reactivate a rider account (Uber/Lyft-style moderation).
+
+    - suspended / banned require a `reason` (stored + audited + shown to the rider).
+    - `suspended_until` makes a suspension temporary (auto-lifts at booking time);
+      omit it for an indefinite suspension that an admin must reactivate.
+    - reactivating (status='active') clears the reason and the suspension timer.
+
+    Enforcement lives at booking time (routes/rides.py): suspended/banned riders
+    cannot request a ride.
+    """
     new_status = status_data.status
+    reason = (status_data.reason or "").strip()
 
     user = await db_supabase.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    old_status = user.get("status")
 
-    await db_supabase.update_one(
-        "users",
-        {"id": user_id},
-        {"status": new_status, "updated_at": datetime.now(timezone.utc).isoformat()},
-    )
+    if new_status in ("suspended", "banned") and not reason:
+        verb = "ban" if new_status == "banned" else "suspend"
+        raise HTTPException(status_code=422, detail=f"A reason is required to {verb} an account.")
+
+    old_status = user.get("status") or "active"
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    update: Dict[str, Any] = {
+        "status": new_status,
+        "status_changed_at": now_iso,
+        "status_changed_by": admin["id"],
+        "updated_at": now_iso,
+    }
+    if new_status == "active":
+        # Reactivation clears the moderation context.
+        update["status_reason"] = None
+        update["suspended_until"] = None
+    else:
+        update["status_reason"] = reason
+        # suspended_until only applies to a temporary suspension.
+        update["suspended_until"] = status_data.suspended_until if new_status == "suspended" else None
+
+    try:
+        await db_supabase.update_one("users", {"id": user_id}, update)
+    except Exception as e:
+        logger.error(
+            "Failed to update user status",
+            exc_info=True,
+            extra={"domain": "admin", "user_id": user_id, "new_status": new_status},
+        )
+        raise HTTPException(status_code=503, detail="Could not update account status.") from e
 
     await db_supabase.insert_one(
         "audit_logs",
@@ -149,15 +190,43 @@ async def admin_update_user_status(user_id: str, status_data: UserStatusRequest,
             "id": str(uuid.uuid4()),
             "actor_id": admin["id"],
             "actor_role": admin.get("role"),
-            "action": "status_change",
+            "action": "user_status_change",
             "entity_type": "user",
             "entity_id": user_id,
-            "details": {"old_status": old_status, "new_status": new_status},
-            "created_at": datetime.now(timezone.utc).isoformat(),
+            "details": {
+                "old_status": old_status,
+                "new_status": new_status,
+                "reason": reason or None,
+                "suspended_until": update.get("suspended_until"),
+            },
+            "created_at": now_iso,
         },
     )
 
-    return {"message": f"User status updated to {new_status}"}
+    # Best-effort: tell the rider their account state changed (never blocks the
+    # admin action if push delivery fails).
+    if new_status != old_status:
+        try:
+            try:
+                from ...features import send_push_notification
+            except ImportError:
+                from features import send_push_notification  # type: ignore
+            if new_status == "banned":
+                title, body = "Account deactivated", reason or "Your account has been deactivated. Contact support."
+            elif new_status == "suspended":
+                title, body = "Account suspended", reason or "Your account has been suspended. Contact support."
+            else:
+                title, body = "Account reactivated", "Your account is active again. Welcome back!"
+            await send_push_notification(user_id, title, body, data={"type": "account_status", "status": new_status})
+        except Exception:
+            logger.warning("account status push failed", exc_info=True, extra={"domain": "admin", "user_id": user_id})
+
+    return {
+        "message": f"User status updated to {new_status}",
+        "status": new_status,
+        "status_reason": update.get("status_reason"),
+        "suspended_until": update.get("suspended_until"),
+    }
 
 
 class UserFlagsRequest(BaseModel):

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -18,16 +18,19 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Columns the admin Users list / search / export actually render. We project
-# explicitly to keep users.profile_image OUT of these bulk reads: for accounts
-# created before the `profile-photos` storage bucket, profile_image holds a full
-# base64 data URI, so `SELECT *` shipped ~one image blob per row — that's the
-# multi-MB payload (and the slow DB read on the 1000-row export). The Users page
-# never displays an avatar, so the column is pure dead weight here. The single-
-# user detail endpoint (admin_get_user_details) still selects everything.
-_USER_LIST_COLUMNS = (
-    "id,first_name,last_name,email,phone,role,created_at,total_rides,rating,is_verified,city,status,is_rider,is_driver"
-)
+# Columns the admin Users list / search / export read that ACTUALLY EXIST on
+# the users table. We project explicitly to keep users.profile_image OUT of
+# these bulk reads: for accounts created before the `profile-photos` storage
+# bucket, profile_image holds a full base64 data URI, so `SELECT *` shipped ~one
+# image blob per row — that's the multi-MB payload (and the slow DB read on the
+# 1000-row export). The Users page never displays an avatar.
+#
+# NB: total_rides, rating, is_verified, city and status are NOT columns on the
+# users table (they're driver/derived fields); the frontend defaults them
+# client-side. They must NOT be listed here — projecting a non-existent column
+# makes Postgres raise 42703 ("column does not exist") and the endpoint 503s.
+# The single-user detail endpoint (admin_get_user_details) still selects *.
+_USER_LIST_COLUMNS = "id,first_name,last_name,email,phone,role,created_at,is_rider,is_driver"
 
 
 class UserStatusRequest(BaseModel):

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -166,9 +166,13 @@ async def admin_update_user_status(user_id: str, status_data: UserStatusRequest,
         "updated_at": now_iso,
     }
     if new_status == "active":
-        # Reactivation clears the moderation context.
+        # Reactivation clears the moderation context — and also any pending
+        # deletion, so an admin can honour a rider withdrawing their DSAR
+        # delete request within the 30-day grace window.
         update["status_reason"] = None
         update["suspended_until"] = None
+        update["deletion_requested_at"] = None
+        update["deletion_scheduled_at"] = None
     else:
         update["status_reason"] = reason
         # suspended_until only applies to a temporary suspension.

--- a/backend/routes/admin/users.py
+++ b/backend/routes/admin/users.py
@@ -30,7 +30,7 @@ router = APIRouter()
 # client-side. They must NOT be listed here — projecting a non-existent column
 # makes Postgres raise 42703 ("column does not exist") and the endpoint 503s.
 # The single-user detail endpoint (admin_get_user_details) still selects *.
-_USER_LIST_COLUMNS = "id,first_name,last_name,email,phone,role,created_at,is_rider,is_driver,status,suspended_until"
+_USER_LIST_COLUMNS = "id,first_name,last_name,email,phone,role,created_at,is_rider,is_driver,status,status_reason,suspended_until"
 
 
 class UserStatusRequest(BaseModel):

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -2053,13 +2053,27 @@ async def create_ride(
     if user_status == "banned":
         raise HTTPException(
             status_code=403,
-            detail="Your account has been suspended due to policy violations.",
+            detail=(rider_row or {}).get("status_reason")
+            or "Your account has been deactivated due to policy violations. Please contact support.",
         )
     if user_status == "suspended":
-        raise HTTPException(
-            status_code=403,
-            detail="Your account is currently suspended. Please contact support.",
-        )
+        # A temporary suspension (suspended_until set) auto-lifts once that time
+        # passes — the rider can book again without an admin reactivating.
+        suspended_until = (rider_row or {}).get("suspended_until")
+        still_suspended = True
+        if suspended_until:
+            try:
+                still_suspended = datetime.fromisoformat(
+                    str(suspended_until).replace("Z", "+00:00")
+                ) > datetime.now(timezone.utc)
+            except ValueError:
+                still_suspended = True
+        if still_suspended:
+            raise HTTPException(
+                status_code=403,
+                detail=(rider_row or {}).get("status_reason")
+                or "Your account is currently suspended. Please contact support.",
+            )
     if body.payment_method == "card" and not body.work_profile:
         if not rider_row or not rider_row.get("stripe_customer_id"):
             raise HTTPException(

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -221,10 +221,11 @@ class TestAdminUserStatus:
             patch("db_supabase.get_user_by_id", new_callable=AsyncMock, return_value=_FAKE_USER),
             patch("db_supabase.update_one", new_callable=AsyncMock, return_value=None),
             patch("db_supabase.insert_one", new_callable=AsyncMock, return_value={}),
+            patch("features.send_push_notification", new_callable=AsyncMock, create=True),
         ):
             resp = client.put(
                 "/api/admin/users/usr-1/status",
-                json={"status": "suspended"},
+                json={"status": "suspended", "reason": "Policy violation"},
             )
         assert resp.status_code == 200
 
@@ -239,16 +240,17 @@ class TestAdminUserStatus:
             patch("db_supabase.get_user_by_id", new_callable=AsyncMock, return_value=_FAKE_USER),
             patch("db_supabase.update_one", new_callable=AsyncMock, return_value=None),
             patch("db_supabase.insert_one", side_effect=_capture_insert),
+            patch("features.send_push_notification", new_callable=AsyncMock, create=True),
         ):
             resp = client.put(
                 "/api/admin/users/usr-1/status",
-                json={"status": "banned"},
+                json={"status": "banned", "reason": "Fraudulent chargebacks"},
             )
 
         assert resp.status_code == 200
         audit_rows = [r for r in inserted if r["table"] == "audit_logs"]
         assert len(audit_rows) == 1
-        assert audit_rows[0]["doc"]["action"] == "status_change"
+        assert audit_rows[0]["doc"]["action"] == "user_status_change"
         assert audit_rows[0]["doc"]["entity_id"] == "usr-1"
 
 
@@ -636,3 +638,64 @@ class TestAdminUsersProjection:
         with patch("db_supabase.get_rows", new_callable=AsyncMock, return_value=rows):
             resp = client.get("/api/admin/users?role=all&limit=51&offset=0")
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Rider account moderation (suspend / ban / reactivate). Feature added once the
+# users.status column existed (migration 167); enforced at booking in rides.py.
+# ---------------------------------------------------------------------------
+
+
+class TestAdminUserModeration:
+    _USER = {"id": "usr-1", "status": "active", "first_name": "Al", "last_name": "R"}
+
+    def test_suspend_without_reason_422(self, client):
+        with patch("db_supabase.get_user_by_id", new_callable=AsyncMock, return_value=self._USER):
+            resp = client.put("/api/admin/users/usr-1/status", json={"status": "suspended"})
+        assert resp.status_code == 422
+
+    def test_ban_without_reason_422(self, client):
+        with patch("db_supabase.get_user_by_id", new_callable=AsyncMock, return_value=self._USER):
+            resp = client.put("/api/admin/users/usr-1/status", json={"status": "banned"})
+        assert resp.status_code == 422
+
+    def test_suspend_with_reason_writes_metadata(self, client):
+        captured: dict = {}
+
+        async def _update(table, filt, payload):
+            captured.update(payload)
+
+        with (
+            patch("db_supabase.get_user_by_id", new_callable=AsyncMock, return_value=self._USER),
+            patch("db_supabase.update_one", new=AsyncMock(side_effect=_update)),
+            patch("db_supabase.insert_one", new_callable=AsyncMock, return_value={}),
+            patch("features.send_push_notification", new_callable=AsyncMock, create=True),
+        ):
+            resp = client.put(
+                "/api/admin/users/usr-1/status",
+                json={"status": "suspended", "reason": "Multiple chargebacks", "suspended_until": "2099-01-01T00:00:00+00:00"},
+            )
+        assert resp.status_code == 200
+        assert captured["status"] == "suspended"
+        assert captured["status_reason"] == "Multiple chargebacks"
+        assert captured["status_changed_by"] == _SUPER_ADMIN["id"]
+        assert captured["suspended_until"] == "2099-01-01T00:00:00+00:00"
+
+    def test_reactivate_clears_moderation(self, client):
+        captured: dict = {}
+
+        async def _update(table, filt, payload):
+            captured.update(payload)
+
+        suspended = {**self._USER, "status": "suspended", "status_reason": "x"}
+        with (
+            patch("db_supabase.get_user_by_id", new_callable=AsyncMock, return_value=suspended),
+            patch("db_supabase.update_one", new=AsyncMock(side_effect=_update)),
+            patch("db_supabase.insert_one", new_callable=AsyncMock, return_value={}),
+            patch("features.send_push_notification", new_callable=AsyncMock, create=True),
+        ):
+            resp = client.put("/api/admin/users/usr-1/status", json={"status": "active"})
+        assert resp.status_code == 200
+        assert captured["status"] == "active"
+        assert captured["status_reason"] is None
+        assert captured["suspended_until"] is None

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -699,3 +699,6 @@ class TestAdminUserModeration:
         assert captured["status"] == "active"
         assert captured["status_reason"] is None
         assert captured["suspended_until"] is None
+        # Reactivating also withdraws a pending DSAR deletion.
+        assert captured["deletion_requested_at"] is None
+        assert captured["deletion_scheduled_at"] is None

--- a/backend/tests/test_admin_business_logic.py
+++ b/backend/tests/test_admin_business_logic.py
@@ -610,3 +610,29 @@ class TestServiceAreaValidation:
         assert captured["surge_enabled"] is False
         assert captured["surge_active"] is False
         assert captured["surge_multiplier"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Admin Users list projection (regression: _USER_LIST_COLUMNS listed columns
+# that don't exist on the users table — total_rides/rating/is_verified/city/
+# status — so the projected SELECT raised Postgres 42703 and /users 503'd).
+# ---------------------------------------------------------------------------
+
+
+class TestAdminUsersProjection:
+    def test_projection_has_no_nonexistent_columns(self):
+        from routes.admin.users import _USER_LIST_COLUMNS
+
+        cols = set(_USER_LIST_COLUMNS.split(","))
+        # These are driver/derived fields the frontend defaults client-side;
+        # they are NOT columns on the users table and must never be projected.
+        forbidden = {"total_rides", "rating", "is_verified", "city", "status"}
+        assert not (cols & forbidden), f"non-existent users columns projected: {cols & forbidden}"
+        # profile_image (the heavy base64 blob) must stay excluded.
+        assert "profile_image" not in cols
+
+    def test_users_list_returns_200(self, client):
+        rows = [{"id": "u1", "first_name": "A", "last_name": "B", "phone": "+13065550001", "role": "rider"}]
+        with patch("db_supabase.get_rows", new_callable=AsyncMock, return_value=rows):
+            resp = client.get("/api/admin/users?role=all&limit=51&offset=0")
+        assert resp.status_code == 200

--- a/backend/tests/test_suspension_reactivation.py
+++ b/backend/tests/test_suspension_reactivation.py
@@ -1,0 +1,64 @@
+"""Auto-reactivation loop for expired temporary rider suspensions."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_reactivate_tick_flips_expired_suspension():
+    from utils.suspension_reactivation import _reactivate_tick
+
+    captured: dict = {}
+
+    async def _update(table, filt, fields):
+        captured["table"] = table
+        captured["filt"] = filt
+        captured["fields"] = fields
+        return [{"id": "u1"}]  # truthy → the conditional update "stuck"
+
+    audited: list = []
+
+    async def _insert(table, doc):
+        audited.append((table, doc))
+        return doc
+
+    with (
+        patch(
+            "db_supabase.get_rows",
+            new_callable=AsyncMock,
+            return_value=[{"id": "u1", "suspended_until": "2000-01-01T00:00:00+00:00"}],
+        ),
+        patch("db_supabase.update_one", new=AsyncMock(side_effect=_update)),
+        patch("db_supabase.insert_one", new=AsyncMock(side_effect=_insert)),
+    ):
+        await _reactivate_tick()
+
+    # Conditional, replay-safe filter + the active flip clearing the timer.
+    assert captured["filt"] == {"id": "u1", "status": "suspended"}
+    assert captured["fields"]["status"] == "active"
+    assert captured["fields"]["suspended_until"] is None
+    assert captured["fields"]["status_reason"] is None
+    assert captured["fields"]["status_changed_by"] == "system:auto_reactivation"
+    # Audited exactly once (only because the update returned a row).
+    assert [t for t, _ in audited] == ["audit_logs"]
+    assert audited[0][1]["details"]["new_status"] == "active"
+
+
+@pytest.mark.anyio
+async def test_reactivate_tick_skips_audit_when_update_lost_race():
+    from utils.suspension_reactivation import _reactivate_tick
+
+    with (
+        patch(
+            "db_supabase.get_rows",
+            new_callable=AsyncMock,
+            return_value=[{"id": "u1", "suspended_until": "2000-01-01T00:00:00+00:00"}],
+        ),
+        # Another replica already flipped it → conditional update matches nothing.
+        patch("db_supabase.update_one", new_callable=AsyncMock, return_value=None),
+        patch("db_supabase.insert_one", new_callable=AsyncMock) as mock_insert,
+    ):
+        await _reactivate_tick()
+
+    mock_insert.assert_not_called()

--- a/backend/utils/suspension_reactivation.py
+++ b/backend/utils/suspension_reactivation.py
@@ -1,0 +1,139 @@
+"""Auto-reactivation of expired temporary suspensions.
+
+A temporary rider suspension stores ``suspended_until``. The booking gate
+(routes/rides.py) already lets the rider book once that time passes, but the
+stored ``status`` stays 'suspended' until something flips it — so the admin
+Users list shows a stale "Suspended" badge. This loop closes that gap: it sets
+status back to 'active' (clearing the moderation context) once suspended_until
+has elapsed.
+
+Replay-safety (CLAUDE.md, Background loops):
+  - Redis leader lock (best-effort throttle across replicas).
+  - The flip is an ATOMIC conditional update filtered on status='suspended', so
+    if another replica already reactivated the row the update matches 0 rows —
+    no double-write, no double audit (we only audit when the update sticks).
+  - Indefinite suspensions (suspended_until IS NULL) never match the query and
+    are left untouched — only an admin reactivates those.
+"""
+
+import asyncio
+import logging
+import os
+import random
+import socket
+import uuid
+from datetime import datetime, timezone
+
+try:
+    from ..db import db
+    from .loop_monitor import record_heartbeat as _record_heartbeat
+    from .redis_client import redis_set_nx
+except ImportError:
+    from db import db  # type: ignore
+    from utils.redis_client import redis_set_nx  # type: ignore
+
+    try:
+        from utils.loop_monitor import record_heartbeat as _record_heartbeat  # type: ignore
+    except ImportError:  # pragma: no cover
+
+        def _record_heartbeat(name: str) -> None:  # type: ignore[misc]
+            pass
+
+
+logger = logging.getLogger(__name__)
+
+REACTIVATION_INTERVAL_SECONDS = 600  # 10 min — not time-critical (booking gate already lets them book)
+_LOOP_NAME = "suspension_reactivation (10min)"
+
+
+def _pod_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+async def _reactivate_tick() -> None:
+    """Flip expired temporary suspensions back to active."""
+    now = datetime.now(timezone.utc)
+    now_iso = now.isoformat()
+    try:
+        # suspended_until <= now naturally excludes indefinite (NULL) suspensions.
+        candidates = await db.get_rows(
+            "users",
+            {"status": "suspended", "suspended_until": {"$lte": now_iso}},
+            limit=500,
+            columns="id,suspended_until",
+        )
+    except Exception:
+        logger.error("[suspension-reactivation] failed to fetch candidates", exc_info=True, extra={"domain": "admin"})
+        return
+
+    for u in candidates or []:
+        uid = u.get("id")
+        if not uid:
+            continue
+        try:
+            # Atomic + idempotent: only flips if still 'suspended' (another
+            # replica racing this loses the filter and writes nothing).
+            updated = await db.update_one(
+                "users",
+                {"id": uid, "status": "suspended"},
+                {
+                    "status": "active",
+                    "status_reason": None,
+                    "suspended_until": None,
+                    "status_changed_at": now_iso,
+                    "status_changed_by": "system:auto_reactivation",
+                    "updated_at": now_iso,
+                },
+            )
+        except Exception:
+            logger.error(
+                "[suspension-reactivation] reactivate failed", exc_info=True, extra={"domain": "admin", "user_id": uid}
+            )
+            continue
+
+        # Only audit when our update actually took effect (some db wrappers
+        # return the row/list on success and None/[] when the filter matched
+        # nothing). Treat a falsy result as "another replica won" and skip.
+        if not updated:
+            continue
+        try:
+            await db.insert_one(
+                "audit_logs",
+                {
+                    "id": str(uuid.uuid4()),
+                    "actor_id": "system",
+                    "actor_role": "system",
+                    "action": "user_status_change",
+                    "entity_type": "user",
+                    "entity_id": uid,
+                    "details": {
+                        "old_status": "suspended",
+                        "new_status": "active",
+                        "reason": "temporary suspension expired",
+                        "suspended_until": u.get("suspended_until"),
+                    },
+                    "created_at": now_iso,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "[suspension-reactivation] audit insert failed", exc_info=True, extra={"domain": "admin", "user_id": uid}
+            )
+
+
+async def suspension_reactivation_loop() -> None:
+    """Background loop: reactivate expired temporary suspensions every interval."""
+    logger.info(f"Suspension reactivation loop started (interval={REACTIVATION_INTERVAL_SECONDS}s)")
+    while True:
+        lock_ttl = int(REACTIVATION_INTERVAL_SECONDS * 2)
+        if not await redis_set_nx("spinr:users:suspension_reactivation:lock", _pod_id(), lock_ttl):
+            _record_heartbeat(_LOOP_NAME)
+            await asyncio.sleep(REACTIVATION_INTERVAL_SECONDS)
+            continue
+        try:
+            await _reactivate_tick()
+        except Exception:
+            logger.error("Suspension reactivation loop error", exc_info=True)
+        _record_heartbeat(_LOOP_NAME)
+        delta = REACTIVATION_INTERVAL_SECONDS * 0.1
+        await asyncio.sleep(REACTIVATION_INTERVAL_SECONDS + random.uniform(-delta, delta))


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
