### PR TITLE
Claude/driver app inactivity display b3cyak

### DIFF
--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
-import { getDriverStats, getDrivers, getDriverDocuments, reviewDocument, updateDriver, reviewDriverPhoto, getDriverVehicleHistory, getServiceAreas, getVehicleTypes, getFareConfigs, exportDrivers, getDriverRides, getDriverLiveStats, getDriverPayoutsSummary, retryPayout, refreshDriverStripeKyc, revealDriverSin, logPiiReveal, type DriverLiveStats, type DriverPayoutSummary } from "@/lib/api";
+import { getDriverStats, getDrivers, getDriverDocuments, reviewDocument, updateDriver, reviewDriverPhoto, getDriverVehicleHistory, getServiceAreas, getVehicleTypes, getFareConfigs, exportDrivers, getDriverRides, getDriverLiveStats, getDriverPayoutsSummary, getDriverReferrals, retryPayout, refreshDriverStripeKyc, revealDriverSin, logPiiReveal, type DriverLiveStats, type DriverPayoutSummary, type DriverReferralSummary } from "@/lib/api";
 import { Pagination } from "@/components/ui/pagination";
 import { exportToCsv } from "@/lib/export-csv";
 import { formatCurrency } from "@/lib/utils";
@@ -114,6 +114,9 @@ export default function DriversPage() {
     const [ridesLoading, setRidesLoading] = useState(false);
     const [ridesLoaded, setRidesLoaded] = useState<string | null>(null);
     const [detailTab, setDetailTab] = useState<string>("overview");
+    const [referrals, setReferrals] = useState<DriverReferralSummary | null>(null);
+    const [referralsLoading, setReferralsLoading] = useState(false);
+    const [referralsLoaded, setReferralsLoaded] = useState<string | null>(null);
     const [liveStats, setLiveStats] = useState<DriverLiveStats | null>(null);
     const [payoutSummary, setPayoutSummary] = useState<DriverPayoutSummary | null>(null);
     const [payoutLoading, setPayoutLoading] = useState(false);
@@ -151,6 +154,20 @@ export default function DriversPage() {
             setRidesLoading(false);
         }
     }, [ridesLoaded]);
