### PR TITLE
fix(payouts): surface progress + failure point in Stripe embedded onb…

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2149,25 +2149,40 @@ _STRIPE_EMBEDDED_HTML = """<!doctype html>
   html,body{margin:0;height:100%;background:#0f0f10;
     font-family:-apple-system,Segoe UI,Roboto,sans-serif}
   #msg{color:#bdbdbd;padding:28px;text-align:center;font-size:15px}
+  #dbg{color:#6b7280;padding:6px 12px;text-align:center;font-size:11px;
+    font-family:ui-monospace,Menlo,Consolas,monospace;word-break:break-all}
   #container{padding:0 4px}
 </style></head>
 <body>
   <div id="msg">Loading secure verification…</div>
   <div id="container"></div>
+  <div id="dbg"></div>
   <script>
     var PK = __SPINR_PK__;
+    var mounted = false;
     function post(m){ if(window.ReactNativeWebView){ window.ReactNativeWebView.postMessage(m); } }
+    // Surface progress to BOTH the RN host (debug strip) and on-page, so the
+    // same URL opened directly in a browser shows exactly where it stalls.
+    function stage(s){ post("stage:" + s); var d=document.getElementById("dbg"); if(d){ d.textContent="stage: "+s; } }
+    function fail(c){ post("error:" + c); var d=document.getElementById("dbg"); if(d){ d.textContent="error: "+c; } }
     async function fetchClientSecret(){
+      stage("fetch-start");
       var token = window.__SPINR_TOKEN || "";
-      var res = await fetch("/api/v1/drivers/stripe-account-session", {
-        method: "POST",
-        headers: { "Authorization": "Bearer " + token, "Content-Type": "application/json" }
-      });
-      if(!res.ok){ post("error:" + res.status); throw new Error("account_session " + res.status); }
+      if(!token){ fail("no-token"); throw new Error("no token"); }
+      var res;
+      try{
+        res = await fetch("/api/v1/drivers/stripe-account-session", {
+          method: "POST",
+          headers: { "Authorization": "Bearer " + token, "Content-Type": "application/json" }
+        });
+      }catch(e){ fail("fetch-network"); throw e; }  // network/CSP block — previously silent
+      if(!res.ok){ fail(String(res.status)); throw new Error("account_session " + res.status); }
       var data = await res.json();
+      stage("fetch-ok");
       return data.client_secret;
     }
     function mount(){
+      stage("mounting");
       try{
         var instance = StripeConnect.init({
           publishableKey: PK,
@@ -2176,6 +2191,7 @@ _STRIPE_EMBEDDED_HTML = """<!doctype html>
             colorBackground: "#0f0f10", colorText: "#ffffff",
             colorPrimary: "#16a34a", colorSecondaryText: "#bdbdbd" } }
         });
+        stage("init-ok");
         var onboarding = instance.create("account-onboarding");
         // Mirror the hosted flow: collect eventually/future-due fields up front
         // so the SIN (individual.id_number) is requested during onboarding.
@@ -2183,18 +2199,24 @@ _STRIPE_EMBEDDED_HTML = """<!doctype html>
         onboarding.setOnExit(function(){ post("exit"); });
         document.getElementById("msg").style.display = "none";
         document.getElementById("container").appendChild(onboarding);
-      }catch(e){ post("error:init"); }
+        mounted = true;
+        stage("mounted");
+      }catch(e){ fail("init"); }
     }
-    if(!PK){ document.getElementById("msg").textContent =
+    if(!PK){ stage("no-pk"); document.getElementById("msg").textContent =
       "Payouts setup is not available yet. Please try again later."; }
     else {
+      stage("script-init");
       window.StripeConnect = window.StripeConnect || {};
       // connect.js calls StripeConnect.onLoad once the script finishes loading.
       if(window.StripeConnect && typeof window.StripeConnect.init === "function"){ mount(); }
-      else { window.StripeConnect.onLoad = mount; }
+      else { stage("awaiting-connectjs"); window.StripeConnect.onLoad = mount; }
+      // Watchdog: if connect.js never loads (CSP/network block), onLoad never
+      // fires and the page would spin forever — surface it instead.
+      setTimeout(function(){ if(!mounted){ fail("connectjs-timeout"); } }, 12000);
     }
   </script>
-  <script src="https://connect-js.stripe.com/v1.0/connect.js" async></script>
+  <script src="https://connect-js.stripe.com/v1.0/connect.js" async onerror="fail('connectjs-load')"></script>
 </body></html>"""
 
 

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1323,6 +1323,25 @@ class TestStripeEmbeddedOnboarding:
         # SIN-forcing collection options carried into the embedded component.
         assert 'futureRequirements: "include"' in body
 
