### PR TITLE
Stripe embedded onboarding + SIN collection + GST/HST payout gate

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     COOKIE_SECURE: bool = True  # HTTPS only in production
     COOKIE_HTTPONLY: bool = True  # JavaScript cannot read
     COOKIE_SAMESITE: str = "Strict"  # Prevent CSRF token leaks
-    COOKIE_DOMAIN: str = ""  # Set to ".spinrvm.ca" in production env vars for cross-subdomain support
+    COOKIE_DOMAIN: str = ""  # Set to ".spinr.ca" in production env vars for cross-subdomain support
     COOKIE_PATH: str = "/"  # Available to all routes
 
     # CORS settings

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -72,6 +72,13 @@ _APP_CHECK_EXEMPT_PREFIXES = (
     # with no App Check header. It is authorised instead by a short-TTL,
     # ride+driver-bound HMAC token in the query string (routes/offer_card.py).
     "/api/v1/offer-cards/",
+    # Stripe embedded onboarding: the driver app loads these inside a WebView
+    # (Stripe's connect.js page + its same-origin fetchClientSecret POST), which
+    # cannot attach the app's X-Firebase-AppCheck header. Alternative auth holds:
+    # /stripe-embedded is public and serves only the publishable key (no secret),
+    # and /stripe-account-session still requires the driver's JWT Bearer token.
+    "/api/v1/drivers/stripe-embedded",
+    "/api/v1/drivers/stripe-account-session",
 )
 
 
@@ -214,6 +221,37 @@ _DOCS_CSP = (
 
 _DOCS_PATHS = ("/docs", "/redoc", "/openapi.json")
 
+# The driver app's in-WebView Stripe onboarding page (GET .../stripe-embedded)
+# loads connect.js, mounts cross-origin Stripe iframes, posts back to our API,
+# and captures a camera photo for identity verification. The strict API CSP
+# (default-src 'none') + Permissions-Policy camera=() would render a blank page,
+# so this single server-rendered path gets a Stripe-scoped CSP and camera
+# delegation. Domains follow Stripe's embedded-components CSP guidance. The
+# inline <script>/<style> in the page is fully server-controlled (only the
+# public publishable key is injected, and it's <script>-escaped at render time),
+# so 'unsafe-inline' here is bounded.
+_STRIPE_EMBED_PATHS = ("/api/v1/drivers/stripe-embedded",)
+
+_STRIPE_EMBED_CSP = (
+    "default-src 'none'; "
+    "script-src 'self' 'unsafe-inline' https://connect-js.stripe.com https://*.js.stripe.com https://js.stripe.com; "
+    "style-src 'self' 'unsafe-inline' https://connect-js.stripe.com https://*.js.stripe.com; "
+    "frame-src https://connect-js.stripe.com https://*.js.stripe.com https://js.stripe.com "
+    "https://hooks.stripe.com https://m.stripe.network; "
+    "connect-src 'self' https://api.stripe.com https://connect-js.stripe.com https://*.js.stripe.com "
+    "https://merchant-ui-api.stripe.com https://m.stripe.network; "
+    "img-src 'self' data: https://*.stripe.com; "
+    "font-src 'self' data: https://*.js.stripe.com; "
+    "frame-ancestors 'none'; base-uri 'none'"
+)
+
+# Delegate camera to Stripe's identity-capture iframe (and self) ONLY on the
+# embedded path; every other path keeps camera=() from the base headers. If
+# Stripe serves the capture iframe from another origin, add it here.
+_STRIPE_EMBED_PERMISSIONS_POLICY = (
+    'camera=(self "https://js.stripe.com" "https://connect-js.stripe.com"), microphone=(), geolocation=(), payment=()'
+)
+
 
 def _apply_security_headers(response: Response, path: str, enable_hsts: bool) -> None:
     """Attach the baseline security headers to a response.
@@ -228,7 +266,10 @@ def _apply_security_headers(response: Response, path: str, enable_hsts: bool) ->
         # 1 year, include subdomains, eligible for preload.
         response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload"
 
-    if any(path.startswith(p) for p in _DOCS_PATHS):
+    if any(path.startswith(p) for p in _STRIPE_EMBED_PATHS):
+        response.headers["Content-Security-Policy"] = _STRIPE_EMBED_CSP
+        response.headers["Permissions-Policy"] = _STRIPE_EMBED_PERMISSIONS_POLICY
+    elif any(path.startswith(p) for p in _DOCS_PATHS):
         response.headers["Content-Security-Policy"] = _DOCS_CSP
     else:
         response.headers["Content-Security-Policy"] = _STRICT_CSP

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1941,6 +1941,11 @@ async def _ensure_stripe_account(driver: dict, user: dict, stripe_secret: str) -
     account_id = driver.get("stripe_account_id")
     if account_id:
         return account_id
+    # Idempotency key keyed on the driver makes concurrent / rapid-retry creates
+    # converge on ONE Express account instead of leaking duplicate orphans —
+    # the embedded onboarding's fetchClientSecret can fire this twice before the
+    # first write lands. It also lets a retry recover a create whose DB write
+    # below failed (same key → same account within Stripe's 24h window).
     account = stripe.Account.create(
         type="express",
         country="CA",
@@ -1948,8 +1953,17 @@ async def _ensure_stripe_account(driver: dict, user: dict, stripe_secret: str) -
         capabilities={"transfers": {"requested": True}},
         business_type="individual",
         api_key=stripe_secret,
+        idempotency_key=f"connect-acct-{driver['id']}",
     )
-    await db_supabase.update_one("drivers", {"id": driver["id"]}, {"stripe_account_id": account.id})
+    try:
+        await db_supabase.update_one("drivers", {"id": driver["id"]}, {"stripe_account_id": account.id})
+    except Exception as e:
+        # Never return an unpersisted account id — payouts read the DB column, so
+        # a lost write would strand the driver on an account nothing points to.
+        # Surface loudly; a retry re-creates with the same idempotency key and
+        # converges on this same account, then persists it.
+        logger.error("Failed to persist stripe_account_id", exc_info=True)
+        raise HTTPException(status_code=502, detail="Could not start verification. Please try again.") from e
     return account.id
 
 
@@ -2011,8 +2025,12 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
         # which mis-classified every driver who abandoned Stripe's hosted
         # flow halfway through as fully onboarded. Removed.
         return {"url": account_link.url, "mock": False}
+    except HTTPException:
+        # Preserve the helper's 502 (e.g. failed stripe_account_id persist)
+        # instead of masking it as a generic 500.
+        raise
     except Exception as e:
-        logger.error(f"Stripe error: {e}")
+        logger.error("Stripe onboarding error", exc_info=True)
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
 
@@ -2117,7 +2135,7 @@ async def stripe_account_session(current_user: dict = Depends(get_current_user))
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Stripe AccountSession error: {e}")
+        logger.error("Stripe AccountSession error", exc_info=True)
         raise HTTPException(status_code=502, detail="Could not start verification. Please try again.") from e
 
 
@@ -2189,7 +2207,21 @@ def _stripe_embedded_page(publishable_key: str) -> str:
     the WebView via injectedJavaScriptBeforeContentLoaded (window.__SPINR_TOKEN),
     never placed in the URL or server logs. setCollectionOptions mirrors the
     hosted flow so the SIN (eventually/future-due) is collected up front."""
-    return _STRIPE_EMBEDDED_HTML.replace("__SPINR_PK__", json.dumps(publishable_key))
+    # The publishable key comes from the admin-writable app_settings table, so
+    # treat it as untrusted: plain json.dumps does NOT escape </script>, which
+    # would let a tampered value break out of the inline <script> (stored XSS
+    # that could read window.__SPINR_TOKEN). Escape the HTML-significant chars
+    # to their \uXXXX forms — still a valid JS string literal, no breakout.
+    safe_pk = json.dumps(publishable_key)
+    for _ch, _esc in (
+        ("<", "\\u003c"),
+        (">", "\\u003e"),
+        ("&", "\\u0026"),
+        ("\u2028", "\\u2028"),  # JS line separator — illegal raw in a string literal
+        ("\u2029", "\\u2029"),  # JS paragraph separator
+    ):
+        safe_pk = safe_pk.replace(_ch, _esc)
+    return _STRIPE_EMBEDDED_HTML.replace("__SPINR_PK__", safe_pk)
 
 
 @api_router.get("/stripe-embedded", include_in_schema=False)

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1,5 +1,6 @@
 import asyncio
 import hmac
+import json
 import logging
 import os
 import socket
@@ -1932,6 +1933,25 @@ async def get_bank_account(current_user: dict = Depends(get_current_user)):
     return {"has_bank_account": False, "bank_account": None}
 
 
+async def _ensure_stripe_account(driver: dict, user: dict, stripe_secret: str) -> str:
+    """Return the driver's Stripe Connect (Express) account id, creating it on
+    first use. Shared by the hosted-link and embedded-onboarding flows so both
+    converge on a single CA individual Express account per driver."""
+    account_id = driver.get("stripe_account_id")
+    if account_id:
+        return account_id
+    account = stripe.Account.create(
+        type="express",
+        country="CA",
+        email=user.get("email"),
+        capabilities={"transfers": {"requested": True}},
+        business_type="individual",
+        api_key=stripe_secret,
+    )
+    await db_supabase.update_one("drivers", {"id": driver["id"]}, {"stripe_account_id": account.id})
+    return account.id
+
+
 @api_router.post("/stripe-onboard")
 async def onboard_stripe(current_user: dict = Depends(get_current_user)):
     driver = (lambda _r: _r[0] if _r else None)(
@@ -1952,21 +1972,7 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
         return {"url": "https://spinr-demo-onboard.com", "mock": True}
 
     try:
-        account_id = driver.get("stripe_account_id")
-
-        if not account_id:
-            account = stripe.Account.create(
-                type="express",
-                country="CA",
-                email=user.get("email"),
-                capabilities={
-                    "transfers": {"requested": True},
-                },
-                business_type="individual",
-                api_key=stripe_secret,
-            )
-            account_id = account.id
-            await db_supabase.update_one("drivers", {"id": driver["id"]}, {"stripe_account_id": account_id})
+        account_id = await _ensure_stripe_account(driver, user, stripe_secret)
 
         # Build return/refresh URLs from the externally-routable API host
         # (Cloudflare CNAME), NOT the app_settings dict. The dict has no
@@ -2063,6 +2069,140 @@ async def stripe_refresh() -> HTMLResponse:
             "Return to the Spinr Driver app and tap Connect again to continue.",
         )
     )
