### PR TITLE
fix(payouts): live Stripe status sync on return from hosted onboarding

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2034,6 +2034,47 @@ async def onboard_stripe(current_user: dict = Depends(get_current_user)):
         raise HTTPException(status_code=500, detail="An internal error occurred. Please try again.") from e
 
 
+@api_router.post("/stripe-sync")
+async def stripe_sync_status(current_user: dict = Depends(get_current_user)) -> dict:
+    """Pull the driver's LIVE Stripe Connect status (Account.retrieve) and
+    mirror it onto the drivers row, then return the verification state.
+
+    Called by the driver app immediately after returning from Stripe's hosted
+    onboarding so the UI reflects acceptance right away — without waiting on the
+    account.updated webhook, which can be delayed or, if the Connect webhook
+    isn't configured, never arrive at all."""
+    driver = (lambda _r: _r[0] if _r else None)(
+        await db_supabase.get_rows("drivers", {"user_id": current_user.get("id")}, limit=1)
+    )
+    if not driver:
+        raise HTTPException(status_code=404, detail="Driver profile not found")
+
+    try:
+        from ..services.stripe_kyc_sync import refresh_driver_kyc
+    except ImportError:
+        from services.stripe_kyc_sync import refresh_driver_kyc  # type: ignore
+
+    result = await refresh_driver_kyc(driver)
+    status = result.get("status")
+    if status == "no_stripe_account":
+        # Driver hasn't started onboarding yet — not an error, just not set up.
+        return {"synced": False, "onboarded": False, "payouts_enabled": False, "requirements_due": []}
+    if status != "ok":
+        # stripe_not_configured / stripe_error — surface it (don't silently
+        # report "not onboarded") so the app can retry instead of masking it.
+        raise HTTPException(status_code=502, detail="Could not sync verification status. Please try again.")
+
+    updates = result.get("updates") or {}
+    return {
+        "synced": True,
+        "onboarded": bool(updates.get("stripe_account_onboarded")),
+        "details_submitted": bool(updates.get("stripe_details_submitted")),
+        "payouts_enabled": bool(updates.get("stripe_payouts_enabled")),
+        "id_number_provided": bool(updates.get("stripe_id_number_provided")),
+        "requirements_due": list(updates.get("stripe_requirements_due") or []),
+    }
+
+
 # Driver-app deep link (scheme defined in driver-app/app.config.ts: SCHEME).
 _STRIPE_RETURN_DEEP_LINK = "spinr-driver://driver/payout"
 

--- a/backend/tests/test_drivers_extended.py
+++ b/backend/tests/test_drivers_extended.py
@@ -1385,3 +1385,79 @@ class TestStripeEmbeddedOnboarding:
         ):
             body = asyncio.run(drv.stripe_embedded()).body.decode()
         assert 'var PK = "pk_test_51ABCxyz";' in body
