### PR TITLE
fix(rider): expand ride sheet on vehicle selection

### DIFF
--- a/backend/geo_utils.py
+++ b/backend/geo_utils.py
@@ -11,6 +11,40 @@ def calculate_distance(lat1: float, lng1: float, lat2: float, lng2: float) -> fl
     return R * c
 
 
+def multi_leg_distance(
+    pickup_lat: float,
+    pickup_lng: float,
+    dropoff_lat: float,
+    dropoff_lng: float,
+    stops: List[Dict[str, Any]] | None = None,
+) -> float:
+    """Total distance (km) of the route pickup → stops → dropoff.
+
+    Sums the haversine length of each leg through the intermediate stops, so a
+    multi-stop ride is priced on the actual detour rather than the straight
+    pickup→dropoff line. With no stops this is identical to a single
+    ``calculate_distance`` call.
+
+    Stops missing coordinates, or carrying the placeholder ``(0, 0)`` an
+    unfilled stop field sends from the rider app, are skipped — they must not
+    inflate the fare or bend the route into the ocean off West Africa.
+    """
+    points = [(pickup_lat, pickup_lng)]
+    for stop in stops or []:
+        lat = stop.get("lat")
+        lng = stop.get("lng")
+        # `0`/`0.0` placeholder or missing coord → not a real stop. A genuine
+        # Saskatchewan coordinate is never exactly on the equator/prime meridian.
+        if not lat or not lng:
+            continue
+        points.append((lat, lng))
+    points.append((dropoff_lat, dropoff_lng))
+    return sum(
+        calculate_distance(points[i][0], points[i][1], points[i + 1][0], points[i + 1][1])
+        for i in range(len(points) - 1)
+    )
+
+
 def get_service_area_polygon(area: Dict[str, Any]) -> List[Dict[str, float]]:
     """
     Return polygon as list of {lat, lng} from a service area row.

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -25,6 +25,7 @@ try:
     from ..geo_utils import (
         calculate_distance,
         get_service_area_polygon,
+        multi_leg_distance,
         point_in_polygon,
     )
     from ..models.ride_status import RideStatus
@@ -69,7 +70,7 @@ except ImportError:
         notify_safety_team,
         send_push_notification,
     )
-    from geo_utils import calculate_distance, get_service_area_polygon, point_in_polygon
+    from geo_utils import calculate_distance, get_service_area_polygon, multi_leg_distance, point_in_polygon
     from models.ride_status import RideStatus  # noqa: F401
     from schemas import CreateRideRequest, DriverPublicView, Ride, RideRatingRequest
     from services.dispatch_service import (
@@ -343,15 +344,13 @@ def _reestimate_fare_for_stops(ride: dict, new_stops: list) -> dict:
     surge)), then applies them to the new multi-leg distance.  Returns a dict
     suitable for merging into a $set update.
     """