+
+
+@api_router.post("/stripe-account-session")
+async def stripe_account_session(current_user: dict = Depends(get_current_user)) -> dict:
+    """Mint a single-use Stripe AccountSession client secret for the embedded
+    account-onboarding component (Option B — fully in-app, no browser redirect).
+
+    The connected account collects and *holds* the SIN itself; we never see the
+    raw value, preserving the PIPEDA posture (only last-4 + status is mirrored
+    back via the account.updated webhook). Called repeatedly by the WebView's
+    fetchClientSecret callback, so it must stay cheap and idempotent."""
+    driver = (lambda _r: _r[0] if _r else None)(
+        await db_supabase.get_rows("drivers", {"user_id": current_user.get("id")}, limit=1)
+    )
+    user = await db_supabase.get_user_by_id(current_user.get("id"))
+    if not driver or not user:
+        raise HTTPException(status_code=404, detail="Driver/User profile not found")
+
+    try:
+        from ..settings_loader import get_app_settings
+    except ImportError:
+        from settings_loader import get_app_settings
+    settings = await get_app_settings()
+    stripe_secret = settings.get("stripe_secret_key", "")
+    if not stripe_secret:
+        # Dev/demo: Stripe not configured. 503 lets the WebView surface a clean
+        # "not available yet" state instead of a blank embedded component.
+        raise HTTPException(status_code=503, detail="Stripe is not configured")
+
+    try:
+        account_id = await _ensure_stripe_account(driver, user, stripe_secret)
+        session = stripe.AccountSession.create(
+            account=account_id,
+            components={
+                "account_onboarding": {
+                    "enabled": True,
+                    # Let the driver add their payout bank account inside the
+                    # same embedded flow.
+                    "features": {"external_account_collection": True},
+                },
+            },
+            api_key=stripe_secret,
+        )
+        return {"client_secret": session.client_secret}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Stripe AccountSession error: {e}")
+        raise HTTPException(status_code=502, detail="Could not start verification. Please try again.") from e
+
+
+# Plain template (NOT an f-string) so the embedded JS braces stay literal.
+# __SPINR_PK__ is substituted with json.dumps(publishable_key) at render time.
+_STRIPE_EMBEDDED_HTML = """<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+<title>Spinr Driver — Verification</title>
+<style>
+  html,body{margin:0;height:100%;background:#0f0f10;
+    font-family:-apple-system,Segoe UI,Roboto,sans-serif}
+  #msg{color:#bdbdbd;padding:28px;text-align:center;font-size:15px}
+  #container{padding:0 4px}
+</style></head>
+<body>
+  <div id="msg">Loading secure verification…</div>
+  <div id="container"></div>
+  <script>
+    var PK = __SPINR_PK__;
+    function post(m){ if(window.ReactNativeWebView){ window.ReactNativeWebView.postMessage(m); } }
+    async function fetchClientSecret(){
+      var token = window.__SPINR_TOKEN || "";
+      var res = await fetch("/api/drivers/stripe-account-session", {
+        method: "POST",
+        headers: { "Authorization": "Bearer " + token, "Content-Type": "application/json" }
+      });
+      if(!res.ok){ post("error:" + res.status); throw new Error("account_session " + res.status); }
+      var data = await res.json();
+      return data.client_secret;
+    }
+    function mount(){
+      try{
+        var instance = StripeConnect.init({
+          publishableKey: PK,
+          fetchClientSecret: fetchClientSecret,
+          appearance: { variables: {
+            colorBackground: "#0f0f10", colorText: "#ffffff",
+            colorPrimary: "#16a34a", colorSecondaryText: "#bdbdbd" } }
+        });
+        var onboarding = instance.create("account-onboarding");
+        // Mirror the hosted flow: collect eventually/future-due fields up front
+        // so the SIN (individual.id_number) is requested during onboarding.
+        onboarding.setCollectionOptions({ fields: "eventually_due", futureRequirements: "include" });
+        onboarding.setOnExit(function(){ post("exit"); });
+        document.getElementById("msg").style.display = "none";
+        document.getElementById("container").appendChild(onboarding);
+      }catch(e){ post("error:init"); }
+    }
+    if(!PK){ document.getElementById("msg").textContent =
+      "Payouts setup is not available yet. Please try again later."; }
+    else {
+      window.StripeConnect = window.StripeConnect || {};
+      // connect.js calls StripeConnect.onLoad once the script finishes loading.
+      if(window.StripeConnect && typeof window.StripeConnect.init === "function"){ mount(); }
+      else { window.StripeConnect.onLoad = mount; }
+    }
+  </script>
+  <script src="https://connect-js.stripe.com/v1.0/connect.js" async></script>
+</body></html>"""
+
+
+def _stripe_embedded_page(publishable_key: str) -> str:
+    """HTML shell that mounts Stripe's embedded account-onboarding component.
+
+    Served same-origin with the API so the in-page fetchClientSecret POST to
+    /stripe-account-session needs no CORS. The page carries only the publishable
+    key (public by design); the driver's bearer token is injected at runtime by
+    the WebView via injectedJavaScriptBeforeContentLoaded (window.__SPINR_TOKEN),
+    never placed in the URL or server logs. setCollectionOptions mirrors the
+    hosted flow so the SIN (eventually/future-due) is collected up front."""
+    return _STRIPE_EMBEDDED_HTML.replace("__SPINR_PK__", json.dumps(publishable_key))
+
+
+@api_router.get("/stripe-embedded", include_in_schema=False)
+async def stripe_embedded() -> HTMLResponse:
+    """Public HTML host for the embedded onboarding WebView. Contains no secret
+    (publishable key only); all privileged work goes through the authenticated
+    /stripe-account-session endpoint the page calls back into."""
+    try:
+        from ..settings_loader import get_app_settings
+    except ImportError:
+        from settings_loader import get_app_settings
+    settings = await get_app_settings()
+    publishable_key = settings.get("stripe_publishable_key", "")
+    return HTMLResponse(_stripe_embedded_page(publishable_key))
 
 
 @api_router.post("/bank-account")
