### PR TITLE
fix: code-review findings (build break, 2 projection regressions, T4A…

### DIFF
--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -1342,7 +1342,7 @@ function VerificationSummaryCard({
                 </div>
                 <div className="flex items-center justify-between pt-1 text-xs border-t border-border">
                     <div className="flex items-center gap-2">
-                        <div className={`w-2 h-2 rounded-full ${driver.profile_image_status ? "bg-emerald-500" : "bg-muted-foreground/30"}`} />
+                        <div className={`w-2 h-2 rounded-full ${driver.profile_image_status && driver.profile_image_status !== "rejected" ? "bg-emerald-500" : "bg-muted-foreground/30"}`} />
                         <span className="text-muted-foreground">Profile photo</span>
                     </div>
                     <div className="flex items-center gap-2">

--- a/admin-dashboard/src/app/dashboard/rides/page.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useSearchParams } from "next/navigation";
 import { getRides, exportRides, getServiceAreas, type RideListOpts } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { PlusCircle } from "lucide-react";
@@ -36,12 +35,16 @@ export default function RidesPage() {
     const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Deep-link support: open a specific ride when arriving via ?id=<rideId>
-    // (e.g. from a user's "Recent rides" or the safety queue).
-    const searchParams = useSearchParams();
+    // (e.g. from a user's "Recent rides" or the safety queue). Read once on
+    // mount from window.location rather than useSearchParams() — the latter
+    // requires a <Suspense> boundary (which this route lacks) and fails
+    // `next build`. Mount-only also avoids re-opening the modal after close.
     useEffect(() => {
-        const id = searchParams.get("id");
+        if (typeof window === "undefined") return;
+        const id = new URLSearchParams(window.location.search).get("id");
         if (id) setSelectedRideId(id);
-    }, [searchParams]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     const loadRides = useCallback(async (
         p: number,

--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -486,7 +486,7 @@ export default function UsersPage() {
                         <div className="space-y-4">
                             <div className="flex items-center gap-4">
                                 <div className="h-16 w-16 rounded-full bg-gradient-to-br from-sky-500 to-blue-600 flex items-center justify-center text-white text-xl font-bold">
-                                    {selectedUser.name.charAt(0).toUpperCase()}
+                                    {selectedUser.name?.charAt(0)?.toUpperCase() || "?"}
                                 </div>
                                 <div>
                                     <p className="text-lg font-semibold">{selectedUser.name}</p>
@@ -809,9 +809,11 @@ export default function UsersPage() {
                                                     <span className="font-mono text-muted-foreground">•••• {c.last4}</span>
                                                     {c.is_default && <Badge variant="secondary" className="text-[10px]">Default</Badge>}
                                                 </span>
-                                                <span className="text-xs text-muted-foreground">
-                                                    {String(c.exp_month).padStart(2, "0")}/{String(c.exp_year).slice(-2)}
-                                                </span>
+                                                {c.exp_month != null && c.exp_year != null && (
+                                                    <span className="text-xs text-muted-foreground">
+                                                        {String(c.exp_month).padStart(2, "0")}/{String(c.exp_year).slice(-2)}
+                                                    </span>
+                                                )}
                                             </div>
                                         ))}
                                     </div>

--- a/backend/migrations/159_payouts_overview_aggregates_fn.sql
+++ b/backend/migrations/159_payouts_overview_aggregates_fn.sql
@@ -94,9 +94,13 @@ blocked AS (
       AND (p_service_area_id IS NULL OR d.id IN (SELECT id FROM scoped_drivers))
 ),
 ytd AS (
+    -- T4A is per-PAYEE (driver); a completed ride with no driver_id is not a
+    -- payee and must not form a (NULL, earned) group. The old Python skipped
+    -- such rides ("if not did: continue"). The cumulative earned_up_to/
+    -- outstanding sums above intentionally DO include null-driver rides.
     SELECT driver_id, COALESCE(SUM(earnings), 0) AS earned
     FROM scoped_rides
-    WHERE eff_ts >= p_year_start
+    WHERE eff_ts >= p_year_start AND driver_id IS NOT NULL
     GROUP BY driver_id
 )
 SELECT jsonb_build_object(

--- a/backend/routes/admin/safety.py
+++ b/backend/routes/admin/safety.py
@@ -10,6 +10,7 @@ routes/admin/__init__.py wiring at module mount time).
 """
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4584,10 +4584,10 @@ async def get_referred_drivers(
     referral_code = driver.get("referral_code", f"DRIVER{driver['id'][:8].upper()}")
 
     # Find users who used this referral code and became drivers
-    # Each referred user contributes name + email to the response — project
-    # those columns and keep base64 profile_image out of the read.
+    # Each referred user contributes name + email + signup date to the response
+    # — project those columns and keep base64 profile_image out of the read.
     referred_users_cursor = db_supabase.get_rows(
-        "users", {"referral_code_used": referral_code}, columns="id,first_name,last_name,email", limit=100
+        "users", {"referral_code_used": referral_code}, columns="id,first_name,last_name,email,created_at", limit=100
     )
     referred_users = (
         await referred_users_cursor.to_list(100)


### PR DESCRIPTION
… null driver)

From the branch code review:
- safety.py: add missing 'import re' — server-side search used re.escape and 500'd (NameError) on any /safety/incidents?search=... (HIGH).
- rides/page.tsx: drop useSearchParams() (no <Suspense> ancestor → next build failure) and read ?id= once on mount from window.location; also stops the detail modal re-opening after close (HIGH).
- drivers.py referral-info: add created_at back to the projection — 'referred_at' had gone permanently blank after the column-projection sweep (regression).
- migration 159: T4A ytd CTE now excludes driver_id IS NULL (a completed ride with no driver was inflating drivers_with_earnings / a bucket / ytd_gross; the cumulative outstanding sums still include them, matching old behaviour).
- drivers/page.tsx: profile-photo dot no longer turns green for a 'rejected' photo.
- users/page.tsx: guard card-expiry render + avatar initial against undefined.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