+    def test_embedded_page_emits_progress_and_failure_diagnostics(self):
+        # The page must surface where it stalls instead of spinning silently:
+        # per-stage progress, a connect.js load watchdog, an onerror handler,
+        # and a network-level fetch failure signal (previously swallowed).
+        from backend.routes import drivers as drv
+
+        with patch(
+            "backend.settings_loader.get_app_settings",
+            AsyncMock(return_value={"stripe_publishable_key": "pk_test_pub42"}),
+            create=True,
+        ):
+            body = asyncio.run(drv.stripe_embedded()).body.decode()
+
+        assert 'post("stage:" + s)' in body  # progress relayed to the RN host
+        assert 'stage("mounting")' in body and 'stage("mounted")' in body
+        assert 'fail("fetch-network")' in body  # network/CSP fetch reject made visible
+        assert 'fail("connectjs-timeout")' in body  # connect.js load watchdog
+        assert "onerror=\"fail('connectjs-load')\"" in body
+
     def test_embedded_page_has_no_secret_key(self):
         from backend.routes import drivers as drv
 

--- a/driver-app/app/driver/stripe-onboarding.tsx
+++ b/driver-app/app/driver/stripe-onboarding.tsx
@@ -11,6 +11,14 @@
  * runtime via injectedJavaScriptBeforeContentLoaded (window.__SPINR_TOKEN) and
  * used by the page's same-origin POST to /stripe-account-session — it is never
  * placed in the URL or written to logs.
+ *
+ * Diagnostics: this screen used to collapse every failure (token hang, page not
+ * loading, connect.js blocked, COOP, slow fetchClientSecret) into one identical
+ * infinite spinner. It now (a) logs the URL + each progress stage to the JS
+ * console, (b) shows a live debug strip with the exact URL (long-press to copy
+ * and open in a browser) + current stage, (c) trips a no-progress watchdog that
+ * replaces the spinner with an actionable error naming the stall point, and
+ * (d) surfaces HTTP / network / connect.js errors instead of swallowing them.
  */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
@@ -31,6 +39,9 @@ const EMBEDDED_URL = `${SpinrConfig.backendUrl}/api/v1/drivers/stripe-embedded`;
 // alongside mediaCapturePermissionGrantType="grant" — Stripe renders inside
 // iframes, which aren't subject to this list, so this stays tight).
 const ORIGIN_WHITELIST = [SpinrConfig.backendUrl, 'https://*.stripe.com', 'https://connect-js.stripe.com'];
