### PR TITLE
style(driver): align referral screen to rider design; drop redundant …

### DIFF
--- a/driver-app/app/driver/referral.tsx
+++ b/driver-app/app/driver/referral.tsx
@@ -5,18 +5,14 @@ import {
     StyleSheet,
     TouchableOpacity,
     ScrollView,
-    Platform,
-    TextInput,
-    Modal,
-    Pressable,
-    KeyboardAvoidingView,
+    ActivityIndicator,
+    Share,
 } from 'react-native';
 import { showToast } from '../../hooks/useToast';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
-import { Share } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import api from '@shared/api/client';
 import { useTheme } from '@shared/theme/ThemeContext';
@@ -54,8 +50,7 @@ export default function ReferralScreen() {
     const [referralInfo, setReferralInfo] = useState<ReferralInfo | null>(null);
     const [referredDrivers, setReferredDrivers] = useState<ReferredDriver[]>([]);
     const [isLoading, setIsLoading] = useState(true);
-    const [showApplyModal, setShowApplyModal] = useState(false);
-    const [referralCodeInput, setReferralCodeInput] = useState('');
+    const [error, setError] = useState(false);
 
     useEffect(() => {
         fetchReferralInfo();
@@ -63,6 +58,7 @@ export default function ReferralScreen() {
 
     const fetchReferralInfo = async () => {
         setIsLoading(true);
+        setError(false);
         try {
             const res = await api.get<ReferralInfo>('/drivers/referral');
             setReferralInfo(res.data);
@@ -71,7 +67,12 @@ export default function ReferralScreen() {
             const driversRes = await api.get<{ referred_drivers: any[] }>('/drivers/referrals?limit=50');
             setReferredDrivers(driversRes.data.referred_drivers || []);
         } catch (err) {
-            console.log('Error fetching referral info:', err);
+            // Surface the failure instead of silently rendering an empty
+            // "success" state — a null `referralInfo` otherwise hides the code
+            // box and zeroes the stats, which reads as a broken/blank screen.
+            console.error('[DriverReferral] load failed:', err);
+            setReferralInfo(null);
+            setError(true);
         } finally {
             setIsLoading(false);
         }
@@ -96,23 +97,6 @@ export default function ReferralScreen() {
         }
     };
 
-    const applyReferralCode = async () => {
-        if (!referralCodeInput.trim()) {
-            showToast('error', 'Error', 'Please enter a referral code');
-            return;
-        }
-
-        try {
-            await api.post('/drivers/referral/apply', { referral_code: referralCodeInput.trim() });
-            showToast('success', 'Success', 'Referral code applied successfully!');
-            setShowApplyModal(false);
-            setReferralCodeInput('');
-        } catch (err: any) {
-            const errorMessage = err.response?.data?.detail || 'Failed to apply referral code';
-            showToast('error', 'Error', errorMessage);
-        }
-    };
-
     return (
         <View style={styles.container}>
             {/* Header */}
@@ -124,8 +108,20 @@ export default function ReferralScreen() {
                 <View style={{ width: 40 }} />
             </View>
 
-            <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
-            <ScrollView style={styles.content} contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 16) + 24 }} keyboardShouldPersistTaps="handled" automaticallyAdjustKeyboardInsets={true} showsVerticalScrollIndicator={false}>
+            {isLoading ? (
+                <View style={styles.loading}><ActivityIndicator size="large" color={colors.primary} /></View>
+            ) : error ? (
+                <View style={styles.errorState}>
+                    <Ionicons name="cloud-offline-outline" size={48} color={colors.textDim} />
+                    <Text style={styles.errorTitle}>{"Couldn't load your referrals"}</Text>
+                    <Text style={styles.errorSub}>Something went wrong reaching our servers. Please try again.</Text>
+                    <TouchableOpacity style={styles.retryBtn} onPress={fetchReferralInfo} accessibilityLabel="Retry loading referrals">
+                        <Ionicons name="refresh" size={18} color="#fff" />
+                        <Text style={styles.retryBtnText}>Try Again</Text>
+                    </TouchableOpacity>
+                </View>
+            ) : (
+            <ScrollView style={styles.content} contentContainerStyle={{ paddingBottom: Math.max(insets.bottom, 16) + 24 }} showsVerticalScrollIndicator={false}>
                 {/* Hero Section */}
                 <LinearGradient
                     colors={[colors.primary, colors.primaryDark]}
@@ -162,7 +158,7 @@ export default function ReferralScreen() {
                 <View style={styles.statsRow}>
                     <View style={styles.statCard}>
                         <Text style={styles.statValue}>{referralInfo?.total_referrals || 0}</Text>
-                        <Text style={styles.statLabel}>Total</Text>
+                        <Text style={styles.statLabel}>Invited</Text>
                     </View>
                     <View style={styles.statCard}>
                         <Text style={styles.statValue}>{referralInfo?.qualified_referrals || 0}</Text>
@@ -170,25 +166,13 @@ export default function ReferralScreen() {
                     </View>
                     <View style={styles.statCard}>
                         <Text style={styles.statValue}>${parseFloat(String(referralInfo?.referral_earnings ?? 0)).toFixed(2)}</Text>
-                        <Text style={styles.statLabel}>Earnings</Text>
+                        <Text style={styles.statLabel}>Earned</Text>
                     </View>
-                </View>
-
-                {/* Apply Referral Code */}
-                <View style={styles.section}>
-                    <Text style={styles.sectionTitle}>Have a referral code?</Text>
-                    <TouchableOpacity
-                        style={styles.applyBtn}
-                        onPress={() => setShowApplyModal(true)}
-                    >
-                        <Ionicons name="add-circle-outline" size={20} color={colors.primary} />
-                        <Text style={styles.applyBtnText}>Apply Referral Code</Text>
-                    </TouchableOpacity>
                 </View>
 
                 {/* Referred Drivers List */}
                 <View style={styles.section}>
-                    <Text style={styles.sectionTitle}>Your Referrals</Text>
+                    <Text style={styles.sectionTitle}>Your Invites</Text>
                     {referredDrivers.length > 0 ? (
                         <View style={styles.referralsList}>
                             {referredDrivers.map((driver, index) => (
@@ -228,7 +212,7 @@ export default function ReferralScreen() {
                                             styles.badgeText,
                                             driver.qualified ? styles.badgeTextActive : styles.badgeTextPending
                                         ]}>
-                                            {driver.qualified ? 'Earned' : 'In progress'}
+                                            {driver.qualified ? 'Earned' : 'Pending'}
                                         </Text>
                                     </View>
                                 </View>
@@ -236,8 +220,8 @@ export default function ReferralScreen() {
                         </View>
                     ) : (
                         <View style={styles.emptyState}>
-                            <Ionicons name="people-outline" size={48} color={colors.surfaceLight} />
-                            <Text style={styles.emptyText}>No referrals yet</Text>
+                            <Ionicons name="people-outline" size={44} color={colors.surfaceLight} />
+                            <Text style={styles.emptyText}>No invites yet</Text>
                             <Text style={styles.emptySubtext}>
                                 Share your code to start earning!
                             </Text>
@@ -253,44 +237,7 @@ export default function ReferralScreen() {
                     </View>
                 )}
             </ScrollView>
-            </KeyboardAvoidingView>
-
-            {/* Apply Referral Modal */}
-            <Modal
-                visible={showApplyModal}
-                transparent
-                animationType="slide"
-                onRequestClose={() => setShowApplyModal(false)}
-            >
-                <KeyboardAvoidingView
-                    style={{ flex: 1 }}
-                    behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-                >
-                <Pressable style={styles.modalOverlay} onPress={() => setShowApplyModal(false)}>
-                    <Pressable style={[styles.modalContent, { paddingBottom: Math.max(insets.bottom + 12, 20) }]} onPress={(e) => e.stopPropagation()}>
-                        <View style={styles.modalHeader}>
-                            <Text style={styles.modalTitle}>Apply Referral Code</Text>
-                            <TouchableOpacity onPress={() => setShowApplyModal(false)}>
-                                <Ionicons name="close" size={24} color={colors.text} />
-                            </TouchableOpacity>
-                        </View>
-                        <View style={styles.modalBody}>
-                            <TextInput
-                                style={styles.input}
-                                placeholder="Enter referral code"
-                                placeholderTextColor={colors.textDim}
-                                value={referralCodeInput}
-                                onChangeText={setReferralCodeInput}
-                                autoCapitalize="characters"
-                            />
-                            <TouchableOpacity style={styles.submitBtn} onPress={applyReferralCode}>
-                                <Text style={styles.submitBtnText}>Apply Code</Text>
-                            </TouchableOpacity>
-                        </View>
-                    </Pressable>
-                </Pressable>
-                </KeyboardAvoidingView>
-            </Modal>
+            )}
         </View>
     );
 }
@@ -305,11 +252,20 @@ function createStyles(colors: ThemeColors) {
         flexDirection: 'row',
         alignItems: 'center',
         justifyContent: 'space-between',
-        paddingBottom: 15,
+        paddingBottom: 14,
         paddingHorizontal: 16,
         borderBottomWidth: 1,
         borderBottomColor: colors.border,
     },
+    loading: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+    errorState: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 32 },
+    errorTitle: { fontSize: 18, fontWeight: '700', color: colors.text, marginTop: 16, textAlign: 'center' },
+    errorSub: { fontSize: 14, color: colors.textDim, marginTop: 8, textAlign: 'center', lineHeight: 20 },
+    retryBtn: {
+        flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 24,
+        backgroundColor: colors.primary, paddingHorizontal: 24, paddingVertical: 12, borderRadius: 25,
+    },
+    retryBtnText: { color: '#fff', fontSize: 16, fontWeight: '600' },
     backBtn: {
         width: 40,
         height: 40,
@@ -334,7 +290,7 @@ function createStyles(colors: ThemeColors) {
         alignItems: 'center',
     },
     heroTitle: {
-        fontSize: 24,
+        fontSize: 22,
         fontWeight: '700',
         color: '#fff',
         marginBottom: 8,
@@ -359,7 +315,7 @@ function createStyles(colors: ThemeColors) {
         marginBottom: 4,
     },
     referralCode: {
-        fontSize: 28,
+        fontSize: 26,
         fontWeight: '700',
         color: '#fff',
         letterSpacing: 2,
@@ -406,12 +362,12 @@ function createStyles(colors: ThemeColors) {
         alignItems: 'center',
     },
     statValue: {
-        fontSize: 24,
+        fontSize: 22,
         fontWeight: '700',
         color: colors.primary,
     },
     statLabel: {
-        fontSize: 13,
+        fontSize: 12,
         color: colors.textDim,
         marginTop: 4,
     },
@@ -423,23 +379,6 @@ function createStyles(colors: ThemeColors) {
         fontWeight: '600',
         color: colors.text,
         marginBottom: 12,
-    },
-    applyBtn: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center',
-        backgroundColor: colors.surface,
-        padding: 16,
-        borderRadius: 12,
-        borderWidth: 1,
-        borderColor: colors.primary,
-        borderStyle: 'dashed',
-    },
-    applyBtnText: {
-        color: colors.primary,
-        fontSize: 15,
-        fontWeight: '600',
-        marginLeft: 8,
     },
     referralsList: {
         backgroundColor: colors.surface,
@@ -492,6 +431,7 @@ function createStyles(colors: ThemeColors) {
         backgroundColor: colors.border,
         overflow: 'hidden',
         marginTop: 6,
+        maxWidth: 180,
     },
     refProgressFill: {
         height: '100%',
@@ -504,10 +444,10 @@ function createStyles(colors: ThemeColors) {
         borderRadius: 12,
     },
     badgeActive: {
-        backgroundColor: 'rgba(76,175,80,0.1)',
+        backgroundColor: 'rgba(16,185,129,0.12)',
     },
     badgePending: {
-        backgroundColor: 'rgba(255,152,0,0.1)',
+        backgroundColor: 'rgba(245,158,11,0.12)',
     },
     badgeText: {
         fontSize: 12,
@@ -517,7 +457,7 @@ function createStyles(colors: ThemeColors) {
         color: colors.success,
     },
     badgeTextPending: {
-        color: '#FF9800',
+        color: '#F59E0B',
     },
     emptyState: {
         backgroundColor: colors.surface,
@@ -553,52 +493,6 @@ function createStyles(colors: ThemeColors) {
         fontSize: 13,
         color: colors.textDim,
         lineHeight: 18,
-    },
-    // Modal styles
-    modalOverlay: {
-        flex: 1,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-        justifyContent: 'flex-end',
-    },
-    modalContent: {
-        backgroundColor: colors.background,
-        borderTopLeftRadius: 20,
-        borderTopRightRadius: 20,
-    },
-    modalHeader: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        padding: 20,
-        borderBottomWidth: 1,
-        borderBottomColor: colors.border,
-    },
-    modalTitle: {
-        fontSize: 18,
-        fontWeight: '600',
-        color: colors.text,
-    },
-    modalBody: {
-        padding: 20,
-    },
-    input: {
-        backgroundColor: colors.surface,
-        borderRadius: 12,
-        padding: 16,
-        fontSize: 16,
-        color: colors.text,
-        marginBottom: 16,
-    },
-    submitBtn: {
-        backgroundColor: colors.primary,
-        padding: 16,
-        borderRadius: 12,
-        alignItems: 'center',
-    },
-    submitBtnText: {
-        color: '#fff',
-        fontSize: 16,
-        fontWeight: '600',
     },
     });
 }

--- a/driver-app/app/driver/referral.tsx
+++ b/driver-app/app/driver/referral.tsx
@@ -59,20 +59,28 @@ export default function ReferralScreen() {
     const fetchReferralInfo = async () => {
         setIsLoading(true);
         setError(false);
+        // The summary (/drivers/referral) is the critical data — it carries the
+        // code, share link and stats. Only its failure shows the full error
+        // state. The referrals list is secondary: if it fails on its own we keep
+        // the summary visible (code stays shareable) and just show the list's
+        // empty state, instead of blanking a screen whose data actually loaded.
         try {
             const res = await api.get<ReferralInfo>('/drivers/referral');
             setReferralInfo(res.data);
+        } catch (err) {
+            console.error('[DriverReferral] summary load failed:', err);
+            setReferralInfo(null);
+            setError(true);
+            setIsLoading(false);
+            return;
+        }
 
-            // Fetch referred drivers
+        try {
             const driversRes = await api.get<{ referred_drivers: any[] }>('/drivers/referrals?limit=50');
             setReferredDrivers(driversRes.data.referred_drivers || []);
         } catch (err) {
-            // Surface the failure instead of silently rendering an empty
-            // "success" state — a null `referralInfo` otherwise hides the code
-            // box and zeroes the stats, which reads as a broken/blank screen.
-            console.error('[DriverReferral] load failed:', err);
-            setReferralInfo(null);
-            setError(true);
+            console.error('[DriverReferral] referrals list load failed:', err);
+            setReferredDrivers([]);
         } finally {
             setIsLoading(false);
         }

--- a/driver-app/app/profile-setup.tsx
+++ b/driver-app/app/profile-setup.tsx
@@ -205,17 +205,32 @@ export default function ProfileSetupScreen() {
         if (__DEV__) console.log('[ProfileSetup] auto-register result:', regErr?.message);
       }
 
-      // Optional referral code — best-effort, never blocks signup. The user is
-      // authenticated by this point, so /drivers/referral/apply can attribute
-      // the referrer. An invalid/duplicate code just surfaces a toast.
+      // Optional referral code — best-effort, never blocks signup. Profile
+      // creation already succeeded above (so the network is up), which means a
+      // failed apply is almost always a transient blip — retry a few times
+      // rather than silently dropping the referrer credit. "Already applied"
+      // counts as success (idempotent); only a genuine 4xx rejection toasts.
       const code = referralCode.trim();
       if (code) {
-        try {
-          await api.post('/drivers/referral/apply', { referral_code: code });
-          showToast('success', 'Referral applied', 'Your referral code was added.');
-        } catch (refErr: any) {
-          showToast('error', 'Referral code', refErr?.response?.data?.detail || "That referral code couldn't be applied.");
+        let applied = false;
+        for (let attempt = 0; attempt < 3 && !applied; attempt++) {
+          try {
+            await api.post('/drivers/referral/apply', { referral_code: code });
+            applied = true;
+          } catch (refErr: any) {
+            const status = refErr?.response?.status;
+            const detail: string = refErr?.response?.data?.detail || '';
+            if (status === 400 && /already applied/i.test(detail)) {
+              applied = true; // the code was already attributed — success
+            } else if (typeof status === 'number' && status >= 400 && status < 500) {
+              showToast('error', 'Referral code', detail || "That referral code couldn't be applied.");
+              break; // permanent rejection (bad code) — retrying won't help
+            } else if (attempt < 2) {
+              await new Promise((r) => setTimeout(r, 400 * (attempt + 1))); // transient — back off and retry
+            }
+          }
         }
+        if (applied) showToast('success', 'Referral applied', 'Your referral code was added.');
       }
       router.replace('/driver' as any);
     } catch (err: any) {

--- a/rider-app/app/profile-setup.tsx
+++ b/rider-app/app/profile-setup.tsx
@@ -98,15 +98,32 @@ export default function ProfileSetupScreen() {
       if (isEditing) {
         router.back();
       } else {
-        // Optional referral code — best-effort, never blocks signup.
+        // Optional referral code — best-effort, never blocks signup. Profile
+        // save already succeeded above (network is up), so a failed apply is
+        // almost always a transient blip — retry a few times rather than
+        // silently dropping the referrer credit. "Already applied" counts as
+        // success (idempotent); only a genuine 4xx rejection toasts.
         const code = form.referralCode.trim();
         if (code) {
-          try {
-            await api.post('/users/referral/apply', { referral_code: code });
-            showToast('Referral applied', 'Your referral code was added.', 'success');
-          } catch (refErr: any) {
-            showToast('Referral code', refErr?.response?.data?.detail || "That code couldn't be applied.", 'warning');
+          let applied = false;
+          for (let attempt = 0; attempt < 3 && !applied; attempt++) {
+            try {
+              await api.post('/users/referral/apply', { referral_code: code });
+              applied = true;
+            } catch (refErr: any) {
+              const status = refErr?.response?.status;
+              const detail: string = refErr?.response?.data?.detail || '';
+              if (status === 400 && /already applied/i.test(detail)) {
+                applied = true; // already attributed — success
+              } else if (typeof status === 'number' && status >= 400 && status < 500) {
+                showToast('Referral code', detail || "That code couldn't be applied.", 'warning');
+                break; // permanent rejection (bad code) — retrying won't help
+              } else if (attempt < 2) {
+                await new Promise((r) => setTimeout(r, 400 * (attempt + 1))); // transient — back off and retry
+              }
+            }
           }
+          if (applied) showToast('Referral applied', 'Your referral code was added.', 'success');
         }
         router.replace('/(tabs)' as any);
       }


### PR DESCRIPTION
The driver Refer & Earn screen had drifted from the rider one (different stat labels, font sizes, badge colors, no error state) and carried an "Apply Referral Code" modal that duplicated signup: the code is already captured at onboarding (profile-setup) and `/drivers/referral/apply` is one-time, so the in-app apply just errored "already applied" for anyone who entered it at signup. This PR aligns the driver screen to the rider design, removes the redundant apply modal, and hardens the signup-time apply on both apps so the removed retry path isn't missed.

driver-app + rider-app only; tsc + eslint clean.

## Tier 1 — Summary

- **Summary** [required]: Align the driver referral screen to the rider design (stat labels, fonts, badge colors, loading + error/retry state), remove the redundant in-app "Apply Referral Code" modal, and make the signup referral apply retry transient failures (rider + driver).
- **Type** [required]: `fix`
- **Linked issue** [required]: none — UI-consistency cleanup + Codex follow-ups surfaced while reviewing #1919.
- **Risk** [required]: `low` — UI plus a best-effort, non-blocking signup side-effect; no schema/API/money changes.
- **User-visible change** [required]: `drivers` — driver referral screen restyled to match rider; signup retry is invisible.
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[x]` rider-app  `[x]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `multi-surface`
- **Data schema change** [required]: `none`
- **API contract change** [required]: `none`
- **Background job change** [required]: `none`
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none`
- **Rollback plan** [required]: `git-revert-safe`
- **Dependencies / coordination** [required]: `none`
- **Assumptions** [required]: `/users/referral/apply` and `/drivers/referral/apply` are idempotent (return 400 "already applied" on repeat), so retrying a transient failure cannot double-credit.
- **Not changing but considered** (optional): Persisting an un-applied code to retry on next launch — unnecessary, since profile creation must already have succeeded (network up) before the apply runs.

## Tier 3 — Compliance flags

_None apply — UI + best-effort referral attribution; no money mutation, PII, auth/RLS, or third-party SDK changes._

## Tier 4 — Verification

- **Unit tests** [required]: `not-applicable` — UI restyle + a best-effort retry wrapper; no new pure logic unit. tsc + eslint clean across all three files.
- **Integration tests** [required]: `not-applicable` — no API/contract change.
- **Metrics / logs introduced** [required]: `none`
- **Screenshots / video** [required if UI files touched]: N/A to attach — the target design *is* the existing rider Refer & Earn screen; this change makes the driver screen match it (labels Invited/Rewarded/Earned, "Your Invites", "Pending" badge, matching fonts/colors, loading + error/retry state).
- **Perf numbers** [required if SLA-critical path touched]: N/A — not an SLA-critical path.

**Pre-merge checklist** [required]:

- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics
- [ ] Ran the changed code against real Supabase dev — N/A, no backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works — N/A, risk:low (git-revert-safe)
- [ ] Updated CLAUDE.md / context if a convention changed — N/A

## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): N/A — matches the existing rider screen
- **Accessibility** — labels, contrast, screen reader: `[x]` retry button has an accessibilityLabel; theme tokens drive contrast
- **Dark mode verified** (if theme-aware): `[x]` uses `useTheme()` tokens (same as rider)
- **i18n / localization strings added** (if user-visible copy): N/A
- **Tested on smallest supported device width**: `[ ]`

AI-assisted — spinr platform (Claude Code)

https://claude.ai/code/session_01VYM8XTsnvLKMaFe4GzfoCa

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