+
+    const loadDriverReferrals = useCallback(async (driverId: string) => {
+        if (referralsLoaded === driverId) return;
+        setReferralsLoading(true);
+        try {
+            const res = await getDriverReferrals(driverId);
+            setReferrals(res);
+            setReferralsLoaded(driverId);
+        } catch {
+            setReferrals(null);
+        } finally {
+            setReferralsLoading(false);
+        }
+    }, [referralsLoaded]);
 
     const loadData = useCallback(() => {
         setLoading(true);
@@ -263,6 +280,8 @@ export default function DriversPage() {
         if (!selected?.id) {
             setDriverRides([]);
             setRidesLoaded(null);
+            setReferrals(null);
+            setReferralsLoaded(null);
             setLiveStats(null);
             setPayoutSummary(null);
             return;
@@ -806,12 +825,13 @@ export default function DriversPage() {
                             </div>
                         </div>
 
-                        <Tabs value={detailTab} onValueChange={(v) => { setDetailTab(v); if (v === "rides") loadDriverRides(selected.id); }} className="flex-1 overflow-hidden flex flex-col">
+                        <Tabs value={detailTab} onValueChange={(v) => { setDetailTab(v); if (v === "rides") loadDriverRides(selected.id); if (v === "referrals") loadDriverReferrals(selected.id); }} className="flex-1 overflow-hidden flex flex-col">
                             <TabsList className="mx-6 mt-4 w-fit">
                                 <TabsTrigger value="overview">Overview</TabsTrigger>
                                 <TabsTrigger value="documents">Documents{pendingDocsCount > 0 && <span className="ml-1.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-[10px] font-bold px-1.5 py-0.5 rounded-full" title={`${pendingDocsCount} document${pendingDocsCount === 1 ? "" : "s"} awaiting review`}>{pendingDocsCount}</span>}</TabsTrigger>
                                 <TabsTrigger value="rides">Rides{selected.total_rides > 0 && <span className="ml-1.5 bg-primary/10 text-primary text-[10px] font-bold px-1.5 py-0.5 rounded-full">{(selected.total_rides || 0).toLocaleString()}</span>}</TabsTrigger>
                                 <TabsTrigger value="payouts">Payouts{payoutSummary && payoutSummary.summary.pending_balance > 0 && <span className="ml-1.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-[10px] font-bold px-1.5 py-0.5 rounded-full" title={`${formatCurrency(payoutSummary.summary.pending_balance)} pending payout`}>!</span>}</TabsTrigger>
+                                <TabsTrigger value="referrals">Referrals</TabsTrigger>
                                 <TabsTrigger value="verification">Actions</TabsTrigger>
                                 <TabsTrigger value="notes">Notes</TabsTrigger>
                                 <TabsTrigger value="history">History</TabsTrigger>
@@ -969,6 +989,11 @@ export default function DriversPage() {
                                         driverName={`${selected.first_name || ""} ${selected.last_name || ""}`.trim()}
                                         fmtDate={fmtDate}
                                     />
+                                </TabsContent>
+
+                                {/* Referrals */}
+                                <TabsContent value="referrals" className="mt-4">
+                                    <DriverReferralsTab data={referrals} loading={referralsLoading} fmtDate={fmtDate} />
                                 </TabsContent>
 
                                 {/* Payouts */}
@@ -1764,6 +1789,84 @@ function DriverPayoutsTab({ data, loading, driverName, retryingPayoutId, onRetry
                     </TableBody>
                 </Table>
             </div>
+        </div>
+    );
+}
+
+function DriverReferralsTab({ data, loading, fmtDate }: {
+    data: DriverReferralSummary | null;
+    loading: boolean;
+    fmtDate: (d: string) => string;
+}) {
+    if (loading) {
+        return <div className="text-sm text-muted-foreground py-10 text-center">Loading referrals…</div>;
+    }
+    if (!data) {
+        return <div className="text-sm text-muted-foreground py-10 text-center">No referral data.</div>;
+    }
+    const referees = data.referees || [];
+    return (
+        <div className="space-y-5">
+            {/* Summary */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Referrals</p>
+                    <p className="text-xl font-bold mt-0.5">{data.total_referrals}</p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Rewarded</p>
+                    <p className="text-xl font-bold mt-0.5 text-emerald-600 dark:text-emerald-400">{data.qualified_referrals}</p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Pending</p>
+                    <p className="text-xl font-bold mt-0.5 text-amber-600 dark:text-amber-400">{data.pending_referrals}</p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Earned</p>
+                    <p className="text-xl font-bold mt-0.5">{formatCurrency(data.referral_earnings)}</p>
+                </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+                Code <span className="font-mono font-semibold">{data.referral_code}</span> · reward {formatCurrency(data.reward_amount)} once a referee completes {data.rides_required} rides.
+            </p>
+
+            {/* Referee list */}
+            {referees.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-6 text-center">No one has signed up with this driver&apos;s code yet.</p>
+            ) : (
+                <div className="space-y-2">
+                    {referees.map((r, i) => {
+                        const pct = Math.min(100, Math.round(((r.completed_rides || 0) / (r.rides_required || 1)) * 100));
+                        return (
+                            <div key={i} className="rounded-xl border border-border/50 p-3 flex items-center gap-3">
+                                <div className="flex-1 min-w-0">
+                                    <div className="flex items-center gap-2">
+                                        <p className="text-sm font-medium truncate">{r.name}</p>
+                                        <span className="text-[11px] text-muted-foreground">{fmtDate(r.referred_at)}</span>
+                                    </div>
+                                    {r.qualified ? (
+                                        <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium mt-0.5">Reward earned</p>
+                                    ) : (
+                                        <>
+                                            <p className="text-xs text-muted-foreground mt-0.5">
+                                                {r.completed_rides}/{r.rides_required} rides
+                                                {r.rides_remaining > 0 ? ` · ${r.rides_remaining} to go` : ""}
+                                                {!r.is_driver ? " · not a driver yet" : ""}
+                                            </p>
+                                            <div className="h-1.5 rounded-full bg-muted overflow-hidden mt-1.5 max-w-[200px]">
+                                                <div className="h-full bg-primary rounded-full" style={{ width: `${pct}%` }} />
+                                            </div>
+                                        </>
+                                    )}
+                                </div>
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide shrink-0 ${r.qualified ? "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300" : "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300"}`}>
+                                    {r.qualified ? "Earned" : "In progress"}
+                                </span>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -839,6 +839,20 @@ export default function DriversPage() {
                             <div className="flex-1 overflow-y-auto px-6 pb-6">
                                 {/* Overview */}
                                 <TabsContent value="overview" className="mt-4 space-y-5">
+                                    <DetailSection title="Performance" icon={Star}>
+                                        {liveStats ? (
+                                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5">
+                                                <DetailField icon={Car} label="Total Assigned" value={(liveStats.total_assigned ?? 0).toLocaleString()} />
+                                                <DetailField icon={CheckCircle} label="Completed" value={(liveStats.total_rides ?? 0).toLocaleString()} />
+                                                <DetailField icon={ShieldCheck} label="Acceptance Rate" value={liveStats.acceptance_rate != null ? `${liveStats.acceptance_rate}%` : "—"} />
+                                                <DetailField icon={XCircle} label="Cancelled (driver)" value={(liveStats.cancelled_by_driver ?? 0).toLocaleString()} />
+                                                <DetailField icon={Star} label="Avg Rating" value={liveStats.avg_rating != null ? liveStats.avg_rating.toFixed(2) : "—"} />
+                                                <DetailField icon={DollarSign} label="Avg / Ride" value={liveStats.total_rides > 0 ? formatCurrency(liveStats.total_earnings / liveStats.total_rides) : "—"} />
+                                            </div>
+                                        ) : (
+                                            <p className="text-xs text-muted-foreground">Loading stats…</p>
+                                        )}
+                                    </DetailSection>
                                     <DetailSection title="Contact Information" icon={Mail}>
                                         {editing ? (
                                             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/admin-dashboard/src/app/dashboard/earnings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/earnings/page.tsx
@@ -13,7 +13,8 @@ import { Button } from "@/components/ui/button";
 import {
     Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from "@/components/ui/table";
-import { Download, Car, CreditCard, Users, TrendingUp, TrendingDown, DollarSign, UserPlus, Clock, MapPin, X, GitCompareArrows, Wallet, CheckCircle, AlertTriangle, Percent, Receipt, UserCheck, XCircle, Ticket, Zap, Landmark, Undo2, Filter, Hourglass, Activity } from "lucide-react";
+import { Download, Car, CreditCard, Users, TrendingUp, TrendingDown, DollarSign, UserPlus, Clock, MapPin, X, GitCompareArrows, Wallet, CheckCircle, AlertTriangle, Percent, Receipt, UserCheck, XCircle, Ticket, Zap, Landmark, Undo2, Filter, Hourglass, Activity, Gift } from "lucide-react";
+import ReferralLeaderboard from "@/components/referral-leaderboard";
 import { getPayouts, getPayoutStats, getPayoutsOverview, retryPayout, bulkRetryPayouts, closePayoutPeriod, type PayoutsOverview } from "@/lib/api";
 import { useToast } from "@/components/ui/use-toast";
 import { useRequireModule } from "@/hooks/useRequireModule";
@@ -34,7 +35,7 @@ const tooltipStyle = {
 
 export default function EarningsPage() {
     const { allowed } = useRequireModule("earnings");
-    const [tab, setTab] = useState<"rides" | "spinr-pass" | "payouts">("rides");
+    const [tab, setTab] = useState<"rides" | "spinr-pass" | "payouts" | "referrals">("rides");
 
     if (!allowed) return null;
     return (
@@ -60,11 +61,20 @@ export default function EarningsPage() {
                     className={`flex items-center gap-1.5 px-5 py-2 rounded-lg text-sm font-semibold transition ${tab === "payouts" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
                     <Wallet className="h-4 w-4" /> Payouts
                 </button>
+                <button onClick={() => setTab("referrals")}
+                    className={`flex items-center gap-1.5 px-5 py-2 rounded-lg text-sm font-semibold transition ${tab === "referrals" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
+                    <Gift className="h-4 w-4" /> Referrals
+                </button>
             </div>
 
             {tab === "rides" && <RideEarningsTab />}
             {tab === "spinr-pass" && <SpinrPassRevenueTab />}
             {tab === "payouts" && <PayoutsTab />}
+            {tab === "referrals" && (
+                <div className="pt-1">
+                    <ReferralLeaderboard limit={25} />
+                </div>
+            )}
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/earnings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/earnings/page.tsx
@@ -18,6 +18,7 @@ import ReferralLeaderboard from "@/components/referral-leaderboard";
 import { getPayouts, getPayoutStats, getPayoutsOverview, retryPayout, bulkRetryPayouts, closePayoutPeriod, type PayoutsOverview } from "@/lib/api";
 import { useToast } from "@/components/ui/use-toast";
 import { useRequireModule } from "@/hooks/useRequireModule";
+import { useAuthStore } from "@/store/authStore";
 import { Legend } from "recharts";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -36,6 +37,13 @@ const tooltipStyle = {
 export default function EarningsPage() {
     const { allowed } = useRequireModule("earnings");
     const [tab, setTab] = useState<"rides" | "spinr-pass" | "payouts" | "referrals">("rides");
+
+    // The Referrals tab calls /api/admin/referrals/leaderboard, which is gated by
+    // the `drivers` module on the backend. Only show it to admins who actually
+    // have drivers access — otherwise they'd see the tab and hit a 403.
+    const user = useAuthStore((s) => s.user);
+    const canSeeReferrals =
+        user?.role === "super_admin" || user?.role === "admin" || (user?.modules ?? []).includes("drivers");
 
     if (!allowed) return null;
     return (
@@ -61,16 +69,18 @@ export default function EarningsPage() {
                     className={`flex items-center gap-1.5 px-5 py-2 rounded-lg text-sm font-semibold transition ${tab === "payouts" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
                     <Wallet className="h-4 w-4" /> Payouts
                 </button>
-                <button onClick={() => setTab("referrals")}
-                    className={`flex items-center gap-1.5 px-5 py-2 rounded-lg text-sm font-semibold transition ${tab === "referrals" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
-                    <Gift className="h-4 w-4" /> Referrals
-                </button>
+                {canSeeReferrals && (
+                    <button onClick={() => setTab("referrals")}
+                        className={`flex items-center gap-1.5 px-5 py-2 rounded-lg text-sm font-semibold transition ${tab === "referrals" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
+                        <Gift className="h-4 w-4" /> Referrals
+                    </button>
+                )}
             </div>
 
             {tab === "rides" && <RideEarningsTab />}
             {tab === "spinr-pass" && <SpinrPassRevenueTab />}
             {tab === "payouts" && <PayoutsTab />}
-            {tab === "referrals" && (
+            {tab === "referrals" && canSeeReferrals && (
                 <div className="pt-1">
                     <ReferralLeaderboard limit={25} />
                 </div>

--- a/admin-dashboard/src/app/dashboard/referrals/page.tsx
+++ b/admin-dashboard/src/app/dashboard/referrals/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import ReferralLeaderboard from "@/components/referral-leaderboard";
+import { useRequireModule } from "@/hooks/useRequireModule";
+
+export default function ReferralsPage() {
+    const { allowed } = useRequireModule("drivers");
+    if (!allowed) return null;
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="text-3xl font-bold tracking-tight">Referrals</h1>
+                <p className="text-muted-foreground mt-1">Driver referral program — top referrers and fleet totals</p>
+            </div>
+            <ReferralLeaderboard limit={50} />
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/dashboard/referrals/page.tsx
+++ b/admin-dashboard/src/app/dashboard/referrals/page.tsx
@@ -1,19 +1,33 @@
 "use client";
 
+import { useState } from "react";
 import ReferralLeaderboard from "@/components/referral-leaderboard";
 import { useRequireModule } from "@/hooks/useRequireModule";
 
 export default function ReferralsPage() {
     const { allowed } = useRequireModule("drivers");
+    const [source, setSource] = useState<"driver" | "rider">("driver");
     if (!allowed) return null;
 
     return (
         <div className="space-y-6">
             <div>
                 <h1 className="text-3xl font-bold tracking-tight">Referrals</h1>
-                <p className="text-muted-foreground mt-1">Driver referral program — top referrers and fleet totals</p>
+                <p className="text-muted-foreground mt-1">Referral program — top referrers and fleet totals</p>
             </div>
-            <ReferralLeaderboard limit={50} />
+
+            <div className="flex gap-1 bg-muted rounded-xl p-1 w-fit">
+                <button onClick={() => setSource("driver")}
+                    className={`px-5 py-2 rounded-lg text-sm font-semibold transition ${source === "driver" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
+                    Drivers
+                </button>
+                <button onClick={() => setSource("rider")}
+                    className={`px-5 py-2 rounded-lg text-sm font-semibold transition ${source === "rider" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground"}`}>
+                    Riders
+                </button>
+            </div>
+
+            <ReferralLeaderboard limit={50} source={source} />
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/users/page.tsx
+++ b/admin-dashboard/src/app/dashboard/users/page.tsx
@@ -39,7 +39,7 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import { Pagination } from "@/components/ui/pagination";
-import { Users, Search, Mail, Phone, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff, CreditCard } from "lucide-react";
+import { Users, Search, Mail, Phone, Calendar, Car, ShieldCheck, Download, RefreshCw, Ban, CheckCircle, AlertTriangle, Wallet, Plus, Minus, Eye, EyeOff, CreditCard, MapPin, Gift } from "lucide-react";
 import { exportToCsv } from "@/lib/export-csv";
 import { formatDate } from "@/lib/utils";
 import { getUsersPaginated, getUserDetails, updateUserStatus, updateUserFlags, getStats, getUserWallet, creditUserWallet, debitUserWallet, exportUsers, logPiiReveal } from "@/lib/api";
@@ -475,7 +475,7 @@ export default function UsersPage() {
 
             {/* User Details Dialog */}
             <Dialog open={!!selectedUser} onOpenChange={(open) => { if (!open) setSelectedUser(null); }}>
-                <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+                <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
                     <DialogHeader>
                         <DialogTitle className="flex items-center gap-2">
                             <Users className="h-5 w-5 text-sky-500" />
@@ -501,12 +501,12 @@ export default function UsersPage() {
                                 </div>
                             </div>
 
-                            <div className="grid grid-cols-2 gap-4">
+                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
                                 <div className="space-y-1">
                                     <Label className="text-xs text-muted-foreground flex items-center gap-1">
                                         <Mail className="h-3 w-3" /> Email
                                     </Label>
-                                    <p className="text-sm">{showPii ? selectedUser.email : maskEmail(selectedUser.email)}</p>
+                                    <p className="text-sm break-all">{showPii ? selectedUser.email : maskEmail(selectedUser.email)}</p>
                                 </div>
                                 <div className="space-y-1">
                                     <Label className="text-xs text-muted-foreground flex items-center gap-1">
@@ -525,6 +525,36 @@ export default function UsersPage() {
                                         <Car className="h-3 w-3" /> Total rides
                                     </Label>
                                     <p className="text-sm">{userDetail == null ? "…" : (userDetail.total_rides ?? 0).toLocaleString()}</p>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                        <Users className="h-3 w-3" /> Gender
+                                    </Label>
+                                    <p className="text-sm">{userDetail?.gender || selectedUser.gender || "—"}</p>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                        <MapPin className="h-3 w-3" /> City
+                                    </Label>
+                                    <p className="text-sm">{userDetail?.city || selectedUser.city || "—"}</p>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                        <Gift className="h-3 w-3" /> Referred by
+                                    </Label>
+                                    <p className="text-sm font-mono">{userDetail?.referral_code_used || "—"}</p>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                        <CreditCard className="h-3 w-3" /> Cards on file
+                                    </Label>
+                                    <p className="text-sm">{userDetail == null ? "…" : (userDetail.cards?.length ?? 0)}</p>
+                                </div>
+                                <div className="space-y-1">
+                                    <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                                        <ShieldCheck className="h-3 w-3" /> Account
+                                    </Label>
+                                    <p className="text-sm">{selectedUser.is_driver && selectedUser.is_rider ? "Rider + Driver" : selectedUser.is_driver ? "Driver" : "Rider"}</p>
                                 </div>
                             </div>
 

--- a/admin-dashboard/src/components/referral-leaderboard.tsx
+++ b/admin-dashboard/src/components/referral-leaderboard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getReferralLeaderboard, type ReferralLeaderboard as Data } from "@/lib/api";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/utils";
+import { Gift, Users, Award, Trophy } from "lucide-react";
+
+/**
+ * Fleet-wide referral stats — top referrers leaderboard plus totals.
+ * Shared by the standalone Referrals page and the Earnings → Referrals tab so
+ * the two can never diverge.
+ */
+export default function ReferralLeaderboard({ limit = 20 }: { limit?: number }) {
+    const [data, setData] = useState<Data | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        getReferralLeaderboard(limit)
+            .then((d) => { if (!cancelled) setData(d); })
+            .catch((e) => { if (!cancelled) setError(e?.message || "Failed to load referral stats"); })
+            .finally(() => { if (!cancelled) setLoading(false); });
+        return () => { cancelled = true; };
+    }, [limit]);
+
+    if (loading) {
+        return <div className="text-sm text-muted-foreground py-10 text-center">Loading referral stats…</div>;
+    }
+    if (error) {
+        return <div className="text-sm text-red-600 dark:text-red-400 py-10 text-center">{error}</div>;
+    }
+    if (!data) return null;
+
+    const leaders = data.leaders || [];
+
+    return (
+        <div className="space-y-5">
+            {/* Fleet summary */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <SummaryCard icon={Gift} label="Total Referrals" value={data.fleet_total_referrals.toLocaleString()} accent="text-violet-600 dark:text-violet-400" />
+                <SummaryCard icon={Users} label="Active Referrers" value={data.fleet_total_referrers.toLocaleString()} accent="text-sky-600 dark:text-sky-400" />
+                <SummaryCard
+                    icon={Award}
+                    label="Reward Terms"
+                    value={`${formatCurrency(data.reward_amount)} / ${data.rides_required} rides`}
+                    accent="text-emerald-600 dark:text-emerald-400"
+                />
+            </div>
+
+            {/* Top referrers */}
+            <Card className="border-border/50">
+                <CardContent className="p-0">
+                    <div className="flex items-center gap-2 px-4 py-3 border-b border-border/50">
+                        <Trophy className="h-4 w-4 text-amber-500" />
+                        <h3 className="text-sm font-semibold">Top Referrers</h3>
+                    </div>
+                    {leaders.length === 0 ? (
+                        <p className="text-sm text-muted-foreground px-4 py-8 text-center">No referrals yet.</p>
+                    ) : (
+                        <div className="overflow-x-auto">
+                            <table className="w-full text-sm">
+                                <thead>
+                                    <tr className="text-left text-[11px] uppercase tracking-wide text-muted-foreground border-b border-border/50">
+                                        <th className="px-4 py-2 font-medium">#</th>
+                                        <th className="px-4 py-2 font-medium">Driver</th>
+                                        <th className="px-4 py-2 font-medium">Code</th>
+                                        <th className="px-4 py-2 font-medium text-right">Referrals</th>
+                                        <th className="px-4 py-2 font-medium text-right">Qualified</th>
+                                        <th className="px-4 py-2 font-medium text-right">Earned</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {leaders.map((l, i) => (
+                                        <tr key={l.driver_id} className="border-b border-border/30 last:border-0">
+                                            <td className="px-4 py-2.5 text-muted-foreground">{i + 1}</td>
+                                            <td className="px-4 py-2.5 font-medium">{l.name}</td>
+                                            <td className="px-4 py-2.5 font-mono text-xs text-muted-foreground">{l.driver_code}</td>
+                                            <td className="px-4 py-2.5 text-right">{l.total_referrals.toLocaleString()}</td>
+                                            <td className="px-4 py-2.5 text-right text-emerald-600 dark:text-emerald-400 font-medium">{l.qualified_referrals.toLocaleString()}</td>
+                                            <td className="px-4 py-2.5 text-right font-semibold">{formatCurrency(l.referral_earnings)}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+function SummaryCard({ icon: Icon, label, value, accent }: { icon: any; label: string; value: string; accent: string }) {
+    return (
+        <Card className="border-border/50">
+            <CardContent className="p-4 flex items-center gap-3">
+                <div className="w-10 h-10 rounded-xl bg-muted flex items-center justify-center shrink-0">
+                    <Icon className={`h-5 w-5 ${accent}`} />
+                </div>
+                <div className="min-w-0">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">{label}</p>
+                    <p className="text-lg font-bold truncate">{value}</p>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/admin-dashboard/src/components/referral-leaderboard.tsx
+++ b/admin-dashboard/src/components/referral-leaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getReferralLeaderboard, type ReferralLeaderboard as Data } from "@/lib/api";
+import { getReferralLeaderboard, getRiderReferralLeaderboard, type ReferralLeaderboard as Data } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/utils";
 import { Gift, Users, Award, Trophy } from "lucide-react";
@@ -11,7 +11,7 @@ import { Gift, Users, Award, Trophy } from "lucide-react";
  * Shared by the standalone Referrals page and the Earnings → Referrals tab so
  * the two can never diverge.
  */
-export default function ReferralLeaderboard({ limit = 20 }: { limit?: number }) {
+export default function ReferralLeaderboard({ limit = 20, source = "driver" }: { limit?: number; source?: "driver" | "rider" }) {
     const [data, setData] = useState<Data | null>(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
@@ -19,12 +19,14 @@ export default function ReferralLeaderboard({ limit = 20 }: { limit?: number }) 
     useEffect(() => {
         let cancelled = false;
         setLoading(true);
-        getReferralLeaderboard(limit)
+        setError("");
+        const fetcher = source === "rider" ? getRiderReferralLeaderboard : getReferralLeaderboard;
+        fetcher(limit)
             .then((d) => { if (!cancelled) setData(d); })
             .catch((e) => { if (!cancelled) setError(e?.message || "Failed to load referral stats"); })
             .finally(() => { if (!cancelled) setLoading(false); });
         return () => { cancelled = true; };
-    }, [limit]);
+    }, [limit, source]);
 
     if (loading) {
         return <div className="text-sm text-muted-foreground py-10 text-center">Loading referral stats…</div>;

--- a/admin-dashboard/src/components/sidebar.tsx
+++ b/admin-dashboard/src/components/sidebar.tsx
@@ -8,7 +8,7 @@ import {
     Flame, Building2, LifeBuoy, HelpCircle,
     LogOut, Menu, X, ChevronLeft, ChevronRight,
     Sun, Moon, Shield, ShieldAlert, Cloud, Trophy, TrendingUp, Activity,
-    Inbox, Clock, Headphones, BarChart3, Send, Sparkles,
+    Inbox, Clock, Headphones, BarChart3, Send, Sparkles, Gift,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState, useEffect } from "react";
@@ -59,6 +59,7 @@ const NAV_GROUPS: NavGroup[] = [
             { href: "/dashboard/heatmap", label: "Heat Map", icon: Flame, module: "heatmap" },
             { href: "/dashboard/analytics", label: "Analytics", icon: LayoutDashboard, module: "dashboard" },
             { href: "/dashboard/driver-offers", label: "Driver Offers", icon: Send, module: "dashboard" },
+            { href: "/dashboard/referrals", label: "Referrals", icon: Gift, module: "drivers" },
             { href: "/dashboard/forecast", label: "Demand Forecast", icon: TrendingUp, module: "dashboard" },
         ],
     },

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -616,6 +616,9 @@ export interface ReferralLeaderboard {
 export const getReferralLeaderboard = (limit = 20) =>
     request<ReferralLeaderboard>(`/api/admin/referrals/leaderboard?limit=${limit}`);
 
+export const getRiderReferralLeaderboard = (limit = 20) =>
+    request<ReferralLeaderboard>(`/api/admin/referrals/rider-leaderboard?limit=${limit}`);
+
 export interface DriverPayoutSummary {
     summary: {
         lifetime_earnings: number;

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -574,6 +574,48 @@ export interface DriverLiveStats {
 export const getDriverLiveStats = (id: string) =>
     request<DriverLiveStats>(`/api/admin/drivers/${id}/live-stats`);
 
+export interface DriverReferee {
+    name: string;
+    email: string;
+    referred_at: string;
+    is_driver: boolean;
+    completed_rides: number;
+    rides_required: number;
+    rides_remaining: number;
+    qualified: boolean;
+    status: "earned" | "in_progress";
+}
+export interface DriverReferralSummary {
+    referral_code: string;
+    total_referrals: number;
+    qualified_referrals: number;
+    pending_referrals: number;
+    referral_earnings: number;
+    reward_amount: number;
+    rides_required: number;
+    referees: DriverReferee[];
+}
+export const getDriverReferrals = (id: string) =>
+    request<DriverReferralSummary>(`/api/admin/drivers/${id}/referrals`);
+
+export interface ReferralLeader {
+    driver_id: string;
+    driver_code: string;
+    name: string;
+    total_referrals: number;
+    qualified_referrals: number;
+    referral_earnings: number;
+}
+export interface ReferralLeaderboard {
+    leaders: ReferralLeader[];
+    fleet_total_referrals: number;
+    fleet_total_referrers: number;
+    reward_amount: number;
+    rides_required: number;
+}
+export const getReferralLeaderboard = (limit = 20) =>
+    request<ReferralLeaderboard>(`/api/admin/referrals/leaderboard?limit=${limit}`);
+
 export interface DriverPayoutSummary {
     summary: {
         lifetime_earnings: number;

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -63,6 +63,11 @@ class Settings(BaseSettings):
     # Refresh-token TTL in days (30 days "remember this device").
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
 
+    # Referral reward payouts (rider + driver). The payout loop moves real
+    # wallet money, so it is OFF by default — enable only after verifying the
+    # reward terms and the loop behaviour in staging.
+    REFERRAL_PAYOUTS_ENABLED: bool = False
+
     # ──── Cookie Settings ────
     # HTTP-only cookie flags for secure token storage (P3 HttpOnly migration)
     COOKIE_SECURE: bool = True  # HTTPS only in production

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -204,6 +204,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to import pre-auth capture sweeper: {e}", exc_info=True)
 
+    # Referral reward payouts — pays referrer/referee rewards once a referee
+    # hits the ride threshold. Idempotent via referral_payouts UNIQUE claim.
+    # No-ops unless settings.REFERRAL_PAYOUTS_ENABLED (OFF by default — it moves
+    # real wallet money, enable only after staging verification).
+    try:
+        from utils.referral_payout import referral_payout_loop
+
+        _spawn("referral_payout (5min)", referral_payout_loop)
+    except Exception as e:
+        logger.error(f"Failed to import referral payout loop: {e}", exc_info=True)
+
     # Driver claim reaper — releases drivers claimed by dispatch whose offer
     # insert never landed (crash/restart), recovering orphaned is_available
     # flags so supply isn't silently eroded. Every 60 seconds.

--- a/backend/migrations/171_referral_payouts.sql
+++ b/backend/migrations/171_referral_payouts.sql
@@ -13,7 +13,7 @@
 -- deletion/anonymisation for reconciliation and tax purposes, while the PII
 -- link is severed per PIPEDA.
 --
--- Rollback (coordinated — do in this order):
+-- Rollback: (coordinated — do in this order)
 --   1. Set REFERRAL_PAYOUTS_ENABLED=false and redeploy so the payout loop stops
 --      touching the table (the loop is wired in core/lifespan.py).
 --   2. DROP TABLE IF EXISTS referral_payouts;

--- a/backend/migrations/171_referral_payouts.sql
+++ b/backend/migrations/171_referral_payouts.sql
@@ -1,0 +1,68 @@
+-- Migration 171: referral_payouts — idempotent ledger of paid referral rewards
+--
+-- Both the rider and driver referral programs reward a referrer once their
+-- referee reaches a ride threshold (driver: 10 rides → $10; rider: 1 ride →
+-- $5 each side). The payout background loop needs an idempotency anchor so a
+-- referral is rewarded EXACTLY once even though the loop runs on every replica
+-- and retries. This table is that anchor: one row per referee, claimed by an
+-- INSERT whose UNIQUE(referee_user_id) makes a concurrent/duplicate claim fail
+-- (the loop treats the unique-violation as "already claimed, skip").
+--
+-- Money columns are numeric (never float). This is a financial ledger: the FKs
+-- are ON DELETE SET NULL (NOT cascade) so the payout record survives a user
+-- deletion/anonymisation for reconciliation and tax purposes, while the PII
+-- link is severed per PIPEDA.
+--
+-- Rollback (coordinated — do in this order):
+--   1. Set REFERRAL_PAYOUTS_ENABLED=false and redeploy so the payout loop stops
+--      touching the table (the loop is wired in core/lifespan.py).
+--   2. DROP TABLE IF EXISTS referral_payouts;
+--   NOTE: wallet credits already issued are NOT reversed by dropping the table —
+--   any referrer/referee already paid keeps the credit (manual cleanup if needed).
+
+CREATE TABLE IF NOT EXISTS referral_payouts (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- One payout per referred user — this UNIQUE is the idempotency claim.
+    -- Nullable + SET NULL so the financial row is retained (PII severed) if the
+    -- user is later deleted; multiple NULLs are allowed by the UNIQUE index.
+    referee_user_id   uuid UNIQUE REFERENCES users(id) ON DELETE SET NULL,
+    referrer_user_id  uuid REFERENCES users(id) ON DELETE SET NULL,
+    kind              text NOT NULL CHECK (kind IN ('rider', 'driver')),
+    referrer_reward   numeric(10, 2) NOT NULL DEFAULT 0,
+    referee_reward    numeric(10, 2) NOT NULL DEFAULT 0,
+    -- 'processing' is the in-flight claim (set on the winning INSERT so a second
+    -- replica can't double-pay); finalised to 'paid' or 'failed'.
+    status            text NOT NULL DEFAULT 'processing' CHECK (status IN ('processing', 'paid', 'failed')),
+    paid_at           timestamptz,
+    created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+-- Loop lists a referrer's payouts and the user-facing screen may show them.
+CREATE INDEX IF NOT EXISTS idx_referral_payouts_referrer
+    ON referral_payouts (referrer_user_id);
+
+-- Supports the stale-'processing' reclaim sweep and future status-filtered reads.
+CREATE INDEX IF NOT EXISTS idx_referral_payouts_status
+    ON referral_payouts (status);
+
+-- RLS: backend (service role) bypasses RLS and performs ALL writes. Clients may
+-- read only their own rows; client writes are explicitly denied (never FOR ALL).
+ALTER TABLE referral_payouts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS referral_payouts_select_own ON referral_payouts;
+CREATE POLICY referral_payouts_select_own ON referral_payouts
+    FOR SELECT
+    USING (auth.uid() = referrer_user_id OR auth.uid() = referee_user_id);
+
+-- Explicit client-write denials (service role bypasses these by design).
+DROP POLICY IF EXISTS referral_payouts_no_insert ON referral_payouts;
+CREATE POLICY referral_payouts_no_insert ON referral_payouts
+    FOR INSERT WITH CHECK (false);
+
+DROP POLICY IF EXISTS referral_payouts_no_update ON referral_payouts;
+CREATE POLICY referral_payouts_no_update ON referral_payouts
+    FOR UPDATE USING (false);
+
+DROP POLICY IF EXISTS referral_payouts_no_delete ON referral_payouts;
+CREATE POLICY referral_payouts_no_delete ON referral_payouts
+    FOR DELETE USING (false);

--- a/backend/migrations/171_referral_payouts.sql
+++ b/backend/migrations/171_referral_payouts.sql
@@ -25,8 +25,9 @@ CREATE TABLE IF NOT EXISTS referral_payouts (
     -- One payout per referred user — this UNIQUE is the idempotency claim.
     -- Nullable + SET NULL so the financial row is retained (PII severed) if the
     -- user is later deleted; multiple NULLs are allowed by the UNIQUE index.
-    referee_user_id   uuid UNIQUE REFERENCES users(id) ON DELETE SET NULL,
-    referrer_user_id  uuid REFERENCES users(id) ON DELETE SET NULL,
+    -- users.id is TEXT in this schema, so the FK columns must be TEXT too.
+    referee_user_id   text UNIQUE REFERENCES users(id) ON DELETE SET NULL,
+    referrer_user_id  text REFERENCES users(id) ON DELETE SET NULL,
     kind              text NOT NULL CHECK (kind IN ('rider', 'driver')),
     referrer_reward   numeric(10, 2) NOT NULL DEFAULT 0,
     referee_reward    numeric(10, 2) NOT NULL DEFAULT 0,
@@ -52,7 +53,7 @@ ALTER TABLE referral_payouts ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS referral_payouts_select_own ON referral_payouts;
 CREATE POLICY referral_payouts_select_own ON referral_payouts
     FOR SELECT
-    USING (auth.uid() = referrer_user_id OR auth.uid() = referee_user_id);
+    USING (auth.uid()::text = referrer_user_id OR auth.uid()::text = referee_user_id);
 
 -- Explicit client-write denials (service role bypasses these by design).
 DROP POLICY IF EXISTS referral_payouts_no_insert ON referral_payouts;

--- a/backend/migrations/172_users_referral_columns.sql
+++ b/backend/migrations/172_users_referral_columns.sql
@@ -1,0 +1,31 @@
+-- Migration 172: referral columns on users
+--
+-- The rider AND driver referral "apply" paths write referral_code_used and
+-- referred_by to users, and the rider path also reads an optional custom
+-- referral_code. These columns were used by the existing driver referral code
+-- but never had a migration, so a database built purely from migrations is
+-- missing them and /users/referral/apply (and the driver equivalent) fail with
+-- a missing-column error. Add them idempotently.
+--
+-- referral_applied_at records WHEN the code was applied so the payout loop can
+-- count only rides completed AFTER that point — blocking retroactive rewards
+-- (a user who already passed the ride threshold can't apply a code later and be
+-- paid for past rides).
+--
+-- All additive + nullable → forward-compatible with in-flight traffic.
+--
+-- Rollback:
+--   ALTER TABLE users
+--     DROP COLUMN IF EXISTS referral_code_used,
+--     DROP COLUMN IF EXISTS referred_by,
+--     DROP COLUMN IF EXISTS referral_code,
+--     DROP COLUMN IF EXISTS referral_applied_at;
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code_used   TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referred_by          TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_code        TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS referral_applied_at  TIMESTAMPTZ;
+
+-- Referral summaries and the payout loop group/filter by these.
+CREATE INDEX IF NOT EXISTS idx_users_referred_by        ON users (referred_by);
+CREATE INDEX IF NOT EXISTS idx_users_referral_code_used ON users (referral_code_used);

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -1515,19 +1515,30 @@ def _referral_terms() -> tuple[int, int]:
     return REFERRAL_RIDES_REQUIRED, REFERRAL_REWARD_AMOUNT
 
 
+def _driver_referral_codes(driver: dict) -> list:
+    """Every code a driver may have been shared under (current + legacy), so
+    referees who applied an older code still count."""
+    out: list = []
+    for c in (driver.get("driver_code"), driver.get("referral_code"), f"DRIVER{driver['id'][:8].upper()}"):
+        if c and c not in out:
+            out.append(c)
+    return out
+
+
 def _driver_referral_code(driver: dict) -> str:
-    """The shareable code, matching the app side (driver_code → referral_code → id-derived)."""
-    return driver.get("driver_code") or driver.get("referral_code") or f"DRIVER{driver['id'][:8].upper()}"
+    """The primary shareable code (driver_code → referral_code → id-derived)."""
+    return _driver_referral_codes(driver)[0]
 
 
 async def _driver_referral_summary(driver: dict, *, include_referees: bool) -> dict:
     """Compute a referrer's referral stats (and optionally the referee list)."""
     rides_required, reward_amount = _referral_terms()
-    code = _driver_referral_code(driver)
+    codes = _driver_referral_codes(driver)
+    code = codes[0]
 
     referred_users = await db_supabase.get_rows(
         "users",
-        {"referral_code_used": code},
+        {"referral_code_used": {"$in": codes}},
         columns="id,first_name,last_name,email,created_at",
         limit=200,
     )
@@ -1597,11 +1608,15 @@ async def admin_get_referral_leaderboard(
     """
     rides_required, reward_amount = _referral_terms()
 
-    users = await db_supabase.get_rows("users", {}, columns="id,referred_by", limit=5000)
+    users = await db_supabase.get_rows("users", {}, columns="id,referred_by,referral_code_used", limit=5000)
     by_referrer: dict[str, list[str]] = {}
     for u in users:
         rid = u.get("referred_by")
-        if rid:
+        code = u.get("referral_code_used")
+        # Only DRIVER referrals here — rider referrals (RIDE-prefixed codes) also
+        # populate referred_by (with a user id) and would otherwise inflate the
+        # fleet totals and crowd out real driver referrers in the top-N slice.
+        if rid and code and not str(code).upper().startswith("RIDE"):
             by_referrer.setdefault(rid, []).append(u["id"])
 
     fleet_total_referrals = sum(len(v) for v in by_referrer.values())

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -1540,9 +1540,7 @@ async def _driver_referral_summary(driver: dict, *, include_referees: bool) -> d
         )
         completed = 0
         if ref_drv:
-            completed = await db_supabase.count_documents(
-                "rides", {"driver_id": ref_drv["id"], "status": "completed"}
-            )
+            completed = await db_supabase.count_documents("rides", {"driver_id": ref_drv["id"], "status": "completed"})
         is_qualified = bool(ref_drv) and completed >= rides_required
         if is_qualified:
             qualified += 1
@@ -1599,9 +1597,7 @@ async def admin_get_referral_leaderboard(
     """
     rides_required, reward_amount = _referral_terms()
 
-    users = await db_supabase.get_rows(
-        "users", {}, columns="id,referred_by", limit=5000
-    )
+    users = await db_supabase.get_rows("users", {}, columns="id,referred_by", limit=5000)
     by_referrer: dict[str, list[str]] = {}
     for u in users:
         rid = u.get("referred_by")
@@ -1625,13 +1621,9 @@ async def admin_get_referral_leaderboard(
         )
         qualified = 0
         for uid in referee_user_ids:
-            rdrv = (lambda _r: _r[0] if _r else None)(
-                await db_supabase.get_rows("drivers", {"user_id": uid}, limit=1)
-            )
+            rdrv = (lambda _r: _r[0] if _r else None)(await db_supabase.get_rows("drivers", {"user_id": uid}, limit=1))
             if rdrv:
-                completed = await db_supabase.count_documents(
-                    "rides", {"driver_id": rdrv["id"], "status": "completed"}
-                )
+                completed = await db_supabase.count_documents("rides", {"driver_id": rdrv["id"], "status": "completed"})
                 if completed >= rides_required:
                     qualified += 1
         fleet_qualified += qualified
@@ -1652,6 +1644,69 @@ async def admin_get_referral_leaderboard(
         "fleet_total_referrers": len(by_referrer),
         "reward_amount": reward_amount,
         "rides_required": rides_required,
+    }
+
+
+@router.get("/referrals/rider-leaderboard")
+async def admin_get_rider_referral_leaderboard(
+    limit: int = Query(20, ge=1, le=100),
+    admin: dict = Depends(get_admin_user),
+):
+    """Fleet-wide top RIDER referrers (riders referring riders). Same response
+    shape as the driver leaderboard so the admin UI component is shared."""
+    try:
+        from ..users import (  # type: ignore
+            RIDER_REFERRAL_RIDES_REQUIRED,
+            RIDER_REFERRER_REWARD,
+        )
+    except ImportError:
+        from routes.users import (  # type: ignore
+            RIDER_REFERRAL_RIDES_REQUIRED,
+            RIDER_REFERRER_REWARD,
+        )
+
+    users = await db_supabase.get_rows(
+        "users", {}, columns="id,referral_code_used,referred_by,first_name,last_name", limit=10000
+    )
+    by_referrer: dict[str, list[str]] = {}
+    name_by_id: dict[str, str] = {}
+    for u in users:
+        name_by_id[u["id"]] = f"{u.get('first_name', '')} {u.get('last_name', '')}".strip() or "Rider"
+        code = u.get("referral_code_used")
+        rid = u.get("referred_by")
+        # Rider referrals use a RIDE-prefixed code and store the referrer's user id.
+        if code and str(code).upper().startswith("RIDE") and rid:
+            by_referrer.setdefault(rid, []).append(u["id"])
+
+    fleet_total = sum(len(v) for v in by_referrer.values())
+    top = sorted(by_referrer.items(), key=lambda kv: len(kv[1]), reverse=True)[:limit]
+
+    leaders: list[dict] = []
+    for referrer_id, referee_ids in top:
+        qualified = 0
+        for ride_user_id in referee_ids:
+            completed = await db_supabase.count_documents("rides", {"rider_id": ride_user_id, "status": "completed"})
+            if completed >= RIDER_REFERRAL_RIDES_REQUIRED:
+                qualified += 1
+        leaders.append(
+            {
+                # driver_id/driver_code reuse the shared UI fields — here they
+                # carry the referrer's user id and RIDE code.
+                "driver_id": referrer_id,
+                "driver_code": f"RIDE{referrer_id[:8].upper()}",
+                "name": name_by_id.get(referrer_id, "Rider"),
+                "total_referrals": len(referee_ids),
+                "qualified_referrals": qualified,
+                "referral_earnings": qualified * RIDER_REFERRER_REWARD,
+            }
+        )
+
+    return {
+        "leaders": leaders,
+        "fleet_total_referrals": fleet_total,
+        "fleet_total_referrers": len(by_referrer),
+        "reward_amount": RIDER_REFERRER_REWARD,
+        "rides_required": RIDER_REFERRAL_RIDES_REQUIRED,
     }
 
 

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -1503,6 +1503,158 @@ async def admin_get_driver_live_stats(driver_id: str):
     }
 
 
+# ── Referral admin views ─────────────────────────────────────────────
+# Reuse the reward terms defined in routes.drivers so the admin views can never
+# disagree with what the driver app shows. Lazy import to avoid a circular
+# import at module load (routes.drivers pulls in a lot).
+def _referral_terms() -> tuple[int, int]:
+    try:
+        from ..drivers import REFERRAL_REWARD_AMOUNT, REFERRAL_RIDES_REQUIRED
+    except ImportError:  # module-path fallback (python -m backend.server vs top-level)
+        from routes.drivers import REFERRAL_REWARD_AMOUNT, REFERRAL_RIDES_REQUIRED  # type: ignore
+    return REFERRAL_RIDES_REQUIRED, REFERRAL_REWARD_AMOUNT
+
+
+def _driver_referral_code(driver: dict) -> str:
+    """The shareable code, matching the app side (driver_code → referral_code → id-derived)."""
+    return driver.get("driver_code") or driver.get("referral_code") or f"DRIVER{driver['id'][:8].upper()}"
+
+
+async def _driver_referral_summary(driver: dict, *, include_referees: bool) -> dict:
+    """Compute a referrer's referral stats (and optionally the referee list)."""
+    rides_required, reward_amount = _referral_terms()
+    code = _driver_referral_code(driver)
+
+    referred_users = await db_supabase.get_rows(
+        "users",
+        {"referral_code_used": code},
+        columns="id,first_name,last_name,email,created_at",
+        limit=200,
+    )
+
+    referees: list[dict] = []
+    qualified = 0
+    for u in referred_users:
+        ref_drv = (lambda _r: _r[0] if _r else None)(
+            await db_supabase.get_rows("drivers", {"user_id": u["id"]}, limit=1)
+        )
+        completed = 0
+        if ref_drv:
+            completed = await db_supabase.count_documents(
+                "rides", {"driver_id": ref_drv["id"], "status": "completed"}
+            )
+        is_qualified = bool(ref_drv) and completed >= rides_required
+        if is_qualified:
+            qualified += 1
+        if include_referees:
+            referees.append(
+                {
+                    "name": f"{u.get('first_name', '')} {u.get('last_name', '')}".strip() or "Driver",
+                    "email": u.get("email", ""),
+                    "referred_at": u.get("created_at", ""),
+                    "is_driver": bool(ref_drv),
+                    "completed_rides": completed,
+                    "rides_required": rides_required,
+                    "rides_remaining": max(0, rides_required - completed),
+                    "qualified": is_qualified,
+                    "status": "earned" if is_qualified else "in_progress",
+                }
+            )
+
+    total = len(referred_users)
+    summary = {
+        "referral_code": code,
+        "total_referrals": total,
+        "qualified_referrals": qualified,
+        "pending_referrals": total - qualified,
+        "referral_earnings": qualified * reward_amount,
+        "reward_amount": reward_amount,
+        "rides_required": rides_required,
+    }
+    if include_referees:
+        summary["referees"] = referees
+    return summary
+
+
+@router.get("/drivers/{driver_id}/referrals")
+async def admin_get_driver_referrals(driver_id: str, admin: dict = Depends(get_admin_user)):
+    """Referees a specific driver brought in, with per-referee reward progress."""
+    driver = await db_supabase.get_driver_by_id(driver_id)
+    if not driver:
+        raise HTTPException(status_code=404, detail="Driver not found")
+    return await _driver_referral_summary(driver, include_referees=True)
+
+
+@router.get("/referrals/leaderboard")
+async def admin_get_referral_leaderboard(
+    limit: int = Query(20, ge=1, le=100),
+    admin: dict = Depends(get_admin_user),
+):
+    """Fleet-wide top referrers, with fleet totals.
+
+    Tallies users by their `referred_by` (the referrer's driver id) in memory —
+    fine for the Saskatchewan-first fleet; would move to a SQL rollup/RPC if the
+    user table grows large. Earnings/qualified counts are computed only for the
+    top `limit` referrers to bound the per-referee ride scans.
+    """
+    rides_required, reward_amount = _referral_terms()
+
+    users = await db_supabase.get_rows(
+        "users", {}, columns="id,referred_by", limit=5000
+    )
+    by_referrer: dict[str, list[str]] = {}
+    for u in users:
+        rid = u.get("referred_by")
+        if rid:
+            by_referrer.setdefault(rid, []).append(u["id"])
+
+    fleet_total_referrals = sum(len(v) for v in by_referrer.values())
+    top = sorted(by_referrer.items(), key=lambda kv: len(kv[1]), reverse=True)[:limit]
+
+    leaders: list[dict] = []
+    fleet_qualified = 0
+    for ref_driver_id, referee_user_ids in top:
+        drv = await db_supabase.get_driver_by_id(ref_driver_id)
+        if not drv:
+            continue
+        ref_user = await db_supabase.get_user_by_id(drv.get("user_id")) if drv.get("user_id") else None
+        name = (
+            f"{(ref_user or {}).get('first_name', '')} {(ref_user or {}).get('last_name', '')}".strip()
+            or drv.get("name")
+            or "Driver"
+        )
+        qualified = 0
+        for uid in referee_user_ids:
+            rdrv = (lambda _r: _r[0] if _r else None)(
+                await db_supabase.get_rows("drivers", {"user_id": uid}, limit=1)
+            )
+            if rdrv:
+                completed = await db_supabase.count_documents(
+                    "rides", {"driver_id": rdrv["id"], "status": "completed"}
+                )
+                if completed >= rides_required:
+                    qualified += 1
+        fleet_qualified += qualified
+        leaders.append(
+            {
+                "driver_id": ref_driver_id,
+                "driver_code": _driver_referral_code(drv),
+                "name": name,
+                "total_referrals": len(referee_user_ids),
+                "qualified_referrals": qualified,
+                "referral_earnings": qualified * reward_amount,
+            }
+        )
+
+    return {
+        "leaders": leaders,
+        "fleet_total_referrals": fleet_total_referrals,
+        "fleet_total_referrers": len(by_referrer),
+        "reward_amount": reward_amount,
+        "rides_required": rides_required,
+    }
+
+
 @router.get("/drivers/{driver_id}/payouts-summary")
 async def admin_get_driver_payouts_summary(driver_id: str, limit: int = Query(50, ge=1, le=200)):
     """Comprehensive payout view for the driver slideout's Payouts tab.

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4967,21 +4967,28 @@ async def apply_referral_code(req: ApplyReferralCodeRequest, current_user: dict 
         await db_supabase.get_rows("drivers", {"referral_code": code}, limit=1)
     )
     if not ref_driver:
-        # Legacy fallback: allow `DRIVER<id-suffix>` format where the
-        # suffix is the last 8 chars of a driver ID. The original
-        # implementation used a `$regex` filter which (a) the Supabase
-        # translator silently dropped, so this path never matched, and
-        # (b) would have been a ReDoS vector on MongoDB.
+        # Fallback for the auto-generated default code, which is
+        # "DRIVER" + the first 8 chars of the driver id, upper-cased
+        # (see get_driver_referral_info). Resolve it back to the driver.
         #
-        # Replacement: accept only an 8-char alphanumeric suffix, then
-        # use a bounded PostgREST `.ilike()` lookup. The `%` suffix
-        # wildcard means "id ends with this string" — exactly what the
-        # original code was trying to do.
+        # NOTE: _apply_filters maps {"$regex": x} onto a SQL LIKE/ILIKE
+        # pattern (%x%), NOT a real regex — so the previous ".*<id>.*"
+        # value was matched *literally* (looking for ".*" inside the id)
+        # and never hit. Pass the bare 8-char token and set $options:"i"
+        # for a case-insensitive contains match (the code upper-cases the
+        # lower-case hex id, so a case-sensitive match would also miss).
         potential_id = code.replace("DRIVER", "")
-        if len(potential_id) == 8:
-            ref_driver = (lambda _r: _r[0] if _r else None)(
-                await db_supabase.get_rows("drivers", {"id": {"$regex": f".*{potential_id}.*"}}, limit=1)
-            )
+        if len(potential_id) == 8 and potential_id.isalnum():
+            try:
+                ref_driver = (lambda _r: _r[0] if _r else None)(
+                    await db_supabase.get_rows(
+                        "drivers",
+                        {"id": {"$regex": potential_id, "$options": "i"}},
+                        limit=1,
+                    )
+                )
+            except Exception as e:
+                logger.warning(f"Referral default-code fallback lookup failed: {e}")
 
     if not ref_driver:
         raise HTTPException(status_code=404, detail="Invalid referral code")

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4907,6 +4907,17 @@ REFERRAL_RIDES_REQUIRED = 10
 REFERRAL_REWARD_AMOUNT = 10  # CAD, paid per referee who reaches the ride target
 
 
+def _driver_referral_codes(driver: dict) -> list:
+    """Every code this driver may have been shared under — the current
+    driver_code plus the legacy referral_code / DRIVER<id8> defaults — so
+    referees who signed up with an older code still count in the summary."""
+    out: list = []
+    for c in (driver.get("driver_code"), driver.get("referral_code"), f"DRIVER{driver['id'][:8].upper()}"):
+        if c and c not in out:
+            out.append(c)
+    return out
+
+
 @api_router.get("/referral")
 async def get_driver_referral_info(current_user: dict = Depends(get_current_user)):
     """Get driver's referral code and earnings from referrals."""
@@ -4920,13 +4931,15 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
     # when present — it's designed to be spoken/typed. Fall back to a stored
     # custom referral_code, then to the id-derived default for legacy rows that
     # predate driver_code (migration 156).
-    referral_code = driver.get("driver_code") or driver.get("referral_code") or f"DRIVER{driver['id'][:8].upper()}"
+    codes = _driver_referral_codes(driver)
+    referral_code = codes[0]  # primary code shown/shared (driver_code when present)
 
-    # Find users who used this referral code
+    # Find users who used ANY of this driver's codes (incl. legacy ones) so a
+    # referrer doesn't lose progress for referees who applied an older code.
     # Only the id is used below (to look up each referred user's driver row),
     # so project it and keep base64 profile_image out of the read.
     referred_users_cursor = db_supabase.get_rows(
-        "users", {"referral_code_used": referral_code}, columns="id", limit=100
+        "users", {"referral_code_used": {"$in": codes}}, columns="id", limit=100
     )
     referred_users = (
         await referred_users_cursor.to_list(100)
@@ -5026,7 +5039,12 @@ async def apply_referral_code(req: ApplyReferralCodeRequest, current_user: dict 
     await db_supabase.update_one(
         "users",
         {"id": current_user["id"]},
-        {"referral_code_used": code, "referred_by": ref_driver["id"]},
+        {
+            "referral_code_used": code,
+            "referred_by": ref_driver["id"],
+            # Recorded so the payout loop only rewards rides completed AFTER this.
+            "referral_applied_at": datetime.now(timezone.utc).isoformat(),
+        },
     )
 
     return {"success": True, "referral_code": code}
@@ -5045,15 +5063,14 @@ async def get_referred_drivers(
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    # Match the shareable code used everywhere else (driver_code / DRV-XXXXXX),
-    # falling back the same way get_driver_referral_info does.
-    referral_code = driver.get("driver_code") or driver.get("referral_code") or f"DRIVER{driver['id'][:8].upper()}"
+    # Match every code this driver may have been shared under (incl. legacy)
+    # so referees who applied an older code still appear in the list.
+    codes = _driver_referral_codes(driver)
 
-    # Find users who used this referral code and became drivers
     # Each referred user contributes name + email + signup date to the response
     # — project those columns and keep base64 profile_image out of the read.
     referred_users_cursor = db_supabase.get_rows(
-        "users", {"referral_code_used": referral_code}, columns="id,first_name,last_name,email,created_at", limit=100
+        "users", {"referral_code_used": {"$in": codes}}, columns="id,first_name,last_name,email,created_at", limit=100
     )
     referred_users = (
         await referred_users_cursor.to_list(100)

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4901,6 +4901,12 @@ class ApplyReferralCodeRequest(BaseModel):
     referral_code: str
 
 
+# Referral reward terms — single source of truth so the earnings calc, the
+# per-referee progress, and the displayed terms can never drift apart.
+REFERRAL_RIDES_REQUIRED = 10
+REFERRAL_REWARD_AMOUNT = 10  # CAD, paid per referee who reaches the ride target
+
+
 @api_router.get("/referral")
 async def get_driver_referral_info(current_user: dict = Depends(get_current_user)):
     """Get driver's referral code and earnings from referrals."""
@@ -4928,11 +4934,11 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
         else list(referred_users_cursor)
     )
 
-    # Calculate referral earnings (e.g., $10 per referred driver who completes 10 rides)
+    # A referral pays out once the referred driver completes REFERRAL_RIDES_REQUIRED
+    # rides; until then it's "in progress". Earnings are the sum of qualified ones.
     total_referrals = len(referred_users)
-    referral_earnings = 0
+    qualified_referrals = 0
 
-    # Check how many referred drivers have completed rides
     for user in referred_users:
         # Check if user became a driver and completed rides
         referred_driver = (lambda _r: _r[0] if _r else None)(
@@ -4943,15 +4949,24 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
                 "rides",
                 {"driver_id": referred_driver["id"], "status": RideStatus.COMPLETED},
             )
-            if completed_rides >= 10:
-                referral_earnings += 10  # $10 bonus
+            if completed_rides >= REFERRAL_RIDES_REQUIRED:
+                qualified_referrals += 1
+
+    referral_earnings = qualified_referrals * REFERRAL_REWARD_AMOUNT
 
     return {
         "referral_code": referral_code,
         "referral_link": f"https://spinr.app/join/{referral_code}",
         "total_referrals": total_referrals,
+        "qualified_referrals": qualified_referrals,
+        "pending_referrals": total_referrals - qualified_referrals,
         "referral_earnings": referral_earnings,
-        "terms": "Earn $10 for each driver who signs up with your code and completes 10 rides.",
+        "reward_amount": REFERRAL_REWARD_AMOUNT,
+        "rides_required": REFERRAL_RIDES_REQUIRED,
+        "terms": (
+            f"Earn ${REFERRAL_REWARD_AMOUNT} for each driver who signs up with your code "
+            f"and completes {REFERRAL_RIDES_REQUIRED} rides."
+        ),
     }
 
 
@@ -5025,7 +5040,9 @@ async def get_referred_drivers(
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    referral_code = driver.get("referral_code", f"DRIVER{driver['id'][:8].upper()}")
+    # Match the shareable code used everywhere else (driver_code / DRV-XXXXXX),
+    # falling back the same way get_driver_referral_info does.
+    referral_code = driver.get("driver_code") or driver.get("referral_code") or f"DRIVER{driver['id'][:8].upper()}"
 
     # Find users who used this referral code and became drivers
     # Each referred user contributes name + email + signup date to the response
@@ -5050,13 +5067,23 @@ async def get_referred_drivers(
                 "rides",
                 {"driver_id": referred_driver["id"], "status": RideStatus.COMPLETED},
             )
+            # Progress toward the reward: qualified once they hit the ride target.
+            qualified = completed_rides >= REFERRAL_RIDES_REQUIRED
+            rides_remaining = max(0, REFERRAL_RIDES_REQUIRED - completed_rides)
             referred_drivers.append(
                 {
                     "name": f"{user.get('first_name', '')} {user.get('last_name', '')}".strip() or "Driver",
                     "email": user.get("email", ""),
                     "referred_at": user.get("created_at", ""),
                     "total_trips": completed_rides,
-                    "status": "active" if completed_rides > 0 else "pending",
+                    # Reward-progress detail surfaced to the referrer.
+                    "rides_required": REFERRAL_RIDES_REQUIRED,
+                    "rides_remaining": rides_remaining,
+                    "reward_amount": REFERRAL_REWARD_AMOUNT,
+                    "qualified": qualified,
+                    # "earned"  → reward unlocked (>= target rides)
+                    # "in_progress" → started but not yet at target
+                    "status": "earned" if qualified else "in_progress",
                 }
             )
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4910,8 +4910,11 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    # Get or create referral code (use driver ID as default code)
-    referral_code = driver.get("referral_code", f"DRIVER{driver['id'][:8].upper()}")
+    # The shareable referral code IS the human-readable driver_code (DRV-XXXXXX)
+    # when present — it's designed to be spoken/typed. Fall back to a stored
+    # custom referral_code, then to the id-derived default for legacy rows that
+    # predate driver_code (migration 156).
+    referral_code = driver.get("driver_code") or driver.get("referral_code") or f"DRIVER{driver['id'][:8].upper()}"
 
     # Find users who used this referral code
     # Only the id is used below (to look up each referred user's driver row),
@@ -4962,10 +4965,16 @@ async def apply_referral_code(req: ApplyReferralCodeRequest, current_user: dict 
     if user and user.get("referral_code_used"):
         raise HTTPException(status_code=400, detail="Referral code already applied")
 
-    # Validate referral code exists (check if any driver has this code)
+    # Resolve the referrer. The primary shareable code is the human-readable
+    # driver_code (DRV-XXXXXX) shown in the profile / referral screen; also
+    # accept a stored custom referral_code for backward compatibility.
     ref_driver = (lambda _r: _r[0] if _r else None)(
-        await db_supabase.get_rows("drivers", {"referral_code": code}, limit=1)
+        await db_supabase.get_rows("drivers", {"driver_code": code}, limit=1)
     )
+    if not ref_driver:
+        ref_driver = (lambda _r: _r[0] if _r else None)(
+            await db_supabase.get_rows("drivers", {"referral_code": code}, limit=1)
+        )
     if not ref_driver:
         # Fallback for the auto-generated default code, which is
         # "DRIVER" + the first 8 chars of the driver id, upper-cased

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5017,6 +5017,11 @@ async def apply_referral_code(req: ApplyReferralCodeRequest, current_user: dict 
     if not ref_driver:
         raise HTTPException(status_code=404, detail="Invalid referral code")
 
+    # Block self-referral — a driver can't refer themselves (now that the code
+    # can be entered at signup, this is an easy thing to try).
+    if ref_driver.get("user_id") == current_user["id"]:
+        raise HTTPException(status_code=400, detail="You can't use your own referral code")
+
     # Apply referral code to user
     await db_supabase.update_one(
         "users",

--- a/backend/routes/quests.py
+++ b/backend/routes/quests.py
@@ -36,6 +36,30 @@ def _f(v: Decimal) -> str:
     return str(v)
 
 
+def _parse_dt(value) -> Optional[datetime]:
+    """Parse an ISO datetime to a tz-aware UTC datetime, or None.
+
+    Quest start/end dates are stored as whatever string the admin dashboard
+    sent, which may use a trailing 'Z', omit the timezone, or be date-only.
+    The old code compared these as raw strings against now().isoformat(), so
+    any format mismatch ('Z' vs '+00:00', differing precision) silently
+    excluded a perfectly valid quest from the available list. Parsing to a
+    real datetime makes the window check correct regardless of format.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 # ── Request Schemas ──────────────────────────────────────────────────
 
 
@@ -74,7 +98,7 @@ async def get_available_quests(current_user: dict = Depends(get_current_user)):
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
 
-    now = datetime.now(timezone.utc).isoformat()
+    now_dt = datetime.now(timezone.utc)
 
     try:
         # Get all active quests
@@ -91,9 +115,13 @@ async def get_available_quests(current_user: dict = Depends(get_current_user)):
     # Filter by date range and eligibility
     available = []
     for q in quests:
-        start = q.get("start_date", "")
-        end = q.get("end_date", "")
-        if start > now or end < now:
+        # Parse to real datetimes — a missing/unparseable bound is treated as
+        # open-ended on that side rather than silently hiding the quest.
+        start_dt = _parse_dt(q.get("start_date"))
+        end_dt = _parse_dt(q.get("end_date"))
+        if start_dt and start_dt > now_dt:
+            continue
+        if end_dt and end_dt < now_dt:
             continue
 
         # Check rating requirement
@@ -164,8 +192,8 @@ async def join_quest(quest_id: str, current_user: dict = Depends(get_current_use
     if not quest.get("is_active", True):
         raise HTTPException(status_code=400, detail="Quest is no longer active")
 
-    now = datetime.now(timezone.utc).isoformat()
-    if quest.get("end_date", "") < now:
+    end_dt = _parse_dt(quest.get("end_date"))
+    if end_dt and end_dt < datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="Quest has ended")
 
     # Check if already joined

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -558,6 +558,11 @@ async def apply_rider_referral(req: ApplyRiderReferralRequest, current_user: dic
     await db_supabase.update_one(
         "users",
         {"id": current_user["id"]},
-        {"referral_code_used": code, "referred_by": ref_user["id"]},
+        {
+            "referral_code_used": code,
+            "referred_by": ref_user["id"],
+            # Recorded so the payout loop only rewards rides completed AFTER this.
+            "referral_applied_at": datetime.now(timezone.utc).isoformat(),
+        },
     )
     return {"success": True, "referral_code": code}

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -431,3 +431,133 @@ async def delete_emergency_contact(contact_id: str, current_user: dict = Depends
 
     await db_supabase.delete_one("emergency_contacts", {"id": contact_id})
     return {"success": True}
+
+
+# ── Rider Referral Program ───────────────────────────────────────────
+# Riders refer riders. "First-ride bonus, both sides": the referee gets a
+# first-ride credit and the referrer earns a credit once the referee completes
+# their first paid ride. Reward terms live here as the single source of truth.
+# NOTE: like the driver referral, the figures below are TRACKED/DISPLAYED only —
+# the actual wallet crediting is a separate money task (idempotent payout +
+# migration + money-auditor review) and is intentionally not done here.
+RIDER_REFERRAL_RIDES_REQUIRED = 1
+RIDER_REFERRER_REWARD = 5  # CAD — referrer credit once referee takes first ride
+RIDER_REFEREE_REWARD = 5   # CAD — new rider's first-ride credit
+
+
+def _rider_referral_code(user: dict) -> str:
+    """Rider's shareable code — a stored custom code, else derived from the id."""
+    return user.get("referral_code") or f"RIDE{user['id'][:8].upper()}"
+
+
+async def _rider_referral_summary(user: dict, *, include_referees: bool) -> dict:
+    code = _rider_referral_code(user)
+    referred = await db_supabase.get_rows(
+        "users",
+        {"referral_code_used": code},
+        columns="id,first_name,last_name,created_at",
+        limit=200,
+    )
+    referees: list = []
+    qualified = 0
+    for u in referred:
+        completed = await db_supabase.count_documents(
+            "rides", {"rider_id": u["id"], "status": "completed"}
+        )
+        is_qualified = completed >= RIDER_REFERRAL_RIDES_REQUIRED
+        if is_qualified:
+            qualified += 1
+        if include_referees:
+            referees.append(
+                {
+                    "name": f"{u.get('first_name', '')} {u.get('last_name', '')}".strip() or "Rider",
+                    "referred_at": u.get("created_at", ""),
+                    "completed_rides": completed,
+                    "rides_required": RIDER_REFERRAL_RIDES_REQUIRED,
+                    "qualified": is_qualified,
+                    "status": "earned" if is_qualified else "in_progress",
+                }
+            )
+    total = len(referred)
+    summary = {
+        "referral_code": code,
+        "referral_link": f"https://spinr.app/r/{code}",
+        "total_referrals": total,
+        "qualified_referrals": qualified,
+        "pending_referrals": total - qualified,
+        "referral_earnings": qualified * RIDER_REFERRER_REWARD,
+        "referrer_reward": RIDER_REFERRER_REWARD,
+        "referee_reward": RIDER_REFEREE_REWARD,
+        "rides_required": RIDER_REFERRAL_RIDES_REQUIRED,
+        "terms": (
+            f"Give ${RIDER_REFEREE_REWARD}, get ${RIDER_REFERRER_REWARD} when your friend "
+            f"takes their first ride."
+        ),
+    }
+    if include_referees:
+        summary["referees"] = referees
+    return summary
+
+
+class ApplyRiderReferralRequest(BaseModel):
+    referral_code: str
+
+
+@api_router.get("/referral")
+async def get_rider_referral_info(current_user: dict = Depends(get_current_user)):
+    """The rider's own referral code, link, and progress stats."""
+    user = await db_supabase.get_user_by_id(current_user["id"])
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return await _rider_referral_summary(user, include_referees=False)
+
+
+@api_router.get("/referrals")
+async def get_rider_referrals(current_user: dict = Depends(get_current_user)):
+    """The riders this user has referred, with first-ride progress."""
+    user = await db_supabase.get_user_by_id(current_user["id"])
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return await _rider_referral_summary(user, include_referees=True)
+
+
+@api_router.post("/referral/apply")
+async def apply_rider_referral(req: ApplyRiderReferralRequest, current_user: dict = Depends(get_current_user)):
+    """Apply a referral code (at signup or later). Links the referee to the referrer."""
+    code = req.referral_code.strip().upper()
+
+    user = await db_supabase.get_user_by_id(current_user["id"])
+    if user and user.get("referral_code_used"):
+        raise HTTPException(status_code=400, detail="Referral code already applied")
+
+    # Resolve the referrer. Codes are "RIDE" + first 8 chars of the user id
+    # (case-insensitive contains match — _apply_filters maps $regex to ILIKE),
+    # or a stored custom referral_code.
+    ref_user = None
+    if code.startswith("RIDE"):
+        suffix = code[4:]
+        if len(suffix) == 8 and suffix.isalnum():
+            try:
+                ref_user = (lambda _r: _r[0] if _r else None)(
+                    await db_supabase.get_rows(
+                        "users", {"id": {"$regex": suffix, "$options": "i"}}, columns="id", limit=1
+                    )
+                )
+            except Exception as e:
+                logger.warning(f"Rider referral code lookup failed: {e}")
+    if not ref_user:
+        ref_user = (lambda _r: _r[0] if _r else None)(
+            await db_supabase.get_rows("users", {"referral_code": code}, columns="id", limit=1)
+        )
+
+    if not ref_user:
+        raise HTTPException(status_code=404, detail="Invalid referral code")
+    if ref_user["id"] == current_user["id"]:
+        raise HTTPException(status_code=400, detail="You can't use your own referral code")
+
+    await db_supabase.update_one(
+        "users",
+        {"id": current_user["id"]},
+        {"referral_code_used": code, "referred_by": ref_user["id"]},
+    )
+    return {"success": True, "referral_code": code}

--- a/backend/utils/referral_payout.py
+++ b/backend/utils/referral_payout.py
@@ -27,9 +27,11 @@ from decimal import ROUND_HALF_UP, Decimal
 try:
     from .. import db_supabase  # type: ignore
     from ..core.config import settings  # type: ignore
+    from ..utils.error_handling import DuplicateRecordError  # type: ignore
 except ImportError:
     import db_supabase  # type: ignore
     from core.config import settings  # type: ignore
+    from utils.error_handling import DuplicateRecordError  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +115,9 @@ async def _tick() -> None:
     # Referred users. A not-null filter isn't supported by the query translator,
     # so project minimal columns and filter in memory (bounded; fine for the
     # current fleet — move to an RPC/rollup if the user table grows large).
-    users = await db_supabase.get_rows("users", {}, columns="id,referral_code_used,referred_by", limit=10000)
+    users = await db_supabase.get_rows(
+        "users", {}, columns="id,referral_code_used,referred_by,referral_applied_at", limit=10000
+    )
     for u in users:
         code = u.get("referral_code_used")
         if not code or u["id"] in done:
@@ -144,16 +148,26 @@ async def _process_one(referee: dict, code: str, terms: dict) -> None:
     if not referrer_user_id or referrer_user_id == referee_id:
         return  # unresolved or self — nothing to pay
 
+    # Count only rides completed AFTER the referral was applied — never pay
+    # retroactively for rides that predate the referral. (Legacy rows with no
+    # referral_applied_at fall back to lifetime count.)
+    applied_at = referee.get("referral_applied_at")
+    since = {"created_at": {"$gte": applied_at}} if applied_at else {}
+
     # Has the referee reached the ride threshold?
     if is_rider:
-        completed = await db_supabase.count_documents("rides", {"rider_id": referee_id, "status": "completed"})
+        completed = await db_supabase.count_documents(
+            "rides", {"rider_id": referee_id, "status": "completed", **since}
+        )
     else:
         ref_as_driver = (lambda _r: _r[0] if _r else None)(
             await db_supabase.get_rows("drivers", {"user_id": referee_id}, limit=1)
         )
         if not ref_as_driver:
             return
-        completed = await db_supabase.count_documents("rides", {"driver_id": ref_as_driver["id"], "status": "completed"})
+        completed = await db_supabase.count_documents(
+            "rides", {"driver_id": ref_as_driver["id"], "status": "completed", **since}
+        )
     if completed < t["rides"]:
         return
 
@@ -176,51 +190,34 @@ async def _process_one(referee: dict, code: str, terms: dict) -> None:
                 "created_at": now_iso,
             },
         )
-    except Exception as e:
-        logger.info(f"referral_payout: claim skipped for referee {referee_id} (already claimed): {e}")
+    except DuplicateRecordError:
+        # Another replica/tick already claimed this referee — expected, skip.
+        logger.info(f"referral_payout: claim already exists for referee {referee_id} — skipping")
         return
+    # Any other DB error (table missing, RLS/schema, connectivity) propagates to
+    # the outer handler in _tick, which logs it as an error rather than silently
+    # treating it as 'already claimed'.
 
-    # Credit the referrer first, then the referee (rider only). Make a partial
-    # failure recoverable: if the second credit fails, reverse the first with a
-    # compensating debit and DELETE the claim so the next tick retries cleanly.
-    # Only if the compensation itself fails do we leave the row 'failed' for
-    # manual reconciliation — never a silent half-applied state.
+    # Credit the referrer, then the referee (rider only). Each _credit is
+    # self-atomic — it reverses its own increment if the ledger write fails, so
+    # money is never left unrecorded. On ANY credit failure we mark the claim
+    # 'failed' and stop: we deliberately do NOT delete/retry, because the claim
+    # row staying in place is exactly what prevents a re-claim and a double
+    # credit on the next tick. 'failed' rows surface for manual reconciliation.
     meta = {"kind": kind, "referee_id": referee_id, "referrer_user_id": referrer_user_id}
-    referrer_paid = False
     try:
         await _credit(referrer_user_id, referrer_reward, kind, referee_id, "referral_reward", meta)
-        referrer_paid = True
         if referee_reward > 0:
             await _credit(referee_id, referee_reward, kind, referee_id, "referral_bonus", meta)
     except Exception:
         logger.error(
-            "referral_payout: credit failed — compensating and releasing claim",
+            "referral_payout: credit failed — marking claim 'failed' for manual reconciliation",
             exc_info=True,
             extra=meta,
         )
-        compensated = True
-        if referrer_paid:
-            try:
-                await _credit(referrer_user_id, -referrer_reward, kind, referee_id, "referral_reversal", meta)
-            except Exception:
-                compensated = False
-                logger.error(
-                    "referral_payout: compensation debit FAILED — manual reconciliation required",
-                    exc_info=True,
-                    extra=meta,
-                )
-        if compensated:
-            # Release the claim so a future tick retries from a clean slate.
-            try:
-                await db_supabase.delete_one("referral_payouts", {"referee_user_id": referee_id})
-            except Exception:
-                await db_supabase.update_one(
-                    "referral_payouts", {"referee_user_id": referee_id}, {"$set": {"status": "failed"}}
-                )
-        else:
-            await db_supabase.update_one(
-                "referral_payouts", {"referee_user_id": referee_id}, {"$set": {"status": "failed"}}
-            )
+        await db_supabase.update_one(
+            "referral_payouts", {"referee_user_id": referee_id}, {"$set": {"status": "failed"}}
+        )
         return
 
     await db_supabase.update_one(
@@ -232,8 +229,13 @@ async def _process_one(referee: dict, code: str, terms: dict) -> None:
 
 
 async def _credit(user_id: str, amount: Decimal, kind: str, reference_id: str, txn_type: str, metadata: dict) -> None:
-    """Credit (or, with a negative amount, reverse) a wallet and write the
-    immutable ledger entry. Decimal-only."""
+    """Credit a wallet and write the immutable ledger entry — atomically.
+
+    If the ledger write fails after the balance already moved, reverse the
+    increment so money is never left without a matching ledger entry, then
+    re-raise. (Same compensate-on-ledger-failure pattern as the quest-reward
+    payout.) Decimal-only.
+    """
     try:
         from ..routes.wallet import _record_transaction, get_or_create_wallet  # type: ignore
     except ImportError:
@@ -241,13 +243,28 @@ async def _credit(user_id: str, amount: Decimal, kind: str, reference_id: str, t
 
     wallet = await get_or_create_wallet(user_id)
     new_balance = await db_supabase.wallet_increment_balance(wallet["id"], amount)
-    await _record_transaction(
-        wallet_id=wallet["id"],
-        user_id=user_id,
-        txn_type=txn_type,
-        amount=_f(amount),
-        balance_after=_f(new_balance),
-        reference_id=reference_id,
-        description=f"{kind.capitalize()} referral reward",
-        metadata=metadata,
-    )
+    try:
+        await _record_transaction(
+            wallet_id=wallet["id"],
+            user_id=user_id,
+            txn_type=txn_type,
+            amount=_f(amount),
+            balance_after=_f(new_balance),
+            reference_id=reference_id,
+            description=f"{kind.capitalize()} referral reward",
+            metadata=metadata,
+        )
+    except Exception:
+        # Ledger write failed after the balance moved — reverse the increment so
+        # no money is left unrecorded, then surface the error to the caller.
+        try:
+            await db_supabase.wallet_increment_balance(wallet["id"], -amount)
+        except Exception:
+            logger.error(
+                "referral_payout: ledger write AND its reversal failed — wallet %s left with an "
+                "unrecorded %s credit; manual reconciliation required",
+                wallet["id"],
+                _f(amount),
+                exc_info=True,
+            )
+        raise

--- a/backend/utils/referral_payout.py
+++ b/backend/utils/referral_payout.py
@@ -1,0 +1,253 @@
+"""Referral reward payout loop (rider + driver).
+
+Pays a referrer once their referee reaches the ride threshold:
+  - driver referral: referrer earns $10 once the referee (a driver) completes
+    REFERRAL_RIDES_REQUIRED (10) rides.
+  - rider referral: referrer AND referee each earn $5 once the referee completes
+    RIDER_REFERRAL_RIDES_REQUIRED (1) ride ("first-ride bonus, both sides").
+
+Money safety:
+  - OFF by default (settings.REFERRAL_PAYOUTS_ENABLED) — enable after staging.
+  - Idempotent: a payout is claimed by INSERTing a referral_payouts row whose
+    UNIQUE(referee_user_id) makes a duplicate/concurrent claim fail, so each
+    referral is paid at most once even across replicas and retries.
+  - Decimal-only money; credits go through the same wallet RPC + immutable
+    ledger entry used by the quest-reward payout.
+  - A credit failure marks the row 'failed' (NO auto-retry) so it surfaces for
+    manual reconciliation rather than risking a double-credit race.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from decimal import ROUND_HALF_UP, Decimal
+
+try:
+    from .. import db_supabase  # type: ignore
+    from ..core.config import settings  # type: ignore
+except ImportError:
+    import db_supabase  # type: ignore
+    from core.config import settings  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+INTERVAL_SECONDS = 300  # every 5 minutes
+_TWO = Decimal("0.01")
+
+
+def _d(v) -> Decimal:
+    return Decimal(str(v or 0)).quantize(_TWO, rounding=ROUND_HALF_UP)
+
+
+def _f(v: Decimal) -> str:
+    return str(v)
+
+
+def _terms() -> dict:
+    """Reward terms, imported lazily to avoid circular imports at module load."""
+    try:
+        from ..routes.drivers import REFERRAL_REWARD_AMOUNT, REFERRAL_RIDES_REQUIRED  # type: ignore
+        from ..routes.users import (  # type: ignore
+            RIDER_REFEREE_REWARD,
+            RIDER_REFERRAL_RIDES_REQUIRED,
+            RIDER_REFERRER_REWARD,
+        )
+    except ImportError:
+        from routes.drivers import REFERRAL_REWARD_AMOUNT, REFERRAL_RIDES_REQUIRED  # type: ignore
+        from routes.users import (  # type: ignore
+            RIDER_REFEREE_REWARD,
+            RIDER_REFERRAL_RIDES_REQUIRED,
+            RIDER_REFERRER_REWARD,
+        )
+    return {
+        "driver": {"rides": REFERRAL_RIDES_REQUIRED, "referrer": REFERRAL_REWARD_AMOUNT, "referee": 0},
+        "rider": {"rides": RIDER_REFERRAL_RIDES_REQUIRED, "referrer": RIDER_REFERRER_REWARD, "referee": RIDER_REFEREE_REWARD},
+    }
+
+
+async def referral_payout_loop() -> None:
+    """Every 5 min, pay any newly-qualified referral rewards. Replay-safe."""
+    while True:
+        try:
+            await _tick()
+        except Exception:
+            logger.error("referral_payout tick failed", exc_info=True)
+        await asyncio.sleep(INTERVAL_SECONDS)
+
+
+async def _tick() -> None:
+    if not settings.REFERRAL_PAYOUTS_ENABLED:
+        return
+    terms = _terms()
+
+    # Reclaim crash-stranded claims: a row stuck 'processing' past the grace
+    # window means a replica died between claiming and finalising. We can't tell
+    # whether the credit landed, so mark it 'failed' for manual review rather
+    # than risk a double-credit by auto-retrying.
+    cutoff = (datetime.now(timezone.utc) - timedelta(minutes=15)).isoformat()
+    try:
+        stale = await db_supabase.get_rows(
+            "referral_payouts",
+            {"status": "processing", "created_at": {"$lt": cutoff}},
+            columns="id,referee_user_id",
+            limit=500,
+        )
+        for s in stale:
+            await db_supabase.update_one(
+                "referral_payouts", {"id": s["id"], "status": "processing"}, {"$set": {"status": "failed"}}
+            )
+            logger.error(
+                "referral_payout: stale 'processing' claim marked 'failed' for manual review",
+                extra={"referee_id": s.get("referee_user_id")},
+            )
+    except Exception:
+        logger.error("referral_payout: stale-claim sweep failed", exc_info=True)
+
+    # Referees we've already claimed/paid/failed — skip them. (Transient credit
+    # failures DELETE their claim row, so those are absent here and get retried.)
+    existing = await db_supabase.get_rows("referral_payouts", {}, columns="referee_user_id", limit=20000)
+    done = {r["referee_user_id"] for r in existing}
+
+    # Referred users. A not-null filter isn't supported by the query translator,
+    # so project minimal columns and filter in memory (bounded; fine for the
+    # current fleet — move to an RPC/rollup if the user table grows large).
+    users = await db_supabase.get_rows("users", {}, columns="id,referral_code_used,referred_by", limit=10000)
+    for u in users:
+        code = u.get("referral_code_used")
+        if not code or u["id"] in done:
+            continue
+        try:
+            await _process_one(u, code, terms)
+        except Exception:
+            logger.error("referral_payout: processing referee failed", exc_info=True, extra={"referee_id": u["id"]})
+
+
+async def _process_one(referee: dict, code: str, terms: dict) -> None:
+    referee_id = referee["id"]
+    is_rider = str(code).upper().startswith("RIDE")
+    kind = "rider" if is_rider else "driver"
+    t = terms[kind]
+
+    # Resolve the referrer's USER id (wallets are per user).
+    referrer_user_id = None
+    if is_rider:
+        # rider referral stores referred_by = referrer's user id
+        referrer_user_id = referee.get("referred_by")
+    else:
+        # driver referral stores referred_by = referrer's DRIVER id
+        ref_driver_id = referee.get("referred_by")
+        if ref_driver_id:
+            ref_driver = await db_supabase.get_driver_by_id(ref_driver_id)
+            referrer_user_id = (ref_driver or {}).get("user_id")
+    if not referrer_user_id or referrer_user_id == referee_id:
+        return  # unresolved or self — nothing to pay
+
+    # Has the referee reached the ride threshold?
+    if is_rider:
+        completed = await db_supabase.count_documents("rides", {"rider_id": referee_id, "status": "completed"})
+    else:
+        ref_as_driver = (lambda _r: _r[0] if _r else None)(
+            await db_supabase.get_rows("drivers", {"user_id": referee_id}, limit=1)
+        )
+        if not ref_as_driver:
+            return
+        completed = await db_supabase.count_documents("rides", {"driver_id": ref_as_driver["id"], "status": "completed"})
+    if completed < t["rides"]:
+        return
+
+    referrer_reward = _d(t["referrer"])
+    referee_reward = _d(t["referee"])
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    # Atomic claim: the UNIQUE(referee_user_id) means only one replica/tick wins
+    # this INSERT; a duplicate raises and we skip (already being handled).
+    try:
+        await db_supabase.insert_one(
+            "referral_payouts",
+            {
+                "referee_user_id": referee_id,
+                "referrer_user_id": referrer_user_id,
+                "kind": kind,
+                "referrer_reward": _f(referrer_reward),
+                "referee_reward": _f(referee_reward),
+                "status": "processing",
+                "created_at": now_iso,
+            },
+        )
+    except Exception as e:
+        logger.info(f"referral_payout: claim skipped for referee {referee_id} (already claimed): {e}")
+        return
+
+    # Credit the referrer first, then the referee (rider only). Make a partial
+    # failure recoverable: if the second credit fails, reverse the first with a
+    # compensating debit and DELETE the claim so the next tick retries cleanly.
+    # Only if the compensation itself fails do we leave the row 'failed' for
+    # manual reconciliation — never a silent half-applied state.
+    meta = {"kind": kind, "referee_id": referee_id, "referrer_user_id": referrer_user_id}
+    referrer_paid = False
+    try:
+        await _credit(referrer_user_id, referrer_reward, kind, referee_id, "referral_reward", meta)
+        referrer_paid = True
+        if referee_reward > 0:
+            await _credit(referee_id, referee_reward, kind, referee_id, "referral_bonus", meta)
+    except Exception:
+        logger.error(
+            "referral_payout: credit failed — compensating and releasing claim",
+            exc_info=True,
+            extra=meta,
+        )
+        compensated = True
+        if referrer_paid:
+            try:
+                await _credit(referrer_user_id, -referrer_reward, kind, referee_id, "referral_reversal", meta)
+            except Exception:
+                compensated = False
+                logger.error(
+                    "referral_payout: compensation debit FAILED — manual reconciliation required",
+                    exc_info=True,
+                    extra=meta,
+                )
+        if compensated:
+            # Release the claim so a future tick retries from a clean slate.
+            try:
+                await db_supabase.delete_one("referral_payouts", {"referee_user_id": referee_id})
+            except Exception:
+                await db_supabase.update_one(
+                    "referral_payouts", {"referee_user_id": referee_id}, {"$set": {"status": "failed"}}
+                )
+        else:
+            await db_supabase.update_one(
+                "referral_payouts", {"referee_user_id": referee_id}, {"$set": {"status": "failed"}}
+            )
+        return
+
+    await db_supabase.update_one(
+        "referral_payouts",
+        {"referee_user_id": referee_id},
+        {"$set": {"status": "paid", "paid_at": datetime.now(timezone.utc).isoformat()}},
+    )
+    logger.info(f"referral_payout: paid {kind} referral reward for referee {referee_id}")
+
+
+async def _credit(user_id: str, amount: Decimal, kind: str, reference_id: str, txn_type: str, metadata: dict) -> None:
+    """Credit (or, with a negative amount, reverse) a wallet and write the
+    immutable ledger entry. Decimal-only."""
+    try:
+        from ..routes.wallet import _record_transaction, get_or_create_wallet  # type: ignore
+    except ImportError:
+        from routes.wallet import _record_transaction, get_or_create_wallet  # type: ignore
+
+    wallet = await get_or_create_wallet(user_id)
+    new_balance = await db_supabase.wallet_increment_balance(wallet["id"], amount)
+    await _record_transaction(
+        wallet_id=wallet["id"],
+        user_id=user_id,
+        txn_type=txn_type,
+        amount=_f(amount),
+        balance_after=_f(new_balance),
+        reference_id=reference_id,
+        description=f"{kind.capitalize()} referral reward",
+        metadata=metadata,
+    )

--- a/driver-app/app/driver/(tabs)/index.tsx
+++ b/driver-app/app/driver/(tabs)/index.tsx
@@ -899,8 +899,6 @@ function DriverDashboard() {
       {rideState === 'idle' && (
         <DriverIdlePanel
           isOnline={isOnline}
-          driverData={driverData as any ?? undefined}
-          earnings={earnings ?? undefined}
           onToggleOnline={toggleOnline}
           pulseAnim={pulseAnim}
         />

--- a/driver-app/app/driver/(tabs)/profile.tsx
+++ b/driver-app/app/driver/(tabs)/profile.tsx
@@ -42,11 +42,12 @@ export default function ProfileScreen() {
   const styles = useMemo(() => createStyles(colors), [colors]);
   const modalStyles = useMemo(() => createModalStyles(colors), [colors]);
 
-  // Referral code shown in the profile. Prefer a stored custom code; otherwise
-  // derive it automatically from the driver id exactly as the backend does
-  // (get_driver_referral_info: "DRIVER" + first 8 chars of the id, upper-cased)
-  // so a code is always present without the driver doing anything. Tap to copy.
-  const referralCode = (driverData?.referral_code as string | undefined)
+  // Referral code shown in the profile. It IS the human-readable driver_code
+  // (DRV-XXXXXX) — designed to be spoken/typed — falling back to a stored
+  // custom code or the id-derived default only for legacy rows without one.
+  // Tap to copy.
+  const referralCode = (driverData?.driver_code as string | undefined)
+    || (driverData?.referral_code as string | undefined)
     || (driverData?.id ? `DRIVER${String(driverData.id).slice(0, 8).toUpperCase()}` : '');
 
   const copyReferralCode = useCallback(async () => {
@@ -313,9 +314,6 @@ export default function ProfileScreen() {
           <Text style={styles.name}>
             {driverData?.name || (user?.first_name ? `${user.first_name} ${user.last_name || ''}` : 'Driver')}
           </Text>
-          {!!driverData?.driver_code && (
-            <Text style={styles.driverCode}>{driverData.driver_code}</Text>
-          )}
           {!!referralCode && (
             <TouchableOpacity
               style={styles.referralChip}

--- a/driver-app/app/driver/(tabs)/profile.tsx
+++ b/driver-app/app/driver/(tabs)/profile.tsx
@@ -28,6 +28,7 @@ import api from '@shared/api/client';
 import { useDriverMe } from '@shared/hooks/queries';
 import SpinrConfig from '@shared/config/spinr.config';
 import { showToast } from '../../../hooks/useToast';
+import * as Clipboard from 'expo-clipboard';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
 
@@ -40,6 +41,23 @@ export default function ProfileScreen() {
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const modalStyles = useMemo(() => createModalStyles(colors), [colors]);
+
+  // Referral code shown in the profile. Prefer a stored custom code; otherwise
+  // derive it automatically from the driver id exactly as the backend does
+  // (get_driver_referral_info: "DRIVER" + first 8 chars of the id, upper-cased)
+  // so a code is always present without the driver doing anything. Tap to copy.
+  const referralCode = (driverData?.referral_code as string | undefined)
+    || (driverData?.id ? `DRIVER${String(driverData.id).slice(0, 8).toUpperCase()}` : '');
+
+  const copyReferralCode = useCallback(async () => {
+    if (!referralCode) return;
+    try {
+      await Clipboard.setStringAsync(referralCode);
+      showToast('success', 'Copied!', 'Referral code copied to clipboard');
+    } catch {
+      // Clipboard is best-effort — never throw from a copy tap.
+    }
+  }, [referralCode]);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
   const [docRequirements, setDocRequirements] = useState<Array<{id: string; name: string; description?: string}>>([]);
@@ -297,6 +315,20 @@ export default function ProfileScreen() {
           </Text>
           {!!driverData?.driver_code && (
             <Text style={styles.driverCode}>{driverData.driver_code}</Text>
+          )}
+          {!!referralCode && (
+            <TouchableOpacity
+              style={styles.referralChip}
+              onPress={copyReferralCode}
+              activeOpacity={0.7}
+              accessibilityRole="button"
+              accessibilityLabel={`Referral code ${referralCode}. Tap to copy.`}
+            >
+              <Ionicons name="gift-outline" size={13} color="#fff" />
+              <Text style={styles.referralChipLabel}>Referral code</Text>
+              <Text style={styles.referralChipCode}>{referralCode}</Text>
+              <Ionicons name="copy-outline" size={13} color="rgba(255,255,255,0.9)" />
+            </TouchableOpacity>
           )}
           <Text style={styles.subtitle}>
             {driverData?.is_verified ? 'Verified Driver' : 'Pending Verification'}
@@ -954,6 +986,28 @@ function createStyles(colors: ThemeColors) { return StyleSheet.create({
     fontSize: 13,
     marginTop: 4,
     fontWeight: '700',
+    letterSpacing: 1,
+    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }),
+  },
+  referralChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    backgroundColor: 'rgba(255,255,255,0.18)',
+  },
+  referralChipLabel: {
+    color: 'rgba(255,255,255,0.85)',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  referralChipCode: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '800',
     letterSpacing: 1,
     fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace', default: 'monospace' }),
   },

--- a/driver-app/app/driver/quests.tsx
+++ b/driver-app/app/driver/quests.tsx
@@ -317,7 +317,7 @@ function createStyles(colors: ThemeColors) {
 
     tabs: {
       flexDirection: 'row', backgroundColor: colors.surface,
-      paddingHorizontal: 16, paddingBottom: 12, gap: 8,
+      paddingHorizontal: 16, paddingTop: 16, paddingBottom: 14, gap: 10,
     },
     tab: {
       flex: 1, paddingVertical: 10, borderRadius: 24,

--- a/driver-app/app/driver/referral.tsx
+++ b/driver-app/app/driver/referral.tsx
@@ -129,7 +129,10 @@ export default function ReferralScreen() {
                 >
                     <Text style={styles.heroTitle}>Invite Drivers & Earn</Text>
                     <Text style={styles.heroSubtitle}>
-                        {t('referral.earn') || 'Earn $25 for each driver you refer who completes 50 rides'}
+                        {/* Generic tagline only — the exact reward ($ and ride
+                            threshold) is stated in the Terms section below, driven
+                            by the backend so the two can never contradict. */}
+                        {t('referral.earn') || 'Invite drivers to Spinr and earn rewards when they sign up and start driving.'}
                     </Text>
 
                     {referralInfo && (

--- a/driver-app/app/driver/referral.tsx
+++ b/driver-app/app/driver/referral.tsx
@@ -26,7 +26,11 @@ import type { ThemeColors } from '@shared/theme/index';
 interface ReferralInfo {
     referral_code: string;
     total_referrals: number;
+    qualified_referrals?: number;
+    pending_referrals?: number;
     referral_earnings: number;
+    reward_amount?: number;
+    rides_required?: number;
     referral_link: string;
     terms: string;
 }
@@ -36,7 +40,11 @@ interface ReferredDriver {
     email: string;
     referred_at: string;
     total_trips: number;
-    status: string;
+    rides_required?: number;
+    rides_remaining?: number;
+    reward_amount?: number;
+    qualified?: boolean;
+    status: string; // 'earned' | 'in_progress'
 }
 
 export default function ReferralScreen() {
@@ -156,7 +164,11 @@ export default function ReferralScreen() {
                 <View style={styles.statsRow}>
                     <View style={styles.statCard}>
                         <Text style={styles.statValue}>{referralInfo?.total_referrals || 0}</Text>
-                        <Text style={styles.statLabel}>Total Referrals</Text>
+                        <Text style={styles.statLabel}>Total</Text>
+                    </View>
+                    <View style={styles.statCard}>
+                        <Text style={styles.statValue}>{referralInfo?.qualified_referrals || 0}</Text>
+                        <Text style={styles.statLabel}>Rewarded</Text>
                     </View>
                     <View style={styles.statCard}>
                         <Text style={styles.statValue}>${(referralInfo?.referral_earnings || 0).toFixed(2)}</Text>
@@ -190,19 +202,35 @@ export default function ReferralScreen() {
                                     </View>
                                     <View style={styles.referralInfo}>
                                         <Text style={styles.referralName}>{driver.name}</Text>
-                                        <Text style={styles.referralTrips}>
-                                            {driver.total_trips} trips completed
-                                        </Text>
+                                        {driver.qualified ? (
+                                            <Text style={styles.referralEarned}>
+                                                Reward earned · ${(driver.reward_amount ?? 0).toFixed(0)}
+                                            </Text>
+                                        ) : (
+                                            <>
+                                                <Text style={styles.referralTrips}>
+                                                    {driver.total_trips}/{driver.rides_required ?? 10} rides
+                                                    {typeof driver.rides_remaining === 'number' && driver.rides_remaining > 0
+                                                        ? ` · ${driver.rides_remaining} more to unlock`
+                                                        : ''}
+                                                </Text>
+                                                <View style={styles.refProgressBar}>
+                                                    <View style={[styles.refProgressFill, {
+                                                        width: `${Math.min(100, ((driver.total_trips || 0) / (driver.rides_required || 10)) * 100)}%`,
+                                                    }]} />
+                                                </View>
+                                            </>
+                                        )}
                                     </View>
                                     <View style={[
                                         styles.referralBadge,
-                                        driver.status === 'active' ? styles.badgeActive : styles.badgePending
+                                        driver.qualified ? styles.badgeActive : styles.badgePending
                                     ]}>
                                         <Text style={[
                                             styles.badgeText,
-                                            driver.status === 'active' ? styles.badgeTextActive : styles.badgeTextPending
+                                            driver.qualified ? styles.badgeTextActive : styles.badgeTextPending
                                         ]}>
-                                            {driver.status === 'active' ? 'Paid' : 'Pending'}
+                                            {driver.qualified ? 'Earned' : 'In progress'}
                                         </Text>
                                     </View>
                                 </View>
@@ -453,6 +481,24 @@ function createStyles(colors: ThemeColors) {
         fontSize: 12,
         color: colors.textDim,
         marginTop: 2,
+    },
+    referralEarned: {
+        fontSize: 12,
+        color: colors.success,
+        fontWeight: '700',
+        marginTop: 2,
+    },
+    refProgressBar: {
+        height: 5,
+        borderRadius: 3,
+        backgroundColor: colors.border,
+        overflow: 'hidden',
+        marginTop: 6,
+    },
+    refProgressFill: {
+        height: '100%',
+        borderRadius: 3,
+        backgroundColor: colors.primary,
     },
     referralBadge: {
         paddingHorizontal: 10,

--- a/driver-app/app/profile-setup.tsx
+++ b/driver-app/app/profile-setup.tsx
@@ -43,6 +43,7 @@ export default function ProfileSetupScreen() {
   const [serviceAreaId, setServiceAreaId] = useState('');
   const [serviceAreas, setServiceAreas] = useState<any[]>([]);
   const [city, setCity] = useState('');
+  const [referralCode, setReferralCode] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
 
@@ -202,6 +203,19 @@ export default function ProfileSetupScreen() {
         // Non-fatal: the driver record might already exist (idempotent register)
         // or will be created on the next refresh. Don't block navigation.
         if (__DEV__) console.log('[ProfileSetup] auto-register result:', regErr?.message);
+      }
+
+      // Optional referral code — best-effort, never blocks signup. The user is
+      // authenticated by this point, so /drivers/referral/apply can attribute
+      // the referrer. An invalid/duplicate code just surfaces a toast.
+      const code = referralCode.trim();
+      if (code) {
+        try {
+          await api.post('/drivers/referral/apply', { referral_code: code });
+          showToast('success', 'Referral applied', 'Your referral code was added.');
+        } catch (refErr: any) {
+          showToast('error', 'Referral code', refErr?.response?.data?.detail || "That referral code couldn't be applied.");
+        }
       }
       router.replace('/driver' as any);
     } catch (err: any) {
@@ -448,6 +462,26 @@ export default function ProfileSetupScreen() {
             <Text style={styles.serviceAreaHint}>
               {serviceAreaId ? 'You can only operate in your selected area' : 'Select your service area to continue'}
             </Text>
+          </View>
+
+          {/* Referral code (optional) — invited by another driver? */}
+          <View style={styles.inputGroup}>
+            <Text style={styles.label}>Referral Code (optional)</Text>
+            <View style={styles.inputContainer}>
+              <View style={styles.inputIconContainer}>
+                <Ionicons name="gift-outline" size={20} color={referralCode ? colors.text : '#A0A0A0'} />
+              </View>
+              <TextInput
+                style={styles.input}
+                value={referralCode}
+                onChangeText={(t) => setReferralCode(t.toUpperCase())}
+                placeholder="e.g. DRV-7K9M2P"
+                placeholderTextColor="#B0B0B0"
+                autoCapitalize="characters"
+                autoCorrect={false}
+              />
+            </View>
+            <Text style={styles.serviceAreaHint}>Invited by a driver? Enter their code to credit them.</Text>
           </View>
         </View>
 

--- a/driver-app/components/dashboard/DriverIdlePanel.tsx
+++ b/driver-app/components/dashboard/DriverIdlePanel.tsx
@@ -2,119 +2,46 @@ import React, { useRef, useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Animated, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
 import { LinearGradient } from 'expo-linear-gradient';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { useTheme } from '@shared/theme/ThemeContext';
 import type { ThemeColors } from '@shared/theme/index';
-import { useAuthStore, DriverOnboardingStatus } from '@shared/store/authStore';
+import { useAuthStore } from '@shared/store/authStore';
 import { useLanguageStore } from '../../store/languageStore';
 
 const isExpoGo = Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
 const Notifications: typeof import('expo-notifications') | null =
   (!isExpoGo && Platform.OS !== 'web') ? require('expo-notifications') : null;
 
-interface DriverData {
-  acceptance_rate?: string;
-  total_rides?: string;
-  is_verified?: boolean;
-}
-
-interface Earnings {
-  total_earnings?: string; // MoneyString
-}
-
 interface IdlePanelProps {
   isOnline: boolean;
-  driverData?: DriverData;
-  earnings?: Earnings;
   onToggleOnline: () => void;
   pulseAnim: any;
 }
 
-function getStateBanners(t: (key: string) => string, driverData?: any) {
-  return {
-    profile_incomplete: {
-      title: t('dashboard.completeProfile'),
-      subtitle: t('dashboard.profileIncompleteMsg'),
-      button: t('dashboard.finishProfile'),
-      icon: 'person', tone: 'info', target: '/profile-setup',
-    },
-    vehicle_required: {
-      title: t('dashboard.addVehicle'),
-      subtitle: t('dashboard.profileIncompleteMsg'),
-      button: t('dashboard.addVehicleDetails'),
-      icon: 'car', tone: 'info', target: '/vehicle-info',
-    },
-    documents_required: {
-      title: t('dashboard.actionRequired'),
-      subtitle: t('dashboard.uploadDocs'),
-      button: t('dashboard.uploadDocs'),
-      icon: 'document-text', tone: 'warning', target: '/documents',
-    },
-    documents_rejected: {
-      title: t('dashboard.docsRejected'),
-      subtitle: t('dashboard.fixDocuments'),
-      button: t('dashboard.fixDocuments'),
-      icon: 'alert-circle', tone: 'danger', target: '/documents',
-    },
-    documents_expired: {
-      title: t('dashboard.docsExpired'),
-      subtitle: t('dashboard.updateDocs'),
-      button: t('dashboard.updateDocs'),
-      icon: 'time', tone: 'warning', target: '/documents',
-    },
-    pending_review: {
-      title: t('dashboard.underReview'),
-      subtitle: t('dashboard.viewStatus'),
-      button: t('dashboard.viewStatus'),
-      icon: 'hourglass', tone: 'info', target: '/documents',
-    },
-    suspended: {
-      title: t('dashboard.accountSuspended'),
-      subtitle: driverData?.suspension_reason || driverData?.ban_reason || t('dashboard.contactSupport'),
-      button: t('dashboard.contactSupport'),
-      icon: 'ban', tone: 'danger', target: 'mailto:support@spinr.ca?subject=Account%20Suspended',
-    },
-  };
-}
-
 export const DriverIdlePanel: React.FC<IdlePanelProps> = ({
   isOnline,
-  driverData,
-  earnings,
   onToggleOnline,
 }) => {
   const { colors } = useTheme();
   const { t } = useLanguageStore();
   const styles = useMemo(() => createStyles(colors), [colors]);
-  const STATE_BANNERS = getStateBanners(t, driverData);
   const insets = useSafeAreaInsets();
-  const router = useRouter();
-  let onboardingStatus = useAuthStore(s => s.user?.driver_onboarding_status ?? null);
   const driver = useAuthStore(s => s.driver);
 
-  // Fallback: If backend returns null (e.g. role still 'rider'), infer status locally
-  if (!onboardingStatus) {
-    if (!driver) {
-      // No driver row at all — they need to register a vehicle
-      onboardingStatus = 'vehicle_required';
-    } else if (!driver.vehicle_make) {
-      onboardingStatus = 'vehicle_required';
-    } else if (!driver.is_verified) {
-      onboardingStatus = 'documents_required';
-    }
-  }
-
-  const banner = onboardingStatus && onboardingStatus !== 'verified'
-    ? STATE_BANNERS[onboardingStatus as keyof typeof STATE_BANNERS]
-    : null;
-
-  // Only drivers with status='active' can go online. The backend enforces
-  // this too, but we disable the GO button client-side for better UX.
-  const driverStatus = (driverData as any)?.status || 'pending';
+  // Only drivers with status='active' can go online. The button stays
+  // pressable in every state so toggleOnline can surface a specific toast
+  // for each ineligible case (missing vehicle, documents pending, etc.).
+  const driverStatus = (driver as any)?.status || 'pending';
   const canGoOnline = driverStatus === 'active';
+
+  // Vehicle shown as persistent text — reads from the auth store, which is
+  // hydrated from cache on cold start / offline, so it stays visible instead
+  // of blanking. Falls back to the make/model line when color/plate missing.
+  const vehicleLine = driver
+    ? [driver.vehicle_color, driver.vehicle_make, driver.vehicle_model].filter(Boolean).join(' ')
+    : '';
 
   const goAnim = useRef(new Animated.Value(1)).current;
 
@@ -139,8 +66,10 @@ export const DriverIdlePanel: React.FC<IdlePanelProps> = ({
     };
   }, [canGoOnline, isOnline]);
 
-  // Welcome / Onboarding Notification Check
+  // Welcome / Onboarding Notification Check — fires once when documents are
+  // first required so a new driver knows to upload them.
   useEffect(() => {
+    const onboardingStatus = (driver as any)?.onboarding_status;
     if (onboardingStatus === 'documents_required') {
       const triggerWelcomeNotif = async () => {
         try {
@@ -148,7 +77,7 @@ export const DriverIdlePanel: React.FC<IdlePanelProps> = ({
           if (!hasSent && Notifications) {
             await Notifications.scheduleNotificationAsync({
               content: {
-                title: 'Welcome to Spinr! 🎉',
+                title: 'Welcome to Spinr!',
                 body: 'Please upload your required documents to get approved and start driving.',
                 sound: true,
               },
@@ -162,52 +91,26 @@ export const DriverIdlePanel: React.FC<IdlePanelProps> = ({
       };
       triggerWelcomeNotif();
     }
-  }, [onboardingStatus]);
+  }, [driver]);
 
   return (
     <View style={[styles.idlePanelContainer, { paddingBottom: insets.bottom + 16 }]} pointerEvents="box-none">
-      
+
       {/* HUD Info Area */}
       <View style={styles.hudArea} pointerEvents="box-none">
-        
-        {/* Onboarding banner */}
-        {banner && (
-          <TouchableOpacity
-            style={[
-              styles.actionBar,
-              banner.tone === 'danger' && styles.actionBarDanger,
-              banner.tone === 'warning' && styles.actionBarWarning,
-            ]}
-            onPress={() => {
-              if (banner.target.startsWith('mailto:') || banner.target.startsWith('http')) {
-                require('react-native').Linking.openURL(banner.target);
-              } else {
-                router.push(banner.target as any);
-              }
-            }}
-            activeOpacity={0.85}
-            accessibilityRole="button"
-            accessibilityLabel={banner.button}
-          >
-            <Ionicons
-              name={banner.icon as keyof typeof Ionicons.glyphMap}
-              size={16}
-              color={banner.tone === 'danger' ? colors.error : banner.tone === 'warning' ? '#92400E' : colors.primary}
-            />
-            <Text
-              style={[
-                styles.actionBarText,
-                banner.tone === 'danger' && styles.actionBarTextDanger,
-                banner.tone === 'warning' && styles.actionBarTextWarning,
-              ]}
-              numberOfLines={1}
-            >
-              {banner.title}
-            </Text>
-            <Text style={styles.actionBarCta}>{banner.button}</Text>
-            <Ionicons name="chevron-forward" size={14} color={colors.primary} />
-          </TouchableOpacity>
-        )}
+
+        {/* Vehicle details as persistent text — stays visible offline */}
+        {vehicleLine ? (
+          <View style={styles.vehiclePill}>
+            <Ionicons name="car-outline" size={14} color={colors.textSecondary} />
+            <Text style={styles.vehiclePillText} numberOfLines={1}>{vehicleLine}</Text>
+            {driver?.license_plate ? (
+              <View style={styles.plateBadge}>
+                <Text style={styles.plateBadgeText}>{driver.license_plate.toUpperCase()}</Text>
+              </View>
+            ) : null}
+          </View>
+        ) : null}
 
 
         {/* Status Indicator Pill */}
@@ -232,7 +135,6 @@ export const DriverIdlePanel: React.FC<IdlePanelProps> = ({
         
         <TouchableOpacity
           activeOpacity={0.9}
-          disabled={!canGoOnline}
           onPress={onToggleOnline}
           style={styles.goButtonOuterContainer}
           accessibilityRole="button"
@@ -281,48 +183,41 @@ function createStyles(colors: ThemeColors) {
       paddingHorizontal: 20,
       marginBottom: 20,
     },
-    actionBar: {
+    vehiclePill: {
       flexDirection: 'row',
       alignItems: 'center',
-      width: '100%',
       backgroundColor: colors.surface,
-      borderRadius: 16,
+      borderRadius: 20,
       paddingHorizontal: 14,
-      paddingVertical: 12,
-      marginBottom: 12,
-      gap: 8,
+      paddingVertical: 8,
+      marginBottom: 10,
+      gap: 6,
       shadowColor: '#000',
-      shadowOffset: { width: 0, height: 4 },
-      shadowOpacity: 0.1,
-      shadowRadius: 10,
-      elevation: 5,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.08,
+      shadowRadius: 6,
+      elevation: 3,
       borderWidth: 1,
       borderColor: colors.border,
+      maxWidth: '90%',
     },
-    actionBarWarning: {
-      backgroundColor: colors.warningBg,
-      borderColor: colors.warning,
-    },
-    actionBarDanger: {
-      backgroundColor: colors.dangerBg,
-      borderColor: colors.error,
-    },
-    actionBarText: {
-      flex: 1,
-      fontSize: 13,
-      fontWeight: '700',
-      color: colors.text,
-    },
-    actionBarTextWarning: {
-      color: '#92400E',
-    },
-    actionBarTextDanger: {
-      color: '#991B1B',
-    },
-    actionBarCta: {
+    vehiclePillText: {
       fontSize: 12,
+      fontWeight: '600',
+      color: colors.textSecondary,
+      flexShrink: 1,
+    },
+    plateBadge: {
+      backgroundColor: colors.primary + '20',
+      borderRadius: 6,
+      paddingHorizontal: 7,
+      paddingVertical: 2,
+    },
+    plateBadgeText: {
+      fontSize: 11,
       fontWeight: '700',
       color: colors.primary,
+      letterSpacing: 0.5,
     },
 
     statusPillWrapper: {

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -15,6 +15,7 @@ import { tKey } from '../i18n';
 import api from '@shared/api/client';
 import { useDriverConfig } from '@shared/hooks/queries';
 import { API_URL } from '@shared/config';
+import SpinrConfig from '@shared/config/spinr.config';
 import { onForegroundMessage } from '@shared/services/firebase';
 import { Dimensions } from 'react-native';
 import {
@@ -60,6 +61,28 @@ const _toFiniteCoord = (v: unknown): number | null => {
   if (!Number.isFinite(n)) return null;
   if (n < -180 || n > 180) return null; // valid range for both lat (-90..90) and lng (-180..180)
   return n;
+};
+
+/**
+ * Resolve a backend base URL that is guaranteed to carry an http(s) scheme,
+ * or null if none can be found.
+ *
+ * `@shared/config`'s API_URL is env-var-only and resolves to '' when
+ * EXPO_PUBLIC_BACKEND_URL was not baked into the build (a known EAS / OTA
+ * hazard — the var is compiled in at build time, not read at runtime). An
+ * empty base produced a scheme-less WebSocket URL like "/ws/driver/123",
+ * which crashed the native OkHttp layer with a FATAL EXCEPTION:
+ * "Expected URL scheme 'http' or 'https' but no scheme was found".
+ *
+ * Defence: prefer API_URL when it has a valid scheme, otherwise fall back to
+ * SpinrConfig.backendUrl (which carries the hardcoded production safety net
+ * + HTTPS enforcement). Only ever return a value that starts with http(s);
+ * callers treat null as "cannot connect" and surface it instead of crashing.
+ */
+const _resolveBackendBaseUrl = (): string | null => {
+  const candidate = API_URL && /^https?:\/\//.test(API_URL) ? API_URL : SpinrConfig.backendUrl;
+  if (!candidate || !/^https?:\/\//.test(candidate)) return null;
+  return candidate.replace(/\/+$/, '');
 };
 
 export type LocationStatus = 'pending' | 'denied' | 'unavailable' | 'ok';
@@ -894,11 +917,27 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
       return;
     }
 
+    // Defence against a misconfigured build: if no backend URL with a valid
+    // http(s) scheme can be resolved, do NOT construct the socket — a
+    // scheme-less URL ("/ws/driver/123") crashes the native OkHttp layer with
+    // a FATAL EXCEPTION. Surface a connection error and bail gracefully so the
+    // driver sees "Connection lost" instead of the app dying on tap-GO.
+    const baseUrl = _resolveBackendBaseUrl();
+    if (!baseUrl) {
+      console.error(
+        '[WS] No valid backend URL — cannot open driver socket. ' +
+        'EXPO_PUBLIC_BACKEND_URL is likely missing from this build.',
+      );
+      setConnectionState('disconnected');
+      setWsError(tKey('dashboard.connectionLost'));
+      return;
+    }
+
     // Match URL scheme: https backends (prod or DEV pointing at prod) use wss://,
     // http backends (local dev) use ws://. Checking __DEV__ is wrong — Railway's
     // edge proxy rejects plain ws:// with "Invalid Sec-WebSocket-Accept response".
-    const useSecure = API_URL.startsWith('https');
-    const wsBaseUrl = `${API_URL.replace(/^https?/, useSecure ? 'wss' : 'ws')}/ws/driver/${currentUser.id}`;
+    const useSecure = baseUrl.startsWith('https');
+    const wsBaseUrl = `${baseUrl.replace(/^https?/, useSecure ? 'wss' : 'ws')}/ws/driver/${currentUser.id}`;
     const wsUrl = lastSeqRef.current > 0 ? `${wsBaseUrl}?last_seq=${lastSeqRef.current}` : wsBaseUrl;
     // Flip the banner to 'reconnecting' the moment we start connecting.
     // The initial state is 'disconnected', which renders as the red

--- a/driver-app/hooks/useDriverDashboard.ts
+++ b/driver-app/hooks/useDriverDashboard.ts
@@ -3,6 +3,7 @@ import { Animated } from 'react-native';
 import { showAlert } from '../components/AlertDialog';
 import * as Location from 'expo-location';
 import { Platform, Vibration, Linking, AppState } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import { showToast } from './useToast';
 
 export type ConnectionState = 'connected' | 'reconnecting' | 'disconnected';
@@ -1183,27 +1184,57 @@ export const useDriverDashboard = (): UseDriverDashboardReturn => {
   // ─── Toggle Online/Offline ───────────────────────────────────────
   const toggleOnline = async () => {
     try {
+      // Offline guard — only when going ONLINE. Without a connection the
+      // go-online request can't reach the backend, so tell the driver with a
+      // toast instead of letting it silently fail. (Going offline is always
+      // allowed so a driver on a dead connection can still flip themselves off.)
+      if (!isOnline) {
+        const net = await NetInfo.fetch().catch(() => null);
+        const connected = net ? (net.isConnected ?? net.isInternetReachable ?? true) : true;
+        if (connected === false) {
+          showToast('error', 'Internet offline', 'Your internet is offline. Reconnect and try again.');
+          return;
+        }
+      }
+
+      // Onboarding status is computed server-side on /auth/me; read it live.
+      const onboardingStatus = useAuthStore.getState().user?.driver_onboarding_status;
+
+      // Vehicle details missing → toast + send them to the vehicle form.
       if (!driverData?.vehicle_make || !driverData?.license_plate) {
-        showAlert(
-          "Profile Incomplete",
-          "You must provide vehicle details before going online.",
-          [
-            { text: "Add Vehicle Info", onPress: () => router.push('/vehicle-info' as any) },
-            { text: "Cancel", style: "cancel" },
-          ]
-        );
+        showToast('error', tKey('dashboard.addVehicle'), tKey('dashboard.profileIncompleteMsg'));
+        router.push('/vehicle-info' as any);
+        return;
+      }
+
+      // Documents pending / rejected / expired / under review → toast + docs page.
+      if (onboardingStatus === 'documents_required') {
+        showToast('error', tKey('dashboard.actionRequired'), tKey('dashboard.uploadDocs'));
+        router.push('/documents' as any);
+        return;
+      }
+      if (onboardingStatus === 'documents_rejected') {
+        showToast('error', tKey('dashboard.docsRejected'), tKey('dashboard.fixDocuments'));
+        router.push('/documents' as any);
+        return;
+      }
+      if (onboardingStatus === 'documents_expired') {
+        showToast('error', tKey('dashboard.docsExpired'), tKey('dashboard.updateDocs'));
+        router.push('/documents' as any);
+        return;
+      }
+      if (onboardingStatus === 'pending_review') {
+        showToast('info', tKey('dashboard.underReview'), tKey('dashboard.viewStatus'));
+        router.push('/documents' as any);
+        return;
+      }
+      if (onboardingStatus === 'suspended') {
+        showToast('error', tKey('dashboard.accountSuspended'), tKey('dashboard.contactSupport'));
         return;
       }
 
       if (!driverData?.is_verified) {
-        showAlert(
-          "Account Not Verified",
-          "Your account is not verified yet. Please complete your profile and wait for admin approval before going online.",
-          [
-            { text: "Check Status", onPress: () => router.push('/driver/profile' as any) },
-            { text: "OK", style: "default" },
-          ]
-        );
+        showToast('error', tKey('dashboard.accountNotVerified'), tKey('dashboard.accountNotVerifiedMsg'));
         return;
       }
 

--- a/driver-app/index.js
+++ b/driver-app/index.js
@@ -12,6 +12,17 @@
 // offer is silently dropped — the exact bug this fixes. require() gives us
 // guaranteed top-to-bottom order so the FCM handler wins the race.
 
+// 0. Silence the @react-native-firebase v22+ modular-API deprecation warnings.
+//    We still use the namespaced API (messaging()/appCheck()/crashlytics()) in
+//    shared/services/firebase.ts; on v24 every call logs a "Please use getApp()
+//    … migrating-to-v22" warning. These are cosmetic only — the namespaced API
+//    keeps working until the next major release. This flag (read by the SDK at
+//    @react-native-firebase/app/lib/common) suppresses the console spam without
+//    changing any behaviour. Must be set before the first Firebase call below,
+//    which is why it leads the entry file. Remove once firebase.ts is migrated
+//    to the modular API.
+globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+
 // 1. Register the headless FCM + Notifee background handlers FIRST, before the
 //    app component is registered. Ride offers are data-only FCM messages; when
 //    the app is killed Android delivers them via a headless JS launch where no

--- a/driver-app/utils/crashlytics.ts
+++ b/driver-app/utils/crashlytics.ts
@@ -12,10 +12,13 @@ import { NativeModules } from 'react-native';
  * side effects in the firebase/crashlytics module scope.
  */
 const hasFirebaseNative = !!NativeModules.RNFBAppModule;
-let crashlytics: any = null;
+// Whole module namespace (not `.default`) so the v22+ modular named exports
+// (getCrashlytics, setAttribute, recordError) are available — the namespaced
+// crashlytics() API is deprecated and logs a warning on every call.
+let crashlyticsApi: typeof import('@react-native-firebase/crashlytics') | null = null;
 if (hasFirebaseNative) {
   try {
-    crashlytics = require('@react-native-firebase/crashlytics').default;
+    crashlyticsApi = require('@react-native-firebase/crashlytics');
   } catch (e) {
     console.log('[Crashlytics] module load error:', e);
   }
@@ -25,15 +28,16 @@ export function recordNonFatal(
   error: unknown,
   context?: Record<string, string>
 ): void {
-  if (!crashlytics) return;
+  if (!crashlyticsApi) return;
   try {
+    const crashlytics = crashlyticsApi.getCrashlytics();
     const err = error instanceof Error ? error : new Error(String(error));
     if (context) {
       for (const [key, value] of Object.entries(context)) {
-        crashlytics().setAttribute(key, value);
+        crashlyticsApi.setAttribute(crashlytics, key, value);
       }
     }
-    crashlytics().recordError(err);
+    crashlyticsApi.recordError(crashlytics, err);
   } catch {
     // Never let Crashlytics reporting itself throw — it would shadow the
     // original error and confuse callers.

--- a/rider-app/app/(tabs)/account.tsx
+++ b/rider-app/app/(tabs)/account.tsx
@@ -292,6 +292,8 @@ export default function AccountScreen() {
               <MenuRow styles={styles} colors={colors} icon="card" iconColor="#7C3AED" iconBg="rgba(124, 58, 237, 0.1)" label="Payment Methods" onPress={() => router.push('/manage-cards' as any)} />
               <View style={styles.cardDivider} />
               <MenuRow styles={styles} colors={colors} icon="pricetag" iconColor="#10B981" iconBg="rgba(16, 185, 129, 0.1)" label="Promotions" onPress={() => router.push('/promotions' as any)} />
+              <View style={styles.cardDivider} />
+              <MenuRow styles={styles} colors={colors} icon="gift" iconColor="#8B5CF6" iconBg="rgba(139, 92, 246, 0.1)" label="Refer & Earn" onPress={() => router.push('/referral' as any)} />
             </View>
           </View>
 

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -677,6 +677,7 @@ function RootLayoutInner({
             <Stack.Screen name="saved-places" />
             <Stack.Screen name="scheduled-rides" />
             <Stack.Screen name="promotions" />
+            <Stack.Screen name="referral" />
             <Stack.Screen name="loyalty" />
             <Stack.Screen name="support" />
             <Stack.Screen name="ai-assistant" />

--- a/rider-app/app/profile-setup.tsx
+++ b/rider-app/app/profile-setup.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { useAuthStore } from '@shared/store/authStore';
+import api from '@shared/api/client';
 import { showToast } from '../store/toastStore';
 import ConfirmSheet from '../components/ConfirmSheet';
 import { useTheme } from '@shared/theme/ThemeContext';
@@ -37,6 +38,7 @@ export default function ProfileSetupScreen() {
     lastName: user?.last_name || '',
     email: user?.email || '',
     gender: user?.gender || '',
+    referralCode: '',
   });
 
   const [focusedField, setFocusedField] = useState<string | null>(null);
@@ -96,6 +98,16 @@ export default function ProfileSetupScreen() {
       if (isEditing) {
         router.back();
       } else {
+        // Optional referral code — best-effort, never blocks signup.
+        const code = form.referralCode.trim();
+        if (code) {
+          try {
+            await api.post('/users/referral/apply', { referral_code: code });
+            showToast('Referral applied', 'Your referral code was added.', 'success');
+          } catch (refErr: any) {
+            showToast('Referral code', refErr?.response?.data?.detail || "That code couldn't be applied.", 'warning');
+          }
+        }
         router.replace('/(tabs)' as any);
       }
     } catch (err: any) {
@@ -231,6 +243,8 @@ export default function ProfileSetupScreen() {
             </View>
           )}
         </View>
+
+        {!isEditing && renderInput('referralCode', 'REFERRAL CODE (OPTIONAL)', 'e.g. RIDE3F8A9C21', 'gift-outline', 'default', 'characters')}
       </View>
 
       {!isEditing && (

--- a/rider-app/app/referral.tsx
+++ b/rider-app/app/referral.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import {
+    View,
+    Text,
+    StyleSheet,
+    TouchableOpacity,
+    ScrollView,
+    ActivityIndicator,
+    Share,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
+import * as Clipboard from 'expo-clipboard';
+import api from '@shared/api/client';
+import { showToast } from '../store/toastStore';
+import { useTheme } from '@shared/theme/ThemeContext';
+import type { ThemeColors } from '@shared/theme/index';
+
+interface ReferralInfo {
+    referral_code: string;
+    referral_link: string;
+    total_referrals: number;
+    qualified_referrals: number;
+    pending_referrals: number;
+    referral_earnings: number;
+    referrer_reward: number;
+    referee_reward: number;
+    rides_required: number;
+    terms: string;
+}
+
+interface ReferredRider {
+    name: string;
+    referred_at: string;
+    completed_rides: number;
+    rides_required: number;
+    qualified: boolean;
+    status: string; // 'earned' | 'in_progress'
+}
+
+export default function RiderReferralScreen() {
+    const router = useRouter();
+    const insets = useSafeAreaInsets();
+    const { colors } = useTheme();
+    const styles = useMemo(() => createStyles(colors), [colors]);
+
+    const [info, setInfo] = useState<ReferralInfo | null>(null);
+    const [referees, setReferees] = useState<ReferredRider[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        try {
+            const [infoRes, refsRes] = await Promise.all([
+                api.get<ReferralInfo>('/users/referral'),
+                api.get<{ referees: ReferredRider[] }>('/users/referrals'),
+            ]);
+            setInfo(infoRes.data);
+            setReferees(refsRes.data?.referees || []);
+        } catch (err) {
+            console.log('[RiderReferral] load failed:', err);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { load(); }, [load]);
+
+    const copyCode = async () => {
+        if (!info?.referral_code) return;
+        await Clipboard.setStringAsync(info.referral_code);
+        showToast('Copied!', 'Referral code copied to clipboard', 'success');
+    };
+
+    const share = async () => {
+        if (!info) return;
+        try {
+            await Share.share({
+                message: `Join me on Spinr! Use my code ${info.referral_code} and we both get a reward when you take your first ride. ${info.referral_link}`,
+            });
+        } catch {
+            await Clipboard.setStringAsync(info.referral_link);
+            showToast('Link copied', 'Referral link copied to clipboard', 'info');
+        }
+    };
+
+    return (
+        <View style={styles.container}>
+            <View style={[styles.header, { paddingTop: insets.top + 12 }]}>
+                <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+                    <Ionicons name="arrow-back" size={24} color={colors.text} />
+                </TouchableOpacity>
+                <Text style={styles.headerTitle}>Refer & Earn</Text>
+                <View style={{ width: 40 }} />
+            </View>
+
+            {loading ? (
+                <View style={styles.loading}><ActivityIndicator size="large" color={colors.primary} /></View>
+            ) : (
+                <ScrollView style={styles.content} contentContainerStyle={{ paddingBottom: insets.bottom + 32 }} showsVerticalScrollIndicator={false}>
+                    <LinearGradient colors={['#7C3AED', '#6D28D9']} start={{ x: 0, y: 0 }} end={{ x: 1, y: 1 }} style={styles.hero}>
+                        <Text style={styles.heroTitle}>Give a ride, get a reward</Text>
+                        <Text style={styles.heroSubtitle}>{info?.terms || 'Invite friends and earn when they take their first ride.'}</Text>
+
+                        {info && (
+                            <View style={styles.codeBox}>
+                                <Text style={styles.codeLabel}>Your Referral Code</Text>
+                                <Text style={styles.code}>{info.referral_code}</Text>
+                                <TouchableOpacity style={styles.copyBtn} onPress={copyCode}>
+                                    <Ionicons name="copy-outline" size={16} color="#fff" />
+                                    <Text style={styles.copyBtnText}>Copy</Text>
+                                </TouchableOpacity>
+                            </View>
+                        )}
+
+                        <TouchableOpacity style={styles.shareBtn} onPress={share}>
+                            <Ionicons name="share-social-outline" size={20} color="#7C3AED" />
+                            <Text style={styles.shareBtnText}>Share Invite Link</Text>
+                        </TouchableOpacity>
+                    </LinearGradient>
+
+                    <View style={styles.statsRow}>
+                        <Stat styles={styles} value={String(info?.total_referrals ?? 0)} label="Invited" />
+                        <Stat styles={styles} value={String(info?.qualified_referrals ?? 0)} label="Rewarded" />
+                        <Stat styles={styles} value={`$${(info?.referral_earnings ?? 0).toFixed(2)}`} label="Earned" />
+                    </View>
+
+                    <Text style={styles.sectionTitle}>Your Invites</Text>
+                    {referees.length === 0 ? (
+                        <View style={styles.empty}>
+                            <Ionicons name="people-outline" size={44} color={colors.surfaceLight} />
+                            <Text style={styles.emptyText}>No invites yet</Text>
+                            <Text style={styles.emptySub}>Share your code to start earning!</Text>
+                        </View>
+                    ) : (
+                        <View style={styles.list}>
+                            {referees.map((r, i) => {
+                                const pct = Math.min(100, Math.round(((r.completed_rides || 0) / (r.rides_required || 1)) * 100));
+                                return (
+                                    <View key={i} style={styles.item}>
+                                        <View style={styles.avatar}><Text style={styles.avatarText}>{r.name.charAt(0).toUpperCase()}</Text></View>
+                                        <View style={{ flex: 1, marginLeft: 12 }}>
+                                            <Text style={styles.itemName}>{r.name}</Text>
+                                            {r.qualified ? (
+                                                <Text style={styles.itemEarned}>Reward earned</Text>
+                                            ) : (
+                                                <>
+                                                    <Text style={styles.itemProgress}>
+                                                        {r.completed_rides}/{r.rides_required} rides
+                                                    </Text>
+                                                    <View style={styles.bar}><View style={[styles.barFill, { width: `${pct}%` }]} /></View>
+                                                </>
+                                            )}
+                                        </View>
+                                        <View style={[styles.badge, r.qualified ? styles.badgeEarned : styles.badgePending]}>
+                                            <Text style={[styles.badgeText, r.qualified ? styles.badgeTextEarned : styles.badgeTextPending]}>
+                                                {r.qualified ? 'Earned' : 'Pending'}
+                                            </Text>
+                                        </View>
+                                    </View>
+                                );
+                            })}
+                        </View>
+                    )}
+                </ScrollView>
+            )}
+        </View>
+    );
+}
+
+function Stat({ styles, value, label }: { styles: any; value: string; label: string }) {
+    return (
+        <View style={styles.statCard}>
+            <Text style={styles.statValue}>{value}</Text>
+            <Text style={styles.statLabel}>{label}</Text>
+        </View>
+    );
+}
+
+function createStyles(colors: ThemeColors) {
+    return StyleSheet.create({
+        container: { flex: 1, backgroundColor: colors.background },
+        header: {
+            flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+            paddingBottom: 14, paddingHorizontal: 16, borderBottomWidth: 1, borderBottomColor: colors.border,
+        },
+        backBtn: { width: 40, height: 40, borderRadius: 20, backgroundColor: colors.surfaceLight, justifyContent: 'center', alignItems: 'center' },
+        headerTitle: { fontSize: 18, fontWeight: '600', color: colors.text },
+        loading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+        content: { flex: 1, paddingHorizontal: 16 },
+        hero: { borderRadius: 16, padding: 24, marginTop: 16, alignItems: 'center' },
+        heroTitle: { fontSize: 22, fontWeight: '700', color: '#fff', marginBottom: 8 },
+        heroSubtitle: { fontSize: 14, color: 'rgba(255,255,255,0.9)', textAlign: 'center', marginBottom: 20 },
+        codeBox: { backgroundColor: 'rgba(255,255,255,0.2)', borderRadius: 12, padding: 16, alignItems: 'center', width: '100%', marginBottom: 16 },
+        codeLabel: { fontSize: 12, color: 'rgba(255,255,255,0.8)', marginBottom: 4 },
+        code: { fontSize: 26, fontWeight: '700', color: '#fff', letterSpacing: 2, marginBottom: 8 },
+        copyBtn: { flexDirection: 'row', alignItems: 'center', gap: 6, backgroundColor: 'rgba(255,255,255,0.3)', paddingHorizontal: 16, paddingVertical: 8, borderRadius: 20 },
+        copyBtnText: { color: '#fff', fontSize: 14, fontWeight: '600' },
+        shareBtn: { flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: '#fff', paddingHorizontal: 24, paddingVertical: 12, borderRadius: 25 },
+        shareBtnText: { color: '#7C3AED', fontSize: 16, fontWeight: '600' },
+        statsRow: { flexDirection: 'row', gap: 12, marginTop: 16 },
+        statCard: { flex: 1, backgroundColor: colors.surface, borderRadius: 12, padding: 16, alignItems: 'center' },
+        statValue: { fontSize: 22, fontWeight: '700', color: colors.primary },
+        statLabel: { fontSize: 12, color: colors.textDim, marginTop: 4 },
+        sectionTitle: { fontSize: 16, fontWeight: '600', color: colors.text, marginTop: 24, marginBottom: 12 },
+        empty: { backgroundColor: colors.surface, borderRadius: 12, padding: 32, alignItems: 'center' },
+        emptyText: { fontSize: 16, fontWeight: '600', color: colors.text, marginTop: 12 },
+        emptySub: { fontSize: 14, color: colors.textDim, marginTop: 4 },
+        list: { backgroundColor: colors.surface, borderRadius: 12, overflow: 'hidden' },
+        item: { flexDirection: 'row', alignItems: 'center', padding: 12, borderBottomWidth: 1, borderBottomColor: colors.border },
+        avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: colors.surfaceLight, justifyContent: 'center', alignItems: 'center' },
+        avatarText: { fontSize: 18, fontWeight: '600', color: colors.text },
+        itemName: { fontSize: 15, fontWeight: '500', color: colors.text },
+        itemProgress: { fontSize: 12, color: colors.textDim, marginTop: 2 },
+        itemEarned: { fontSize: 12, color: colors.success, fontWeight: '700', marginTop: 2 },
+        bar: { height: 5, borderRadius: 3, backgroundColor: colors.border, overflow: 'hidden', marginTop: 6, maxWidth: 180 },
+        barFill: { height: '100%', borderRadius: 3, backgroundColor: colors.primary },
+        badge: { paddingHorizontal: 10, paddingVertical: 4, borderRadius: 12 },
+        badgeEarned: { backgroundColor: 'rgba(16,185,129,0.12)' },
+        badgePending: { backgroundColor: 'rgba(245,158,11,0.12)' },
+        badgeText: { fontSize: 12, fontWeight: '600' },
+        badgeTextEarned: { color: colors.success },
+        badgeTextPending: { color: '#F59E0B' },
+    });
+}

--- a/rider-app/utils/crashlytics.ts
+++ b/rider-app/utils/crashlytics.ts
@@ -12,10 +12,13 @@ import { NativeModules } from 'react-native';
  * side effects in the firebase/crashlytics module scope.
  */
 const hasFirebaseNative = !!NativeModules.RNFBAppModule;
-let crashlytics: any = null;
+// Whole module namespace (not `.default`) so the v22+ modular named exports
+// (getCrashlytics, setAttribute, recordError) are available — the namespaced
+// crashlytics() API is deprecated and logs a warning on every call.
+let crashlyticsApi: typeof import('@react-native-firebase/crashlytics') | null = null;
 if (hasFirebaseNative) {
   try {
-    crashlytics = require('@react-native-firebase/crashlytics').default;
+    crashlyticsApi = require('@react-native-firebase/crashlytics');
   } catch (e) {
     console.log('[Crashlytics] module load error:', e);
   }
@@ -25,15 +28,16 @@ export function recordNonFatal(
   error: unknown,
   context?: Record<string, string>
 ): void {
-  if (!crashlytics) return;
+  if (!crashlyticsApi) return;
   try {
+    const crashlytics = crashlyticsApi.getCrashlytics();
     const err = error instanceof Error ? error : new Error(String(error));
     if (context) {
       for (const [key, value] of Object.entries(context)) {
-        crashlytics().setAttribute(key, value);
+        crashlyticsApi.setAttribute(crashlytics, key, value);
       }
     }
-    crashlytics().recordError(err);
+    crashlyticsApi.recordError(crashlytics, err);
   } catch {
     // Never let Crashlytics reporting itself throw — it would shadow the
     // original error and confuse callers.

--- a/shared/services/firebase.ts
+++ b/shared/services/firebase.ts
@@ -3,8 +3,13 @@ import { NativeModules, Platform } from 'react-native';
 /**
  * Firebase Services — FCM, Crashlytics, App Check
  *
- * These use @react-native-firebase (native modules).
- * Only work in custom dev builds, NOT Expo Go.
+ * Uses the @react-native-firebase v22+ **modular** API (getMessaging(),
+ * getCrashlytics(), initializeAppCheck(), getToken(), …) rather than the
+ * deprecated namespaced API (messaging(), crashlytics(), appCheck()). The
+ * namespaced API still works on v24 but logs a deprecation warning on every
+ * call and is slated for removal in the next major release.
+ *
+ * These are native modules — only work in custom dev/release builds, NOT Expo Go.
  */
 
 // Gate on native-module presence. require()-ing @react-native-firebase
@@ -15,27 +20,31 @@ import { NativeModules, Platform } from 'react-native';
 const hasFirebaseNative = !!NativeModules.RNFBAppModule;
 
 // Type-only imports — runtime loads via require() guarded by hasFirebaseNative.
-// `typeof import(...)` gives us the correct factory-function type without
-// pulling the packages into shared/'s runtime bundle.
-type MessagingFactory = typeof import('@react-native-firebase/messaging').default;
-type CrashlyticsFactory = typeof import('@react-native-firebase/crashlytics').default;
-type AppCheckFactory = typeof import('@react-native-firebase/app-check').default;
+// `typeof import(...)` gives the full module namespace type (including the
+// modular function exports) without pulling the packages into shared/'s bundle.
+type MessagingModule = typeof import('@react-native-firebase/messaging');
+type CrashlyticsModule = typeof import('@react-native-firebase/crashlytics');
+type AppCheckModule = typeof import('@react-native-firebase/app-check');
+type AppCheckInstance = import('@react-native-firebase/app-check').AppCheck;
+type RemoteMessage = import('@react-native-firebase/messaging').FirebaseMessagingTypes.RemoteMessage;
 
-let messaging: MessagingFactory | null = null;
-let crashlytics: CrashlyticsFactory | null = null;
-let appCheck: AppCheckFactory | null = null;
+// The whole module namespaces are loaded (not `.default`) so the modular
+// named exports (getMessaging, getToken, initializeAppCheck, …) are available.
+let messagingApi: MessagingModule | null = null;
+let crashlyticsApi: CrashlyticsModule | null = null;
+let appCheckApi: AppCheckModule | null = null;
 
 if (hasFirebaseNative) {
   try {
-    messaging = require('@react-native-firebase/messaging').default;
+    messagingApi = require('@react-native-firebase/messaging');
   } catch (e) { console.log('[Firebase] messaging load error:', e); }
 
   try {
-    crashlytics = require('@react-native-firebase/crashlytics').default;
+    crashlyticsApi = require('@react-native-firebase/crashlytics');
   } catch (e) { console.log('[Firebase] crashlytics load error:', e); }
 
   try {
-    appCheck = require('@react-native-firebase/app-check').default;
+    appCheckApi = require('@react-native-firebase/app-check');
   } catch (e) { console.log('[Firebase] app-check load error:', e); }
 } else {
   console.log('[Firebase] native module not linked (Expo Go) — push/crashlytics disabled');
@@ -54,6 +63,11 @@ if (hasFirebaseNative) {
  */
 let _initServicesPromise: Promise<void> | null = null;
 
+// The modular App Check getToken(appCheckInstance, …) needs the instance
+// returned by initializeAppCheck(). We cache it here from _doInit so
+// getAppCheckToken() (called per-request + per background batch) can reuse it.
+let _appCheckInstance: AppCheckInstance | null = null;
+
 export function initFirebaseServices(): Promise<void> {
   if (_initServicesPromise) return _initServicesPromise;
   _initServicesPromise = _doInitFirebaseServices();
@@ -62,9 +76,10 @@ export function initFirebaseServices(): Promise<void> {
 
 async function _doInitFirebaseServices(): Promise<void> {
   // 1. Crashlytics — enable automatic crash reporting
-  if (crashlytics) {
+  if (crashlyticsApi) {
     try {
-      await crashlytics().setCrashlyticsCollectionEnabled(true);
+      const crashlytics = crashlyticsApi.getCrashlytics();
+      await crashlyticsApi.setCrashlyticsCollectionEnabled(crashlytics, true);
       console.log('[Firebase] Crashlytics enabled');
     } catch (e) {
       console.log('[Firebase] Crashlytics init error:', e);
@@ -76,9 +91,13 @@ async function _doInitFirebaseServices(): Promise<void> {
   // via the @react-native-firebase/app-check config plugin in app.config.ts.
   // Here we configure the runtime provider to match. Without configure(),
   // initializeAppCheck() throws "no provider or no provider options defined".
-  if (appCheck) {
+  //
+  // newReactNativeFirebaseAppCheckProvider() exists only on the namespaced
+  // module instance (it has no modular replacement and so does not warn);
+  // everything after it — initializeAppCheck()/getToken() — is modular.
+  if (appCheckApi) {
     try {
-      const provider = appCheck().newReactNativeFirebaseAppCheckProvider();
+      const provider = appCheckApi.default().newReactNativeFirebaseAppCheckProvider();
       provider.configure({
         android: {
           provider: 'playIntegrity',
@@ -93,7 +112,9 @@ async function _doInitFirebaseServices(): Promise<void> {
         },
       });
 
-      await appCheck().initializeAppCheck({
+      // First arg (app) omitted — initializeAppCheck() falls back to the
+      // default app internally, so we don't need @react-native-firebase/app.
+      _appCheckInstance = await appCheckApi.initializeAppCheck(undefined, {
         provider,
         isTokenAutoRefreshEnabled: true,
       });
@@ -110,12 +131,13 @@ async function _doInitFirebaseServices(): Promise<void> {
  * Call on first open so the OS dialog appears before login.
  */
 export async function requestNotificationPermission(): Promise<boolean> {
-  if (!messaging) return false;
+  if (!messagingApi) return false;
   try {
-    const authStatus = await messaging().requestPermission();
+    const messaging = messagingApi.getMessaging();
+    const authStatus = await messagingApi.requestPermission(messaging);
     const enabled =
-      authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
-      authStatus === messaging.AuthorizationStatus.PROVISIONAL;
+      authStatus === messagingApi.AuthorizationStatus.AUTHORIZED ||
+      authStatus === messagingApi.AuthorizationStatus.PROVISIONAL;
     console.log('[Firebase] Notification permission:', enabled ? 'granted' : 'denied');
     return enabled;
   } catch (e) {
@@ -130,14 +152,15 @@ export async function requestNotificationPermission(): Promise<boolean> {
  * Returns the token string or null.
  */
 export async function requestPushPermissionAndGetToken(): Promise<string | null> {
-  if (!messaging) return null;
+  if (!messagingApi) return null;
 
   try {
+    const messaging = messagingApi.getMessaging();
     // Request permission (iOS — Android auto-grants)
-    const authStatus = await messaging().requestPermission();
+    const authStatus = await messagingApi.requestPermission(messaging);
     const enabled =
-      authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
-      authStatus === messaging.AuthorizationStatus.PROVISIONAL;
+      authStatus === messagingApi.AuthorizationStatus.AUTHORIZED ||
+      authStatus === messagingApi.AuthorizationStatus.PROVISIONAL;
 
     if (!enabled) {
       console.log('[Firebase] Push permission denied');
@@ -145,7 +168,7 @@ export async function requestPushPermissionAndGetToken(): Promise<string | null>
     }
 
     // Get FCM token
-    const token = await messaging().getToken();
+    const token = await messagingApi.getToken(messaging);
     // A token prefix is still a device-routable identifier — keep it out of
     // production logs. In dev we log only whether one was obtained.
     if (__DEV__) console.log('[Firebase] FCM token obtained:', token ? 'yes' : 'no');
@@ -160,9 +183,9 @@ export async function requestPushPermissionAndGetToken(): Promise<string | null>
 /**
  * Register a handler for incoming push notifications (foreground).
  */
-export function onForegroundMessage(handler: (message: import('@react-native-firebase/messaging').FirebaseMessagingTypes.RemoteMessage) => void) {
-  if (!messaging) return () => {};
-  return messaging().onMessage(handler);
+export function onForegroundMessage(handler: (message: RemoteMessage) => void) {
+  if (!messagingApi) return () => {};
+  return messagingApi.onMessage(messagingApi.getMessaging(), handler);
 }
 
 
@@ -170,9 +193,9 @@ export function onForegroundMessage(handler: (message: import('@react-native-fir
  * Set the background message handler.
  * Must be called at the TOP LEVEL (outside of any component).
  */
-export function setBackgroundMessageHandler(handler: (message: import('@react-native-firebase/messaging').FirebaseMessagingTypes.RemoteMessage) => Promise<unknown> | void) {
-  if (!messaging) return;
-  messaging().setBackgroundMessageHandler((msg) => handler(msg) ?? Promise.resolve());
+export function setBackgroundMessageHandler(handler: (message: RemoteMessage) => Promise<unknown> | void) {
+  if (!messagingApi) return;
+  messagingApi.setBackgroundMessageHandler(messagingApi.getMessaging(), (msg) => handler(msg) ?? Promise.resolve());
 }
 
 
@@ -190,8 +213,8 @@ export function setBackgroundMessageHandler(handler: (message: import('@react-na
  * @param onRefresh - called with the new FCM token string.
  */
 export function onTokenRefresh(onRefresh: (newToken: string) => void): () => void {
-  if (!messaging) return () => {};
-  return messaging().onTokenRefresh(onRefresh);
+  if (!messagingApi) return () => {};
+  return messagingApi.onTokenRefresh(messagingApi.getMessaging(), onRefresh);
 }
 
 
@@ -199,8 +222,8 @@ export function onTokenRefresh(onRefresh: (newToken: string) => void): () => voi
  * Log a custom event to Crashlytics.
  */
 export function logCrashlyticsEvent(message: string) {
-  if (!crashlytics) return;
-  crashlytics().log(message);
+  if (!crashlyticsApi) return;
+  crashlyticsApi.log(crashlyticsApi.getCrashlytics(), message);
 }
 
 
@@ -208,8 +231,8 @@ export function logCrashlyticsEvent(message: string) {
  * Set user ID for Crashlytics (helps identify crashes per user).
  */
 export function setCrashlyticsUser(userId: string) {
-  if (!crashlytics) return;
-  crashlytics().setUserId(userId);
+  if (!crashlyticsApi) return;
+  crashlyticsApi.setUserId(crashlyticsApi.getCrashlytics(), userId);
 }
 
 
@@ -217,8 +240,8 @@ export function setCrashlyticsUser(userId: string) {
  * Record a non-fatal error in Crashlytics.
  */
 export function recordError(error: Error) {
-  if (!crashlytics) return;
-  crashlytics().recordError(error);
+  if (!crashlyticsApi) return;
+  crashlyticsApi.recordError(crashlyticsApi.getCrashlytics(), error);
 }
 
 
@@ -231,9 +254,14 @@ export function recordError(error: Error) {
  * enforcement mode determines whether the call succeeds.
  */
 export async function getAppCheckToken(): Promise<string | null> {
-  if (!appCheck) return null;
+  if (!appCheckApi) return null;
   try {
-    const result = await appCheck().getToken(false);
+    // The modular getToken() needs the AppCheck instance from init. If init
+    // hasn't run in this context yet (e.g. a headless task), run it now —
+    // initFirebaseServices() is idempotent and cheap when already resolved.
+    if (!_appCheckInstance) await initFirebaseServices();
+    if (!_appCheckInstance) return null;
+    const result = await appCheckApi.getToken(_appCheckInstance, false);
     return result?.token ?? null;
   } catch (e) {
     console.log('[Firebase] App Check token fetch error:', e);

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -2,7 +2,16 @@ import { create } from 'zustand';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
 import api, { setCsrfToken, setInMemoryToken, setRefreshCallback } from '../api/client';
-import { appCache, CACHE_KEYS, CACHE_CONFIG } from '../cache';
+import { appCache, CACHE_KEYS } from '../cache';
+
+// Last-known profile is cached with a long TTL so the driver/rider still sees
+// their photo, name, phone, and vehicle after a long idle period or when the
+// device is offline on relaunch — instead of the screen blanking to "N/A" /
+// "Add Vehicle" while the network refresh is in flight. Wiped on logout via
+// appCache.clearUserCache(), so it does not extend PII retention beyond the
+// active session (TanStack Query already persists /drivers/me for 24h; this
+// brings the user row to parity).
+const PROFILE_CACHE_TTL = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 // Registry of callbacks that must run when the user logs out. Other stores
 // (rideStore, driverStore) register here on mount to wipe per-session state
@@ -281,13 +290,28 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     // to restore a session without forcing the user back to the OTP screen.
     const storedRefresh = await storage.getItem('refresh_token');
     if (storedRefresh) {
+      // Optimistic hydration: paint the last-known profile from cache before
+      // the network round-trips below resolve, so the first frame after the
+      // splash never flashes blank ("N/A" / "Add Vehicle"). Fresh data from
+      // /auth/me + /drivers/me overwrites this on success.
+      try {
+        const [cachedUser, cachedDriver] = await Promise.all([
+          appCache.get<User>(CACHE_KEYS.USER_PROFILE),
+          appCache.get<Driver>(CACHE_KEYS.DRIVER_PROFILE),
+        ]);
+        if (cachedUser) set({ user: cachedUser });
+        if (cachedDriver) set({ driver: cachedDriver });
+      } catch {
+        // Cache read is best-effort — never block init on it.
+      }
+
       const refreshed = await get().refreshTokens();
       if (refreshed) {
         const newToken = get().token;
         try {
           const meRes = await api.get('/auth/me');
           const userData = meRes.data as User;
-          await appCache.set(CACHE_KEYS.USER_PROFILE, userData, CACHE_CONFIG.USER_PROFILE_TTL);
+          await appCache.set(CACHE_KEYS.USER_PROFILE, userData, PROFILE_CACHE_TTL);
 
           let driverData: Driver | null = null;
           const looksLikeDriver =
@@ -297,19 +321,23 @@ export const useAuthStore = create<AuthState>((set, get) => ({
             try {
               const driverRes = await api.get('/drivers/me');
               driverData = driverRes.data as Driver;
-              await appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverData, CACHE_CONFIG.USER_PROFILE_TTL);
+              await appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverData, PROFILE_CACHE_TTL);
             } catch (e: unknown) {
               if (isApiError(e) && e.response?.status === 404) {
                 if (__DEV__) console.log('[Auth] No driver row on refresh-init — auto-registering');
                 try {
                   const regRes = await api.post('/drivers/register', {});
                   driverData = regRes.data as Driver;
-                  await appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverData, CACHE_CONFIG.USER_PROFILE_TTL);
+                  await appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverData, PROFILE_CACHE_TTL);
                 } catch (regErr) {
                   if (__DEV__) console.log('[Auth] Auto-register failed on refresh-init:', regErr);
                 }
               } else {
+                // Network/transient failure fetching the driver row — keep the
+                // cached driver (set optimistically above) so vehicle details
+                // stay visible instead of reverting to "Add Vehicle".
                 if (__DEV__) console.log('Failed to fetch driver data on refresh-init');
+                driverData = get().driver;
               }
             }
           }
@@ -324,11 +352,26 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           return;
         } catch (e) {
           if (__DEV__) console.log('[Auth] Profile hydration after refresh failed:', e);
-          // Refresh succeeded but /auth/me failed — clear the in-memory
-          // token so the app doesn't send a stale Authorization header
-          // while Zustand thinks the user is logged out. This mismatch
-          // previously left a zombie auth state that could corrupt HTTP/2
-          // connections on the next request.
+          // Refresh succeeded (access token is valid) but /auth/me failed —
+          // almost always a transient network blip right after resume, or the
+          // device is offline. Rather than bouncing the driver to the OTP
+          // screen, fall back to the last-known cached profile and keep the
+          // session so their photo/name/phone/vehicle stay on screen.
+          const cachedUser = await appCache.get<User>(CACHE_KEYS.USER_PROFILE);
+          if (cachedUser && newToken) {
+            const cachedDriver = await appCache.get<Driver>(CACHE_KEYS.DRIVER_PROFILE);
+            set({
+              user: cachedUser,
+              driver: cachedDriver,
+              token: newToken,
+              isInitialized: true,
+              isLoading: false,
+            });
+            return;
+          }
+          // No cached profile to fall back on — clear the in-memory token so
+          // the app doesn't send a stale Authorization header while Zustand
+          // thinks the user is logged out.
           setInMemoryToken(null);
           setCsrfToken(null);
         }
@@ -395,6 +438,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const meRes = await api.get('/auth/me');
       const userData = meRes.data as User;
       set({ user: userData });
+      // Keep the offline-fallback cache warm so a later cold start / resume
+      // still has a recent profile to paint while the network refresh runs.
+      appCache.set(CACHE_KEYS.USER_PROFILE, userData, PROFILE_CACHE_TTL).catch(() => {});
       // A driver row exists iff the server returned a driver_onboarding_status
       // — that derivation only runs when there's a driver row (or role=driver).
       // This signal is more reliable than `is_driver` / `role`, which can be
@@ -408,6 +454,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         try {
           const driverRes = await api.get('/drivers/me');
           set({ driver: driverRes.data as Driver });
+          appCache.set(CACHE_KEYS.DRIVER_PROFILE, driverRes.data as Driver, PROFILE_CACHE_TTL).catch(() => {});
         } catch (e: unknown) {
           if (__DEV__) console.log('refreshProfile: driver fetch failed', e);
           if (isApiError(e) && e.response?.status === 404) {


### PR DESCRIPTION
<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