-    # Build ordered waypoints: pickup → stops → dropoff
-    waypoints = [
-        (ride["pickup_lat"], ride["pickup_lng"]),
-        *[(s["lat"], s["lng"]) for s in new_stops],
-        (ride["dropoff_lat"], ride["dropoff_lng"]),
-    ]
-    new_distance_km = sum(
-        calculate_distance(waypoints[i][0], waypoints[i][1], waypoints[i + 1][0], waypoints[i + 1][1])
-        for i in range(len(waypoints) - 1)
+    # Multi-leg distance pickup → stops → dropoff (shared with /rides/estimate).
+    new_distance_km = multi_leg_distance(
+        ride["pickup_lat"],
+        ride["pickup_lng"],
+        ride["dropoff_lat"],
+        ride["dropoff_lng"],
+        new_stops,
     )
     new_duration_minutes = max(5, int(new_distance_km / 30 * 60) + 5)
 
@@ -1413,7 +1412,11 @@ async def compute_ride_estimates(
     don't render a map (saves a Maps API call and its latency).
     """
     validate_ride_location(body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng)
-    distance_km = calculate_distance(body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng)
+    # Price the actual route through any intermediate stops, not the straight
+    # pickup→dropoff line — otherwise adding a stop never changes the quote.
+    distance_km = multi_leg_distance(
+        body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng, body.stops
+    )
     duration_minutes = int(distance_km / 30 * 60) + 5
 
     fares = await get_fares_for_location(body.pickup_lat, body.pickup_lng)
@@ -2155,7 +2158,11 @@ async def create_ride(
             message_key=ErrorKeys.PAYMENT_UNPAID_RIDE_BLOCK,
         )
 
-    distance_km = calculate_distance(body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng)
+    # Charge the multi-leg route (pickup → stops → dropoff) so the booked fare
+    # matches the multi-stop quote shown at /rides/estimate.
+    distance_km = multi_leg_distance(
+        body.pickup_lat, body.pickup_lng, body.dropoff_lat, body.dropoff_lng, body.stops
+    )
     duration_minutes = int(distance_km / 30 * 60) + 5
 
     # Fetch service_areas ONCE for this request and share across:

--- a/backend/tests/test_multi_leg_distance.py
+++ b/backend/tests/test_multi_leg_distance.py
@@ -1,0 +1,78 @@
+"""Regression: multi-stop rides must be priced on the through-route distance.
+
+The fare quote (/rides/estimate) and the booked fare (POST /rides) both derive
+distance_km from geo_utils.multi_leg_distance. Before this, distance_km was a
+straight pickup→dropoff haversine that ignored stops, so adding a stop never
+changed the km or the price. These tests pin the helper's contract.
+
+Run:
+    pytest backend/tests/test_multi_leg_distance.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.geo_utils import calculate_distance, multi_leg_distance
+
+# Regina-area coordinates roughly matching the reported flow.
+PICKUP = (50.4452, -104.6189)   # downtown Regina
+STOP_EAST = (50.4700, -104.5400)  # Walmart east
+DROPOFF_NORTH = (50.5000, -104.6000)  # Costco north
+
+
+@pytest.mark.unit
+def test_no_stops_equals_direct_distance():
+    direct = calculate_distance(*PICKUP, *DROPOFF_NORTH)
+    assert multi_leg_distance(*PICKUP, *DROPOFF_NORTH, None) == pytest.approx(direct)
+    assert multi_leg_distance(*PICKUP, *DROPOFF_NORTH, []) == pytest.approx(direct)
+
+
+@pytest.mark.unit
+def test_stop_increases_distance():
+    direct = calculate_distance(*PICKUP, *DROPOFF_NORTH)
+    with_stop = multi_leg_distance(
+        *PICKUP, *DROPOFF_NORTH,
+        [{"address": "Walmart East", "lat": STOP_EAST[0], "lng": STOP_EAST[1]}],
+    )
+    # A detour through an off-axis stop is always at least as long as the
+    # straight line (triangle inequality), and here strictly longer.
+    assert with_stop > direct
+
+
+@pytest.mark.unit
+def test_distance_is_sum_of_legs():
+    leg1 = calculate_distance(*PICKUP, *STOP_EAST)
+    leg2 = calculate_distance(*STOP_EAST, *DROPOFF_NORTH)
+    with_stop = multi_leg_distance(
+        *PICKUP, *DROPOFF_NORTH,
+        [{"lat": STOP_EAST[0], "lng": STOP_EAST[1]}],
+    )
+    assert with_stop == pytest.approx(leg1 + leg2)
+
+
+@pytest.mark.unit
+def test_placeholder_and_missing_stops_are_skipped():
+    direct = calculate_distance(*PICKUP, *DROPOFF_NORTH)
+    # Unfilled stop fields arrive from the rider app as (0, 0) placeholders, and
+    # some carry no coords at all — neither may inflate the fare.
+    polluted = [
+        {"address": "", "lat": 0, "lng": 0},
+        {"address": "no coords"},
+        {"lat": None, "lng": None},
+    ]
+    assert multi_leg_distance(*PICKUP, *DROPOFF_NORTH, polluted) == pytest.approx(direct)
+
+
+@pytest.mark.unit
+def test_multiple_stops_are_ordered():
+    stops = [
+        {"lat": STOP_EAST[0], "lng": STOP_EAST[1]},
+        {"lat": DROPOFF_NORTH[0] - 0.01, "lng": DROPOFF_NORTH[1] - 0.01},
+    ]
+    expected = (
+        calculate_distance(*PICKUP, *STOP_EAST)
+        + calculate_distance(STOP_EAST[0], STOP_EAST[1], stops[1]["lat"], stops[1]["lng"])
+        + calculate_distance(stops[1]["lat"], stops[1]["lng"], *DROPOFF_NORTH)
+    )
+    assert multi_leg_distance(*PICKUP, *DROPOFF_NORTH, stops) == pytest.approx(expected)

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -286,6 +286,11 @@ function RideOptionsScreenContent() {
     }
     setSelectedIndex(index);
     selectVehicle(estimates[index].vehicle_type);
+    // Expand the sheet to its full snap point so the payment, schedule, and
+    // Confirm rows come into view. Riders were tapping a vehicle and getting
+    // stuck on the 40% snap, not realizing they had to drag the sheet up to
+    // reach the Confirm button.
+    sheetRef.current?.expand();
     setTimeout(() => fetchNearbyDrivers(), 100);
     const est = estimates[index];
     const grandTotal = parseFloat((est as any).grand_total || est.total_fare || '0');

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -258,9 +258,15 @@ function RideOptionsScreenContent() {
   // with the estimate response). Falls back to MapViewDirections on-device
   // if the backend didn't return one.
   useEffect(() => {
-    if (routePolyline && routePolyline.length >= 2 && routeCoordinates.length === 0) {
+    if (routePolyline && routePolyline.length >= 2) {
       const coords = routePolyline.map(([lat, lng]: [number, number]) => ({ latitude: lat, longitude: lng }));
       setRouteCoordinates(coords);
+    } else {
+      // The store clears routePolyline whenever a waypoint changes (e.g. the
+      // rider went back and picked a new destination/stop). Drop the old drawn
+      // route too so a stale trace doesn't linger on the map and the
+      // MapViewDirections fallback can redraw for the new route.
+      setRouteCoordinates([]);
     }
   }, [routePolyline]);
 

--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -807,6 +807,7 @@ function RideOptionsScreenContent() {
                   <Ionicons name={paymentIcon} size={18} color={colors.primary} />
                 </View>
                 <View style={{ flex: 1 }}>
+                  <Text style={styles.actionRowLabel}>Payment</Text>
                   <Text style={styles.actionRowValue}>{paymentLabel}</Text>
                 </View>
                 <Ionicons name="chevron-forward" size={16} color="#9CA3AF" />
@@ -819,14 +820,20 @@ function RideOptionsScreenContent() {
                 activeOpacity={0.7}
               >
                 <View style={styles.actionRowIcon}>
-                  <Ionicons name="time" size={18} color={colors.primary} />
+                  <Ionicons name="calendar-outline" size={18} color={colors.primary} />
                 </View>
                 <View style={{ flex: 1 }}>
-                  <Text style={styles.actionRowValue}>
-                    {scheduledTime
-                      ? `${scheduledTime.toLocaleDateString('en-CA', { weekday: 'short', month: 'short', day: 'numeric' })} at ${scheduledTime.toLocaleTimeString('en-CA', { hour: '2-digit', minute: '2-digit' })}`
-                      : 'Now'}
-                  </Text>
+                  <Text style={styles.actionRowLabel}>Pickup time</Text>
+                  {scheduledTime ? (
+                    <Text style={styles.actionRowValue}>
+                      {`${scheduledTime.toLocaleDateString('en-CA', { weekday: 'short', month: 'short', day: 'numeric' })} at ${scheduledTime.toLocaleTimeString('en-CA', { hour: '2-digit', minute: '2-digit' })}`}
+                    </Text>
+                  ) : (
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+                      <Text style={styles.actionRowValue}>Now</Text>
+                      <Text style={styles.actionRowHint}>· tap to schedule</Text>
+                    </View>
+                  )}
                 </View>
                 {scheduledTime ? (
                   <TouchableOpacity onPress={() => setScheduledTime(null)} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
@@ -1688,6 +1695,17 @@ function createStyles(colors: ThemeColors, sf: (size: number) => number, insets:
       fontSize: sf(14),
       fontFamily: 'PlusJakartaSans_500Medium',
       color: colors.text,
+    },
+    actionRowLabel: {
+      fontSize: sf(11),
+      fontFamily: 'PlusJakartaSans_500Medium',
+      color: colors.textDim,
+      marginBottom: 1,
+    },
+    actionRowHint: {
+      fontSize: sf(11),
+      fontFamily: 'PlusJakartaSans_500Medium',
+      color: colors.primary,
     },
     confirmButton: {
       backgroundColor: colors.primary,

--- a/rider-app/app/search-destination.tsx
+++ b/rider-app/app/search-destination.tsx
@@ -34,6 +34,7 @@ export default function SearchDestinationScreen() {
     savedAddresses, fetchSavedAddresses,
     recentSearches, addRecentSearch, loadRecentSearches,
     userLocation, setUserLocation,
+    clearEstimates,
   } = useRideStore();
 
   const { colors, isDark } = useTheme();
@@ -289,6 +290,10 @@ export default function SearchDestinationScreen() {
 
   const handleSearchRide = () => {
     if (pickup && dropoff) {
+      // Force a fresh quote for the current pickup/dropoff/stops: drop any
+      // estimate, route line, or promo left over from a previous search so
+      // ride-options recomputes from scratch rather than flashing stale data.
+      clearEstimates();
       router.push('/confirm-pickup');
     }
   };

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -223,6 +223,7 @@ interface RideState {
   updateStop: (index: number, location: Location) => void;
   fetchActiveRide: () => Promise<{ active: boolean; ride: Ride } | null>;
   fetchEstimates: () => Promise<void>;
+  clearEstimates: () => void;
   fetchNearbyDrivers: () => Promise<void>;
   selectVehicle: (vehicle: VehicleType) => void;
   createRide: (
@@ -391,6 +392,19 @@ export const useRideStore = create<RideState>((set, get) => ({
       return null;
     }
   },
+
+  // Wipe the previous route's quote so the next estimate fetch starts from a
+  // clean slate. Called when the rider taps "Search Ride" so a recompute is
+  // unconditional — no stale price, route line, or promo can survive into the
+  // new search even if the pickup/dropoff coordinates happen to be unchanged.
+  clearEstimates: () => set({
+    estimates: [],
+    routePolyline: [],
+    availablePromos: [],
+    appliedPromo: null,
+    isLoading: true,
+    error: null,
+  }),
 
   fetchEstimates: async () => {
     const { pickup, dropoff, stops, estimates: existing } = get();

--- a/rider-app/store/rideStore.ts
+++ b/rider-app/store/rideStore.ts
@@ -323,17 +323,24 @@ export const useRideStore = create<RideState>((set, get) => ({
   // server-side validation rejects the booking but the screen looks
   // committed). fetchAvailablePromos re-runs from the ride-options effect
   // and will auto-apply the best eligible promo for the new route.
+  // routePolyline is cleared alongside estimates here: changing any waypoint
+  // invalidates the drawn route, and a stale polyline would otherwise linger
+  // on the ride-options map (e.g. the previous destination's route trace still
+  // showing after the rider goes back and searches a new one). The next
+  // estimate fetch repopulates it for the new route.
   setPickup: (location) => set({
     pickup: location,
     estimates: [],
     availablePromos: [],
     appliedPromo: null,
+    routePolyline: [],
   }),
   setDropoff: (location) => set({
     dropoff: location,
     estimates: [],
     availablePromos: [],
     appliedPromo: null,
+    routePolyline: [],
   }),
   setUserLocation: (loc) => set({ userLocation: loc }),
 
@@ -342,12 +349,14 @@ export const useRideStore = create<RideState>((set, get) => ({
     estimates: [],
     availablePromos: [],
     appliedPromo: null,
+    routePolyline: [],
   })),
   removeStop: (index) => set((state) => ({
     stops: state.stops.filter((_, i) => i !== index),
     estimates: [],
     availablePromos: [],
     appliedPromo: null,
+    routePolyline: [],
   })),
   updateStop: (index, location) => set((state) => {
     const newStops = [...state.stops];
@@ -357,6 +366,7 @@ export const useRideStore = create<RideState>((set, get) => ({
       estimates: [],
       availablePromos: [],
       appliedPromo: null,
+      routePolyline: [],
     };
   }),
 
@@ -385,6 +395,10 @@ export const useRideStore = create<RideState>((set, get) => ({
   fetchEstimates: async () => {
     const { pickup, dropoff, stops, estimates: existing } = get();
     if (!pickup || !dropoff) return;
+    // Drop unfilled stop rows (the rider added a stop field but hasn't picked a
+    // place yet — lat/lng are still 0). Sending those would geofence-reject the
+    // quote or bend the route to (0,0).
+    const validStops = stops.filter((s) => s.lat && s.lng);
 
     try {
       // Only show loading skeleton on the initial fetch. Subsequent
@@ -397,7 +411,7 @@ export const useRideStore = create<RideState>((set, get) => ({
         pickup_lng: pickup.lng,
         dropoff_lat: dropoff.lat,
         dropoff_lng: dropoff.lng,
-        stops: stops,
+        stops: validStops,
       });
       // Backend returns {estimates, route_polyline} — handle both old (array) and new (object) shapes.
       const raw = response.data;
@@ -602,7 +616,9 @@ export const useRideStore = create<RideState>((set, get) => ({
         dropoff_address: dropoff.address,
         dropoff_lat: dropoff.lat,
         dropoff_lng: dropoff.lng,
-        stops: stops,
+        // Only send stops the rider actually resolved to a place — never the
+        // (0,0) placeholders of empty stop fields.
+        stops: stops.filter((s) => s.lat && s.lng),
         payment_method: paymentMethod,
         payment_method_id: paymentMethodId ?? null,
         // SCA two-step: a hold the app already confirmed on-device after a prior


### PR DESCRIPTION
Tapping a vehicle card left the pricing sheet stuck on its 40% snap
point, hiding the payment, schedule, and Confirm rows below the fold.
Riders couldn't tell what to do next without manually dragging the
sheet up. Now selecting a vehicle calls expand() to snap the sheet to
its full height, surfacing the Confirm button immediately.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PjsddsjhQCgCMfJJtBakKv

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
