### PR TITLE
fix(users): actionable message when email is reused on a different phone

### DIFF
--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -36,7 +36,14 @@ async def create_profile(request: CreateProfileRequest, current_user: dict = Dep
     if request.gender not in valid_genders:
         raise HTTPException(status_code=400, detail=f"Gender must be one of: {', '.join(valid_genders)}")
 
-    # GAP FIX: Check for duplicate email across users
+    # GAP FIX: Check for duplicate email across users.
+    # Spinr is a single-identity-per-person model (one account, dual rider+driver
+    # role via is_rider/is_driver). Phone is the unique login key, so reusing an
+    # email on a second phone number means the person accidentally created a
+    # second account. A blunt "already in use" 400 leaves them at a dead-end
+    # (logged in, but unable to complete their profile). Return an actionable
+    # account-recovery nudge instead. We deliberately do NOT disclose the other
+    # account's phone number (PII / account-enumeration).
     email_lower = request.email.strip().lower()
     existing_email_user = (lambda _r: _r[0] if _r else None)(
         await db_supabase.get_rows("users", {"email": email_lower, "id": {"$ne": current_user["id"]}}, limit=1)
@@ -44,7 +51,12 @@ async def create_profile(request: CreateProfileRequest, current_user: dict = Dep
     if existing_email_user:
         raise HTTPException(
             status_code=400,
-            detail="This email address is already in use by another account",
+            detail=(
+                "This email is already linked to a Spinr account registered with a "
+                "different phone number. Your rider and driver profiles live on one "
+                "account — please log in with that phone number, or contact support "
+                "if you need to update the number on your account."
+            ),
         )
 
     update_data = {
@@ -461,9 +473,7 @@ async def _rider_referral_summary(user: dict, *, include_referees: bool) -> dict
     referees: list = []
     qualified = 0
     for u in referred:
-        completed = await db_supabase.count_documents(
-            "rides", {"rider_id": u["id"], "status": "completed"}
-        )
+        completed = await db_supabase.count_documents("rides", {"rider_id": u["id"], "status": "completed"})
         is_qualified = completed >= RIDER_REFERRAL_RIDES_REQUIRED
         if is_qualified:
             qualified += 1
@@ -490,8 +500,7 @@ async def _rider_referral_summary(user: dict, *, include_referees: bool) -> dict
         "referee_reward": RIDER_REFEREE_REWARD,
         "rides_required": RIDER_REFERRAL_RIDES_REQUIRED,
         "terms": (
-            f"Give ${RIDER_REFEREE_REWARD}, get ${RIDER_REFERRER_REWARD} when your friend "
-            f"takes their first ride."
+            f"Give ${RIDER_REFEREE_REWARD}, get ${RIDER_REFERRER_REWARD} when your friend takes their first ride."
         ),
     }
     if include_referees:

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -36,10 +36,12 @@ async def create_profile(request: CreateProfileRequest, current_user: dict = Dep
     if request.gender not in valid_genders:
         raise HTTPException(status_code=400, detail=f"Gender must be one of: {', '.join(valid_genders)}")
 
-    # Enforce unique email across accounts. Spinr requires both phone and email
-    # to be unique (no duplicates of either), so if this email already belongs to
-    # another account the user must use a different email address. We deliberately
-    # do NOT disclose the other account's phone number (PII / account-enumeration).
+    # Uber-style single-identity model: one person = one account holding both
+    # rider and driver roles (is_rider/is_driver), keyed on a unique phone AND a
+    # unique email. If this email already belongs to another account, the user
+    # already has an account — point them to log in / recover it rather than
+    # creating a duplicate. We deliberately do NOT disclose the other account's
+    # phone number (PII / account-enumeration).
     email_lower = request.email.strip().lower()
     existing_email_user = (lambda _r: _r[0] if _r else None)(
         await db_supabase.get_rows("users", {"email": email_lower, "id": {"$ne": current_user["id"]}}, limit=1)
@@ -47,7 +49,12 @@ async def create_profile(request: CreateProfileRequest, current_user: dict = Dep
     if existing_email_user:
         raise HTTPException(
             status_code=400,
-            detail="This email is already in use with another account. Please change your email address.",
+            detail=(
+                "This email is already linked to an existing Spinr account. Your rider "
+                "and driver profiles share one account — please log in to that account "
+                "instead of creating a new one. If you no longer have access to its "
+                "phone number, contact support."
+            ),
         )
 
     update_data = {

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -36,14 +36,10 @@ async def create_profile(request: CreateProfileRequest, current_user: dict = Dep
     if request.gender not in valid_genders:
         raise HTTPException(status_code=400, detail=f"Gender must be one of: {', '.join(valid_genders)}")
 
-    # GAP FIX: Check for duplicate email across users.
-    # Spinr is a single-identity-per-person model (one account, dual rider+driver
-    # role via is_rider/is_driver). Phone is the unique login key, so reusing an
-    # email on a second phone number means the person accidentally created a
-    # second account. A blunt "already in use" 400 leaves them at a dead-end
-    # (logged in, but unable to complete their profile). Return an actionable
-    # account-recovery nudge instead. We deliberately do NOT disclose the other
-    # account's phone number (PII / account-enumeration).
+    # Enforce unique email across accounts. Spinr requires both phone and email
+    # to be unique (no duplicates of either), so if this email already belongs to
+    # another account the user must use a different email address. We deliberately
+    # do NOT disclose the other account's phone number (PII / account-enumeration).
     email_lower = request.email.strip().lower()
     existing_email_user = (lambda _r: _r[0] if _r else None)(
         await db_supabase.get_rows("users", {"email": email_lower, "id": {"$ne": current_user["id"]}}, limit=1)
@@ -51,12 +47,7 @@ async def create_profile(request: CreateProfileRequest, current_user: dict = Dep
     if existing_email_user:
         raise HTTPException(
             status_code=400,
-            detail=(
-                "This email is already linked to a Spinr account registered with a "
-                "different phone number. Your rider and driver profiles live on one "
-                "account — please log in with that phone number, or contact support "
-                "if you need to update the number on your account."
-            ),
+            detail="This email is already in use with another account. Please change your email address.",
         )
 
     update_data = {
@@ -454,7 +445,7 @@ async def delete_emergency_contact(contact_id: str, current_user: dict = Depends
 # migration + money-auditor review) and is intentionally not done here.
 RIDER_REFERRAL_RIDES_REQUIRED = 1
 RIDER_REFERRER_REWARD = 5  # CAD — referrer credit once referee takes first ride
-RIDER_REFEREE_REWARD = 5   # CAD — new rider's first-ride credit
+RIDER_REFEREE_REWARD = 5  # CAD — new rider's first-ride credit
 
 
 def _rider_referral_code(user: dict) -> str:

--- a/backend/tests/test_profile_duplicate_email.py
+++ b/backend/tests/test_profile_duplicate_email.py
@@ -1,9 +1,10 @@
 """Unit tests for POST /users/profile duplicate-email handling.
 
-Spinr requires both phone and email to be unique across accounts (no duplicates
-of either). If an email already belongs to another account, the profile route
-must block it and tell the user to use a different email address, while never
-disclosing the other account's phone number.
+Uber-style single-identity model: one person = one account (both rider and
+driver roles), keyed on a unique phone AND a unique email. If an email already
+belongs to another account, the profile route must block it and point the user
+to log into their existing account, while never disclosing the other account's
+phone number.
 """
 
 from __future__ import annotations
@@ -32,8 +33,8 @@ def _req(email: str = "Shared@Example.com", role: str | None = None) -> CreatePr
 
 
 @pytest.mark.anyio
-async def test_duplicate_email_is_blocked_with_change_email_message():
-    """Email already on another account → 400 telling the user to change their email."""
+async def test_duplicate_email_is_blocked_with_account_recovery_message():
+    """Email already on another account → 400 pointing the user to log into it."""
     current_user = {"id": "u-new", "phone": "+13060000002"}
     other_account = {"id": "u-existing", "phone": "+13060000001", "email": "shared@example.com"}
 
@@ -49,9 +50,9 @@ async def test_duplicate_email_is_blocked_with_change_email_message():
 
     assert ei.value.status_code == 400
     detail = ei.value.detail.lower()
-    # Tell the user the email is taken and to use a different one.
-    assert "already in use" in detail
-    assert "change your email" in detail
+    # Uber-style: point the user to their existing account, not a new one.
+    assert "already linked to an existing spinr account" in detail
+    assert "log in" in detail
     # Never disclose the other account's phone number (PII / enumeration).
     assert "+13060000001" not in ei.value.detail
     # The duplicate must not be written.

--- a/backend/tests/test_profile_duplicate_email.py
+++ b/backend/tests/test_profile_duplicate_email.py
@@ -1,10 +1,9 @@
 """Unit tests for POST /users/profile duplicate-email handling.
 
-Spinr is a single-identity-per-person model: phone is the unique login key and
-a person holds both rider and driver roles on ONE account. Reusing an email on a
-second phone number means a duplicate account was created by mistake. The profile
-route must block the duplicate email AND return an actionable account-recovery
-message (not a dead-end), while never disclosing the other account's phone.
+Spinr requires both phone and email to be unique across accounts (no duplicates
+of either). If an email already belongs to another account, the profile route
+must block it and tell the user to use a different email address, while never
+disclosing the other account's phone number.
 """
 
 from __future__ import annotations
@@ -33,8 +32,8 @@ def _req(email: str = "Shared@Example.com", role: str | None = None) -> CreatePr
 
 
 @pytest.mark.anyio
-async def test_duplicate_email_on_different_phone_is_blocked_with_recovery_hint():
-    """Email already on another account → 400 with an actionable, PII-safe message."""
+async def test_duplicate_email_is_blocked_with_change_email_message():
+    """Email already on another account → 400 telling the user to change their email."""
     current_user = {"id": "u-new", "phone": "+13060000002"}
     other_account = {"id": "u-existing", "phone": "+13060000001", "email": "shared@example.com"}
 
@@ -50,9 +49,9 @@ async def test_duplicate_email_on_different_phone_is_blocked_with_recovery_hint(
 
     assert ei.value.status_code == 400
     detail = ei.value.detail.lower()
-    # Actionable recovery nudge, not a blunt dead-end.
-    assert "different phone number" in detail
-    assert "log in" in detail
+    # Tell the user the email is taken and to use a different one.
+    assert "already in use" in detail
+    assert "change your email" in detail
     # Never disclose the other account's phone number (PII / enumeration).
     assert "+13060000001" not in ei.value.detail
     # The duplicate must not be written.

--- a/backend/tests/test_profile_duplicate_email.py
+++ b/backend/tests/test_profile_duplicate_email.py
@@ -1,0 +1,102 @@
+"""Unit tests for POST /users/profile duplicate-email handling.
+
+Spinr is a single-identity-per-person model: phone is the unique login key and
+a person holds both rider and driver roles on ONE account. Reusing an email on a
+second phone number means a duplicate account was created by mistake. The profile
+route must block the duplicate email AND return an actionable account-recovery
+message (not a dead-end), while never disclosing the other account's phone.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+try:
+    from routes.users import create_profile
+    from schemas import CreateProfileRequest
+except ImportError:
+    from backend.routes.users import create_profile  # type: ignore[no-redef]
+    from backend.schemas import CreateProfileRequest  # type: ignore[no-redef]
+
+
+def _req(email: str = "Shared@Example.com", role: str | None = None) -> CreateProfileRequest:
+    return CreateProfileRequest(
+        first_name="Sam",
+        last_name="Rider",
+        email=email,
+        gender="Male",
+        role=role,
+    )
+
+
+@pytest.mark.anyio
+async def test_duplicate_email_on_different_phone_is_blocked_with_recovery_hint():
+    """Email already on another account → 400 with an actionable, PII-safe message."""
+    current_user = {"id": "u-new", "phone": "+13060000002"}
+    other_account = {"id": "u-existing", "phone": "+13060000001", "email": "shared@example.com"}
+
+    with (
+        patch(
+            "routes.users.db_supabase.get_rows",
+            AsyncMock(return_value=[other_account]),
+        ),
+        patch("routes.users.db_supabase.update_one", AsyncMock()) as update_mock,
+    ):
+        with pytest.raises(HTTPException) as ei:
+            await create_profile(request=_req(), current_user=current_user)
+
+    assert ei.value.status_code == 400
+    detail = ei.value.detail.lower()
+    # Actionable recovery nudge, not a blunt dead-end.
+    assert "different phone number" in detail
+    assert "log in" in detail
+    # Never disclose the other account's phone number (PII / enumeration).
+    assert "+13060000001" not in ei.value.detail
+    # The duplicate must not be written.
+    update_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_duplicate_email_lookup_is_case_insensitive():
+    """The guard normalizes to lowercase before comparing, so casing can't bypass it."""
+    captured: dict = {}
+
+    async def _get_rows(table, filt, limit=None):
+        captured["filter"] = filt
+        return [{"id": "u-existing", "phone": "+1306", "email": "shared@example.com"}]
+
+    with (
+        patch("routes.users.db_supabase.get_rows", AsyncMock(side_effect=_get_rows)),
+        patch("routes.users.db_supabase.update_one", AsyncMock()),
+    ):
+        with pytest.raises(HTTPException):
+            await create_profile(request=_req(email="SHARED@EXAMPLE.COM"), current_user={"id": "u-new", "phone": "+1"})
+
+    assert captured["filter"]["email"] == "shared@example.com"
+
+
+@pytest.mark.anyio
+async def test_unique_email_completes_profile():
+    """No collision → profile is written and email stored normalized (lowercased)."""
+    captured: dict = {}
+    user = {"id": "u-new", "phone": "+13060000002", "created_at": "2026-06-15T00:00:00Z"}
+
+    async def _update(table, filt, fields):
+        captured.update(fields)
+
+    with (
+        patch("routes.users.db_supabase.get_rows", AsyncMock(return_value=[])),
+        patch("routes.users.db_supabase.update_one", AsyncMock(side_effect=_update)),
+        patch(
+            "routes.users.db_supabase.get_user_by_id",
+            AsyncMock(side_effect=lambda _id: {**user, **captured}),
+        ),
+    ):
+        out = await create_profile(request=_req(email="Fresh@Example.com"), current_user=user)
+
+    assert captured["email"] == "fresh@example.com"
+    assert captured["profile_complete"] is True
+    assert out.email == "fresh@example.com"


### PR DESCRIPTION
Spinr uses a single-identity-per-person model: phone is the unique login
key and one account holds both rider and driver roles (is_rider/is_driver).
Reusing an email on a second phone number means a duplicate account was
created by mistake. The old 400 "email already in use" left that account at
a dead-end — logged in but unable to complete its profile.

Return an account-recovery nudge instead: tell the user the email is linked
to an account under a different phone number and to log in with that number
(or contact support to change it). The other account's phone is never
disclosed (PII / account-enumeration).

Adds regression tests covering the recovery message, case-insensitive
collision detection, and the happy path.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V1xGTgWC8MVnkMYRD35ov1