### PR TITLE
Multi-surface atomicity, perf, and observability fixes (C1–F8, #1–#4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,11 +627,13 @@ jobs:
             echo "url=$FALLBACK" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Health check — confirm 200 + non-empty body
+      - name: Health check — confirm 200 + DB reachable
+        # /health performs a real DB readiness ping (F1): a dead-DB deploy
+        # returns 503 (curl -sf fails) or status!=healthy, turning this red.
         run: |
           BODY=$(curl -sf --retry 3 --retry-delay 5 "${{ steps.resolve.outputs.url }}/health")
           echo "$BODY"
-          echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('status') in ('ok','healthy'), f'bad status: {d}'"
+          echo "$BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('status') in ('ok','healthy'), f'bad status: {d}'; assert d.get('db', {}).get('status') == 'ok', f'DB not ready: {d}'"
 
       - name: Settings endpoint — confirm 200 + JSON
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,12 +309,19 @@ Sentry tags (attach to every captured event):
 - `ride_id`, `driver_id`, `rider_id` — only IDs, never PII
 - `env`: `production` / `staging` / `development`
 
-Metric naming (`spinr.<domain>.<metric>.<unit>`):
-- `spinr.dispatch.offer_sent.count`
-- `spinr.dispatch.offer_to_accept.duration_ms`
-- `spinr.fare.calc.duration_ms`
-- `spinr.payment.settlement.count{outcome=success|failed|retry}`
-- `spinr.ws.fanout.duration_ms`
+Metric naming — Prometheus/OpenMetrics snake_case `spinr_<domain>_<metric>_<unit>`
+(counters end `_total`, latency histograms end `_duration_ms`). `utils/metrics.py`
+is the source of truth and the exposition format `utils/metrics.render_prometheus`
+emits; dashboards/alerts must use these names (the older dotted
+`spinr.<domain>.<metric>.<unit>` spelling is **not** what the code emits — do not
+write alerts against it):
+- `spinr_dispatch_offer_sent_total`
+- `spinr_dispatch_offer_accepted_total`
+- `spinr_dispatch_offer_to_accept_duration_ms`  (KPI: P95 < 2s dispatch latency)
+- `spinr_dispatch_presence_filter_failed_total`  (Redis-presence degradation)
+- `spinr_fare_calc_duration_ms`
+- `spinr_payment_settlement_total{outcome=success|failed|retry}`
+- `spinr_ws_fanout_duration_ms`
 
 What to log vs metric vs Sentry:
 - State transitions → info log + metric

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -78,28 +78,27 @@ async def cleanup_database(db):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage application lifespan events"""
-    # Size the default ThreadPoolExecutor that run_in_executor() uses.
-    # Every Supabase call goes through run_sync() → run_in_executor(),
-    # and each call pins one thread for its entire DB roundtrip (plus
-    # any blocking retry is on asyncio.sleep — not pinning — so the
-    # pool is only loaded during actual wire time).
-    #
-    # Python's default is min(32, os.cpu_count() + 4), which on a 2-vCPU
-    # Railway instance works out to 6 threads. Under any realistic load
-    # that's the bottleneck: at ~200ms average PostgREST latency, 6
-    # threads cap us at 30 concurrent DB RPS. Bumping to 64 gives us
-    # ~300 concurrent RPS headroom while still being well within the
-    # memory budget (each thread is ~8 MB stack).
-    #
-    # Override with BACKEND_EXECUTOR_WORKERS env var if needed.
+    # Size the event-loop DEFAULT ThreadPoolExecutor. IMPORTANT: this does NOT
+    # size DB capacity. Every Supabase call goes through run_sync() →
+    # run_in_executor(_DB_EXECUTOR, ...), a DEDICATED pool sized by
+    # DB_THREAD_POOL_SIZE (repositories/_base.py) — that is the single source of
+    # truth for DB throughput. The default executor here is used only by the few
+    # non-DB blocking offloads that pass None to run_in_executor (currently the
+    # ride-snapshot PNG render + Supabase Storage upload in routes/drivers.py).
+    # Those are low-frequency (per ride completion), so a modest pool suffices;
+    # the previous 64 here (mislabelled as DB sizing) left ~48 idle threads
+    # wasting stack budget on a 1 GB VM. Override with BACKEND_EXECUTOR_WORKERS.
     import asyncio as _asyncio_lifespan
     import os as _os
     from concurrent.futures import ThreadPoolExecutor as _Executor
 
-    executor_size = int(_os.environ.get("BACKEND_EXECUTOR_WORKERS", "64"))
+    executor_size = int(_os.environ.get("BACKEND_EXECUTOR_WORKERS", "16"))
     loop = _asyncio_lifespan.get_event_loop()
-    loop.set_default_executor(_Executor(max_workers=executor_size, thread_name_prefix="spinr-db"))
-    logger.info(f"Default executor sized to {executor_size} workers")
+    loop.set_default_executor(_Executor(max_workers=executor_size, thread_name_prefix="spinr-misc"))
+    logger.info(
+        f"Default (non-DB) executor sized to {executor_size} workers; "
+        f"DB capacity is the separate _DB_EXECUTOR (DB_THREAD_POOL_SIZE)"
+    )
 
     # Initialize database
     logger.info("Initializing database connection...")

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -167,8 +167,12 @@ def _extract_user_id(request: Request) -> str | None:
             return None
         token = auth[len("Bearer ") :]
         payload = jwt.decode(token, options={"verify_signature": False})
-        sub = payload.get("sub")
-        return str(sub) if sub is not None else None
+        # Spinr JWTs carry the user id in `user_id` (see core auth.create_jwt_token),
+        # not the standard `sub` claim — reading `sub` left request.state.user_id
+        # (and every log line's user correlation) permanently None. Fall back to
+        # `sub` for any token that does use it.
+        uid = payload.get("user_id") or payload.get("sub")
+        return str(uid) if uid is not None else None
     except Exception:
         return None
 

--- a/backend/migrations/170_drivers_location_geog_surge.sql
+++ b/backend/migrations/170_drivers_location_geog_surge.sql
@@ -1,0 +1,113 @@
+-- 170_drivers_location_geog_surge.sql
+--
+-- Purpose (ACTION_ITEMS D1): server-side spatial supply counting for the surge
+-- engine. Replaces the Python point-in-polygon over a capped driver fetch
+-- (utils/surge_engine.py) — which truncated supply past the row cap and could
+-- mis-price a regulated fare — with a PostGIS ST_Covers lookup backed by a
+-- partial GIST index (no cap, index-only). The function returns the available
+-- drivers inside a polygon; the surge engine still applies the Redis presence
+-- filter in Python, so ghost-online drivers are excluded exactly as before.
+--
+-- COORDINATED DEPLOY: the surge engine reads this path behind the
+-- SURGE_SPATIAL_COUNT flag (default OFF) and falls back to the Python scan on
+-- any error, so applying this migration changes nothing until the flag is
+-- enabled after a staging rehearsal (run EXPLAIN ANALYZE against a real polygon
+-- to confirm the GIST index is used, and verify driver-id type parity with
+-- utils/driver_presence.present_driver_ids).
+--
+-- FORWARD-COMPATIBLE / lock-safety:
+--   * location_geog is added NULLABLE → instant metadata-only add, NO rewrite
+--     (do NOT use a GENERATED STORED column — that rewrites under ACCESS EXCLUSIVE).
+--   * a BEFORE INSERT/UPDATE-OF-(lat,lng) trigger keeps it in sync going forward.
+--   * existing rows are backfilled in 1000-row batches.
+--   * the GIST index is built CONCURRENTLY (drivers is a high-traffic table); the
+--     migrate runner detects CONCURRENTLY and applies the whole file in autocommit.
+--   * both functions pin search_path = public, extensions (PostGIS lives in the
+--     `extensions` schema on Supabase) so they resolve regardless of session state.
+--   * drivers_available_in_polygon is REVOKEd from PUBLIC/anon/authenticated and
+--     GRANTed only to service_role (it returns driver-location-derived data, so a
+--     default PUBLIC EXECUTE on a SECURITY DEFINER fn would be a PIPEDA leak).
+--
+-- ROLLBACK (on paper):
+--   DROP FUNCTION IF EXISTS drivers_available_in_polygon(text);
+--   DROP TRIGGER IF EXISTS trg_drivers_location_geog ON drivers;
+--   DROP FUNCTION IF EXISTS _drivers_sync_location_geog();
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_drivers_location_geog_available;
+--   ALTER TABLE drivers DROP COLUMN IF EXISTS location_geog;
+--   -- (the postgis extension is left enabled; harmless.)
+
+CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
+
+-- Resolve PostGIS symbols for the rest of this migration session (trigger
+-- creation, backfill DO block). Per-function SET search_path below covers runtime.
+SET search_path = public, extensions;
+
+ALTER TABLE drivers ADD COLUMN IF NOT EXISTS location_geog geography(Point, 4326);
+
+CREATE OR REPLACE FUNCTION _drivers_sync_location_geog() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public, extensions
+AS $$
+BEGIN
+    IF NEW.lat IS NOT NULL AND NEW.lng IS NOT NULL THEN
+        NEW.location_geog := ST_SetSRID(ST_MakePoint(NEW.lng, NEW.lat), 4326)::geography;
+    ELSE
+        NEW.location_geog := NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_drivers_location_geog ON drivers;
+CREATE TRIGGER trg_drivers_location_geog
+    BEFORE INSERT OR UPDATE OF lat, lng ON drivers
+    FOR EACH ROW EXECUTE FUNCTION _drivers_sync_location_geog();
+
+-- Batched backfill of existing rows.
+DO $$
+DECLARE
+    _rows integer;
+BEGIN
+    LOOP
+        UPDATE drivers
+        SET location_geog = ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography
+        WHERE id IN (
+            SELECT id FROM drivers
+            WHERE location_geog IS NULL AND lat IS NOT NULL AND lng IS NOT NULL
+            LIMIT 1000
+        );
+        GET DIAGNOSTICS _rows = ROW_COUNT;
+        EXIT WHEN _rows = 0;
+    END LOOP;
+END;
+$$;
+
+-- drivers is a high-traffic table → build the index CONCURRENTLY so it never
+-- takes an ACCESS EXCLUSIVE lock. The migrate runner detects CONCURRENTLY and
+-- runs the whole file in autocommit (CONCURRENTLY cannot run in a transaction).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_drivers_location_geog_available
+    ON drivers USING GIST (location_geog)
+    WHERE is_online AND is_available;
+
+-- Returns available drivers inside the polygon (presence applied in Python).
+-- SECURITY DEFINER + pinned search_path; the caller builds GeoJSON as [lng, lat].
+CREATE OR REPLACE FUNCTION drivers_available_in_polygon(p_polygon_geojson text)
+RETURNS TABLE(driver_id text, driver_user_id text)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public, extensions AS $$
+    SELECT d.id::text, d.user_id::text
+    FROM drivers d
+    WHERE d.is_online = true
+      AND d.is_available = true
+      AND d.location_geog IS NOT NULL
+      AND ST_Covers(
+          ST_SetSRID(ST_GeomFromGeoJSON(p_polygon_geojson), 4326)::geography,
+          d.location_geog
+      );
+$$;
+
+-- Backend-only: a SECURITY DEFINER fn returning driver-location-derived data must
+-- not be callable by anon/authenticated keys (PIPEDA). Default CREATE grants
+-- EXECUTE to PUBLIC — revoke it and grant only the service role.
+REVOKE EXECUTE ON FUNCTION drivers_available_in_polygon(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION drivers_available_in_polygon(text) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION drivers_available_in_polygon(text) TO service_role;

--- a/backend/repositories/corporate_repo.py
+++ b/backend/repositories/corporate_repo.py
@@ -602,9 +602,25 @@ async def list_allowances_due_for_reset(as_of: str) -> List[Dict[str, Any]]:
     return await run_sync(_fn)
 
 
-async def reset_allowance_period(*, allowance_id: str, period_start: str, period_end: str) -> Optional[Dict[str, Any]]:
+async def reset_allowance_period(
+    *,
+    allowance_id: str,
+    period_start: str,
+    period_end: str,
+    expected_period_end: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Advance an allowance's billing period.
+
+    When ``expected_period_end`` is provided this becomes an atomic
+    compare-and-swap: the row is updated only if its current ``period_end``
+    still equals the expected value, so exactly one replica can claim a given
+    period roll-forward (replay-safety F8). Returns the updated row, or None
+    when the CAS lost (another replica already advanced it). With
+    ``expected_period_end=None`` it behaves as before (unconditional update).
+    """
+
     def _fn():
-        res = (
+        q = (
             supabase.table("corporate_member_allowances")
             .update(
                 {
@@ -615,8 +631,10 @@ async def reset_allowance_period(*, allowance_id: str, period_start: str, period
                 }
             )
             .eq("id", allowance_id)
-            .execute()
         )
+        if expected_period_end is not None:
+            q = q.eq("period_end", expected_period_end)
+        res = q.execute()
         return _single_row_from_res(res)
 
     return await run_sync(_fn)

--- a/backend/repositories/driver_repo.py
+++ b/backend/repositories/driver_repo.py
@@ -177,7 +177,11 @@ async def set_driver_available(driver_id: str, available: bool = True, total_rid
             f"is never written here)"
         )
         res = supabase.table("drivers").update(payload).eq("id", driver_id).execute()
-        logger.info(f"[GO-ONLINE] set_driver_available executed, res.data={getattr(res, 'data', None)}")
+        # PIPEDA: never log res.data — supabase-py returns the full driver row by
+        # default, which includes the encrypted address, driver-license number,
+        # and name/phone. Log only the driver_id and whether a row was updated.
+        _rows = getattr(res, "data", None) or []
+        logger.info(f"[GO-ONLINE] set_driver_available executed driver_id={driver_id} rows_updated={len(_rows)}")
         return _single_row_from_res(res)
 
     result = await run_sync(_update)

--- a/backend/repositories/ride_repo.py
+++ b/backend/repositories/ride_repo.py
@@ -58,8 +58,9 @@ async def insert_ride(payload: Dict[str, Any]):
     if not supabase:
         raise RuntimeError("Supabase client not configured")
     payload = _serialize_for_api(payload)
+    # PIPEDA: never log the full payload — it carries raw GPS (pickup/dropoff
+    # lat/lng) and exact addresses. Log only the field names present.
     logger.info(f"[DEBUG-INSERT-RIDE] payload keys: {sorted(payload.keys())}")
-    logger.info(f"[DEBUG-INSERT-RIDE] full payload: {payload}")
     try:
         result = await run_sync(lambda: _single_row_from_res(supabase.table("rides").insert(payload).execute()))
         logger.info(f"[DEBUG-INSERT-RIDE] SUCCESS ride_id={payload.get('id')}")
@@ -627,7 +628,9 @@ async def get_live_ride_data(ride_id: str) -> Optional[Dict[str, Any]]:
         driver = await run_sync(
             lambda did=driver_id: _single_row_from_res(
                 supabase.table("drivers")
-                .select("user_id,name,phone,lat,lng,vehicle_make,vehicle_model,vehicle_color,license_plate,rating,photo_url")
+                .select(
+                    "user_id,name,phone,lat,lng,vehicle_make,vehicle_model,vehicle_color,license_plate,rating,photo_url"
+                )
                 .eq("id", did)
                 .execute()
             )

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4485,13 +4485,36 @@ async def cancel_ride(
         "updated_at": now,
     }
 
+    # C2: atomic, status-guarded cancel. The in-memory check above can race —
+    # between get_ride and the write the rider/driver can call verify-otp/start
+    # and flip the ride to in_progress. An unguarded update_ride (filters on id
+    # only) would then overwrite in_progress -> cancelled, violating "never cancel
+    # after trip start" (Period 3 left open, fare settlement skipped, regulatory
+    # trip log corrupted). Filtering on the pre-trip states matches zero rows once
+    # the ride has started/ended -> 409, nothing mutated. Mirrors the rider cancel
+    # path in routes/rides.py.
+    _cancel_filter = {
+        "id": ride_id,
+        "status": {
+            "$in": [
+                "requested",
+                RideStatus.SEARCHING,
+                RideStatus.DRIVER_ASSIGNED,
+                RideStatus.DRIVER_ACCEPTED,
+                "en_route",
+                RideStatus.DRIVER_ARRIVED,
+            ]
+        },
+    }
+
     # Try to persist cancelled_by / cancellation_reason for audit. These
     # columns may not exist in older Supabase schemas — PGRST204 on an
     # unknown column would crash the whole cancel. Fall back to the
-    # minimal update so the cancellation still succeeds.
+    # minimal (still status-guarded) update so the cancellation still succeeds.
     try:
-        await db_supabase.update_ride(
-            ride_id,
+        _claim = await db_supabase.update_one(
+            "rides",
+            _cancel_filter,
             {
                 **base_update,
                 "cancelled_by": "driver",
@@ -4504,7 +4527,13 @@ async def cancel_ride(
         logger.warning(
             f"[CANCEL] cancelled_by/cancellation_reason write failed (likely PGRST204); retrying minimal update: {exc}"
         )
-        await db_supabase.update_ride(ride_id, base_update)
+        _claim = await db_supabase.update_one("rides", _cancel_filter, base_update)
+
+    if _claim is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Ride can no longer be cancelled (it has started or already ended)",
+        )
 
     # Make driver available again
     await db_supabase.set_driver_available(driver["id"], True)
@@ -4604,6 +4633,25 @@ async def mark_rider_noshow(
             detail=f"Must wait {remaining} more seconds before marking no-show",
         )
 
+    # C2: atomically claim the no-show cancel (driver_arrived -> cancelled) BEFORE
+    # charging anyone. No-show charges the rider and pays the driver; if the status
+    # write were deferred until after the charge (and filtered on id only), a ride
+    # that started in the race window would be BOTH charged a no-show fee AND
+    # overwritten cancelled. The status-guarded claim matches zero rows once the
+    # ride leaves driver_arrived -> 409, nothing charged. It also makes a duplicate
+    # no-show call idempotent (no double charge).
+    _noshow_now = datetime.now(timezone.utc)
+    _noshow_claim = await db_supabase.update_one(
+        "rides",
+        {"id": ride_id, "status": RideStatus.DRIVER_ARRIVED},
+        {"status": RideStatus.CANCELLED, "cancelled_at": _noshow_now, "updated_at": _noshow_now},
+    )
+    if _noshow_claim is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Ride can no longer be marked no-show (it has started or already ended)",
+        )
+
     try:
         from ..services.cancellation_service import (
             calculate_noshow_fee,
@@ -4661,26 +4709,25 @@ async def mark_rider_noshow(
             ride_status_at_cancel="noshow",
         )
 
-    now = datetime.now(timezone.utc)
-    base_update = {
-        "status": RideStatus.CANCELLED,
-        "cancelled_at": now,
-        "updated_at": now,
-    }
+    # Status was already flipped to cancelled by the atomic claim above; here we
+    # only persist the fee attribution. Writing these columns onto an already-
+    # terminal cancelled ride is safe (cancelled cannot transition away), so an
+    # id-only update is fine. Optional columns may not exist on older schemas.
+    _fee_now = datetime.now(timezone.utc)
     try:
         await db_supabase.update_ride(
             ride_id,
             {
-                **base_update,
                 "cancelled_by": "driver",
                 "cancellation_type": "noshow",
                 "cancellation_fee_admin": float(fee_admin.quantize(Decimal("0.01"))),
                 "cancellation_fee_driver": float(fee_driver.quantize(Decimal("0.01"))),
+                "updated_at": _fee_now,
             },
         )
     except Exception as exc:
         logger.warning(f"[NOSHOW] extended fields write failed; retrying minimal: {exc}")
-        await db_supabase.update_ride(ride_id, base_update)
+        await db_supabase.update_ride(ride_id, {"updated_at": _fee_now})
 
     await db_supabase.set_driver_available(driver["id"], True)
     await record_period_transition(driver["id"], 1)

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -50,6 +50,8 @@ try:
         ErrorCode,
         RideStateError,
         SpinrException,
+        db_error_text,
+        pg_error_code,
     )
     from ..utils.error_keys import ErrorKeys
     from ..utils.idempotency import idempotent_endpoint
@@ -85,6 +87,8 @@ except ImportError:
         ErrorCode,
         RideStateError,
         SpinrException,
+        db_error_text,
+        pg_error_code,
     )
     from utils.error_keys import ErrorKeys
     from utils.idempotency import idempotent_endpoint
@@ -4255,9 +4259,11 @@ async def complete_ride(ride_id: str, current_user: dict = Depends(get_current_u
         _updated_ride_row = await db_supabase.update_one("rides", _complete_filters, update_fields)
     except Exception as e:
         # Some columns may not exist yet in older deployments. Retry with only
-        # the essential fields so ride completion never fails.
-        err_msg = str(e).lower()
-        if "column" in err_msg or "pgrst204" in err_msg:
+        # the essential fields so ride completion never fails. run_sync wraps the
+        # PostgREST error, so match the real text + structured code, not str(e)
+        # (the generic "Database operation failed" sentinel never contains it).
+        err_msg = db_error_text(e)
+        if pg_error_code(e).upper() == "PGRST204" or "column" in err_msg or "pgrst204" in err_msg:
             logger.warning(f"Retrying ride update with minimal fields: {e}")
             safe_keys = {
                 "status",

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -598,20 +598,33 @@ async def create_demo_drivers(vehicle_type_id: str, lat: float, lng: float):
     return
 
 
-async def _dispatch_retry(ride_id: str, delay: int = 10) -> None:
-    """Re-attempt dispatch after a delay. Stops if the ride left searching."""
+# Cap the no-driver re-dispatch chain. At 10s/attempt this is ~5 min, matching
+# the stuck-ride sweeper's cancel window — defense-in-depth so a sweeper failure
+# can't leave a ride re-dispatching (and re-querying drivers) forever.
+_MAX_DISPATCH_ATTEMPTS = 30
+
+
+async def _dispatch_retry(ride_id: str, delay: int = 10, *, attempt: int = 1) -> None:
+    """Re-attempt dispatch after a delay. Stops if the ride left searching or the
+    per-ride attempt cap is reached (the stuck-ride sweeper then owns resolution)."""
     await asyncio.sleep(delay)
+    if attempt > _MAX_DISPATCH_ATTEMPTS:
+        logger.warning(
+            f"[DISPATCH] ride {ride_id} hit {_MAX_DISPATCH_ATTEMPTS} dispatch attempts — "
+            f"stopping retries; stuck-ride sweeper will resolve it"
+        )
+        return
     try:
         ride = await db_supabase.get_ride(ride_id)
         if not ride or ride.get("status") != RideStatus.SEARCHING:
             return
-        logger.info(f"[DISPATCH] retry for ride {ride_id}")
-        await match_driver_to_ride(ride_id, ride=ride)
+        logger.info(f"[DISPATCH] retry {attempt} for ride {ride_id}")
+        await match_driver_to_ride(ride_id, ride=ride, attempt=attempt)
     except Exception as e:
         logger.error(f"[DISPATCH] retry failed for {ride_id}: {e}", exc_info=True)
 
 
-async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
+async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None, attempt: int = 0):
     """Dispatch a driver for ``ride_id``.
 
     ``ride`` may be passed when the caller already has the fresh row
@@ -731,15 +744,16 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
         logger.warning(f"[DISPATCH] presence filter failed, using all DB-online drivers: {_pres_exc}")
 
     # Skip drivers who recently timed out or declined this specific offer
-    # so the same driver is not hammered with repeat notifications.
+    # so the same driver is not hammered with repeat notifications. Batch the
+    # lookups into one MGET — the old per-candidate redis_get was an N+1 on the
+    # dispatch hot path (N round-trips per attempt per replica).
     try:
-        from ..utils.redis_client import redis_get as _redis_get  # type: ignore
+        from ..utils.redis_client import redis_mget as _redis_mget  # type: ignore
     except ImportError:
-        from utils.redis_client import redis_get as _redis_get  # type: ignore
-    _skip_ids: set = set()
-    for _d in all_drivers:
-        if await _redis_get(f"spinr:offer_skip:{ride_id}:{_d['id']}"):
-            _skip_ids.add(_d["id"])
+        from utils.redis_client import redis_mget as _redis_mget  # type: ignore
+    _skip_keys = [f"spinr:offer_skip:{ride_id}:{_d['id']}" for _d in all_drivers]
+    _skip_vals = await _redis_mget(_skip_keys)
+    _skip_ids: set = {_d["id"] for _d, _v in zip(all_drivers, _skip_vals) if _v}
     if _skip_ids:
         all_drivers = [d for d in all_drivers if d["id"] not in _skip_ids]
         logger.info(f"[DISPATCH] skipped {len(_skip_ids)} driver(s) with recent timeout/decline for ride {ride_id}")
@@ -754,8 +768,8 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
     )
 
     if not drivers_with_distance:
-        logger.info(f"[DISPATCH] no eligible drivers for ride {ride_id} — scheduling retry in 10s")
-        asyncio.create_task(_dispatch_retry(ride_id, delay=10))
+        logger.info(f"[DISPATCH] no eligible drivers for ride {ride_id} — scheduling retry in 10s (attempt {attempt})")
+        asyncio.create_task(_dispatch_retry(ride_id, delay=10, attempt=attempt + 1))
         return
 
     # ── ETA ranking ───────────────────────────────────────────────

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -43,6 +43,8 @@ try:
         ErrorCode,
         RideNotFoundException,
         SpinrException,
+        db_error_text,
+        pg_error_code,
     )
     from ..utils.error_keys import ErrorKeys
     from ..utils.idempotency import idempotent_endpoint
@@ -84,6 +86,8 @@ except ImportError:
         ErrorCode,
         RideNotFoundException,
         SpinrException,
+        db_error_text,
+        pg_error_code,
     )
     from utils.error_keys import ErrorKeys
     from utils.idempotency import idempotent_endpoint
@@ -2626,8 +2630,14 @@ async def create_ride(
             break
         except Exception as e:
             last_exc = e
-            msg = str(e).lower()
-            if "column" in msg or "pgrst204" in msg:
+            # db_supabase.run_sync wraps PostgREST errors in DatabaseError/
+            # DuplicateRecordError, so str(e) is a generic sentinel — the SQLSTATE
+            # and constraint name live in details['original']/__cause__. Match the
+            # real text + structured code, not str(e) (which silently missed every
+            # branch below and fell through to a generic 409/503).
+            msg = db_error_text(e)
+            code = pg_error_code(e).upper()
+            if code == "PGRST204" or "pgrst204" in msg or "column" in msg:
                 ride_data.pop("ride_code", None)
                 inserted = await db_supabase.insert_ride(ride_data)
                 break
@@ -2643,7 +2653,7 @@ async def create_ride(
                 if existing:
                     return existing
                 raise HTTPException(status_code=409, detail="Duplicate ride request") from e
-            if "unique" in msg or "duplicate" in msg or "23505" in msg:
+            if code == "23505" or "unique" in msg or "duplicate" in msg:
                 continue  # retry with a new code for ride_code conflicts
             raise
     else:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -657,9 +657,10 @@ async def match_driver_to_ride(ride_id: str, *, ride: Optional[dict] = None):
         ride, app_settings=app_settings
     )
 
+    # PIPEDA: do not log raw pickup lat/lng — coordinates are forbidden in logs
+    # (and this line fires on every dispatch). Correlate by ride_id only.
     logger.info(
         f"[DISPATCH] match start ride_id={ride_id} "
-        f"pickup=({ride['pickup_lat']},{ride['pickup_lng']}) "
         f"vehicle_type_id={ride['vehicle_type_id']} algorithm={algorithm} "
         f"radius_km={search_radius} batch={max_offers} eta={use_eta}"
     )
@@ -2084,9 +2085,9 @@ async def create_ride(
         still_suspended = True
         if suspended_until:
             try:
-                still_suspended = datetime.fromisoformat(
-                    str(suspended_until).replace("Z", "+00:00")
-                ) > datetime.now(timezone.utc)
+                still_suspended = datetime.fromisoformat(str(suspended_until).replace("Z", "+00:00")) > datetime.now(
+                    timezone.utc
+                )
             except ValueError:
                 still_suspended = True
         if still_suspended:

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -690,8 +690,10 @@ async def websocket_endpoint(
                             f"rider_{ride['rider_id']}",
                         )
 
-                    # Broadcast live location to all connected admin monitoring clients
-                    await manager.broadcast_to_admins(location_update)
+                    # Broadcast live location to admin monitoring clients —
+                    # throttled per driver (#3) so 1 Hz pings don't fan out
+                    # N drivers x A admins every second.
+                    await manager.broadcast_driver_location_to_admins(driver_id, location_update)
 
             elif data.get("type") in ("location_batch", "driver_location_batch"):
                 # Batch upload of buffered GPS points (offline recovery).
@@ -844,7 +846,7 @@ async def websocket_endpoint(
                                     _batch_rider_msg,
                                     f"rider_{_batch_ride['rider_id']}",
                                 )
-                            await manager.broadcast_to_admins(_batch_loc_update)
+                            await manager.broadcast_driver_location_to_admins(driver_id, _batch_loc_update)
                     await websocket.send_json({"type": "location_batch_ack", "count": inserted})
 
             elif data.get("type") == "ride_status_update":

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -37,17 +37,27 @@ db = db_supabase  # legacy alias
 # without the formatter stripping them from the main block's except branch.
 try:
     from ..settings_loader import get_app_settings
-    from ..utils.maps_eta import get_ride_eta_seconds
+    from ..utils.maps_eta import get_cached_ride_eta, get_ride_eta_seconds, refresh_ride_eta
 except ImportError:
     try:
         from settings_loader import get_app_settings  # type: ignore[no-redef]
-        from utils.maps_eta import get_ride_eta_seconds  # type: ignore[no-redef]
+        from utils.maps_eta import (  # type: ignore[no-redef]
+            get_cached_ride_eta,
+            get_ride_eta_seconds,
+            refresh_ride_eta,
+        )
     except ImportError:
         # Stubs used when backend is imported outside its package (e.g. tests).
         async def get_app_settings():  # type: ignore[misc]
             return {}
 
         async def get_ride_eta_seconds(*_a, **_kw):  # type: ignore[misc]
+            return None
+
+        async def get_cached_ride_eta(*_a, **_kw):  # type: ignore[misc]
+            return None
+
+        async def refresh_ride_eta(*_a, **_kw):  # type: ignore[misc]
             return None
 
 
@@ -668,17 +678,26 @@ async def websocket_endpoint(
                             pickup_lng = ride.get("pickup_lng")
                             if pickup_lat is not None and pickup_lng is not None:
                                 try:
-                                    eta_sec = await get_ride_eta_seconds(
-                                        driver_lat=lat,
-                                        driver_lng=lng,
-                                        dest_lat=pickup_lat,
-                                        dest_lng=pickup_lng,
-                                        maps_api_key=_maps_key_cache,
-                                        driver_id=driver_id,
-                                        ride_id=ride["id"],
-                                    )
+                                    # #1: hot-path read is cache-only (one Redis
+                                    # GET). On a miss, refresh the ETA OFF the
+                                    # receive loop so an OSRM/Google round-trip
+                                    # never blocks the <150ms location write; the
+                                    # value lands in cache for the next ping.
+                                    eta_sec = await get_cached_ride_eta(driver_id, ride["id"])
                                     if eta_sec is not None:
                                         rider_msg["eta_seconds"] = eta_sec
+                                    else:
+                                        asyncio.create_task(
+                                            refresh_ride_eta(
+                                                driver_lat=lat,
+                                                driver_lng=lng,
+                                                dest_lat=pickup_lat,
+                                                dest_lng=pickup_lng,
+                                                maps_api_key=_maps_key_cache,
+                                                driver_id=driver_id,
+                                                ride_id=ride["id"],
+                                            )
+                                        )
                                 except Exception:
                                     logger.debug(
                                         "ETA fetch failed; omitting eta_seconds from location update",
@@ -826,17 +845,23 @@ async def websocket_endpoint(
                                     _p_lng = _batch_ride.get("pickup_lng")
                                     if _p_lat is not None and _p_lng is not None:
                                         try:
-                                            _eta_sec = await get_ride_eta_seconds(
-                                                driver_lat=_lat,
-                                                driver_lng=_lng,
-                                                dest_lat=_p_lat,
-                                                dest_lng=_p_lng,
-                                                maps_api_key=_maps_key_cache,
-                                                driver_id=driver_id,
-                                                ride_id=_batch_ride["id"],
-                                            )
+                                            # #1: cache-only on the hot path;
+                                            # refresh off-loop on a miss.
+                                            _eta_sec = await get_cached_ride_eta(driver_id, _batch_ride["id"])
                                             if _eta_sec is not None:
                                                 _batch_rider_msg["eta_seconds"] = _eta_sec
+                                            else:
+                                                asyncio.create_task(
+                                                    refresh_ride_eta(
+                                                        driver_lat=_lat,
+                                                        driver_lng=_lng,
+                                                        dest_lat=_p_lat,
+                                                        dest_lng=_p_lng,
+                                                        maps_api_key=_maps_key_cache,
+                                                        driver_id=driver_id,
+                                                        ride_id=_batch_ride["id"],
+                                                    )
+                                                )
                                         except Exception:
                                             logger.debug(
                                                 "ETA fetch failed for batch; omitting eta_seconds",

--- a/backend/server.py
+++ b/backend/server.py
@@ -420,7 +420,7 @@ if sentry_dsn:
     # arbitrary error-message strings to a third party; these hooks redact
     # phones/emails/coords/postal codes from event + breadcrumb text and stamp
     # surface=backend before egress. They never drop an event on failure.
-    from utils.sentry_scrub import scrub_breadcrumb, scrub_event
+    from utils.sentry_scrub import scrub_breadcrumb, scrub_event, tags_from_log_extra
 
     sentry_sdk.init(
         dsn=sentry_dsn,
@@ -438,13 +438,23 @@ if sentry_dsn:
     # stdlib `logging` records; the rest of the backend uses loguru and
     # would otherwise be invisible in Sentry (including the high-signal
     # REFRESH TOKEN REUSE DETECTED alert in utils/refresh_tokens.py).
+    #
+    # Promote the loguru `extra={...}` context (domain/ride_id/driver_id/...)
+    # onto a forked Sentry scope so events are triageable by domain/surface and
+    # correlatable — without this they arrived with only `environment` set.
     def _loguru_sentry_sink(message: "Any") -> None:  # noqa: ANN401, F821
         record = message.record
-        exc_info = record["exception"]
-        if exc_info is not None and exc_info.value is not None:
-            sentry_sdk.capture_exception(exc_info.value)
-        else:
-            sentry_sdk.capture_message(record["message"], level="error")
+        tags = tags_from_log_extra(record.get("extra") or {})
+        # sentry-sdk 2.x prefers new_scope(); fall back to push_scope() on 1.x.
+        scope_cm = getattr(sentry_sdk, "new_scope", None) or sentry_sdk.push_scope
+        with scope_cm() as scope:
+            for key, val in tags.items():
+                scope.set_tag(key, val)
+            exc_info = record["exception"]
+            if exc_info is not None and exc_info.value is not None:
+                sentry_sdk.capture_exception(exc_info.value)
+            else:
+                sentry_sdk.capture_message(record["message"], level="error")
 
     logger.add(_loguru_sentry_sink, level="ERROR")
     logger.info("Sentry SDK initialized for error monitoring")

--- a/backend/server.py
+++ b/backend/server.py
@@ -129,10 +129,10 @@ from routes.lost_and_found import api_router as lost_and_found_router
 from routes.loyalty import api_router as loyalty_router
 from routes.maps_proxy import api_router as maps_router
 from routes.notifications import api_router as notifications_router
+from routes.offer_card import router as offer_card_router
 from routes.payments import api_router as payments_router
 from routes.promotions import api_router as promotions_router
 from routes.quests import api_router as quests_router
-from routes.offer_card import router as offer_card_router
 from routes.rides import api_router as rides_router
 from routes.safety import api_router as safety_router
 from routes.service_areas import api_router as service_areas_router
@@ -369,6 +369,12 @@ if sentry_dsn:
     if _StarletteMiddleware is not None:
         integrations.append(_StarletteMiddleware())
 
+    # C1: defense-in-depth PII scrubber. The loguru->Sentry bridge below forwards
+    # arbitrary error-message strings to a third party; these hooks redact
+    # phones/emails/coords/postal codes from event + breadcrumb text and stamp
+    # surface=backend before egress. They never drop an event on failure.
+    from utils.sentry_scrub import scrub_breadcrumb, scrub_event
+
     sentry_sdk.init(
         dsn=sentry_dsn,
         integrations=integrations,
@@ -377,6 +383,8 @@ if sentry_dsn:
         environment=settings.ENV if hasattr(settings, "ENV") else "production",
         # PIPEDA: never send IP, cookies, or auth headers to Sentry.
         send_default_pii=False,
+        before_send=scrub_event,
+        before_breadcrumb=scrub_breadcrumb,
     )
 
     # Bridge loguru → Sentry. The LoggingIntegration above only captures

--- a/backend/server.py
+++ b/backend/server.py
@@ -150,14 +150,61 @@ init_firebase()
 app = FastAPI(title="Spinr API", version="1.0.0", lifespan=lifespan, redirect_slashes=False)
 
 
-# Railway's healthcheckPath in railway.json is /health. If that endpoint
-# returns anything other than 2xx the deployment never goes live and every
-# request to the public domain is answered with "Application failed to
-# respond". Mount it on the root app (not behind /api) so the probe hits it
-# before any auth middleware.
+# /health is the readiness probe every platform gate hits: fly.toml
+# [[http_service.checks]], railway.json healthcheckPath, both Dockerfile
+# HEALTHCHECKs, and the CI post-deploy smoke test. It must verify the DB is
+# actually reachable — otherwise a replica whose Supabase connection is dead
+# (or whose circuit breaker is open) keeps returning 200, stays in the
+# load-balancer rotation, and answers every real request with a 503, while a
+# bad rolling deploy gets promoted. (F1: previously this returned a static
+# {"status":"healthy"} unconditionally.) The DB ping is cached for a few
+# seconds and time-bounded so frequent probes across replicas add no real load
+# and can't hang. Loop-staleness is intentionally NOT part of this probe — a
+# stale background loop must not pull a serving replica out of rotation; that
+# is covered separately by the loop watchdog alert.
+_HEALTH_CACHE_TTL = 5.0  # seconds — bound DB-ping load under frequent probing
+_HEALTH_PING_TIMEOUT = 3.0  # seconds — never let a hung DB hang the probe
+_health_cache: dict = {"at": 0.0, "ok": False, "detail": {}}
+
+
+async def _db_ready() -> "tuple[bool, dict]":
+    import asyncio
+    import time as _time
+
+    import db_supabase
+
+    now = _time.monotonic()
+    if now - _health_cache["at"] < _HEALTH_CACHE_TTL:
+        return _health_cache["ok"], _health_cache["detail"]
+
+    ok = False
+    detail: dict = {}
+    try:
+        info = await asyncio.wait_for(db_supabase.ping(), timeout=_HEALTH_PING_TIMEOUT)
+        ok = True
+        if isinstance(info, dict):
+            # Only non-sensitive telemetry — safe on an unauthenticated probe.
+            detail = {k: info[k] for k in ("ping_ms", "circuit_state") if k in info}
+    except Exception as exc:
+        # Full error is logged server-side; the public body stays generic so the
+        # health endpoint never leaks DB internals.
+        _logging.getLogger(__name__).error(f"/health DB readiness check failed: {exc}")
+
+    _health_cache.update(at=now, ok=ok, detail=detail)
+    return ok, detail
+
+
 @app.get("/health")
 async def health():
-    return {"status": "healthy"}
+    from starlette.responses import JSONResponse
+
+    ok, detail = await _db_ready()
+    if ok:
+        return {"status": "healthy", "db": {"status": "ok", **detail}}
+    return JSONResponse(
+        status_code=503,
+        content={"status": "unhealthy", "db": {"status": "error"}},
+    )
 
 
 # Prometheus-style metrics exposition. Scraped by Grafana / Railway

--- a/backend/services/dispatch_service.py
+++ b/backend/services/dispatch_service.py
@@ -25,11 +25,13 @@ try:
     from ..settings_loader import get_app_settings
     from ..utils.breadcrumbs import invalidate_active_rides_cache
     from ..utils.driver_presence import present_driver_ids
+    from ..utils.metrics import inc as _metric_inc
 except ImportError:  # pragma: no cover - allow direct module imports in tests
     from geo_utils import calculate_distance
     from settings_loader import get_app_settings
     from utils.breadcrumbs import invalidate_active_rides_cache  # type: ignore
     from utils.driver_presence import present_driver_ids
+    from utils.metrics import inc as _metric_inc  # type: ignore
 
 
 # Valid algorithm values. ``nearest`` is the production default.
@@ -294,10 +296,15 @@ class DispatchService:
         try:
             present = await present_driver_ids([d["id"] for d in rows])
         except Exception as exc:
+            # Graceful degradation (Redis presence is best-effort) — keep the
+            # fallback, but emit a metric so a sustained outage on this KPI path
+            # (match rate, P95 dispatch) is visible on dashboards rather than
+            # buried at warning level.
             logger.warning(
                 "Presence filter failed, dispatching all DB-online drivers",
                 exc_info=exc,
             )
+            _metric_inc("spinr_dispatch_presence_filter_failed_total")
             return rows
         if not present:
             return rows

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -13,6 +13,9 @@ from loguru import logger
 # keepalive can take tens of seconds otherwise).
 _BROADCAST_SEND_TIMEOUT = 2.0
 
+# #3: min seconds between admin location-fan-out messages per driver.
+_ADMIN_LOC_MIN_INTERVAL = 3.0
+
 try:
     from .logging_utils import diag_logger  # type: ignore
     from .utils.metrics import observe as _metric_observe  # type: ignore
@@ -46,6 +49,10 @@ class ConnectionManager:
         # B-P1-12: per-user inbound msg timestamps. See module-level
         # comment above for the cross-machine caveat.
         self._user_msg_timestamps: Dict[str, List[float]] = {}
+        # #3: per-driver throttle for the high-frequency admin location fan-out.
+        # A driver's pings land on one replica, so an in-process gate here caps
+        # the publish rate to once per interval per driver.
+        self._admin_loc_last: Dict[str, float] = {}
 
     async def connect(self, websocket: WebSocket, client_id: str):
         # WebSocket is already accepted in the endpoint handler
@@ -345,6 +352,23 @@ class ConnectionManager:
         if await pubsub.publish_broadcast("admin_", message):
             return
         await self._deliver_broadcast_local("admin_", message)
+
+    async def broadcast_driver_location_to_admins(self, driver_id: str, message: dict) -> None:
+        """Throttled admin fan-out for driver location pings (#3).
+
+        Ride-status events go through broadcast_to_admins unthrottled; only the
+        ~1 Hz location pings are rate-limited (admins don't need sub-interval
+        granularity), cutting the N-drivers x A-admins x 1 Hz fan-out down to
+        once per driver per interval. NOTE: this is the load-shedding half —
+        viewport/bbox filtering (only sending drivers an admin is actually
+        looking at) needs an admin-client subscription protocol and is tracked
+        as a follow-up.
+        """
+        now = time.monotonic()
+        if now - self._admin_loc_last.get(driver_id, 0.0) < _ADMIN_LOC_MIN_INTERVAL:
+            return
+        self._admin_loc_last[driver_id] = now
+        await self.broadcast_to_admins(message)
 
     async def broadcast_ride_status(
         self,

--- a/backend/tests/test_admin_location_throttle.py
+++ b/backend/tests/test_admin_location_throttle.py
@@ -1,0 +1,35 @@
+"""#3: admin driver-location fan-out is throttled per driver.
+
+Ride-status events stay unthrottled (broadcast_to_admins); only the ~1 Hz
+location pings are rate-limited so they don't fan out N drivers x A admins/sec.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_location_broadcast_throttled_per_driver():
+    import backend.socket_manager as sm
+    from backend.socket_manager import ConnectionManager
+
+    mgr = ConnectionManager()
+    sent: list = []
+
+    async def _fake_broadcast(msg):
+        sent.append(msg)
+
+    mgr.broadcast_to_admins = _fake_broadcast  # type: ignore[method-assign]
+
+    clock = {"v": 1000.0}
+    with patch("backend.socket_manager.time.monotonic", lambda: clock["v"]):
+        asyncio.run(mgr.broadcast_driver_location_to_admins("d1", {"n": 1}))  # sent
+        asyncio.run(mgr.broadcast_driver_location_to_admins("d1", {"n": 2}))  # throttled (same instant)
+        asyncio.run(mgr.broadcast_driver_location_to_admins("d2", {"n": 3}))  # sent (different driver)
+        clock["v"] += sm._ADMIN_LOC_MIN_INTERVAL + 0.1
+        asyncio.run(mgr.broadcast_driver_location_to_admins("d1", {"n": 4}))  # sent (interval elapsed)
+
+    assert [m["n"] for m in sent] == [1, 3, 4]

--- a/backend/tests/test_c2_driver_cancel_atomic.py
+++ b/backend/tests/test_c2_driver_cancel_atomic.py
@@ -1,0 +1,108 @@
+"""Regression tests for C2: driver-side cancel / no-show must be atomic.
+
+Background
+----------
+`cancel_ride` and `mark_rider_noshow` previously did an in-memory status check
+and then wrote the cancel via `db_supabase.update_ride`, which filters on `id`
+only. Between the read and the write the ride can flip to `in_progress` (rider
+or driver calls verify-otp/start). The unguarded write would then overwrite
+`in_progress -> cancelled`, violating "never cancel after trip start" — and for
+no-show it would charge a fee on a ride that actually began.
+
+Fix: both paths now claim the cancel with a status-guarded `update_one`
+(`status IN (pre-trip states)` for cancel; `status = driver_arrived` for
+no-show). A zero-row claim returns 409 and nothing is mutated/charged.
+
+Layer 1 — pure contract (always runnable). Layer 2 — integration (CI).
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# --------------------------------------------------------------------------- #
+# Layer 1 — contract
+# --------------------------------------------------------------------------- #
+
+_DRIVER_CANCELLABLE = {
+    "requested",
+    "searching",
+    "driver_assigned",
+    "driver_accepted",
+    "en_route",
+    "driver_arrived",
+}
+
+
+def test_started_or_ended_states_are_not_driver_cancellable():
+    for terminal in ("in_progress", "completed", "cancelled"):
+        assert terminal not in _DRIVER_CANCELLABLE
+
+
+# --------------------------------------------------------------------------- #
+# Layer 2 — integration (imports backend; runs in CI)
+# --------------------------------------------------------------------------- #
+
+
+def test_driver_cancel_returns_409_when_ride_left_pretrip_state():
+    """update_one (the atomic claim) matching zero rows -> 409, nothing else runs."""
+    from fastapi import HTTPException
+
+    from backend.routes import drivers as drv
+
+    driver = {"id": "drv-1", "user_id": "user-1"}
+    # Passes the in-memory check (not in_progress/completed) but the row has
+    # since flipped, so the status-guarded claim matches nothing.
+    ride = {"id": "ride-1", "status": "driver_accepted", "rider_id": "rider-1", "driver_id": "drv-1"}
+
+    with (
+        patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[driver])),
+        patch("backend.routes.drivers.db_supabase.get_ride", AsyncMock(return_value=ride)),
+        patch("backend.routes.drivers.db_supabase.update_one", AsyncMock(return_value=None)) as upd,
+        patch("backend.routes.drivers.db_supabase.set_driver_available", AsyncMock()) as avail,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                drv.cancel_ride(ride_id="ride-1", reason="", request=None, current_user={"id": "user-1"})
+            )
+
+    assert exc_info.value.status_code == 409
+    assert upd.await_count == 1  # only the status-guarded claim was attempted
+    avail.assert_not_awaited()  # driver cleanup never ran on the rejected claim
+
+
+def test_driver_noshow_returns_409_and_charges_nothing_on_race():
+    """No-show claim fails -> 409 before any fee is computed or charged."""
+    from fastapi import HTTPException
+
+    from backend.routes import drivers as drv
+
+    driver = {"id": "drv-1", "user_id": "user-1"}
+    arrived = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
+    ride = {
+        "id": "ride-1",
+        "status": "driver_arrived",
+        "driver_id": "drv-1",
+        "rider_id": "rider-1",
+        "driver_arrived_at": arrived,
+        "service_area_id": None,
+    }
+
+    with (
+        patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[driver])),
+        patch("backend.routes.drivers.db_supabase.get_ride", AsyncMock(return_value=ride)),
+        patch("backend.routes.drivers.db_supabase.find_one", AsyncMock(return_value=None)),
+        patch("backend.settings_loader.get_app_settings", AsyncMock(return_value={"noshow_wait_seconds": 300})),
+        patch("backend.routes.drivers.db_supabase.update_one", AsyncMock(return_value=None)) as upd,
+        patch("backend.services.cancellation_service.calculate_noshow_fee", MagicMock()) as fee_calc,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(drv.mark_rider_noshow(ride_id="ride-1", current_user={"id": "user-1"}))
+
+    assert exc_info.value.status_code == 409
+    fee_calc.assert_not_called()  # nothing charged — claim failed before fee calc
+    assert upd.await_count == 1  # only the atomic claim ran (no wallet debit)

--- a/backend/tests/test_c_allowance_reset_atomic.py
+++ b/backend/tests/test_c_allowance_reset_atomic.py
@@ -1,0 +1,59 @@
+"""Replay-safety tests for allowance_reset (F8): CAS claim on the period roll.
+
+Two replicas could both list a due allowance and both run apply_reset + advance
+the period. The loop now claims the roll-forward via a compare-and-swap on
+period_end (reset_allowance_period(expected_period_end=...)); only the winner
+runs apply_reset, so the reset ledger entry is written once per period.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROW = {"id": "a1", "member_id": "m1", "period_end": "2026-01-01", "rollover": False}
+
+
+def _patches(reset_return):
+    return (
+        patch(
+            "backend.utils.allowance_reset.list_allowances_due_for_reset",
+            AsyncMock(return_value=[dict(_ROW)]),
+        ),
+        patch(
+            "backend.utils.allowance_reset.get_corporate_member_by_id",
+            AsyncMock(return_value={"company_id": "c1"}),
+        ),
+        patch(
+            "backend.utils.allowance_reset.get_corporate_wallet_by_company",
+            AsyncMock(return_value={"id": "w1"}),
+        ),
+        patch("backend.utils.allowance_reset.reset_allowance_period", AsyncMock(return_value=reset_return)),
+        patch("backend.utils.allowance_reset.apply_reset", AsyncMock()),
+    )
+
+
+def test_reset_runs_once_when_cas_won():
+    from backend.utils import allowance_reset as ar
+
+    p_list, p_member, p_wallet, p_reset, p_apply = _patches(reset_return={"id": "a1"})
+    with p_list, p_member, p_wallet, p_reset as reset, p_apply as apply_reset:
+        processed = asyncio.run(ar.run_allowance_reset_tick())
+
+    assert processed == 1
+    apply_reset.assert_awaited_once()
+    # Claim was a CAS on the observed period_end.
+    assert reset.await_args.kwargs["expected_period_end"] == "2026-01-01"
+
+
+def test_reset_skipped_when_cas_lost():
+    from backend.utils import allowance_reset as ar
+
+    p_list, p_member, p_wallet, p_reset, p_apply = _patches(reset_return=None)
+    with p_list, p_member, p_wallet, p_reset, p_apply as apply_reset:
+        processed = asyncio.run(ar.run_allowance_reset_tick())
+
+    assert processed == 0
+    apply_reset.assert_not_awaited()  # another replica owns this period -> no double reset

--- a/backend/tests/test_c_document_expiry_atomic.py
+++ b/backend/tests/test_c_document_expiry_atomic.py
@@ -1,0 +1,71 @@
+"""Replay-safety tests for document_expiry (F6): atomic suspension + warn claims.
+
+The suspension UPDATE and the warning throttle were unconditional / read-then-
+write, so on multiple replicas every replica re-suspended and re-sent the
+"account suspended" push each 12h tick, and warning pushes duplicated. The
+suspension is now its own atomic claim (status != 'suspended') and the warning
+is a compare-and-swap on doc_expiry_warned_at; only the winning replica notifies.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _run_with(driver, update_one_return):
+    """Run check_expiring_documents with one driver; return the patched mocks."""
+    from backend.utils import document_expiry as de
+
+    def _get_rows(table, filters=None, limit=None, offset=0, **kw):
+        if table == "drivers":
+            return [driver] if offset == 0 else []
+        return []  # driver_documents
+
+    push = AsyncMock()
+    clearp = AsyncMock()
+    upd = AsyncMock(return_value=update_one_return)
+    mgr = MagicMock()
+
+    with (
+        patch("backend.utils.document_expiry.db.get_rows", AsyncMock(side_effect=_get_rows)),
+        patch("backend.utils.document_expiry.db.update_one", upd),
+        patch("backend.utils.document_expiry.send_push_notification", push),
+        patch("backend.utils.document_expiry.clear_presence", clearp),
+        patch("backend.utils.document_expiry.manager", mgr),
+    ):
+        asyncio.run(de.check_expiring_documents())
+
+    return push, clearp, upd, mgr
+
+
+def test_expired_docs_suspend_and_notify_once_when_claim_won():
+    driver = {"id": "d1", "user_id": "u1", "license_expiry_date": "2020-01-01T00:00:00+00:00"}
+    push, clearp, upd, mgr = _run_with(driver, update_one_return={"id": "d1", "status": "suspended"})
+
+    upd.assert_awaited_once()  # the status-guarded suspension claim
+    push.assert_awaited_once()  # exactly one suspension push
+    clearp.assert_awaited_once()
+    mgr.disconnect.assert_called_once_with("driver_u1")
+
+
+def test_expired_docs_do_not_renotify_when_claim_lost():
+    driver = {"id": "d1", "user_id": "u1", "license_expiry_date": "2020-01-01T00:00:00+00:00"}
+    push, clearp, upd, mgr = _run_with(driver, update_one_return=None)
+
+    upd.assert_awaited_once()  # claim attempted...
+    push.assert_not_awaited()  # ...but lost -> no duplicate suspension push
+    clearp.assert_not_awaited()
+    mgr.disconnect.assert_not_called()
+
+
+def test_expiring_warning_not_sent_when_claim_lost():
+    soon = (datetime.now(timezone.utc) + timedelta(days=4, hours=1)).isoformat()
+    driver = {"id": "d2", "user_id": "u2", "license_expiry_date": soon}
+    push, _clearp, upd, _mgr = _run_with(driver, update_one_return=None)
+
+    upd.assert_awaited_once()  # the doc_expiry_warned_at CAS
+    push.assert_not_awaited()  # another replica already notified this window

--- a/backend/tests/test_c_push_retry_atomic.py
+++ b/backend/tests/test_c_push_retry_atomic.py
@@ -1,0 +1,84 @@
+"""Replay-safety tests for push_retry (F5): atomic per-row lease claim.
+
+Two replicas run the loop concurrently. Before this fix both could SELECT the
+same `sent_at IS NULL` row and both deliver it (duplicate ride-offer / SOS
+pushes). `_process_row` now leases each row via a compare-and-swap on `attempts`
+before sending; only the winning replica delivers.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROW = {
+    "id": "row-1",
+    "user_id": "user-1",
+    "title": "Ride offer",
+    "body": "New ride",
+    "data": {},
+    "attempts": 0,
+    "target_app": "rider",
+    "users": {"fcm_token_rider": "ExponentPushToken[abc]"},
+}
+
+
+def test_process_row_skips_send_when_claim_lost():
+    """A row already claimed by another replica must NOT be delivered again."""
+    from backend.utils import push_retry as pr
+
+    with (
+        patch("backend.utils.push_retry._claim_row", AsyncMock(return_value=False)),
+        patch("backend.utils.push_retry._is_expo_token", MagicMock(return_value=True)),
+        patch("backend.utils.push_retry._send_expo_push", AsyncMock(return_value=True)) as send,
+        patch("backend.utils.push_retry.run_sync", AsyncMock(return_value=None)) as rs,
+    ):
+        asyncio.run(pr._process_row(dict(_ROW)))
+
+    send.assert_not_awaited()  # claim lost -> no duplicate delivery
+    rs.assert_not_awaited()  # and no sent_at write
+
+
+def test_process_row_delivers_and_marks_sent_when_claim_won():
+    from backend.utils import push_retry as pr
+
+    with (
+        patch("backend.utils.push_retry._claim_row", AsyncMock(return_value=True)),
+        patch("backend.utils.push_retry._is_expo_token", MagicMock(return_value=True)),
+        patch("backend.utils.push_retry._send_expo_push", AsyncMock(return_value=True)) as send,
+        patch("backend.utils.push_retry.run_sync", AsyncMock(return_value=None)) as rs,
+    ):
+        asyncio.run(pr._process_row(dict(_ROW)))
+
+    send.assert_awaited_once()  # winner delivers
+    rs.assert_awaited()  # sent_at marked
+
+
+def _supabase_with_claim_result(rows):
+    sb = MagicMock()
+    chain = sb.table.return_value.update.return_value.eq.return_value.eq.return_value.is_.return_value
+    chain.execute.return_value = MagicMock(data=rows)
+    return sb
+
+
+def test_claim_row_true_when_row_returned_false_when_zero_rows():
+    from backend.utils import push_retry as pr
+
+    async def _passthrough(fn):
+        return fn()
+
+    # Non-empty data -> this worker won the compare-and-swap.
+    with (
+        patch("backend.utils.push_retry.supabase", _supabase_with_claim_result([{"id": "row-1"}])),
+        patch("backend.utils.push_retry.run_sync", AsyncMock(side_effect=_passthrough)),
+    ):
+        assert asyncio.run(pr._claim_row("row-1", 0, "2026-01-01T00:00:00+00:00")) is True
+
+    # Zero rows -> another replica already advanced attempts; we skip.
+    with (
+        patch("backend.utils.push_retry.supabase", _supabase_with_claim_result([])),
+        patch("backend.utils.push_retry.run_sync", AsyncMock(side_effect=_passthrough)),
+    ):
+        assert asyncio.run(pr._claim_row("row-1", 0, "2026-01-01T00:00:00+00:00")) is False

--- a/backend/tests/test_db_error_branching.py
+++ b/backend/tests/test_db_error_branching.py
@@ -1,0 +1,54 @@
+"""Tests for pg_error_code / db_error_text (T4).
+
+run_sync wraps PostgREST errors in DatabaseError/DuplicateRecordError whose
+str() is a generic sentinel; the real SQLSTATE + constraint name live in
+details['original'] and the __cause__ chain. Branching on str(e) (as the
+ride-create / completion fallbacks did) silently missed every constraint-
+specific case. These pin that the helpers surface the real signal.
+"""
+
+import pytest
+
+from utils.error_handling import DatabaseError, DuplicateRecordError, db_error_text, pg_error_code
+
+pytestmark = pytest.mark.unit
+
+
+def test_str_of_wrapped_error_is_only_the_sentinel():
+    # This is exactly why matching str(e) was broken.
+    e = DuplicateRecordError(
+        details={"original": 'duplicate key value violates unique constraint "rides_one_active_per_rider"'}
+    )
+    assert str(e).lower() == "record already exists"
+    assert "rides_one_active_per_rider" not in str(e).lower()
+
+
+def test_db_error_text_surfaces_original_constraint_name():
+    e = DuplicateRecordError(
+        details={"original": 'duplicate key value violates unique constraint "rides_one_active_per_rider"'}
+    )
+    text = db_error_text(e)
+    assert "record already exists" in text  # the sentinel is included...
+    assert "rides_one_active_per_rider" in text  # ...and so is the REAL constraint
+
+
+def test_db_error_text_includes_cause_chain():
+    cause = ValueError("PGRST204: could not find the 'foo' column")
+    try:
+        raise DatabaseError(details={}) from cause
+    except DatabaseError as e:
+        assert "pgrst204" in db_error_text(e)
+
+
+def test_pg_error_code_reads_cause_code():
+    class FakeAPIError(Exception):
+        code = "23505"
+
+    try:
+        raise DatabaseError() from FakeAPIError("dup")
+    except DatabaseError as e:
+        assert pg_error_code(e) == "23505"
+
+
+def test_pg_error_code_empty_when_absent():
+    assert pg_error_code(ValueError("no code here")) == ""

--- a/backend/tests/test_dispatch_metrics.py
+++ b/backend/tests/test_dispatch_metrics.py
@@ -102,6 +102,28 @@ async def test_match_driver_to_ride_counts_offers_sent():
 
 
 @pytest.mark.anyio
+async def test_find_candidate_drivers_counts_presence_filter_failure():
+    """A Redis-presence failure falls back to DB-online drivers AND increments
+    spinr_dispatch_presence_filter_failed_total so the degradation is visible."""
+    from backend.services.dispatch_service import DispatchService
+
+    before = _counter_total("spinr_dispatch_presence_filter_failed_total")
+
+    db = MagicMock()
+    db.get_rows = AsyncMock(return_value=[_driver()])
+    svc = DispatchService(db)
+
+    with patch(
+        "backend.services.dispatch_service.present_driver_ids",
+        AsyncMock(side_effect=RuntimeError("redis down")),
+    ):
+        rows = await svc.find_candidate_drivers(_ride())
+
+    assert rows == [_driver()]  # safety valve: fall back to DB-online drivers
+    assert _counter_total("spinr_dispatch_presence_filter_failed_total") == before + 1
+
+
+@pytest.mark.anyio
 async def test_accept_ride_counts_accept_and_observes_latency():
     from backend.routes import drivers as drivers_mod
 

--- a/backend/tests/test_dispatch_perf.py
+++ b/backend/tests/test_dispatch_perf.py
@@ -1,0 +1,52 @@
+"""Perf/correctness tests for dispatch (#4): batched offer_skip + retry cap."""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_redis_mget_aligns_results_and_handles_empty():
+    from backend.utils import redis_client as rc
+
+    async def go():
+        await rc.redis_set("spinr:test:k1", "v1")
+        await rc.redis_set("spinr:test:k2", "v2")
+        return await rc.redis_mget(["spinr:test:k1", "spinr:test:missing", "spinr:test:k2"])
+
+    vals = asyncio.run(go())
+    assert vals[0] == "v1"
+    assert vals[1] is None
+    assert vals[2] == "v2"
+    assert asyncio.run(rc.redis_mget([])) == []  # empty input → no round-trip
+
+
+def test_dispatch_retry_stops_at_attempt_cap():
+    """Past the cap, _dispatch_retry must not re-query or re-dispatch — the
+    stuck-ride sweeper owns resolution from there."""
+    from backend.routes import rides
+
+    with (
+        patch("backend.routes.rides.db_supabase.get_ride", AsyncMock()) as get_ride,
+        patch("backend.routes.rides.match_driver_to_ride", AsyncMock()) as match,
+    ):
+        asyncio.run(rides._dispatch_retry("r1", delay=0, attempt=rides._MAX_DISPATCH_ATTEMPTS + 1))
+
+    get_ride.assert_not_awaited()
+    match.assert_not_awaited()
+
+
+def test_dispatch_retry_continues_below_cap_and_threads_attempt():
+    from backend.routes import rides
+
+    searching = {"id": "r1", "status": "searching"}
+    with (
+        patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=searching)),
+        patch("backend.routes.rides.match_driver_to_ride", AsyncMock()) as match,
+    ):
+        asyncio.run(rides._dispatch_retry("r1", delay=0, attempt=3))
+
+    match.assert_awaited_once()
+    assert match.await_args.kwargs["attempt"] == 3  # attempt threaded through

--- a/backend/tests/test_eta_hot_path.py
+++ b/backend/tests/test_eta_hot_path.py
@@ -1,0 +1,58 @@
+"""#1: WS hot-path ETA is cache-only; provider round-trip happens off-loop.
+
+get_cached_ride_eta does a single Redis read (no OSRM/Google call), and
+refresh_ride_eta (run via create_task) refreshes the cache without ever raising
+into the receive loop.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_get_cached_ride_eta_hit_and_miss():
+    from backend.utils import maps_eta
+    from backend.utils import redis_client as rc
+
+    async def go():
+        await rc.redis_set("eta:dX:rX", "123")
+        return (
+            await maps_eta.get_cached_ride_eta("dX", "rX"),
+            await maps_eta.get_cached_ride_eta("dNONE", "rNONE"),
+        )
+
+    hit, miss = asyncio.run(go())
+    assert hit == 123  # served from cache, no provider call
+    assert miss is None  # caller schedules refresh off-loop
+
+
+def test_get_cached_ride_eta_never_calls_provider():
+    from backend.utils import maps_eta
+
+    # If the hot-path reader ever hit the routing provider this patch would fire.
+    with patch("backend.utils.maps_eta._osrm_eta_seconds", AsyncMock(side_effect=AssertionError)):
+        assert asyncio.run(maps_eta.get_cached_ride_eta("nope", "nope")) is None
+
+
+def test_refresh_ride_eta_swallows_errors():
+    from backend.utils import maps_eta
+
+    with patch(
+        "backend.utils.maps_eta.get_ride_eta_seconds",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        # Must not raise — it runs as a fire-and-forget create_task.
+        asyncio.run(
+            maps_eta.refresh_ride_eta(
+                driver_lat=1.0,
+                driver_lng=2.0,
+                dest_lat=3.0,
+                dest_lng=4.0,
+                maps_api_key="",
+                driver_id="d",
+                ride_id="r",
+            )
+        )

--- a/backend/tests/test_middleware_user_id.py
+++ b/backend/tests/test_middleware_user_id.py
@@ -1,0 +1,40 @@
+"""Test for log-correlation fix: _extract_user_id must read `user_id` (telemetry).
+
+Spinr JWTs carry the user id in `user_id`, not `sub`. Reading `sub` left
+request.state.user_id (and every log line's user correlation) permanently None.
+"""
+
+from types import SimpleNamespace
+
+import jwt
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _req(token: str | None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    return SimpleNamespace(headers=headers)
+
+
+def test_extract_user_id_reads_user_id_claim():
+    from backend.core.middleware import _extract_user_id
+
+    token = jwt.encode({"user_id": "u-123"}, "secret", algorithm="HS256")
+    assert _extract_user_id(_req(token)) == "u-123"
+
+
+def test_extract_user_id_falls_back_to_sub():
+    from backend.core.middleware import _extract_user_id
+
+    token = jwt.encode({"sub": "legacy-1"}, "secret", algorithm="HS256")
+    assert _extract_user_id(_req(token)) == "legacy-1"
+
+
+def test_extract_user_id_none_when_absent_or_unauth():
+    from backend.core.middleware import _extract_user_id
+
+    no_claims = jwt.encode({"role": "rider"}, "secret", algorithm="HS256")
+    assert _extract_user_id(_req(no_claims)) is None
+    assert _extract_user_id(_req(None)) is None  # no Authorization header
+    assert _extract_user_id(SimpleNamespace(headers={"Authorization": "Basic xyz"})) is None

--- a/backend/tests/test_sentry_scrub.py
+++ b/backend/tests/test_sentry_scrub.py
@@ -1,0 +1,52 @@
+"""Tests for the Sentry before_send/before_breadcrumb PII scrubber (C1)."""
+
+import pytest
+
+from utils.sentry_scrub import scrub_breadcrumb, scrub_event
+
+pytestmark = pytest.mark.unit
+
+
+def test_scrub_event_redacts_phone_in_message():
+    event = {"message": "lookup failed for 306-555-1234"}
+    out = scrub_event(event)
+    assert "306-555-1234" not in out["message"]
+    assert "[PHONE]" in out["message"]
+
+
+def test_scrub_event_redacts_email_and_coords_in_exception_value():
+    event = {"exception": {"values": [{"type": "ValueError", "value": "user a@b.com at 52.1234,-106.6543 not found"}]}}
+    out = scrub_event(event)
+    val = out["exception"]["values"][0]["value"]
+    assert "a@b.com" not in val
+    assert "52.1234,-106.6543" not in val
+    assert "[EMAIL]" in val and "[COORDS]" in val
+
+
+def test_scrub_event_redacts_logentry_message():
+    event = {"logentry": {"message": "contact b@c.ca"}}
+    out = scrub_event(event)
+    assert "b@c.ca" not in out["logentry"]["message"]
+
+
+def test_scrub_event_stamps_surface_tag_without_overwriting():
+    assert scrub_event({})["tags"]["surface"] == "backend"
+    # An explicitly-set surface tag is preserved.
+    out = scrub_event({"tags": {"surface": "worker"}})
+    assert out["tags"]["surface"] == "worker"
+
+
+def test_scrub_event_is_lossless_on_clean_and_malformed_events():
+    clean = {"message": "ride completed", "exception": {"values": []}}
+    assert scrub_event(clean)["message"] == "ride completed"
+    # Non-dict / missing keys must not raise; event is returned as-is.
+    weird = {"message": 12345, "logentry": None, "exception": "nope"}
+    assert scrub_event(weird) is weird
+
+
+def test_scrub_breadcrumb_redacts_message():
+    crumb = {"message": "sms to 306.555.9999 failed"}
+    out = scrub_breadcrumb(crumb)
+    assert "306.555.9999" not in out["message"]
+    # Missing message key is a no-op, not a crash.
+    assert scrub_breadcrumb({"category": "http"}) == {"category": "http"}

--- a/backend/tests/test_sentry_scrub.py
+++ b/backend/tests/test_sentry_scrub.py
@@ -2,9 +2,32 @@
 
 import pytest
 
-from utils.sentry_scrub import scrub_breadcrumb, scrub_event
+from utils.sentry_scrub import scrub_breadcrumb, scrub_event, tags_from_log_extra
 
 pytestmark = pytest.mark.unit
+
+
+def test_tags_from_log_extra_promotes_known_keys():
+    tags = tags_from_log_extra(
+        {"domain": "payments", "ride_id": "r1", "driver_id": "d1", "noise": "ignored"}
+    )
+    assert tags["domain"] == "payments"
+    assert tags["ride_id"] == "r1"
+    assert tags["driver_id"] == "d1"
+    assert tags["surface"] == "backend"  # always stamped
+    assert "noise" not in tags  # only whitelisted keys promoted
+
+
+def test_tags_from_log_extra_stamps_surface_on_empty_or_bad_input():
+    assert tags_from_log_extra({}) == {"surface": "backend"}
+    assert tags_from_log_extra(None) == {"surface": "backend"}
+    # An explicit surface is preserved.
+    assert tags_from_log_extra({"surface": "worker"})["surface"] == "worker"
+
+
+def test_tags_from_log_extra_coerces_values_to_str():
+    tags = tags_from_log_extra({"ride_id": 123})
+    assert tags["ride_id"] == "123"
 
 
 def test_scrub_event_redacts_phone_in_message():

--- a/backend/tests/test_surge_spatial_count.py
+++ b/backend/tests/test_surge_spatial_count.py
@@ -1,0 +1,54 @@
+"""#2 (D1): PostGIS spatial supply count — GeoJSON correctness + safe fallback."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_POLY = [
+    {"lat": 52.00, "lng": -106.00},
+    {"lat": 52.10, "lng": -106.00},
+    {"lat": 52.10, "lng": -106.10},
+]
+
+
+def test_spatial_count_builds_lng_lat_closed_ring_and_applies_presence():
+    from backend.utils import surge_engine as se
+
+    rpc = AsyncMock(
+        return_value=[
+            {"driver_id": "d1", "driver_user_id": "u1"},
+            {"driver_id": "d2", "driver_user_id": "u2"},
+        ]
+    )
+    with (
+        patch("backend.utils.surge_engine.db.rpc", rpc),
+        patch("backend.utils.surge_engine.present_driver_ids", AsyncMock(return_value={"d1"})),
+    ):
+        count = asyncio.run(se._count_supply_spatial(_POLY))
+
+    assert count == 1  # only the present driver counts
+
+    # GeoJSON must be [lng, lat] and a closed ring.
+    args, kwargs = rpc.await_args
+    assert args[0] == "drivers_available_in_polygon"
+    ring = json.loads(args[1]["p_polygon_geojson"])["coordinates"][0]
+    assert ring[0] == [-106.00, 52.00]  # [lng, lat], not [lat, lng]
+    assert ring[0] == ring[-1]  # closed
+
+
+def test_count_supply_falls_back_to_python_scan_on_spatial_error():
+    from backend.utils import surge_engine as se
+
+    with (
+        patch("backend.utils.surge_engine._SURGE_SPATIAL_COUNT", True),
+        patch("backend.utils.surge_engine._count_supply_spatial", AsyncMock(side_effect=RuntimeError("no postgis"))),
+        patch("backend.utils.surge_engine.db.get_rows", AsyncMock(return_value=[])) as get_rows,
+    ):
+        count = asyncio.run(se._count_supply_in_area({"polygon": _POLY}))
+
+    assert count == 0
+    get_rows.assert_awaited()  # fell back to the Python scan; surge never broke

--- a/backend/utils/allowance_reset.py
+++ b/backend/utils/allowance_reset.py
@@ -1,8 +1,10 @@
 """Monthly allowance reset — rolls fixed_recurring periods forward and
 zeroes `used` for non-rollover allowances.
 
-Runs as a scheduled loop (pattern: utils/scheduled_rides.py). Idempotent:
-`list_allowances_due_for_reset` short-circuits when `period_end >= today`.
+Runs as a scheduled loop (pattern: utils/scheduled_rides.py). Replay-safe:
+`list_allowances_due_for_reset` short-circuits when `period_end >= today`, and
+each period roll-forward is claimed via an atomic compare-and-swap on
+`period_end` so only one replica processes a given allowance per period (F8).
 """
 
 from __future__ import annotations
@@ -78,6 +80,21 @@ async def run_allowance_reset_tick(now: Optional[date] = None) -> int:
             wallet = await get_corporate_wallet_by_company(member["company_id"])
             if not wallet:
                 continue
+            # Replay-safety (F8): claim this period roll-forward atomically via a
+            # compare-and-swap on period_end BEFORE zeroing `used`. On >=2 replicas
+            # only the winner advances the period (the others match zero rows and
+            # skip), so apply_reset's reset ledger entry is written once per period.
+            # apply_reset is itself idempotent (re-zeroing `used` is a no-op and a
+            # reset moves no master funds), so a crash between the claim and the
+            # reset fails safe — `used` simply stays as-is (less budget, never more).
+            claimed = await reset_allowance_period(
+                allowance_id=r["id"],
+                period_start=new_start.isoformat(),
+                period_end=new_end.isoformat(),
+                expected_period_end=r["period_end"],
+            )
+            if not claimed:
+                continue
             if not r.get("rollover"):
                 await apply_reset(
                     wallet_id=wallet["id"],
@@ -86,11 +103,6 @@ async def run_allowance_reset_tick(now: Optional[date] = None) -> int:
                     actor_user_id=None,
                     notes=f"period reset {new_start} -> {new_end}",
                 )
-            await reset_allowance_period(
-                allowance_id=r["id"],
-                period_start=new_start.isoformat(),
-                period_end=new_end.isoformat(),
-            )
             processed += 1
         except Exception:
             logger.exception("allowance reset failed for %s", r.get("id"))

--- a/backend/utils/document_expiry.py
+++ b/backend/utils/document_expiry.py
@@ -137,16 +137,25 @@ async def check_expiring_documents():
         # spam-guard below — expiry events must always trigger a new notification.
         if expired_docs:
             doc_list = ", ".join(expired_docs)
-            logger.warning(f"Doc expiry: driver {driver['id']} has expired docs ({doc_list}) — suspending")
-            # 1. Suspension
+            # Replay-safety (F6): make the suspension itself the atomic claim.
+            # Filtering on status != 'suspended' means only the replica that
+            # actually transitions the driver into suspension gets a row back; it
+            # alone clears presence, disconnects, and sends the single suspension
+            # push. Re-ticks (driver already suspended) and sibling replicas match
+            # zero rows, so the driver is not re-suspended or re-notified every 12h.
             try:
-                await db.update_one(
+                claimed = await db.update_one(
                     "drivers",
-                    {"id": driver["id"]},
+                    {"id": driver["id"], "status": {"$ne": "suspended"}},
                     {"is_online": False, "is_available": False, "status": "suspended"},
                 )
             except Exception as e:
                 logger.error(f"Doc expiry: failed to suspend driver {driver['id']}: {e}", exc_info=True)
+                continue
+            if not claimed:
+                # Already suspended by a prior tick or another replica — nothing to do.
+                continue
+            logger.warning(f"Doc expiry: driver {driver['id']} suspended for expired docs ({doc_list})")
             # Clear Redis presence so dispatch filters drop this driver
             # immediately — otherwise they'd remain eligible for up to
             # PRESENCE_TTL (90 s) and could still be assigned a ride.
@@ -155,7 +164,6 @@ async def check_expiring_documents():
             except Exception as e:
                 logger.error(f"Doc expiry: clear_presence failed for {driver['id']}: {e}", exc_info=True)
             manager.disconnect(f"driver_{user_id}")
-            # 2. Notification
             try:
                 await send_push_notification(
                     user_id,
@@ -189,14 +197,29 @@ async def check_expiring_documents():
             notif_body = f"Please renew: {doc_list}. You won't be able to go online with expired documents."
             notif_type = "document_expiry_warning"
 
-        # Spam-guard: apply 24 h throttle only for the 7-day tier.
-        # 1-day and day-of warnings bypass the guard — these are urgent enough
-        # that they must reach the driver even if a 7-day reminder was sent
-        # within the past 24 h.
-        if days_left >= 2:
-            warned_dt = parse_iso_utc(driver.get("doc_expiry_warned_at"))
-            if warned_dt is not None and (now - warned_dt).total_seconds() < 86400:
-                continue
+        # Replay-safety (F6) + spam-guard: claim the notification slot atomically
+        # with a compare-and-swap on doc_expiry_warned_at BEFORE sending, so two
+        # replicas can't both notify in the same tick (the old read-then-write let
+        # every replica pass the throttle and send). The 7-day tier keeps the 24 h
+        # throttle; urgent tiers (today / tomorrow) use a 6 h window so they still
+        # fire on each 12 h tick but exactly once across replicas.
+        throttle_seconds = 86400 if days_left >= 2 else 21600
+        cutoff = (now - timedelta(seconds=throttle_seconds)).isoformat()
+        try:
+            claimed = await db.update_one(
+                "drivers",
+                {
+                    "id": driver["id"],
+                    "$or": [f"doc_expiry_warned_at.is.null,doc_expiry_warned_at.lt.{cutoff}"],
+                },
+                {"doc_expiry_warned_at": now.isoformat()},
+            )
+        except Exception as e:
+            logger.warning(f"Doc expiry: warn-claim failed for driver {driver['id']}: {e}")
+            continue
+        if not claimed:
+            # Another replica already notified within the throttle window.
+            continue
 
         try:
             await send_push_notification(
@@ -204,11 +227,6 @@ async def check_expiring_documents():
                 notif_title,
                 notif_body,
                 data={"type": notif_type, "driver_id": driver["id"]},
-            )
-            await db.update_one(
-                "drivers",
-                {"id": driver["id"]},
-                {"doc_expiry_warned_at": now.isoformat()},
             )
             notified += 1
         except Exception as e:

--- a/backend/utils/error_handling.py
+++ b/backend/utils/error_handling.py
@@ -563,6 +563,42 @@ class DuplicateRecordError(SpinrException):
         )
 
 
+def pg_error_code(exc: Exception) -> str:
+    """Return the SQLSTATE / PostgREST error code for a DB exception, or ''.
+
+    db_supabase.run_sync wraps PostgREST errors in DatabaseError/
+    DuplicateRecordError; the original postgrest-py APIError (which carries
+    ``.code`` — e.g. "23505" unique_violation, "PGRST204" schema-cache miss) is
+    on the ``__cause__`` chain. Prefer the structured code over fragile message
+    substrings.
+    """
+    code = getattr(exc, "code", None)
+    if not code:
+        cause = getattr(exc, "__cause__", None)
+        code = getattr(cause, "code", None)
+    return str(code or "")
+
+
+def db_error_text(exc: Exception) -> str:
+    """Best-effort lowercased underlying DB error text for branching.
+
+    ``str(exc)`` on a wrapped DatabaseError/DuplicateRecordError is a generic
+    sentinel ("Database operation failed" / "Record already exists") — the real
+    message with the SQLSTATE and constraint name lives in
+    ``details['original']`` and the ``__cause__`` chain. Matching ``str(exc)``
+    alone silently misses constraint-specific handling; this joins all three so
+    callers can reliably detect e.g. a specific unique-index violation.
+    """
+    parts = [str(exc)]
+    details = getattr(exc, "details", None)
+    if isinstance(details, dict) and details.get("original"):
+        parts.append(str(details["original"]))
+    cause = getattr(exc, "__cause__", None)
+    if cause is not None:
+        parts.append(str(cause))
+    return " ".join(parts).lower()
+
+
 # Error handling middleware
 async def spinr_exception_handler(
     request: Request, exc: SpinrException

--- a/backend/utils/maps_eta.py
+++ b/backend/utils/maps_eta.py
@@ -244,6 +244,49 @@ async def get_ride_eta_seconds(
     return eta_seconds
 
 
+async def get_cached_ride_eta(driver_id: str, ride_id: str) -> int | None:
+    """Cache-only ETA read (no routing-provider call) — safe on the WS hot path.
+
+    Returns the last computed ETA if still cached, else None. On a miss the
+    caller should schedule refresh_ride_eta() OFF the receive loop (#1) so the
+    sub-150ms location write is never blocked by an OSRM/Google round-trip; the
+    refreshed value is then served from cache on the next ping.
+    """
+    try:
+        cached = await redis_get(f"eta:{driver_id}:{ride_id}")
+        return int(cached) if cached is not None else None
+    except Exception:
+        logger.debug("[ETA] cache-only read failed", exc_info=False)
+        return None
+
+
+async def refresh_ride_eta(
+    *,
+    driver_lat: float,
+    driver_lng: float,
+    dest_lat: float,
+    dest_lng: float,
+    maps_api_key: str,
+    driver_id: str,
+    ride_id: str,
+) -> None:
+    """Exception-safe background ETA refresh (compute + cache) for use via
+    asyncio.create_task, keeping the routing-provider round-trip off the WS
+    receive loop. Never raises to the caller."""
+    try:
+        await get_ride_eta_seconds(
+            driver_lat=driver_lat,
+            driver_lng=driver_lng,
+            dest_lat=dest_lat,
+            dest_lng=dest_lng,
+            maps_api_key=maps_api_key,
+            driver_id=driver_id,
+            ride_id=ride_id,
+        )
+    except Exception:
+        logger.debug("[ETA] background refresh failed", exc_info=True)
+
+
 async def batch_get_etas(
     drivers: list[dict],
     dest_lat: float,

--- a/backend/utils/push_retry.py
+++ b/backend/utils/push_retry.py
@@ -135,6 +135,19 @@ async def _process_row(row: dict) -> None:
         await _delete_row(row_id)
         return
 
+    # Replay-safety (F5): atomically lease this row BEFORE sending so two
+    # replicas can't both deliver it. The conditional update bumps attempts
+    # (compare-and-swap on the observed value) and sets the back-off window in
+    # one statement; a racing replica that already claimed the row gets zero
+    # rows back here and skips. Writing next_attempt_at at claim time also acts
+    # as a crash-safe lease: if this worker dies after claiming but before
+    # delivering, the row becomes due again after the back-off rather than lost.
+    backoff_seconds = _BACKOFF_BASE * (2**attempts)
+    next_attempt_at = (datetime.now(timezone.utc) + timedelta(seconds=backoff_seconds)).isoformat()
+    if not await _claim_row(row_id, attempts, next_attempt_at):
+        logger.info(f"push_retry: row {row_id} already claimed by another worker; skipping")
+        return
+
     success = False
     try:
         if _is_expo_token(token):
@@ -148,9 +161,8 @@ async def _process_row(row: dict) -> None:
         )
         success = False
 
-    now_iso = datetime.now(timezone.utc).isoformat()
-
     if success:
+        now_iso = datetime.now(timezone.utc).isoformat()
         try:
             await run_sync(
                 lambda: supabase.table("push_retry_queue").update({"sent_at": now_iso}).eq("id", row_id).execute()
@@ -165,7 +177,9 @@ async def _process_row(row: dict) -> None:
             )
         return
 
-    # Delivery failed — apply back-off or drop if exhausted.
+    # Delivery failed. The atomic claim already incremented attempts and
+    # scheduled the next retry via next_attempt_at; here we only drop the row
+    # once attempts are exhausted.
     new_attempts = attempts + 1
     if new_attempts >= _MAX_ATTEMPTS:
         logger.error(
@@ -174,28 +188,7 @@ async def _process_row(row: dict) -> None:
         await _delete_row(row_id)
         return
 
-    backoff_seconds = _BACKOFF_BASE * (2**attempts)
-    next_attempt_at = (datetime.now(timezone.utc) + timedelta(seconds=backoff_seconds)).isoformat()
-    try:
-        await run_sync(
-            lambda: (
-                supabase.table("push_retry_queue")
-                .update(
-                    {
-                        "attempts": new_attempts,
-                        "next_attempt_at": next_attempt_at,
-                    }
-                )
-                .eq("id", row_id)
-                .execute()
-            )
-        )
-        logger.warning(f"push_retry: attempt {new_attempts} failed for row {row_id}; next retry in {backoff_seconds}s")
-    except Exception:
-        logger.error(
-            f"push_retry: failed to update back-off for row {row_id}",
-            exc_info=True,
-        )
+    logger.warning(f"push_retry: attempt {new_attempts} failed for row {row_id}; next retry in {backoff_seconds}s")
 
 
 async def _send_fcm_push(
@@ -265,6 +258,34 @@ async def _send_fcm_push(
             f"push_retry: FCM send failed for user {user_id!r}",
             exc_info=True,
         )
+        return False
+
+
+async def _claim_row(row_id: str, observed_attempts: int, next_attempt_at: str) -> bool:
+    """Atomically lease one queue row for delivery (replay-safety, F5).
+
+    Compare-and-swap on the observed ``attempts`` value while ``sent_at IS
+    NULL``: only the worker whose UPDATE flips attempts wins the row;
+    concurrent workers on other replicas read the same snapshot but match zero
+    rows once attempts has advanced, so they skip. Returns True iff this worker
+    claimed the row. Never raises — a claim failure is treated as "not claimed".
+    """
+
+    def _fn() -> bool:
+        res = (
+            supabase.table("push_retry_queue")
+            .update({"attempts": observed_attempts + 1, "next_attempt_at": next_attempt_at})
+            .eq("id", row_id)
+            .eq("attempts", observed_attempts)
+            .is_("sent_at", "null")
+            .execute()
+        )
+        return bool(getattr(res, "data", None))
+
+    try:
+        return await run_sync(_fn)
+    except Exception:
+        logger.error(f"push_retry: failed to claim row {row_id}", exc_info=True)
         return False
 
 

--- a/backend/utils/redis_client.py
+++ b/backend/utils/redis_client.py
@@ -108,6 +108,25 @@ async def redis_get(key: str) -> Optional[str]:
     return _local_get(key)
 
 
+async def redis_mget(keys: list[str]) -> list[Optional[str]]:
+    """Batch GET — one MGET round-trip instead of N redis_get calls.
+
+    Returns a list aligned to ``keys`` (None for misses). Falls back to the
+    in-process store when Redis is unset. Empty input → []. Used on the dispatch
+    hot path to collapse the per-candidate offer_skip lookups into one call.
+    """
+    if not keys:
+        return []
+    r = await _get_redis()
+    if r is not None:
+        try:
+            return await r.mget(keys)
+        except Exception as e:
+            logger.error(f"[REDIS] redis_mget({len(keys)} keys) failed — Redis configured but unavailable: {e}")
+            raise
+    return [_local_get(k) for k in keys]
+
+
 async def redis_set(key: str, value: str, ttl: Optional[int] = None) -> None:
     r = await _get_redis()
     if r is not None:

--- a/backend/utils/sentry_scrub.py
+++ b/backend/utils/sentry_scrub.py
@@ -59,3 +59,40 @@ def scrub_breadcrumb(crumb: dict, hint: Optional[dict] = None) -> dict:
     except Exception:  # noqa: BLE001
         return crumb
     return crumb
+
+
+# Structured-log context keys promoted onto Sentry tags so events are triageable
+# by domain/surface and correlatable to a ride/driver/rider/request. All are IDs
+# or enums — never PII (no phone/email/name/coords), per the logging conventions.
+_TAG_KEYS = (
+    "domain",
+    "surface",
+    "ride_id",
+    "driver_id",
+    "rider_id",
+    "event_id",
+    "request_id",
+    "user_id",
+)
+
+
+def tags_from_log_extra(extra: Any) -> dict:
+    """Lift structured-log ``extra={...}`` context into Sentry tags.
+
+    The codebase already annotates many ``logger.*`` calls with
+    ``extra={"domain": "payments", ...}``; without this the loguru->Sentry
+    bridge dropped that context and events arrived with only ``environment``.
+    Always stamps ``surface=backend`` so every event is at least attributable.
+    Never raises.
+    """
+    tags: dict = {}
+    try:
+        if isinstance(extra, dict):
+            for key in _TAG_KEYS:
+                val = extra.get(key)
+                if val is not None:
+                    tags[key] = str(val)
+    except Exception:  # noqa: BLE001
+        pass
+    tags.setdefault("surface", "backend")
+    return tags

--- a/backend/utils/sentry_scrub.py
+++ b/backend/utils/sentry_scrub.py
@@ -1,0 +1,61 @@
+"""Sentry ``before_send`` / ``before_breadcrumb`` PII scrubber (C1, defense-in-depth).
+
+No log line *should* contain PII — the pre-commit PII-in-logs check and the
+PIPEDA conventions forbid it. But the loguru->Sentry bridge in ``server.py``
+forwards arbitrary error-message strings to a third party, and there was no
+scrubber between the app and Sentry. These hooks redact phones / emails / GPS
+coordinates / postal codes out of event and breadcrumb text before egress, and
+stamp ``surface=backend`` so events are at least minimally attributable.
+
+Hard rule: scrubbing must NEVER drop an event. Any failure returns the event
+unchanged so error reporting keeps working.
+"""
+
+from typing import Any, Optional
+
+try:
+    from ..ai.pii import scrub_pii
+except ImportError:  # pragma: no cover - dual import (uvicorn server:app vs -m backend.server)
+    from ai.pii import scrub_pii
+
+
+def _scrub(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return scrub_pii(value)
+        except Exception:  # noqa: BLE001 - never let scrubbing raise
+            return value
+    return value
+
+
+def scrub_event(event: dict, hint: Optional[dict] = None) -> dict:
+    """``before_send`` hook: stamp ``surface`` tag and redact PII from event text."""
+    try:
+        tags = event.setdefault("tags", {})
+        tags.setdefault("surface", "backend")
+
+        if isinstance(event.get("message"), str):
+            event["message"] = _scrub(event["message"])
+
+        logentry = event.get("logentry")
+        if isinstance(logentry, dict) and isinstance(logentry.get("message"), str):
+            logentry["message"] = _scrub(logentry["message"])
+
+        exc = event.get("exception")
+        if isinstance(exc, dict):
+            for val in exc.get("values", []) or []:
+                if isinstance(val, dict) and isinstance(val.get("value"), str):
+                    val["value"] = _scrub(val["value"])
+    except Exception:  # noqa: BLE001 - never drop an event because scrubbing failed
+        return event
+    return event
+
+
+def scrub_breadcrumb(crumb: dict, hint: Optional[dict] = None) -> dict:
+    """``before_breadcrumb`` hook: redact PII from breadcrumb messages."""
+    try:
+        if isinstance(crumb.get("message"), str):
+            crumb["message"] = _scrub(crumb["message"])
+    except Exception:  # noqa: BLE001
+        return crumb
+    return crumb

--- a/backend/utils/surge_engine.py
+++ b/backend/utils/surge_engine.py
@@ -7,6 +7,8 @@ service_areas.surge_multiplier for areas where surge_source == 'auto'.
 """
 
 import asyncio
+import json
+import os
 import random
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -40,6 +42,11 @@ except ImportError:
 # The real fix is a server-side spatial count (PostGIS ST_Covers + GIST index);
 # tracked as ACTION_ITEMS D1.
 _SURGE_FETCH_CAP = 5000
+
+# D1: enable the PostGIS server-side supply count (migration 170). Off by default
+# so applying the migration changes nothing until it's been rehearsed on staging;
+# flip SURGE_SPATIAL_COUNT=true to activate. The path is fallback-safe regardless.
+_SURGE_SPATIAL_COUNT = os.environ.get("SURGE_SPATIAL_COUNT", "").strip().lower() in ("1", "true", "yes", "on")
 
 # ── Surge tier mapping ───────────────────────────────────────────────
 # Maps demand/supply ratio to multiplier. Thresholds are tuned for a
@@ -104,11 +111,51 @@ async def _count_demand_in_area(area_id: str) -> int:
         return 0
 
 
+async def _count_supply_spatial(poly: List[Dict[str, float]]) -> int:
+    """PostGIS supply count via the drivers_available_in_polygon RPC (D1).
+
+    Builds a GeoJSON polygon with [lng, lat] ordering (what ST_GeomFromGeoJSON
+    expects — we construct it ourselves so there's no axis-swap risk), runs the
+    SECURITY DEFINER spatial lookup (index-only, no row cap), then applies the
+    Redis presence filter in Python so ghost-online drivers are excluded — same
+    semantics as the Python scan, without the truncation cap.
+    """
+    ring = [[p["lng"], p["lat"]] for p in poly]
+    if ring[0] != ring[-1]:
+        ring.append(ring[0])  # GeoJSON rings must be closed
+    geojson = json.dumps({"type": "Polygon", "coordinates": [ring]})
+    rows = await db.rpc("drivers_available_in_polygon", {"p_polygon_geojson": geojson}) or []
+    driver_ids = [r["driver_id"] for r in rows if r.get("driver_id")]
+    if not driver_ids:
+        return 0
+    try:
+        present = await present_driver_ids(driver_ids)
+        if present:
+            driver_ids = [d for d in driver_ids if d in present]
+    except Exception as exc:
+        logger.warning(f"Surge: presence filter failed (spatial), using DB state: {exc}")
+    return len(driver_ids)
+
+
 async def _count_supply_in_area(area: Dict[str, Any]) -> int:
     """Count online+available drivers within a service area polygon."""
     poly = get_service_area_polygon(area)
     if not poly:
         return 0
+
+    # D1: server-side spatial count (no row cap, index-only). Flag-gated and
+    # fully fallback-safe — on any error (flag off, migration 170 not applied,
+    # extension missing, RPC issue) we fall through to the Python scan below, so
+    # surge never breaks.
+    if _SURGE_SPATIAL_COUNT:
+        try:
+            return await _count_supply_spatial(poly)
+        except Exception as exc:
+            logger.warning(
+                f"Surge: spatial supply count failed for area {area.get('id')}, "
+                f"falling back to Python scan: {exc}",
+                exc_info=False,
+            )
 
     try:
         drivers = await db.get_rows(

--- a/backend/utils/surge_engine.py
+++ b/backend/utils/surge_engine.py
@@ -26,10 +26,20 @@ try:
     from db import db
     from geo_utils import get_service_area_polygon, point_in_polygon
     from utils.driver_presence import present_driver_ids
+    from utils.metrics import inc as _metric_inc
 except ImportError:
     from ..db import db
     from ..geo_utils import get_service_area_polygon, point_in_polygon
     from .driver_presence import present_driver_ids
+    from .metrics import inc as _metric_inc
+
+# Per-area supply/demand fetch cap. Surge = demand/supply, a regulated rider-
+# facing price; if a fetch hits this cap the count is TRUNCATED and the
+# multiplier is wrong (supply undercount → over-price). Raised from 500 and made
+# loud (metric + warning below) so truncation can never silently mis-price.
+# The real fix is a server-side spatial count (PostGIS ST_Covers + GIST index);
+# tracked as ACTION_ITEMS D1.
+_SURGE_FETCH_CAP = 5000
 
 # ── Surge tier mapping ───────────────────────────────────────────────
 # Maps demand/supply ratio to multiplier. Thresholds are tuned for a
@@ -70,9 +80,16 @@ async def _count_demand_in_area(area_id: str) -> int:
                 "service_area_id": area_id,
                 "ride_requested_at": {"$gte": cutoff},
             },
-            limit=500,
+            limit=_SURGE_FETCH_CAP,
             columns="id,status",
         )
+        if len(rides) >= _SURGE_FETCH_CAP:
+            _metric_inc("spinr_surge_fetch_cap_hit_total", {"kind": "demand"})
+            logger.error(
+                f"Surge: demand fetch hit the {_SURGE_FETCH_CAP}-row cap for area {area_id} — "
+                f"demand is TRUNCATED and the surge multiplier may be under-stated. "
+                f"Move to a server-side spatial/aggregate count (D1)."
+            )
         # Count rides that are still active or very recently requested
         active_statuses = {
             "searching",
@@ -97,9 +114,16 @@ async def _count_supply_in_area(area: Dict[str, Any]) -> int:
         drivers = await db.get_rows(
             "drivers",
             {"is_online": True, "is_available": True},
-            limit=500,
+            limit=_SURGE_FETCH_CAP,
             columns="id,user_id,lat,lng",
         )
+        if len(drivers) >= _SURGE_FETCH_CAP:
+            _metric_inc("spinr_surge_fetch_cap_hit_total", {"kind": "supply"})
+            logger.error(
+                f"Surge: supply fetch hit the {_SURGE_FETCH_CAP}-row cap for area {area.get('id')} — "
+                f"supply is TRUNCATED and the surge multiplier may be OVER-stated (a regulated price). "
+                f"Move to a server-side spatial count (PostGIS ST_Covers + GIST index, D1)."
+            )
 
         # Presence filter: ghost-online drivers (app force-killed, phone dead)
         # shouldn't count as "supply" or we'd compute a lower surge than the

--- a/driver-app/components/activity/ActivityView.tsx
+++ b/driver-app/components/activity/ActivityView.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  FlatList,
   ActivityIndicator,
   TouchableOpacity,
 } from 'react-native';
@@ -105,8 +106,128 @@ export default function ActivityView() {
       ? true
       : (statusFilter === 'all' && periodRideTotal > filteredRides.length) || filteredRides.length >= PAGE_SIZE);
 
-  return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+  // #6: render one ride card. Extracted from the inline map so the list can be
+  // virtualized by FlatList. Wrapped in the 16px horizontal inset that the old
+  // `ridesSection` View used to provide (rideCard has no inset of its own).
+  const renderRideCard = ({ item: ride }: { item: any }) => {
+    const isCompleted = ride.status === 'completed';
+    const isCancelled = ride.status === 'cancelled';
+    const statusColor = isCompleted ? '#10b981' : isCancelled ? '#ef4444' : '#f59e0b';
+    const statusBg = isCompleted ? 'rgba(16,185,129,0.1)' : isCancelled ? 'rgba(239,68,68,0.1)' : 'rgba(245,158,11,0.1)';
+    const statusLabel = isCompleted ? 'Completed' : isCancelled ? 'Cancelled' : 'Scheduled';
+    const statusIcon = isCompleted ? 'checkmark-circle' : isCancelled ? 'close-circle' : 'time';
+
+    const date = ride.ride_completed_at || (ride as any).cancelled_at || ride.created_at;
+    const tipAmount = parseMoney((ride as any).tip_amount);
+    const incentiveAmount = parseMoney((ride as any).incentive_amount);
+    const totalEarned = parseMoney((ride as any).total_earned);
+
+    return (
+      <View style={styles.ridesSection}>
+        <TouchableOpacity
+          style={styles.rideCard}
+          activeOpacity={0.7}
+          onPress={() => router.push(`/driver/ride-detail?id=${ride.id}` as any)}
+        >
+          {/* Top row: status + date */}
+          <View style={styles.rideTopRow}>
+            <View style={[styles.statusBadge, { backgroundColor: statusBg }]}>
+              <Ionicons name={statusIcon as any} size={14} color={statusColor} />
+              <Text style={[styles.statusText, { color: statusColor }]}>{statusLabel}</Text>
+            </View>
+            <View style={{ alignItems: 'flex-end' }}>
+              <Text style={styles.dateText}>
+                {date ? new Date(date).toLocaleDateString('en', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}
+              </Text>
+              <Text style={styles.rideCodeText}>
+                {ride.ride_code ? String(ride.ride_code) : `#${String(ride.id).substring(0, 8).toUpperCase()}`}
+              </Text>
+            </View>
+          </View>
+
+          {/* Route: pickup → dropoff */}
+          <View style={styles.routeContainer}>
+            <View style={styles.routeDots}>
+              <View style={[styles.dot, { backgroundColor: '#ef4444' }]} />
+              <View style={styles.routeLine} />
+              <View style={[styles.dot, { backgroundColor: '#10b981' }]} />
+            </View>
+            <View style={styles.routeAddresses}>
+              <View>
+                <Text style={styles.routeLabel}>PICKUP</Text>
+                <Text style={styles.routeAddress} numberOfLines={1}>
+                  {ride.pickup_address || 'Unknown'}
+                </Text>
+              </View>
+              <View style={{ height: 16 }} />
+              <View>
+                <Text style={styles.routeLabel}>DROP-OFF</Text>
+                <Text style={styles.routeAddress} numberOfLines={1}>
+                  {ride.dropoff_address || 'Unknown'}
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {/* Bottom row: trip meta + fare */}
+          <View style={styles.rideBottomRow}>
+            <View style={styles.tripMeta}>
+              {ride.distance_km != null && (
+                <View style={styles.metaBadge}>
+                  <Ionicons name="map-outline" size={13} color="#9ca3af" />
+                  <Text style={styles.metaText}>{ride.distance_km.toFixed(1)} km</Text>
+                </View>
+              )}
+              {ride.duration_minutes != null && (
+                <View style={styles.metaBadge}>
+                  <Ionicons name="time-outline" size={13} color="#9ca3af" />
+                  <Text style={styles.metaText}>{ride.duration_minutes} min</Text>
+                </View>
+              )}
+            </View>
+            <View style={{ alignItems: 'flex-end' }}>
+              {isCompleted ? (
+                <>
+                  <Text style={styles.fareAmount}>${toMoney(totalEarned)}</Text>
+                  {(tipAmount > 0 || incentiveAmount > 0) && (
+                    <Text style={styles.tipText}>
+                      {[
+                        tipAmount > 0 ? `$${toMoney(tipAmount)} tip` : '',
+                        incentiveAmount > 0 ? `$${toMoney(incentiveAmount)} bonus` : '',
+                      ].filter(Boolean).join(' + ')}
+                    </Text>
+                  )}
+                </>
+              ) : isCancelled ? (
+                parseMoney((ride as any).cancel_fee_earned) > 0 ? (
+                  <>
+                    <Text style={[styles.fareAmount, { color: '#f59e0b' }]}>
+                      +${toMoney((ride as any).cancel_fee_earned)}
+                    </Text>
+                    <Text style={styles.cancelFeeText}>
+                      {(ride as any).cancellation_type === 'noshow' ? 'No-show fee' : 'Cancel fee'}
+                    </Text>
+                  </>
+                ) : (
+                  <Text style={[styles.fareAmount, { color: '#9ca3af', fontSize: 16 }]}>$0.00</Text>
+                )
+              ) : (
+                <Text style={styles.fareAmount}>Est. ${toMoney(parseMoney((ride as any).driver_earnings))}</Text>
+              )}
+            </View>
+          </View>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
+  // #6: FlatList virtualizes the (potentially long, 'all'-period) ride history
+  // that was previously a filteredRides.map() inside a ScrollView — rendering
+  // every row at once. The chrome (pills/earnings/stats/section header/status
+  // pills) is the ListHeaderComponent; empty + load-more are the empty/footer
+  // slots. Each preserves the 16px inset the old `ridesSection` View provided.
+  const listHeader = (
+    <>
       {/* Period pills */}
       <View style={styles.pillRow}>
         {(['today', 'week', 'month', 'all'] as Period[]).map((item) => (
@@ -201,7 +322,8 @@ export default function ActivityView() {
             </View>
           </View>
 
-          {/* Rides section */}
+          {/* Rides section header + status filter. The ride cards themselves are
+              virtualized below as FlatList items (see renderRideCard). */}
           <View style={styles.ridesSection}>
             <View style={styles.ridesSectionHeader}>
               <Text style={styles.sectionTitle}>Your Rides</Text>
@@ -222,145 +344,54 @@ export default function ActivityView() {
                 </TouchableOpacity>
               ))}
             </ScrollView>
-
-            {/* Ride cards */}
-            {filteredRides.length === 0 ? (
-              <View style={styles.emptyState}>
-                <Ionicons name="car-sport-outline" size={48} color="#d1d5db" />
-                <Text style={styles.emptyTitle}>No Rides Found</Text>
-                <Text style={styles.emptyDesc}>No rides match this filter for the selected period.</Text>
-              </View>
-            ) : (
-              filteredRides.map((ride) => {
-                const isCompleted = ride.status === 'completed';
-                const isCancelled = ride.status === 'cancelled';
-                const statusColor = isCompleted ? '#10b981' : isCancelled ? '#ef4444' : '#f59e0b';
-                const statusBg = isCompleted ? 'rgba(16,185,129,0.1)' : isCancelled ? 'rgba(239,68,68,0.1)' : 'rgba(245,158,11,0.1)';
-                const statusLabel = isCompleted ? 'Completed' : isCancelled ? 'Cancelled' : 'Scheduled';
-                const statusIcon = isCompleted ? 'checkmark-circle' : isCancelled ? 'close-circle' : 'time';
-
-                const date = ride.ride_completed_at || (ride as any).cancelled_at || ride.created_at;
-                const tipAmount = parseMoney((ride as any).tip_amount);
-                const incentiveAmount = parseMoney((ride as any).incentive_amount);
-                const totalEarned = parseMoney((ride as any).total_earned);
-
-                return (
-                  <TouchableOpacity
-                    key={ride.id}
-                    style={styles.rideCard}
-                    activeOpacity={0.7}
-                    onPress={() => router.push(`/driver/ride-detail?id=${ride.id}` as any)}
-                  >
-                    {/* Top row: status + date */}
-                    <View style={styles.rideTopRow}>
-                      <View style={[styles.statusBadge, { backgroundColor: statusBg }]}>
-                        <Ionicons name={statusIcon as any} size={14} color={statusColor} />
-                        <Text style={[styles.statusText, { color: statusColor }]}>{statusLabel}</Text>
-                      </View>
-                      <View style={{ alignItems: 'flex-end' }}>
-                        <Text style={styles.dateText}>
-                          {date ? new Date(date).toLocaleDateString('en', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}
-                        </Text>
-                        <Text style={styles.rideCodeText}>
-                          {ride.ride_code ? String(ride.ride_code) : `#${String(ride.id).substring(0, 8).toUpperCase()}`}
-                        </Text>
-                      </View>
-                    </View>
-
-                    {/* Route: pickup → dropoff */}
-                    <View style={styles.routeContainer}>
-                      <View style={styles.routeDots}>
-                        <View style={[styles.dot, { backgroundColor: '#ef4444' }]} />
-                        <View style={styles.routeLine} />
-                        <View style={[styles.dot, { backgroundColor: '#10b981' }]} />
-                      </View>
-                      <View style={styles.routeAddresses}>
-                        <View>
-                          <Text style={styles.routeLabel}>PICKUP</Text>
-                          <Text style={styles.routeAddress} numberOfLines={1}>
-                            {ride.pickup_address || 'Unknown'}
-                          </Text>
-                        </View>
-                        <View style={{ height: 16 }} />
-                        <View>
-                          <Text style={styles.routeLabel}>DROP-OFF</Text>
-                          <Text style={styles.routeAddress} numberOfLines={1}>
-                            {ride.dropoff_address || 'Unknown'}
-                          </Text>
-                        </View>
-                      </View>
-                    </View>
-
-                    {/* Bottom row: trip meta + fare */}
-                    <View style={styles.rideBottomRow}>
-                      <View style={styles.tripMeta}>
-                        {ride.distance_km != null && (
-                          <View style={styles.metaBadge}>
-                            <Ionicons name="map-outline" size={13} color="#9ca3af" />
-                            <Text style={styles.metaText}>{ride.distance_km.toFixed(1)} km</Text>
-                          </View>
-                        )}
-                        {ride.duration_minutes != null && (
-                          <View style={styles.metaBadge}>
-                            <Ionicons name="time-outline" size={13} color="#9ca3af" />
-                            <Text style={styles.metaText}>{ride.duration_minutes} min</Text>
-                          </View>
-                        )}
-                      </View>
-                      <View style={{ alignItems: 'flex-end' }}>
-                        {isCompleted ? (
-                          <>
-                            <Text style={styles.fareAmount}>${toMoney(totalEarned)}</Text>
-                            {(tipAmount > 0 || incentiveAmount > 0) && (
-                              <Text style={styles.tipText}>
-                                {[
-                                  tipAmount > 0 ? `$${toMoney(tipAmount)} tip` : '',
-                                  incentiveAmount > 0 ? `$${toMoney(incentiveAmount)} bonus` : '',
-                                ].filter(Boolean).join(' + ')}
-                              </Text>
-                            )}
-                          </>
-                        ) : isCancelled ? (
-                          parseMoney((ride as any).cancel_fee_earned) > 0 ? (
-                            <>
-                              <Text style={[styles.fareAmount, { color: '#f59e0b' }]}>
-                                +${toMoney((ride as any).cancel_fee_earned)}
-                              </Text>
-                              <Text style={styles.cancelFeeText}>
-                                {(ride as any).cancellation_type === 'noshow' ? 'No-show fee' : 'Cancel fee'}
-                              </Text>
-                            </>
-                          ) : (
-                            <Text style={[styles.fareAmount, { color: '#9ca3af', fontSize: 16 }]}>$0.00</Text>
-                          )
-                        ) : (
-                          <Text style={styles.fareAmount}>Est. ${toMoney(parseMoney((ride as any).driver_earnings))}</Text>
-                        )}
-                      </View>
-                    </View>
-                  </TouchableOpacity>
-                );
-              })
-            )}
-
-            {canLoadMoreHistory && (
-              <TouchableOpacity
-                style={[styles.loadMoreButton, loadingMore && styles.loadMoreButtonDisabled]}
-                activeOpacity={0.8}
-                disabled={loadingMore}
-                onPress={loadMoreHistory}
-              >
-                {loadingMore ? (
-                  <ActivityIndicator color="#ef4444" />
-                ) : (
-                  <Text style={styles.loadMoreText}>Load more rides</Text>
-                )}
-              </TouchableOpacity>
-            )}
           </View>
         </>
       )}
-    </ScrollView>
+    </>
+  );
+
+  return (
+    <FlatList
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      data={loading ? [] : filteredRides}
+      keyExtractor={(item: any) => String(item.id)}
+      renderItem={renderRideCard}
+      ListHeaderComponent={listHeader}
+      ListEmptyComponent={
+        loading ? null : (
+          <View style={styles.ridesSection}>
+            <View style={styles.emptyState}>
+              <Ionicons name="car-sport-outline" size={48} color="#d1d5db" />
+              <Text style={styles.emptyTitle}>No Rides Found</Text>
+              <Text style={styles.emptyDesc}>No rides match this filter for the selected period.</Text>
+            </View>
+          </View>
+        )
+      }
+      ListFooterComponent={
+        !loading && canLoadMoreHistory ? (
+          <View style={styles.ridesSection}>
+            <TouchableOpacity
+              style={[styles.loadMoreButton, loadingMore && styles.loadMoreButtonDisabled]}
+              activeOpacity={0.8}
+              disabled={loadingMore}
+              onPress={loadMoreHistory}
+            >
+              {loadingMore ? (
+                <ActivityIndicator color="#ef4444" />
+              ) : (
+                <Text style={styles.loadMoreText}>Load more rides</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        ) : null
+      }
+      initialNumToRender={8}
+      maxToRenderPerBatch={8}
+      windowSize={11}
+      removeClippedSubviews
+    />
   );
 }
 

--- a/driver-app/hooks/__tests__/wsLocationBatch.test.ts
+++ b/driver-app/hooks/__tests__/wsLocationBatch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * C4 (P0 GPS OOM): the WS location batch buffer must be bounded.
+ *
+ * In useDriverDashboard.ts the WS batch (wsBatchRef) is only cleared when the
+ * socket is OPEN. During a sustained outage the per-location push grew it
+ * without bound -> OOM on low-memory devices. The fix caps it at 500 (drop
+ * oldest), mirroring the REST buffer. This pins that behavior with a standalone
+ * mirror of the enqueue logic (the full hook lifecycle is out of scope — same
+ * approach as locationBatch.test.ts).
+ *
+ * Code under test: useDriverDashboard.ts location-batch enqueue (~L634).
+ */
+
+const WS_BATCH_CAP = 500;
+
+interface Ref<T> {
+  current: T;
+}
+
+function enqueueWsPoint(
+  batch: Ref<any[]>,
+  lastFlush: Ref<number>,
+  socketOpen: () => boolean,
+  send: (msg: any) => void,
+  payload: any,
+  now: number,
+): void {
+  batch.current.push(payload);
+  const sinceLastFlush = now - lastFlush.current;
+  if (batch.current.length >= 3 || sinceLastFlush > 10_000) {
+    if (socketOpen()) {
+      send({ type: 'driver_location_batch', points: batch.current });
+      batch.current = [];
+      lastFlush.current = now;
+    }
+  }
+  // Mirror of the C4 cap in useDriverDashboard.ts.
+  if (batch.current.length > WS_BATCH_CAP) {
+    batch.current = batch.current.slice(-WS_BATCH_CAP);
+  }
+}
+
+const pt = (i: number) => ({ latitude: 52 + i / 1e6, longitude: -106, seq: i });
+
+describe('WS location batch buffer cap (C4)', () => {
+  it('flushes and clears when the socket is open', () => {
+    const batch: Ref<any[]> = { current: [] };
+    const lastFlush: Ref<number> = { current: 1000 };
+    const send = jest.fn();
+
+    for (let i = 0; i < 3; i++) {
+      enqueueWsPoint(batch, lastFlush, () => true, send, pt(i), 1000 + i);
+    }
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(batch.current).toHaveLength(0);
+  });
+
+  it('stays bounded at 500 during a sustained socket outage (no OOM)', () => {
+    const batch: Ref<any[]> = { current: [] };
+    const lastFlush: Ref<number> = { current: 0 };
+    const send = jest.fn();
+
+    for (let i = 0; i < 2000; i++) {
+      enqueueWsPoint(batch, lastFlush, () => false, send, pt(i), 1_000_000 + i);
+    }
+
+    expect(send).not.toHaveBeenCalled();
+    expect(batch.current.length).toBeLessThanOrEqual(WS_BATCH_CAP);
+    // Oldest dropped, most-recent retained.
+    expect(batch.current[batch.current.length - 1].seq).toBe(1999);
+    expect(batch.current[0].seq).toBe(2000 - WS_BATCH_CAP);
+  });
+
+  it('flushes the capped buffer once the socket recovers', () => {
+    const batch: Ref<any[]> = { current: [] };
+    const lastFlush: Ref<number> = { current: 0 };
+    const send = jest.fn();
+
+    for (let i = 0; i < 600; i++) {
+      enqueueWsPoint(batch, lastFlush, () => false, send, pt(i), 1_000_000 + i);
+    }
+    expect(batch.current.length).toBe(WS_BATCH_CAP);
+
+    // Socket recovers; next enqueue flushes (length >= 3) and clears.
+    enqueueWsPoint(batch, lastFlush, () => true, send, pt(600), 1_000_600);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(batch.current).toHaveLength(0);
+  });
+});

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -643,6 +643,13 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
               lastWsFlushRef.current = Date.now();
             }
           }
+          // C4 (P0 GPS OOM): the batch above is only cleared when the socket is
+          // OPEN. During a sustained outage the push keeps growing it without
+          // bound -> OOM on low-memory devices. Cap it like the REST buffer
+          // below: keep the most recent points, drop the oldest.
+          if (wsBatchRef.current.length > 500) {
+            wsBatchRef.current = wsBatchRef.current.slice(-500);
+          }
 
           // Only buffer for the REST fallback when the socket is DOWN. When WS
           // is open it already persists each point as a breadcrumb server-side,


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Replay-safety/atomicity fixes (C1–F8), WS hot-path ETA off-loop (#1), flag-gated PostGIS surge supply count (D1/#2), admin-location broadcast throttle (#3), dispatch MGET + retry cap (#4), thread-pool consolidation (#5), driver-history FlatList virtualization (#6); plus Sentry PII scrubbing, health-check DB validation, and regression tests.
- **Type**: `fix`
- **Linked issue**: Refs #ACTION_ITEMS (C1, C2, C4, D1, F5, F6, F8, #1–#6)
- **Risk**: `medium` — atomicity fixes are backward-compatible but change error codes in some edge cases; surge spatial count is flag-gated (default OFF) and needs a coordinated deploy + staging rehearsal.
- **User-visible change**: `drivers` — dispatch retry cap prevents stuck rides; WS location batching prevents OOM on low-memory devices; Activity screen list is virtualized.
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors.

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend `[x]` driver-app `[x]` migrations `[x]` infra `[x]` CI
- **Blast radius**: `multi-surface` — dispatch, surge, WebSocket, health checks, background loops, driver-app Activity screen.
- **Data schema change**: `coordinated-deploy` — migration 170 adds `drivers.location_geog` (nullable, instant) + partial GIST index (CONCURRENTLY) + trigger + read-only function. Backfill batched; old backend reads NULL safely and never calls the new function.
- **API contract change**: `none` — internal or behind a feature flag.
- **Background job change**: `modified` — surge engine gains a flag-gated PostGIS supply count; dispatch retry capped at 30 attempts/ride; document-expiry and push-retry loops made atomic.
- **Feature flag**: `behind-new-flag` — `SURGE_SPATIAL_COUNT` (default OFF); falls back to the Python scan on any error.
- **Config / secret change**: `new-env-var` — `SURGE_SPATIAL_COUNT` (optional, defaults false).
- **Rollback plan**: `coordinated` — revert migration 170 (drop function/trigger/index/column), keep `SURGE_SPATIAL_COUNT` off; old backend continues on the Python scan. Other fixes are `git-revert-safe`.
- **Dependencies / coordination**: migration 170 must be applied before `SURGE_SPATIAL_COUNT=true`; staging rehearsal required (EXPLAIN ANALYZE on a real polygon to confirm GIST usage at scale). #6 (FlatList) needs a device/simulator QA pass.
- **Assumptions**: PostGIS available on Supabase (`extensions` schema); driver location kept in sync via trigger; Redis presence filter applied after the spatial count, as before.
- **Not changing but considered**: dispatch retry cap defers to the stuck-ride sweeper for terminal resolution; ETA refresh runs off the WS receive loop so location writes are never blocked by routing-provider latency.

## Tier 3 — Compliance flags

- `[x]` **Money-touching** — surge is a fare input; this changes the surge *supply-count* mechanism only (flag-gated, default OFF), not fare arithmetic. No floats touch fare/wallet/surge math; surge cap (2.5×) unchanged. See Tier 5 money details.
- `[x]` **PIPEDA-relevant** — Sentry scrubber redacts phones/emails/GPS/postal codes from messages + breadcrumbs before egress; `drivers_available_in_polygon` is REVOKEd from PUBLIC/anon/authenticated and granted only to `service_role` (driver-location-derived data).
- `[x]` **SK Transportation Act** — surge supply count (D1) removes potential mis-pricing from a truncated supply count; dispatch retry cap prevents infinite re-dispatch.

## Tier 4 — Verification

- **Unit tests**: `added` — new test files covering atomicity (C2, F5, F6, F8), ETA cache + off-loop (#1), spatial-count GeoJSON/presence/fallback (D1), dispatch MGET + retry cap (#4), admin throttle (#3), health-check DB validation, DB-error branching, middleware `user_id` extraction, and Sentry scrubbing.
- **Integration tests**: `updated` — dispatch-metrics test extended for the presence-filter-failure fallback path.
- **Metrics / logs introduced**: added `spinr_surge_fetch_cap_hit_total` (supply-truncation telemetry) and a dispatch offer-latency metric; names follow the `spinr_<domain>_<metric>_<unit>` convention emitted by `utils/metrics.py`.
- **Screenshots / video**: not attached — no RN runtime in this environment; #6 (FlatList) reviewed structurally and **flagged for device/simulator QA** before merge.
- **Perf numbers**: SLA-critical paths touched (dispatch, WS fan-out, driver location). No captured before/after P95 here — changes are structural (off-loop ETA, MGET batching, broadcast throttle); validate against `perf_baseline.py` / staging before relying on the numbers.

**Pre-merge checklist**:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — **not done**: backend changes are covered by mocked unit tests only; needs a dev-Supabase pass.
- [ ] Tested with rider + driver + admin accounts — **not done**: multi-surface, but not exercised with live accounts in this environment.
- [x] N/A — "verified rollback works": risk is `medium`, not `risk:high`; rollback steps are documented in the migration header and the flag defaults OFF.
- [x] N/A — no CLAUDE.md / `.claude/context/*` convention changed by this PR.
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs/Sentry/analytics — this PR **removes** PII paths and adds the scrubber; verified.

## Tier 5 · Migration details

- **Migration file**: `backend/migrations/170_drivers_location_geog_surge.sql`
- **Next sequence number verified**: `[x]` — 170 is next after 169 (CI sequence check passes).
- **Reversible on paper**: `[x]` — `-- Rollback:` block in the file header (drop function → trigger → trigger fn → index → column).
- **Forward-compatible with in-flight traffic**: `[x]` — nullable column (instant, no rewrite), trigger keeps it in sync, batched backfill, index built CONCURRENTLY; old backend reads NULL and never calls the function.
- **Indexes added for new query patterns**: `[x]` — partial GIST `idx_drivers_location_geog_available WHERE is_online AND is_available`.
- **RLS policies ship in the same migration for any new user-data table**: N/A — no new table; column added to existing `drivers`; the new function is `SECURITY DEFINER` and REVOKEd to `service_role` only.
- **Run-time estimate on prod data**: < 30 s — nullable add is metadata-only; index is CONCURRENT; backfill batched (1000 rows/iter).

## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[x]` — change is integer driver counting + spatial filtering; no fare formula touched.
- **Stripe idempotency** (`claim_stripe_event` before webhook): N/A — not a webhook change.
- **Surge cap 2.5× respected**: `[x]` — `SURGE_CAP` and tier logic unchanged; only the supply *count* source changes.
- **Corporate billing priority preserved**: `[x]` N/A — billing path untouched.
- **Receipt line-items remain transparent** — no hidden "service fee": `[x]` N/A — receipts untouched.
- **PST/GST line items correct**: N/A — not receipt-facing.
- **Before/after fare on a sample trip**: N/A — no fare-formula change; surge multiplier output is unchanged for a given true supply/demand.

## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android): `[ ]` — **not attached**; no RN runtime here. Needs device/simulator QA.
- **Accessibility** — labels, contrast, screen reader: `[x]` N/A — FlatList conversion reuses the exact existing card/chrome components and styles; no new copy or controls.
- **Dark mode verified**: `[x]` N/A — no theme-affecting styles changed.
- **i18n / localization strings added**: `[x]` N/A — no user-visible copy added.
- **Tested on smallest supported device width**: `[ ]` — not tested in this environment (layout/styles unchanged from the prior ScrollView version).

## Tier 5 · Background-loop details

- **Replay-safety mechanism**: no new loop. Modified loops keep their existing guards — dispatch uses the atomic DB claim; document-expiry/push-retry now use atomic claim flags (F5/F6/F8); surge supply count is read-only.
- **Loop interval**: surge engine unchanged (~2 min); dispatch unchanged.
- **Shutdown-safe** — in-flight work finishes or resumes next tick: `[x]`
- **Metric emitted per tick**: `spinr_surge_fetch_cap_hit_total` on supply truncation; dispatch offer-latency metric.
- **Failure mode**: surge spatial count falls back to the Python scan on any error (logged, not Sentry); dispatch tick errors log + retry next tick.

## Tier 6 · Bug-fix notes

- **Root cause**: multiple — non-atomic loop claims (replay duplicates), unbounded driver fetch in surge (supply truncation → potential surge over-pricing), inline routing-provider call on the WS receive loop (latency), per-candidate Redis round-trips + uncapped dispatch retries (stuck rides), full-list render in driver Activity (OOM/jank).
- **How it was introduced**: pre-dates this history (incremental growth of the loops/dispatch/surge paths).
- **Why it was not caught earlier**: dormant under low load / small data; no regression tests on the atomic-claim and surge-cap paths.
- **Regression test added that fails without the fix**: `[x]` — per-item tests (atomicity, ETA cache, spatial GeoJSON/fallback, dispatch cap, throttle).
- **Backport needed?**: `none`

---

AI-assisted — spinr platform (Claude Code)

https://claude.ai/code/session_01U6NRaF2fPfHWMLBfojXNke

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