+
+
+class TestStripeSyncStatus:
+    """POST /stripe-sync does a live Account.retrieve + mirror on return from
+    hosted onboarding, so the driver sees acceptance without the webhook."""
+
+    def test_sync_returns_live_status(self):
+        from backend.routes import drivers as drv
+
+        with (
+            patch(
+                "backend.routes.drivers.db_supabase.get_rows",
+                AsyncMock(return_value=[_driver(stripe_account_id="acct_1")]),
+            ),
+            patch(
+                "backend.services.stripe_kyc_sync.refresh_driver_kyc",
+                AsyncMock(
+                    return_value={
+                        "status": "ok",
+                        "updates": {
+                            "stripe_account_onboarded": True,
+                            "stripe_details_submitted": True,
+                            "stripe_payouts_enabled": True,
+                            "stripe_id_number_provided": True,
+                            "stripe_requirements_due": [],
+                        },
+                    }
+                ),
+            ),
+        ):
+            result = asyncio.run(drv.stripe_sync_status(current_user={"id": USER_ID}))
+
+        assert result["synced"] is True
+        assert result["onboarded"] is True
+        assert result["payouts_enabled"] is True
+        assert result["requirements_due"] == []
+
+    def test_sync_no_stripe_account_is_not_error(self):
+        from backend.routes import drivers as drv
+
+        with (
+            patch(
+                "backend.routes.drivers.db_supabase.get_rows",
+                AsyncMock(return_value=[_driver()]),
+            ),
+            patch(
+                "backend.services.stripe_kyc_sync.refresh_driver_kyc",
+                AsyncMock(return_value={"status": "no_stripe_account"}),
+            ),
+        ):
+            result = asyncio.run(drv.stripe_sync_status(current_user={"id": USER_ID}))
+        assert result == {
+            "synced": False,
+            "onboarded": False,
+            "payouts_enabled": False,
+            "requirements_due": [],
+        }
+
+    def test_sync_stripe_error_raises_502(self):
+        from fastapi import HTTPException
+
+        from backend.routes import drivers as drv
+
+        with (
+            patch(
+                "backend.routes.drivers.db_supabase.get_rows",
+                AsyncMock(return_value=[_driver(stripe_account_id="acct_1")]),
+            ),
+            patch(
+                "backend.services.stripe_kyc_sync.refresh_driver_kyc",
+                AsyncMock(return_value={"status": "stripe_error"}),
+            ),
+        ):
+            with pytest.raises(HTTPException) as ei:
+                asyncio.run(drv.stripe_sync_status(current_user={"id": USER_ID}))
+        assert ei.value.status_code == 502

--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -126,9 +126,30 @@ function PayoutScreen() {
             // (backend/routes/drivers.py); openAuthSessionAsync auto-dismisses
             // the browser when Stripe's return_url bounces to this scheme.
             await WebBrowser.openAuthSessionAsync(url, 'spinr-driver://driver/payout');
-            // Whether they finished or dismissed, re-pull KYC + balance/bank
-            // state. The account.updated webhook is the authoritative gate; this
-            // just refreshes the UI so "Stripe Connected" flips once verified.
+            // Pull the driver's LIVE Stripe status on return — don't wait on the
+            // account.updated webhook (it can be delayed, or never arrive if the
+            // Connect webhook isn't configured). This mirrors the status
+            // server-side AND tells us what to show the driver right now.
+            try {
+                const sync = await api.post<{ onboarded?: boolean; payouts_enabled?: boolean }>(
+                    '/drivers/stripe-sync',
+                );
+                if (sync.data?.onboarded) {
+                    showToast(
+                        'success',
+                        'Verification submitted',
+                        sync.data.payouts_enabled
+                            ? 'Stripe approved your account — payouts are enabled.'
+                            : 'Details received. Stripe is reviewing them; this can take a few minutes.',
+                    );
+                } else {
+                    showToast('info', 'Not finished', 'Stripe onboarding wasn’t completed. You can resume anytime.');
+                }
+            } catch {
+                // Sync failed (e.g. transient) — fall through; loadData still
+                // reflects whatever the webhook may have already mirrored.
+            }
+            // Refresh balance / bank / status so the screen reflects the new state.
             await loadData();
         } catch (err: any) {
             showToast('error', 'Error', err?.response?.data?.detail || 'Could not start verification. Please try again.');


### PR DESCRIPTION
After finishing Stripe's hosted onboarding the driver app only re-read the cached stripe_account_onboarded flag, which flips solely on the account.updated Connect webhook — so if that webhook is unconfigured or delayed, the driver returns to a screen that never confirms acceptance.

Add POST /drivers/stripe-sync: does a live Account.retrieve + KYC mirror for the current driver (reusing services.stripe_kyc_sync.refresh_driver_kyc, previously admin-only) and returns onboarded / payouts_enabled / requirements_due. The app calls it immediately on return and shows the real state (approved / under review / not finished), independent of webhook timing or config.

Tests cover the ok, no-account, and stripe-error paths.

Co-developed with Claude Code (claude-sonnet-4-6)


Claude-Session: https://claude.ai/code/session_01XQKaMHANgbQ6SHBhhWviow

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