@@ -2552,7 +2692,6 @@ async def export_driver_data(
 async def _build_and_email_data_export(user_id: str, email: str) -> None:
     """Background task: collect all driver data and email a JSON export."""
     import asyncio  # noqa: PLC0415
-    import json  # noqa: PLC0415
 
     try:
         # B-P2-6: PIPEDA right-to-access has a 30-day SLA but riders/drivers

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1988,8 +1988,8 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
 
         account_link = stripe.AccountLink.create(
             account=account_id,
-            refresh_url=f"{api_base}/api/drivers/stripe-refresh",
-            return_url=f"{api_base}/api/drivers/stripe-return",
+            refresh_url=f"{api_base}/api/v1/drivers/stripe-refresh",
+            return_url=f"{api_base}/api/v1/drivers/stripe-return",
             type="account_onboarding",
             # Pull everything Stripe will *eventually* require into this session —
             # most importantly the SIN (individual.id_number), which for a CA
@@ -2140,7 +2140,7 @@ _STRIPE_EMBEDDED_HTML = """<!doctype html>
     function post(m){ if(window.ReactNativeWebView){ window.ReactNativeWebView.postMessage(m); } }
     async function fetchClientSecret(){
       var token = window.__SPINR_TOKEN || "";
-      var res = await fetch("/api/drivers/stripe-account-session", {
+      var res = await fetch("/api/v1/drivers/stripe-account-session", {
         method: "POST",
         headers: { "Authorization": "Bearer " + token, "Content-Type": "application/json" }
       });

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -1988,9 +1988,14 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
             # Pull everything Stripe will *eventually* require into this session —
             # most importantly the SIN (individual.id_number), which for a CA
             # Express individual account is "eventually_due" and is otherwise
-            # skipped at initial onboarding. Needed for T4A / CRA platform
-            # reporting (Income Tax Act Part XX).
-            collection_options={"fields": "eventually_due"},
+            # skipped at initial onboarding. future_requirements="include" also
+            # pulls in threshold-gated requirements (Stripe often defers the full
+            # SIN until a CAD payout volume threshold). Needed for T4A / CRA
+            # platform reporting (Income Tax Act Part XX).
+            collection_options={
+                "fields": "eventually_due",
+                "future_requirements": "include",
+            },
             api_key=stripe_secret,
         )
         # The real onboarded gate is now stripe_details_submitted, set by

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -3,6 +3,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import socket
 from datetime import datetime, timedelta, timezone
 from decimal import ROUND_HALF_UP, Decimal
@@ -2248,6 +2249,34 @@ async def delete_bank_account(current_user: dict = Depends(get_current_user)):
     return {"success": True}
 
 
+_GST_BN_RE = re.compile(r"^\d{9}(RT\d{4})?$")
+
+
+def _gst_on_file(driver: dict) -> bool:
+    """True when the driver has a CRA Business Number on file in a valid format
+    (9-digit BN, optionally with the RTxxxx GST/HST program suffix).
+
+    Rideshare drivers must register for GST/HST with the CRA from their first
+    fare — the $30k small-supplier exemption does NOT apply to ride-sharing
+    (Excise Tax Act "taxi business" definition). So a valid BN is a hard
+    precondition for any payout, scheduled or instant."""
+    bn = (driver.get("gst_bn") or "").replace(" ", "").upper()
+    return bool(_GST_BN_RE.match(bn))
+
+
+def _require_gst_for_payout(driver: dict) -> None:
+    """Block payout until the driver's GST/HST Business Number is on file."""
+    if not _gst_on_file(driver):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "A valid GST/HST Business Number is required before you can be paid. "
+                "Rideshare drivers must register for GST/HST with the CRA from their "
+                "first fare. Add your 9-digit Business Number in Payouts to continue."
+            ),
+        )
+
+
 @api_router.post("/payouts")
 @idempotent_endpoint(scope="driver_payout")
 async def request_payout(
@@ -2260,6 +2289,9 @@ async def request_payout(
     )
     if not driver:
         raise HTTPException(status_code=404, detail="Driver profile not found")
+
+    # CRA: rideshare drivers must be GST/HST-registered from their first fare.
+    _require_gst_for_payout(driver)
 
     balance = await get_driver_balance(current_user)
     if req.amount > Decimal(balance.get("payable_balance", "0")):
@@ -2386,6 +2418,9 @@ async def request_instant_payout(
     )
     if not driver:
         raise HTTPException(status_code=404, detail="Driver profile not found")
+
+    # CRA: rideshare drivers must be GST/HST-registered from their first fare.
+    _require_gst_for_payout(driver)
 
     fee = compute_instant_payout_fee(req.amount)
     net_amount = req.amount - fee

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -18,6 +18,7 @@ from fastapi import (
     Query,
     Request,
 )
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 try:
@@ -1967,11 +1968,29 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
             account_id = account.id
             await db_supabase.update_one("drivers", {"id": driver["id"]}, {"stripe_account_id": account_id})
 
+        # Build return/refresh URLs from the externally-routable API host
+        # (Cloudflare CNAME), NOT the app_settings dict. The dict has no
+        # "base_url" key, so the old code always fell back to localhost:8000 —
+        # which is why drivers landed on http://localhost:8000/api/drivers/...
+        # after finishing Stripe's hosted flow. An explicit app_settings
+        # "base_url" still wins if an operator sets one.
+        try:
+            from ..core.config import settings as _config
+        except ImportError:
+            from core.config import settings as _config  # type: ignore
+        api_base = (settings.get("base_url") or _config.PUBLIC_API_BASE_URL).rstrip("/")
+
         account_link = stripe.AccountLink.create(
             account=account_id,
-            refresh_url=f"{settings.get('base_url', 'http://localhost:8000')}/api/drivers/stripe-refresh",
-            return_url=f"{settings.get('base_url', 'http://localhost:8000')}/api/drivers/stripe-return",
+            refresh_url=f"{api_base}/api/drivers/stripe-refresh",
+            return_url=f"{api_base}/api/drivers/stripe-return",
             type="account_onboarding",
+            # Pull everything Stripe will *eventually* require into this session —
+            # most importantly the SIN (individual.id_number), which for a CA
+            # Express individual account is "eventually_due" and is otherwise
+            # skipped at initial onboarding. Needed for T4A / CRA platform
+            # reporting (Income Tax Act Part XX).
+            collection_options={"fields": "eventually_due"},
             api_key=stripe_secret,
         )
         # The real onboarded gate is now stripe_details_submitted, set by
@@ -1983,6 +2002,62 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
     except Exception as e:
         logger.error(f"Stripe error: {e}")
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
+
+
+# Driver-app deep link (scheme defined in driver-app/app.config.ts: SCHEME).
+_STRIPE_RETURN_DEEP_LINK = "spinr-driver://driver/payout"
+
+
+def _stripe_bounce_page(deep_link: str, heading: str, body: str) -> str:
+    """HTML interstitial that bounces the system browser back into the Spinr
+    Driver app. A raw 302 to a custom scheme is unreliable on iOS Safari, so we
+    auto-attempt the deep link and also render a manual button as a fallback."""
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Spinr Driver</title>
+<style>
+  body{{font-family:-apple-system,Segoe UI,Roboto,sans-serif;background:#0f0f10;color:#fff;
+       display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0;text-align:center}}
+  .card{{padding:32px;max-width:360px}}
+  h1{{font-size:20px;margin:0 0 8px}} p{{color:#bdbdbd;margin:0 0 24px}}
+  a.btn{{display:inline-block;background:#16a34a;color:#fff;text-decoration:none;
+         padding:14px 24px;border-radius:12px;font-weight:600}}
+</style></head>
+<body><div class="card">
+  <h1>{heading}</h1><p>{body}</p>
+  <a class="btn" href="{deep_link}">Return to Spinr Driver</a>
+</div>
+<script>setTimeout(function(){{window.location.replace("{deep_link}")}},150);</script>
+</body></html>"""
+
+
+@api_router.get("/stripe-return", include_in_schema=False)
+async def stripe_return() -> HTMLResponse:
+    """Stripe redirects the browser here when the driver finishes (or exits)
+    hosted onboarding. Bounces back into the app, which re-reads KYC status on
+    focus. The authoritative onboarding gate is the account.updated webhook
+    (services/stripe_kyc_sync.py) — this endpoint is UX only, never a trust gate."""
+    return HTMLResponse(
+        _stripe_bounce_page(
+            f"{_STRIPE_RETURN_DEEP_LINK}?stripe=return",
+            "Verification submitted",
+            "You can return to the Spinr Driver app now.",
+        )
+    )
+
+
+@api_router.get("/stripe-refresh", include_in_schema=False)
+async def stripe_refresh() -> HTMLResponse:
+    """Stripe redirects here when an onboarding link expires or is reopened.
+    Sends the driver back into the app, which restarts onboarding on demand."""
+    return HTMLResponse(
+        _stripe_bounce_page(
+            f"{_STRIPE_RETURN_DEEP_LINK}?stripe=refresh",
+            "Link expired",
+            "Return to the Spinr Driver app and tap Connect again to continue.",
+        )
+    )
 
 
 @api_router.post("/bank-account")

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1241,3 +1241,100 @@ class TestStripeOnboarding:
         body = resp.body.decode()
         assert resp.status_code == 200
         assert "spinr-driver://driver/payout?stripe=refresh" in body
+
+
+# ---------------------------------------------------------------------------
+# Stripe embedded onboarding (Option B) — AccountSession + WebView host page
+# ---------------------------------------------------------------------------
+
+
+class TestStripeEmbeddedOnboarding:
+    def test_account_session_returns_client_secret(self):
+        from backend.routes import drivers as drv
+
+        fake_session = type("S", (), {"client_secret": "accs_secret_123"})()
+        captured: dict = {}
+
+        def _session_create(**kwargs):
+            captured.update(kwargs)
+            return fake_session
+
+        with (
+            patch(
+                "backend.routes.drivers.db_supabase.get_rows",
+                AsyncMock(return_value=[_driver(stripe_account_id="acct_123")]),
+            ),
+            patch(
+                "backend.routes.drivers.db_supabase.get_user_by_id",
+                AsyncMock(return_value={"id": USER_ID, "email": "drv@example.com"}),
+            ),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": "sk_test_x"}),
+                create=True,
+            ),
+            patch("backend.routes.drivers.stripe.AccountSession.create", _session_create),
+        ):
+            result = asyncio.run(drv.stripe_account_session(current_user={"id": USER_ID}))
+
+        assert result == {"client_secret": "accs_secret_123"}
+        # account_onboarding component must be enabled for the embedded flow.
+        assert captured["components"]["account_onboarding"]["enabled"] is True
+
+    def test_account_session_503_when_stripe_unconfigured(self):
+        from fastapi import HTTPException
+
+        from backend.routes import drivers as drv
+
+        with (
+            patch(
+                "backend.routes.drivers.db_supabase.get_rows",
+                AsyncMock(return_value=[_driver()]),
+            ),
+            patch(
+                "backend.routes.drivers.db_supabase.get_user_by_id",
+                AsyncMock(return_value={"id": USER_ID, "email": "drv@example.com"}),
+            ),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": ""}),
+                create=True,
+            ),
+        ):
+            with pytest.raises(HTTPException) as ei:
+                asyncio.run(drv.stripe_account_session(current_user={"id": USER_ID}))
+        assert ei.value.status_code == 503
+
+    def test_embedded_page_serves_connect_js_and_publishable_key(self):
+        from backend.routes import drivers as drv
+
+        with patch(
+            "backend.settings_loader.get_app_settings",
+            AsyncMock(return_value={"stripe_publishable_key": "pk_test_pub42"}),
+            create=True,
+        ):
+            resp = asyncio.run(drv.stripe_embedded())
+
+        body = resp.body.decode()
+        assert resp.status_code == 200
+        assert "connect-js.stripe.com/v1.0/connect.js" in body
+        assert '"pk_test_pub42"' in body  # injected as a JS string literal
+        assert "/api/drivers/stripe-account-session" in body
+        # SIN-forcing collection options carried into the embedded component.
+        assert 'futureRequirements: "include"' in body
+
+    def test_embedded_page_has_no_secret_key(self):
+        from backend.routes import drivers as drv
+
+        with patch(
+            "backend.settings_loader.get_app_settings",
+            AsyncMock(
+                return_value={
+                    "stripe_publishable_key": "pk_test_pub42",
+                    "stripe_secret_key": "sk_test_SHOULD_NOT_LEAK",
+                }
+            ),
+            create=True,
+        ):
+            resp = asyncio.run(drv.stripe_embedded())
+        assert "sk_test_SHOULD_NOT_LEAK" not in resp.body.decode()

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1212,8 +1212,8 @@ class TestStripeOnboarding:
         # The headline bug: must NOT fall back to localhost.
         assert "localhost" not in captured["return_url"]
         assert "localhost" not in captured["refresh_url"]
-        assert captured["return_url"] == "https://api-spinr.spinr.ca/api/drivers/stripe-return"
-        assert captured["refresh_url"] == "https://api-spinr.spinr.ca/api/drivers/stripe-refresh"
+        assert captured["return_url"] == "https://api-spinr.spinr.ca/api/v1/drivers/stripe-return"
+        assert captured["refresh_url"] == "https://api-spinr.spinr.ca/api/v1/drivers/stripe-refresh"
 
     def test_onboarding_collects_sin_eventually_due(self):
         captured: dict = {}
@@ -1319,7 +1319,7 @@ class TestStripeEmbeddedOnboarding:
         assert resp.status_code == 200
         assert "connect-js.stripe.com/v1.0/connect.js" in body
         assert '"pk_test_pub42"' in body  # injected as a JS string literal
-        assert "/api/drivers/stripe-account-session" in body
+        assert "/api/v1/drivers/stripe-account-session" in body
         # SIN-forcing collection options carried into the embedded component.
         assert 'futureRequirements: "include"' in body
 

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1168,3 +1168,72 @@ class TestGetCurrentSubscription:
             result = asyncio.run(drv.get_current_subscription(current_user={"id": USER_ID}))
 
         assert result["has_subscription"] is False
+
+
+# ---------------------------------------------------------------------------
+# Stripe Connect onboarding — return URL + SIN collection regression
+# (bugfix: onboarding redirected to localhost:8000 and never collected SIN)
+# ---------------------------------------------------------------------------
+
+
+class TestStripeOnboarding:
+    def _run_onboard(self, captured):
+        from backend.routes import drivers as drv
+
+        fake_link = type("L", (), {"url": "https://connect.stripe.com/setup/x"})()
+
+        def _account_link_create(**kwargs):
+            captured.update(kwargs)
+            return fake_link
+
+        with (
+            patch(
+                "backend.routes.drivers.db_supabase.get_rows",
+                AsyncMock(return_value=[_driver(stripe_account_id="acct_123")]),
+            ),
+            patch(
+                "backend.routes.drivers.db_supabase.get_user_by_id",
+                AsyncMock(return_value={"id": USER_ID, "email": "drv@example.com"}),
+            ),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": "sk_test_x"}),
+                create=True,
+            ),
+            patch("backend.routes.drivers.stripe.AccountLink.create", _account_link_create),
+        ):
+            return asyncio.run(drv.onboard_stripe(current_user={"id": USER_ID}))
+
+    def test_return_url_uses_public_api_host_not_localhost(self):
+        captured: dict = {}
+        result = self._run_onboard(captured)
+
+        assert result["mock"] is False
+        # The headline bug: must NOT fall back to localhost.
+        assert "localhost" not in captured["return_url"]
+        assert "localhost" not in captured["refresh_url"]
+        assert captured["return_url"] == "https://api-spinr.spinr.ca/api/drivers/stripe-return"
+        assert captured["refresh_url"] == "https://api-spinr.spinr.ca/api/drivers/stripe-refresh"
+
+    def test_onboarding_collects_sin_eventually_due(self):
+        captured: dict = {}
+        self._run_onboard(captured)
+        # SIN (individual.id_number) is eventually_due for CA Express individuals;
+        # forcing eventually_due pulls it into the onboarding session.
+        assert captured["collection_options"] == {"fields": "eventually_due"}
+
+    def test_return_endpoint_bounces_into_driver_app(self):
+        from backend.routes import drivers as drv
+
+        resp = asyncio.run(drv.stripe_return())
+        body = resp.body.decode()
+        assert resp.status_code == 200
+        assert "spinr-driver://driver/payout?stripe=return" in body
+
+    def test_refresh_endpoint_bounces_into_driver_app(self):
+        from backend.routes import drivers as drv
+
+        resp = asyncio.run(drv.stripe_refresh())
+        body = resp.body.decode()
+        assert resp.status_code == 200
+        assert "spinr-driver://driver/payout?stripe=refresh" in body

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1338,3 +1338,31 @@ class TestStripeEmbeddedOnboarding:
         ):
             resp = asyncio.run(drv.stripe_embedded())
         assert "sk_test_SHOULD_NOT_LEAK" not in resp.body.decode()
+
+    def test_embedded_page_escapes_script_breakout_in_publishable_key(self):
+        # The publishable key is admin-writable; a tampered value must not be
+        # able to close the inline <script> and inject arbitrary JS (which could
+        # read window.__SPINR_TOKEN). json.dumps alone does NOT escape </script>.
+        from backend.routes import drivers as drv
+
+        evil = "pk_x</script><script>alert(1)</script>"
+        with patch(
+            "backend.settings_loader.get_app_settings",
+            AsyncMock(return_value={"stripe_publishable_key": evil}),
+            create=True,
+        ):
+            body = asyncio.run(drv.stripe_embedded()).body.decode()
+
+        assert "</script><script>alert(1)" not in body
+        assert "\\u003c/script\\u003e" in body  # escaped, still a valid JS string
+
+    def test_embedded_page_keeps_normal_key_intact(self):
+        from backend.routes import drivers as drv
+
+        with patch(
+            "backend.settings_loader.get_app_settings",
+            AsyncMock(return_value={"stripe_publishable_key": "pk_test_51ABCxyz"}),
+            create=True,
+        ):
+            body = asyncio.run(drv.stripe_embedded()).body.decode()
+        assert 'var PK = "pk_test_51ABCxyz";' in body

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1219,8 +1219,12 @@ class TestStripeOnboarding:
         captured: dict = {}
         self._run_onboard(captured)
         # SIN (individual.id_number) is eventually_due for CA Express individuals;
-        # forcing eventually_due pulls it into the onboarding session.
-        assert captured["collection_options"] == {"fields": "eventually_due"}
+        # forcing eventually_due + future_requirements pulls it (incl. the
+        # threshold-gated full SIN) into the onboarding session.
+        assert captured["collection_options"] == {
+            "fields": "eventually_due",
+            "future_requirements": "include",
+        }
 
     def test_return_endpoint_bounces_into_driver_app(self):
         from backend.routes import drivers as drv

--- a/backend/tests/test_instant_payout.py
+++ b/backend/tests/test_instant_payout.py
@@ -54,6 +54,10 @@ def _driver(**extra):
         "id": DRIVER_ID,
         "user_id": USER_ID,
         "stripe_account_id": "acct_TEST",
+        # GST/HST registration is a hard precondition for payout (CRA rideshare
+        # rule). Default to a valid BN so eligibility tests reach the Stripe path;
+        # override with gst_bn=None to exercise the block.
+        "gst_bn": "123456789RT0001",
         **extra,
     }
 
@@ -100,6 +104,35 @@ class TestRequestInstantPayout:
                 )
         assert exc.value.status_code == 400
         assert "Stripe Connect" in exc.value.detail
+
+    def test_rejects_when_gst_not_registered(self):
+        # CRA rideshare rule: no GST/HST Business Number on file → hard block,
+        # before the Stripe eligibility / balance checks.
+        from backend.routes import drivers as drv
+
+        def get_rows_side_effect(table, filters=None, **kw):
+            if table == "drivers":
+                return [_driver(gst_bn=None)]
+            if table == "bank_accounts":
+                return [_bank_account()]
+            return []
+
+        req = drv.InstantPayoutRequest(amount=Decimal("50.00"))
+
+        with (
+            patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(side_effect=get_rows_side_effect)),
+            patch("backend.routes.drivers.get_driver_balance", AsyncMock(return_value=self._balance())),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    drv.request_instant_payout(
+                        req=req,
+                        request=MagicMock(),
+                        current_user={"id": USER_ID},
+                    )
+                )
+        assert exc.value.status_code == 422
+        assert "gst" in exc.value.detail.lower()
 
     def test_rejects_when_insufficient_funds(self):
         from backend.routes import drivers as drv

--- a/backend/tests/test_p1_cors.py
+++ b/backend/tests/test_p1_cors.py
@@ -302,3 +302,55 @@ class TestAlwaysAllowedOrigins:
         cors_mw = next(m for m in fake_app.middlewares if m["cls"] is CORSMiddleware)
         allowed = cors_mw["kwargs"]["allow_origins"]
         assert "https://spinr-admin.vercel.app" in allowed
+
+
+class TestStripeEmbedSecurityHeaders:
+    """The Stripe embedded onboarding page needs a relaxed CSP + camera, but
+    only on its own path — every other API path keeps the strict posture."""
+
+    def _headers_for(self, path: str):
+        from fastapi.responses import JSONResponse
+
+        from backend.core.middleware import _apply_security_headers
+
+        resp = JSONResponse(content={})
+        _apply_security_headers(resp, path, enable_hsts=False)
+        return resp.headers
+
+    def test_stripe_embedded_gets_relaxed_csp_and_camera(self):
+        h = self._headers_for("/api/v1/drivers/stripe-embedded")
+        csp = h["Content-Security-Policy"]
+        # Must allow connect.js, Stripe iframes, and inline script/style.
+        assert "https://connect-js.stripe.com" in csp
+        assert "frame-src" in csp and "js.stripe.com" in csp
+        assert "'unsafe-inline'" in csp
+        assert csp != "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+        # Camera delegated to self + Stripe (not revoked).
+        pp = h["Permissions-Policy"]
+        assert "camera=(self" in pp
+        assert "camera=()" not in pp
+
+    def test_other_api_paths_keep_strict_csp_and_no_camera(self):
+        h = self._headers_for("/api/v1/drivers/payouts")
+        assert h["Content-Security-Policy"] == "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+        assert h["Permissions-Policy"] == "geolocation=(), microphone=(), camera=(), payment=()"
+
+
+class TestStripeAppCheckExemption:
+    """The WebView-loaded Stripe endpoints can't carry X-Firebase-AppCheck;
+    they're exempt (with JWT / public-only alternative auth). The money-moving
+    payout endpoint must stay enforced."""
+
+    def test_stripe_embedded_endpoints_are_exempt(self):
+        from backend.core.middleware import _APP_CHECK_EXEMPT_PREFIXES
+
+        for path in (
+            "/api/v1/drivers/stripe-embedded",
+            "/api/v1/drivers/stripe-account-session",
+        ):
+            assert any(path.startswith(p) for p in _APP_CHECK_EXEMPT_PREFIXES), path
+
+    def test_payout_endpoint_not_exempt(self):
+        from backend.core.middleware import _APP_CHECK_EXEMPT_PREFIXES
+
+        assert not any("/api/v1/drivers/payouts".startswith(p) for p in _APP_CHECK_EXEMPT_PREFIXES)

--- a/backend/tests/test_p2_payout_t4a.py
+++ b/backend/tests/test_p2_payout_t4a.py
@@ -100,13 +100,21 @@ class TestRequestPayout:
     Code under test: backend/routes/drivers.py::request_payout (~line 1353).
     """
 
-    async def _request(self, amount: float = 50.00, payable_balance: float = 100.00, has_bank_account: bool = True):
+    async def _request(
+        self,
+        amount: float = 50.00,
+        payable_balance: float = 100.00,
+        has_bank_account: bool = True,
+        gst_bn: str | None = "123456789RT0001",
+    ):
         from starlette.requests import Request as StarletteRequest
 
         from backend.routes.drivers import PayoutRequest, request_payout
 
         req = PayoutRequest(amount=Decimal(str(amount)))
-        driver = _driver_row()
+        # GST/HST registration is a hard precondition for payout (CRA rideshare
+        # rule); default to a valid BN so the balance/bank logic is reachable.
+        driver = {**_driver_row(), "gst_bn": gst_bn}
         inserted = []
 
         # Build a real Starlette Request so @idempotent_endpoint can read headers.
@@ -179,6 +187,25 @@ class TestRequestPayout:
 
         assert exc_info.value.status_code == 400
         assert "bank" in exc_info.value.detail.lower()
+
+    async def test_payout_blocked_without_gst_raises_422(self):
+        # CRA: rideshare drivers must be GST/HST-registered from their first
+        # fare. No BN on file → hard block before any money moves.
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._request(gst_bn=None)
+
+        assert exc_info.value.status_code == 422
+        assert "gst" in exc_info.value.detail.lower()
+
+    async def test_payout_blocked_with_malformed_gst_raises_422(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._request(gst_bn="12345")  # not a 9-digit BN
+
+        assert exc_info.value.status_code == 422
 
     async def test_driver_not_found_raises_404(self):
         from fastapi import HTTPException

--- a/driver-app/app.config.ts
+++ b/driver-app/app.config.ts
@@ -22,7 +22,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // 'fingerprint'/'appVersion' rejected by EAS CLI). Bump manually when
     // shipping native changes that break JS-bundle compatibility. Pre-launch
     // with no production users, OTA compatibility risk is zero.
-    runtimeVersion: '2.2.0', // bump from 2.1.0: withOfferCardNotificationService adds a new iOS Notification Service Extension target — old binaries lack it, so this JS must not reach them via OTA
+    runtimeVersion: '2.3.0', // bump from 2.2.0: adds react-native-webview (a new native module) for Stripe embedded onboarding + the Android CAMERA permission — old binaries lack both, so this JS must not reach them via OTA
     splash: {
         image: './assets/images/splash-blank.png',
         resizeMode: 'contain',
@@ -43,11 +43,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         // dependency calls a permission-gated API without a matching string.
         // Driver app needs camera + photo library for onboarding document
         // uploads (license, insurance, vehicle registration) per the
-        // Saskatchewan Transportation Act eligibility requirements.
-        // Location strings are supplied by the expo-location plugin block.
+        // Saskatchewan Transportation Act eligibility requirements, and for
+        // Stripe's in-app identity verification (capturing a government ID
+        // during payout setup). Location strings come from the expo-location
+        // plugin block.
         infoPlist: {
             NSCameraUsageDescription:
-                'Spinr Driver uses your camera to scan and upload your driver license, vehicle insurance, and vehicle registration documents during onboarding and renewal.',
+                'Spinr Driver uses your camera to scan and upload your driver license, vehicle insurance, and vehicle registration documents, and to verify your identity for payouts.',
             NSPhotoLibraryUsageDescription:
                 'Spinr Driver accesses your photo library so you can upload existing photos of your driver license, vehicle insurance, and vehicle registration.',
         },
@@ -152,6 +154,14 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
             backgroundColor: '#FFFFFF'
         },
         package: BUNDLE_ID,
+        // CAMERA is needed for in-WebView getUserMedia — Stripe's embedded
+        // identity onboarding (stripe-onboarding.tsx) captures the driver's
+        // government ID live in the page. (The native expo-image-picker
+        // document-upload flows delegate to the system camera app via intent
+        // and don't require this, but in-page getUserMedia does.) Additive to
+        // the permissions auto-added by config plugins (location, notifications).
+        // No RECORD_AUDIO: Stripe Identity captures images only, never audio.
+        permissions: ['android.permission.CAMERA'],
         googleServicesFile: './google-services.json',
         config: {
             googleMaps: {

--- a/driver-app/app/driver/_layout.tsx
+++ b/driver-app/app/driver/_layout.tsx
@@ -37,6 +37,7 @@ export default function DriverStackLayout() {
         <Stack.Screen name="notifications" />
         <Stack.Screen name="payout" />
         <Stack.Screen name="payout-history" />
+        <Stack.Screen name="stripe-onboarding" />
         <Stack.Screen name="tax-documents" />
         <Stack.Screen name="referral" />
         <Stack.Screen name="addresses" />

--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -47,11 +47,13 @@ function PayoutScreen() {
     const stripeOnboarding = false;
     const [downloadingT4A, setDownloadingT4A] = useState(false);
     const [downloadingCSV, setDownloadingCSV] = useState(false);
-    // gst_number is part of the driver row served by useDriverMe — keep
-    // a local form state for the input field but seed it from the cached
-    // server value (also re-seeds from the background refetch).
+    // gst_bn (CRA Business Number) is the canonical column on the driver row
+    // served by useDriverMe and accepted by PUT /drivers/me — keep a local form
+    // state for the input but seed it from the cached server value (also
+    // re-seeds from the background refetch). NOTE: the column is gst_bn, not
+    // gst_number — the latter is silently dropped by the backend schema.
     const { data: driverMeRaw } = useDriverMe();
-    const driverMe = driverMeRaw as { gst_number?: string } | undefined;
+    const driverMe = driverMeRaw as { gst_bn?: string } | undefined;
     const updateDriverMe = useUpdateDriverMe();
     const [gstNumber, setGstNumber] = useState('');
     const [showGstForm, setShowGstForm] = useState(false);
@@ -93,7 +95,7 @@ function PayoutScreen() {
     // The hook has its own cache + background refetch, so this replaces
     // the legacy `loadGstNumber()` round-trip entirely.
     useEffect(() => {
-        if (driverMe) setGstNumber(driverMe.gst_number || '');
+        if (driverMe) setGstNumber(driverMe.gst_bn || '');
     }, [driverMe]);
 
     useEffect(() => {
@@ -120,7 +122,10 @@ function PayoutScreen() {
         }
 
         try {
-            await updateDriverMe.mutateAsync({ gst_number: cleaned || null });
+            // Canonical column is gst_bn; also set gst_registered so the T4A
+            // export and admin KYC view stay in sync. (gst_bn:null is dropped by
+            // the backend's exclude_none, so this is an add/update, not a clear.)
+            await updateDriverMe.mutateAsync({ gst_bn: cleaned || null, gst_registered: !!cleaned });
             setShowGstForm(false);
             showToast('success', 'Saved', 'GST/BN number updated successfully');
         } catch (err: any) {

--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -42,7 +42,9 @@ function PayoutScreen() {
     } = useDriverStore();
 
     const [payoutAmount, setPayoutAmount] = useState('');
-    const [stripeOnboarding, setStripeOnboarding] = useState(false);
+    // Onboarding now opens an in-app WebView screen (instant navigation), so
+    // there's no async "opening…" state to track here.
+    const stripeOnboarding = false;
     const [downloadingT4A, setDownloadingT4A] = useState(false);
     const [downloadingCSV, setDownloadingCSV] = useState(false);
     // gst_number is part of the driver row served by useDriverMe — keep
@@ -101,26 +103,12 @@ function PayoutScreen() {
         }
     }, [error]);
 
-    const handleStripeOnboarding = async () => {
-        setStripeOnboarding(true);
-        try {
-            const res = await api.post<{ url?: string; mock?: boolean }>('/drivers/stripe-onboard');
-            const { url, mock } = res.data;
-
-            if (mock) {
-                showToast(
-                    'info',
-                    'Demo Mode',
-                    'Stripe is not configured yet. In production, you will be redirected to Stripe to complete identity verification and add your bank account.',
-                );
-            } else if (url) {
-                await Linking.openURL(url);
-            }
-        } catch (err: any) {
-            showToast('error', 'Error', err.response?.data?.detail || 'Failed to start Stripe onboarding');
-        } finally {
-            setStripeOnboarding(false);
-        }
+    const handleStripeOnboarding = () => {
+        // Option B: open Stripe's embedded onboarding in an in-app WebView (no
+        // browser redirect). The screen mints an AccountSession and lets Stripe
+        // collect the SIN/identity + payout bank account in-app; we only ever
+        // mirror the last-4 + verification status.
+        router.push('/driver/stripe-onboarding' as any);
     };
 
     const handleSaveGst = async () => {

--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -213,6 +213,10 @@ function PayoutScreen() {
     }, []);
 
     const isStripeReady = stripeAccountStatus === 'active' || hasBankAccount;
+    // CRA hard requirement: rideshare drivers must be GST/HST-registered before
+    // any payout (the backend rejects payouts without a valid BN). Mirror the
+    // server-side ^\d{9}(RT\d{4})?$ check so we gate the UI before the request.
+    const gstOnFile = /^\d{9}(RT\d{4})?$/.test((gstNumber || '').replace(/\s/g, '').toUpperCase());
 
     if (initialLoading) {
         return (
@@ -361,7 +365,7 @@ function PayoutScreen() {
                         <View style={styles.gstForm}>
                             <Text style={styles.inputLabel}>GST/HST Number (Business Number)</Text>
                             <Text style={styles.gstHelpText}>
-                                If you're registered for GST/HST, enter your 9-digit Business Number (BN) or full program account (e.g., 123456789RT0001). Leave blank if not registered.
+                                Enter your 9-digit CRA Business Number (BN) or full program account (e.g., 123456789RT0001).
                             </Text>
                             <TextInput
                                 style={styles.textInput}
@@ -373,7 +377,9 @@ function PayoutScreen() {
                                 maxLength={15}
                             />
                             <Text style={styles.gstNote}>
-                                Drivers earning over $30,000/year must register for GST/HST with CRA.
+                                Required to receive payouts. As a rideshare driver you must register for
+                                GST/HST with the CRA from your first fare — the $30,000 small-supplier
+                                threshold does not apply to ride-sharing.
                             </Text>
                             <View style={styles.gstFormButtons}>
                                 <TouchableOpacity
@@ -436,6 +442,23 @@ function PayoutScreen() {
                 {isStripeReady && driverBalance && parseFloat(driverBalance.payable_balance) > 0 && (
                     <View style={styles.section}>
                         <Text style={styles.sectionTitle}>Request Payout</Text>
+                        {!gstOnFile && (
+                            <TouchableOpacity
+                                style={[styles.payoutCard, { flexDirection: 'row', alignItems: 'flex-start', marginBottom: 12 }]}
+                                onPress={() => setShowGstForm(true)}
+                            >
+                                <Ionicons name="alert-circle" size={22} color={colors.primary} />
+                                <View style={{ flex: 1, marginLeft: 10 }}>
+                                    <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600' }}>
+                                        GST/HST registration required
+                                    </Text>
+                                    <Text style={{ color: colors.textDim, fontSize: 13, marginTop: 2, lineHeight: 18 }}>
+                                        Add your CRA Business Number to receive payouts. Rideshare drivers
+                                        must register for GST/HST from their first fare. Tap to add it.
+                                    </Text>
+                                </View>
+                            </TouchableOpacity>
+                        )}
                         <View style={styles.payoutCard}>
                             <View style={styles.payoutInputRow}>
                                 <Text style={styles.dollarSign}>$</Text>
@@ -446,14 +469,15 @@ function PayoutScreen() {
                                     keyboardType="decimal-pad"
                                     value={payoutAmount}
                                     onChangeText={setPayoutAmount}
+                                    editable={gstOnFile}
                                 />
                                 <TouchableOpacity
                                     style={[
                                         styles.payoutButton,
-                                        (!payoutAmount || isLoading) && styles.payoutButtonDisabled,
+                                        (!payoutAmount || isLoading || !gstOnFile) && styles.payoutButtonDisabled,
                                     ]}
                                     onPress={handleRequestPayout}
-                                    disabled={!payoutAmount || isLoading}
+                                    disabled={!payoutAmount || isLoading || !gstOnFile}
                                 >
                                     {isLoading ? (
                                         <ActivityIndicator size="small" color="#fff" />

--- a/driver-app/app/driver/stripe-onboarding.tsx
+++ b/driver-app/app/driver/stripe-onboarding.tsx
@@ -15,6 +15,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+import * as ImagePicker from 'expo-image-picker';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -42,6 +43,16 @@ export default function StripeOnboardingScreen() {
     useEffect(() => {
         let active = true;
         (async () => {
+            // Best-effort: hold the OS camera permission up front so Stripe's
+            // in-page getUserMedia can capture the driver's government ID. On
+            // Android the WebView can only grant the page's camera request if
+            // the app already holds CAMERA; iOS prompts on first use anyway. If
+            // denied, Stripe falls back to file upload — so never block on this.
+            try {
+                await ImagePicker.requestCameraPermissionsAsync();
+            } catch {
+                // ignore — onboarding continues with the file-upload fallback
+            }
             try {
                 await ensureFreshToken();
                 const t = await getAuthHeader();

--- a/driver-app/app/driver/stripe-onboarding.tsx
+++ b/driver-app/app/driver/stripe-onboarding.tsx
@@ -1,0 +1,169 @@
+/**
+ * Embedded Stripe Connect onboarding (Option B).
+ *
+ * Renders Stripe's `account-onboarding` embedded component inside a WebView so
+ * the driver never leaves the app — no browser redirect, no deep-link bounce.
+ * Stripe still collects and *holds* the SIN itself; we only ever see the last-4
+ * + verification status (mirrored back by the account.updated webhook).
+ *
+ * Auth: the backend's GET /stripe-embedded page is public (it carries only the
+ * publishable key). The driver's bearer token is injected into the WebView at
+ * runtime via injectedJavaScriptBeforeContentLoaded (window.__SPINR_TOKEN) and
+ * used by the page's same-origin POST to /stripe-account-session — it is never
+ * placed in the URL or written to logs.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { LinearGradient } from 'expo-linear-gradient';
+import { showToast } from '../../hooks/useToast';
+import { ensureFreshToken, getAuthHeader } from '@shared/api/client';
+import SpinrConfig from '@shared/config/spinr.config';
+import { useDriverMe } from '@shared/hooks/queries';
+import { useTheme } from '@shared/theme/ThemeContext';
+
+const EMBEDDED_URL = `${SpinrConfig.backendUrl}/api/v1/drivers/stripe-embedded`;
+
+export default function StripeOnboardingScreen() {
+    const router = useRouter();
+    const insets = useSafeAreaInsets();
+    const { colors } = useTheme();
+    const { refetch } = useDriverMe();
+    const webRef = useRef<WebView>(null);
+
+    const [token, setToken] = useState<string | null>(null);
+    const [tokenError, setTokenError] = useState(false);
+    const [pageLoading, setPageLoading] = useState(true);
+    const exitedRef = useRef(false);
+
+    useEffect(() => {
+        let active = true;
+        (async () => {
+            try {
+                await ensureFreshToken();
+                const t = await getAuthHeader();
+                if (!active) return;
+                if (!t) {
+                    setTokenError(true);
+                    return;
+                }
+                setToken(t);
+            } catch {
+                if (active) setTokenError(true);
+            }
+        })();
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    // Inject the bearer token into the page BEFORE its scripts run, so the
+    // embedded component's fetchClientSecret can authenticate its POST.
+    const injectedBeforeLoad = useMemo(
+        () => `window.__SPINR_TOKEN = ${JSON.stringify(token ?? '')}; true;`,
+        [token],
+    );
+
+    const finish = (opts: { refresh: boolean; message?: string; type?: 'success' | 'error' }) => {
+        if (exitedRef.current) return;
+        exitedRef.current = true;
+        if (opts.message) showToast(opts.type ?? 'info', opts.type === 'error' ? 'Error' : 'Done', opts.message);
+        if (opts.refresh) void refetch();
+        router.back();
+    };
+
+    const onMessage = (e: WebViewMessageEvent) => {
+        const data = e.nativeEvent.data || '';
+        if (data === 'exit') {
+            // User finished or closed Stripe's flow. Re-pull KYC status; the
+            // account.updated webhook is the authoritative gate, so the payout
+            // screen reflects "verified" once Stripe confirms.
+            finish({ refresh: true, message: 'Verification updated.', type: 'success' });
+        } else if (data.startsWith('error:')) {
+            finish({
+                refresh: false,
+                message: 'Could not load verification. Please try again.',
+                type: 'error',
+            });
+        }
+    };
+
+    const showSpinner = (!token && !tokenError) || (pageLoading && !tokenError);
+
+    return (
+        <View style={[styles.container, { backgroundColor: colors.background }]}>
+            <LinearGradient
+                colors={[colors.surface, colors.background]}
+                style={[styles.header, { paddingTop: insets.top + 12 }]}
+            >
+                <View style={styles.headerRow}>
+                    <TouchableOpacity onPress={() => finish({ refresh: true })} style={styles.backBtn}>
+                        <Ionicons name="arrow-back" size={22} color={colors.text} />
+                    </TouchableOpacity>
+                    <Text style={[styles.headerTitle, { color: colors.text }]}>Verify Identity</Text>
+                    <View style={styles.backBtn} />
+                </View>
+            </LinearGradient>
+
+            {tokenError ? (
+                <View style={styles.center}>
+                    <Ionicons name="alert-circle-outline" size={40} color={colors.textDim} />
+                    <Text style={[styles.errText, { color: colors.textDim }]}>
+                        Your session expired. Please go back and try again.
+                    </Text>
+                </View>
+            ) : (
+                <View style={{ flex: 1 }}>
+                    {token && (
+                        <WebView
+                            ref={webRef}
+                            source={{ uri: EMBEDDED_URL }}
+                            originWhitelist={['https://*']}
+                            injectedJavaScriptBeforeContentLoaded={injectedBeforeLoad}
+                            onMessage={onMessage}
+                            onLoadEnd={() => setPageLoading(false)}
+                            onError={() =>
+                                finish({
+                                    refresh: false,
+                                    message: 'Network error loading verification.',
+                                    type: 'error',
+                                })
+                            }
+                            javaScriptEnabled
+                            domStorageEnabled
+                            // Stripe identity verification may capture a document photo.
+                            mediaCapturePermissionGrantType="grant"
+                            allowsInlineMediaPlayback
+                            startInLoadingState={false}
+                            setSupportMultipleWindows={false}
+                            style={{ flex: 1, backgroundColor: colors.background }}
+                        />
+                    )}
+                    {showSpinner && (
+                        <View style={[styles.center, styles.overlay, { backgroundColor: colors.background }]}>
+                            <ActivityIndicator size="large" color={colors.primary} />
+                            <Text style={[styles.loadingText, { color: colors.textDim }]}>
+                                Loading secure verification…
+                            </Text>
+                        </View>
+                    )}
+                </View>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1 },
+    header: { paddingBottom: 12, paddingHorizontal: 16 },
+    headerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+    headerTitle: { fontSize: 18, fontWeight: '700' },
+    backBtn: { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
+    center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+    overlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
+    loadingText: { marginTop: 12, fontSize: 14 },
+    errText: { marginTop: 12, fontSize: 14, textAlign: 'center', lineHeight: 20 },
+});

--- a/driver-app/app/driver/stripe-onboarding.tsx
+++ b/driver-app/app/driver/stripe-onboarding.tsx
@@ -27,6 +27,10 @@ import { useDriverMe } from '@shared/hooks/queries';
 import { useTheme } from '@shared/theme/ThemeContext';
 
 const EMBEDDED_URL = `${SpinrConfig.backendUrl}/api/v1/drivers/stripe-embedded`;
+// Restrict top-level navigation to our API origin + Stripe (defence-in-depth
+// alongside mediaCapturePermissionGrantType="grant" — Stripe renders inside
+// iframes, which aren't subject to this list, so this stays tight).
+const ORIGIN_WHITELIST = [SpinrConfig.backendUrl, 'https://*.stripe.com', 'https://connect-js.stripe.com'];
 
 export default function StripeOnboardingScreen() {
     const router = useRouter();
@@ -132,7 +136,7 @@ export default function StripeOnboardingScreen() {
                         <WebView
                             ref={webRef}
                             source={{ uri: EMBEDDED_URL }}
-                            originWhitelist={['https://*']}
+                            originWhitelist={ORIGIN_WHITELIST}
                             injectedJavaScriptBeforeContentLoaded={injectedBeforeLoad}
                             onMessage={onMessage}
                             onLoadEnd={() => setPageLoading(false)}

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -72,6 +72,7 @@
     "react-native-svg": "15.15.3",
     "react-native-toast-message": "^2.3.3",
     "react-native-web": "~0.21.0",
+    "react-native-webview": "13.16.1",
     "react-native-worklets": "~0.8.1",
     "zustand": "^5.0.13"
   },

--- a/driver-app/yarn.lock
+++ b/driver-app/yarn.lock
@@ -5052,6 +5052,13 @@ encodeurl@~2.0.0:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
+end-of-stream@^1.1.0:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
+
 entities@^4.2.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
@@ -6617,7 +6624,7 @@ internal-slot@^1.1.0:
     hasown "^2.0.2"
     side-channel "^1.1.0"
 
-invariant@^2.2.4:
+invariant@2.2.4, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -8636,9 +8643,9 @@ on-headers@~1.1.0:
   resolved "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz"
   integrity sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
@@ -9038,9 +9045,6 @@ pump@^3.0.0:
   version "3.0.4"
   resolved "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz"
   integrity sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
@@ -9245,6 +9249,14 @@ react-native-web@~0.21.0:
     nullthrows "^1.1.1"
     postcss-value-parser "^4.2.0"
     styleq "^0.1.3"
+
+react-native-webview@13.16.1:
+  version "13.16.1"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.16.1.tgz#d5a6483fcb823eac704bd2a3d82c263771c6ede3"
+  integrity sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==
+  dependencies:
+    escape-string-regexp "^4.0.0"
+    invariant "2.2.4"
 
 react-native-worklets@~0.8.1:
   version "0.8.3"


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Add Stripe embedded account-onboarding (in-app WebView, no browser redirect), fix hosted-flow return URLs (was hardcoded to localhost), collect SIN (individual.id_number) up front, and enforce GST/HST registration as a hard payout precondition per CRA rideshare rules.
- **Type**: `feat`
- **Linked issue**: Refs #<pending> (CRA compliance + UX improvement)
- **Risk**: `medium` — Stripe integration change + payout eligibility gate; money-touching code path modified
- **User-visible change**: `drivers` — Onboarding now happens in-app (no browser redirect); payouts blocked until GST/HST BN registered
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend `[ ]` rider-app `[x]` driver-app `[ ]` admin `[x]` shared `[ ]` migrations `[ ]` infra `[ ]` CI
- **Blast radius**: `multi-surface` (backend Stripe endpoints + driver-app WebView screen + shared API client)
- **Data schema change**: `additive` (new `gst_bn` column, `gst_registered` flag; `stripe_account_id` already existed)
- **API contract change**: `additive` (new endpoints: `/stripe-account-session`, `/stripe-embedded`, `/stripe-return`, `/stripe-refresh`; existing `/stripe-onboard` refactored but signature unchanged)
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `app_settings-row` (stripe_publishable_key already required; no new env vars)
- **Rollback plan**: `git-revert-safe` — Old driver app continues to use `/stripe-onboard` (hosted flow); new app uses embedded flow. DB columns are additive. Revert removes new endpoints but leaves schema intact.
- **Dependencies / coordination**: Mobile release required before backend deploy (driver-app adds `react-native-webview` native module; old binaries lack it, so runtimeVersion bumped to 2.3.0 to prevent OTA delivery of new JS to old binaries)
- **Assumptions**: Stripe Connect (Express) account creation is idempotent within 24h (idempotency_key used); account.updated webhook is the authoritative KYC gate (not this endpoint); GST/HST registration is a hard CRA requirement for rideshare drivers from first fare
- **Not changing but considered**: Hosted flow (`/stripe-onboard`) left intact for backward compatibility; both flows converge on same Express account via `_ensure_stripe_account()` helper

## Tier 3 — Compliance flags

- `[x]` **Money-touching** — Payout eligibility now gated on GST/HST registration (CRA rideshare rule); Stripe onboarding collects SIN (individual.id_number) which we never see (held by Stripe, only last-4 + status mirrored back); embedded flow preserves PIPEDA posture
- `[x]` **PIPEDA-relevant** — SIN collection: driver app injects bearer token into WebView at runtime (never in URL/logs); Stripe holds raw SIN; we only mirror last-4 + verification status via webhook; publishable key is public-only (no secret leaked)
- `[x]` **SK Transportation Act** — GST/HST registration enforced as hard payout precondition per CRA rideshare rules (no small-supplier exemption for ride-share)

## Tier 4 — Verification

- **Unit tests**: `added` — 13 new test cases covering:
  - Hosted flow return/refresh URLs use public API host (not localhost)
  - Hosted flow collects SIN (eventually_due + future_requirements)
  - Return/refresh endpoints bounce into driver app via deep link
  - AccountSession mints client secret + enables account_onboarding

https://claude.ai/code/session_012p1guQitTehz1MiBQB7paP

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
