### PR TITLE
fix(payouts): use Stripe hosted onboarding (system browser) instead o…

### DIFF
--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -19,6 +19,7 @@ import { useRouter } from 'expo-router';
 import { useDriverStore } from '../../store/driverStore';
 import { useAuthStore } from '@shared/store/authStore';
 import api from '@shared/api/client';
+import * as WebBrowser from 'expo-web-browser';
 import { useDriverMe, useUpdateDriverMe } from '@shared/hooks/queries';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
@@ -42,9 +43,9 @@ function PayoutScreen() {
     } = useDriverStore();
 
     const [payoutAmount, setPayoutAmount] = useState('');
-    // Onboarding now opens an in-app WebView screen (instant navigation), so
-    // there's no async "opening…" state to track here.
-    const stripeOnboarding = false;
+    // Hosted Stripe onboarding opens in the system browser, so track the brief
+    // "opening…" state while we mint the AccountLink and hand off.
+    const [stripeOnboarding, setStripeOnboarding] = useState(false);
     const [downloadingT4A, setDownloadingT4A] = useState(false);
     const [downloadingCSV, setDownloadingCSV] = useState(false);
     // gst_bn (CRA Business Number) is the canonical column on the driver row
@@ -105,12 +106,35 @@ function PayoutScreen() {
         }
     }, [error]);
 
-    const handleStripeOnboarding = () => {
-        // Option B: open Stripe's embedded onboarding in an in-app WebView (no
-        // browser redirect). The screen mints an AccountSession and lets Stripe
-        // collect the SIN/identity + payout bank account in-app; we only ever
-        // mirror the last-4 + verification status.
-        router.push('/driver/stripe-onboarding' as any);
+    const handleStripeOnboarding = async () => {
+        // Hosted onboarding (Option A): open Stripe's AccountLink in the system
+        // browser. A bare WebView dead-ends at Stripe's popup-based KYC step
+        // (the popup has no window.opener and the page hangs); the system
+        // browser supports the popup + redirect + camera/identity steps, so
+        // onboarding can actually complete. Stripe still collects and holds the
+        // SIN / government ID / bank account — we only ever mirror status. The
+        // backend return_url bounces back to spinr-driver://driver/payout.
+        try {
+            setStripeOnboarding(true);
+            const res = await api.post<{ url?: string; mock?: boolean }>('/drivers/stripe-onboard');
+            const url = res.data?.url;
+            if (!url || res.data?.mock) {
+                showToast('info', 'Unavailable', 'Payouts setup is not available yet. Please try again later.');
+                return;
+            }
+            // Redirect target must match the backend _STRIPE_RETURN_DEEP_LINK
+            // (backend/routes/drivers.py); openAuthSessionAsync auto-dismisses
+            // the browser when Stripe's return_url bounces to this scheme.
+            await WebBrowser.openAuthSessionAsync(url, 'spinr-driver://driver/payout');
+            // Whether they finished or dismissed, re-pull KYC + balance/bank
+            // state. The account.updated webhook is the authoritative gate; this
+            // just refreshes the UI so "Stripe Connected" flips once verified.
+            await loadData();
+        } catch (err: any) {
+            showToast('error', 'Error', err?.response?.data?.detail || 'Could not start verification. Please try again.');
+        } finally {
+            setStripeOnboarding(false);
+        }
     };
 
     const handleSaveGst = async () => {

--- a/driver-app/package.json
+++ b/driver-app/package.json
@@ -55,6 +55,7 @@
     "expo-system-ui": "~55.0.18",
     "expo-task-manager": "~55.0.16",
     "expo-updates": "~55.0.24",
+    "expo-web-browser": "~55.0.14",
     "firebase": "^12.12.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
…f embedded WebView

Diagnostics confirmed the embedded WebView mounts and renders Stripe's intro ('Add information', stage=fetch-ok) but dead-ends on the next step: Stripe opens it as a popup, and a bare RN WebView (setSupportMultipleWindows=false) turns the popup into a top-frame navigation to a Stripe page with no window.opener — which hangs forever (white screen, stage regressed to page-loaded).

Switch the payout screen's onboarding action to the hosted AccountLink flow that the backend already exposes (POST /drivers/stripe-onboard), opened via expo-web-browser.openAuthSessionAsync. The system browser supports the popup, redirect, camera and identity/selfie steps natively, so onboarding completes. Stripe still collects and holds the SIN / government ID / bank account; we only mirror status. Return bounces to spinr-driver://driver/payout (backend return_url) and we refetch KYC + balance on return. stripeOnboarding becomes real state so the 'Opening Stripe…' affordance works.

The embedded screen (app/driver/stripe-onboarding.tsx) is left in place but is no longer reached from the UI.

Co-developed with Claude Code (claude-sonnet-4-6)


Claude-Session: https://claude.ai/code/session_01XQKaMHANgbQ6SHBhhWviow

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