+// If no terminal signal (mounted / exit / error) arrives within this window we
+// stop spinning and show an actionable error naming the current stage.
+const LOAD_TIMEOUT_MS = 30000;
 
 export default function StripeOnboardingScreen() {
     const router = useRouter();
@@ -42,15 +53,33 @@ export default function StripeOnboardingScreen() {
     const [token, setToken] = useState<string | null>(null);
     const [tokenError, setTokenError] = useState(false);
     const [pageLoading, setPageLoading] = useState(true);
+    const [stage, setStageState] = useState<string>('starting');
+    const [fatalError, setFatalError] = useState<string | null>(null);
+    const [reloadKey, setReloadKey] = useState(0);
     const exitedRef = useRef(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // Single place to record progress: logs URL + stage to the JS console
+    // (visible via Metro / `npx react-native log-android|log-ios`) and drives
+    // the on-screen debug strip, so the exact stall point is observable.
+    const log = (s: string) => {
+        // eslint-disable-next-line no-console
+        console.log(`[StripeOnboarding] stage=${s} url=${EMBEDDED_URL}`);
+        setStageState(s);
+    };
+
+    const clearTimer = () => {
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = null;
+        }
+    };
 
     useEffect(() => {
         let active = true;
         (async () => {
             // Best-effort: hold the OS camera permission up front so Stripe's
-            // in-page getUserMedia can capture the driver's government ID. On
-            // Android the WebView can only grant the page's camera request if
-            // the app already holds CAMERA; iOS prompts on first use anyway. If
+            // in-page getUserMedia can capture the driver's government ID. If
             // denied, Stripe falls back to file upload — so never block on this.
             try {
                 await ImagePicker.requestCameraPermissionsAsync();
@@ -58,22 +87,41 @@ export default function StripeOnboardingScreen() {
                 // ignore — onboarding continues with the file-upload fallback
             }
             try {
+                log('requesting-token');
                 await ensureFreshToken();
                 const t = await getAuthHeader();
                 if (!active) return;
                 if (!t) {
+                    log('token-missing');
                     setTokenError(true);
                     return;
                 }
+                log('token-ready');
                 setToken(t);
             } catch {
-                if (active) setTokenError(true);
+                if (active) {
+                    log('token-error');
+                    setTokenError(true);
+                }
             }
         })();
         return () => {
             active = false;
+            clearTimer();
         };
     }, []);
+
+    // Start the no-progress watchdog once the WebView has a token to load with
+    // (and restart it on a manual retry). Cleared on the `mounted` signal.
+    useEffect(() => {
+        if (!token || fatalError) return;
+        clearTimer();
+        timerRef.current = setTimeout(() => {
+            log('timeout');
+            setFatalError('timeout');
+        }, LOAD_TIMEOUT_MS);
+        return clearTimer;
+    }, [token, reloadKey, fatalError]);
 
     // Inject the bearer token into the page BEFORE its scripts run, so the
     // embedded component's fetchClientSecret can authenticate its POST.
@@ -85,6 +133,7 @@ export default function StripeOnboardingScreen() {
     const finish = (opts: { refresh: boolean; message?: string; type?: 'success' | 'error' }) => {
         if (exitedRef.current) return;
         exitedRef.current = true;
+        clearTimer();
         if (opts.message) showToast(opts.type ?? 'info', opts.type === 'error' ? 'Error' : 'Done', opts.message);
         if (opts.refresh) void refetch();
         router.back();
@@ -94,19 +143,33 @@ export default function StripeOnboardingScreen() {
         const data = e.nativeEvent.data || '';
         if (data === 'exit') {
             // User finished or closed Stripe's flow. Re-pull KYC status; the
-            // account.updated webhook is the authoritative gate, so the payout
-            // screen reflects "verified" once Stripe confirms.
+            // account.updated webhook is the authoritative gate.
             finish({ refresh: true, message: 'Verification updated.', type: 'success' });
+        } else if (data.startsWith('stage:')) {
+            const s = data.slice(6);
+            log(s);
+            if (s === 'mounted') clearTimer(); // component is live; stop the watchdog
         } else if (data.startsWith('error:')) {
-            finish({
-                refresh: false,
-                message: 'Could not load verification. Please try again.',
-                type: 'error',
-            });
+            // Show the specific failure (no-token / 401 / fetch-network /
+            // connectjs-timeout / connectjs-load / init / <status>) instead of
+            // an endless spinner.
+            clearTimer();
+            const code = data.slice(6);
+            log(`error:${code}`);
+            setFatalError(code);
         }
     };
 
-    const showSpinner = (!token && !tokenError) || (pageLoading && !tokenError);
+    const retry = () => {
+        exitedRef.current = false;
+        setFatalError(null);
+        setPageLoading(true);
+        log('retry');
+        setReloadKey((k) => k + 1); // remounts the WebView with a fresh load
+    };
+
+    const showSpinner =
+        (!token && !tokenError && !fatalError) || (pageLoading && !tokenError && !fatalError);
 
     return (
         <View style={[styles.container, { backgroundColor: colors.background }]}>
@@ -130,23 +193,48 @@ export default function StripeOnboardingScreen() {
                         Your session expired. Please go back and try again.
                     </Text>
                 </View>
+            ) : fatalError ? (
+                <View style={styles.center}>
+                    <Ionicons name="alert-circle-outline" size={40} color={colors.textDim} />
+                    <Text style={[styles.errText, { color: colors.text, fontWeight: '700' }]}>
+                        Verification couldn’t load.
+                    </Text>
+                    <Text style={[styles.errText, { color: colors.textDim }]}>
+                        {fatalError === 'timeout'
+                            ? `Timed out at stage "${stage}".`
+                            : `Failure: ${fatalError} (last stage "${stage}").`}
+                    </Text>
+                    <Text style={[styles.debugLabel, { color: colors.textDim }]}>
+                        Open this URL in a browser to test it directly:
+                    </Text>
+                    <Text selectable style={[styles.debugUrl, { color: colors.primary }]}>
+                        {EMBEDDED_URL}
+                    </Text>
+                    <TouchableOpacity style={[styles.retryBtn, { backgroundColor: colors.primary }]} onPress={retry}>
+                        <Text style={styles.retryText}>Retry</Text>
+                    </TouchableOpacity>
+                </View>
             ) : (
                 <View style={{ flex: 1 }}>
                     {token && (
                         <WebView
+                            key={reloadKey}
                             ref={webRef}
                             source={{ uri: EMBEDDED_URL }}
                             originWhitelist={ORIGIN_WHITELIST}
                             injectedJavaScriptBeforeContentLoaded={injectedBeforeLoad}
                             onMessage={onMessage}
-                            onLoadEnd={() => setPageLoading(false)}
-                            onError={() =>
-                                finish({
-                                    refresh: false,
-                                    message: 'Network error loading verification.',
-                                    type: 'error',
-                                })
-                            }
+                            onLoadStart={() => log('page-loading')}
+                            onLoadEnd={() => {
+                                setPageLoading(false);
+                                log('page-loaded');
+                            }}
+                            onError={(e) => {
+                                log(`webview-error:${e.nativeEvent?.description ?? ''}`);
+                                clearTimer();
+                                setFatalError('webview-error');
+                            }}
+                            onHttpError={(e) => log(`http-${e.nativeEvent?.statusCode ?? '?'}`)}
                             javaScriptEnabled
                             domStorageEnabled
                             // Stripe identity verification may capture a document photo.
@@ -161,10 +249,23 @@ export default function StripeOnboardingScreen() {
                         <View style={[styles.center, styles.overlay, { backgroundColor: colors.background }]}>
                             <ActivityIndicator size="large" color={colors.primary} />
                             <Text style={[styles.loadingText, { color: colors.textDim }]}>
-                                Loading secure verification…
+                                Loading secure verification… ({stage})
                             </Text>
                         </View>
                     )}
+                    {/* Always-on debug strip: the exact URL (long-press to copy
+                        and open in a browser) + the live progress stage. */}
+                    <View
+                        style={[
+                            styles.debugBar,
+                            { borderTopColor: colors.border, paddingBottom: Math.max(insets.bottom, 6) },
+                        ]}
+                    >
+                        <Text style={[styles.debugLabel, { color: colors.textDim }]}>stage: {stage}</Text>
+                        <Text selectable style={[styles.debugUrl, { color: colors.textDim }]}>
+                            {EMBEDDED_URL}
+                        </Text>
+                    </View>
                 </View>
             )}
         </View>
@@ -181,4 +282,9 @@ const styles = StyleSheet.create({
     overlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 },
     loadingText: { marginTop: 12, fontSize: 14 },
     errText: { marginTop: 12, fontSize: 14, textAlign: 'center', lineHeight: 20 },
+    debugBar: { borderTopWidth: 1, paddingHorizontal: 12, paddingTop: 6 },
+    debugLabel: { fontSize: 11, textAlign: 'center', marginTop: 8 },
+    debugUrl: { fontSize: 11, textAlign: 'center', marginTop: 2 },
+    retryBtn: { marginTop: 18, paddingHorizontal: 32, paddingVertical: 12, borderRadius: 12 },
+    retryText: { color: '#fff', fontSize: 15, fontWeight: '700' },
 });


### PR DESCRIPTION
…oarding

COOP is now unsafe-none in prod yet the Verify Identity screen still hangs, and the screen collapsed every failure mode (token hang, page-load stall, connect.js blocked, slow/failed fetchClientSecret) into one identical infinite spinner with no URL, no stage, no timeout.

Backend embedded page (drivers.py):
- Emit per-stage signals (script-init / awaiting-connectjs / mounting / init-ok / mounted / fetch-start / fetch-ok) to both the RN host and an on-page #dbg strip, so opening the URL directly in a browser shows where it stalls.
- Make a network-level fetchClientSecret rejection visible (was silently swallowed).
- Add a connect.js <script onerror> + a 12s load watchdog (connectjs-timeout).

Driver app (stripe-onboarding.tsx):
- Log URL + each stage to the JS console; show an always-on debug strip with the exact (long-press-copyable) URL + live stage.
- 30s no-progress watchdog replaces the endless spinner with an actionable error naming the stall stage, plus the copyable URL and a Retry.
- Surface onHttpError / onError / error:* messages instead of swallowing them.

Test asserts the diagnostics + watchdog markers are present.

Co-developed with Claude Code (claude-sonnet-4-6)


Claude-Session: https://claude.ai/code/session_01XQKaMHANgbQ6SHBhhWviow

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
