### PR TITLE
fix(payments): re-charge on rider-chosen card to break end-of-ride payment loop

### DIFF
--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-detail-modal.tsx
@@ -595,7 +595,7 @@ export default function RideDetailModal({ rideId, open, onClose }: Props) {
                                             <div className="px-4 pb-4 -mt-1">
                                                 <div className="flex items-center justify-between gap-2 pt-3 border-t">
                                                     <span className="text-[11px] font-medium text-muted-foreground">Receipt</span>
-                                                    <RideInvoice rideId={ride.id} status={ride.status} />
+                                                    <RideInvoice rideId={ride.id} status={ride.status} paymentStatus={ride.payment_status} />
                                                 </div>
                                             </div>
                                         )}

--- a/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
+++ b/admin-dashboard/src/app/dashboard/rides/_components/ride-invoice.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { sendRideInvoice, getRideInvoice, getRideRouteMapDataUrl } from "@/lib/api";
+import { sendRideInvoice, sendPayableRideInvoice, getRideInvoice, getRideRouteMapDataUrl } from "@/lib/api";
 import { Send, Download } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 import { computePhaseDistances } from "./ride-ui-helpers";
@@ -9,6 +9,7 @@ import { computePhaseDistances } from "./ride-ui-helpers";
 interface Props {
     rideId: string;
     status: string;
+    paymentStatus?: string;
 }
 
 // Safe number formatter — returns em-dash for null/undefined/NaN.
@@ -28,20 +29,38 @@ const num = (n: any): number => {
 // Spinr brand red (#ee2b2b) as an RGB triple for jsPDF fills/text.
 const BRAND: [number, number, number] = [238, 43, 43];
 
-export default function RideInvoice({ rideId, status }: Props) {
+export default function RideInvoice({ rideId, status, paymentStatus }: Props) {
     const { toast } = useToast();
     const [sending, setSending] = useState(false);
     const [downloading, setDownloading] = useState(false);
 
     if (status !== "completed") return null;
 
+    // Unpaid completed ride → send a PAYABLE Stripe invoice (rider pays the
+    // hosted page, invoice.paid settles the ride). Paid/waived → re-email the
+    // receipt as before.
+    const isUnpaid = !!paymentStatus && !["paid", "waived_admin"].includes(paymentStatus);
+
     const handleSend = async () => {
         setSending(true);
         try {
-            await sendRideInvoice(rideId);
-            toast({ title: "Invoice sent", description: "Receipt sent to rider's email." });
+            if (isUnpaid) {
+                const res = await sendPayableRideInvoice(rideId);
+                toast({
+                    title: "Payable invoice sent",
+                    description: res?.invoice_url
+                        ? "Stripe emailed the rider a pay link. The ride settles automatically once paid."
+                        : "Stripe emailed the rider a pay link.",
+                });
+            } else {
+                await sendRideInvoice(rideId);
+                toast({ title: "Invoice sent", description: "Receipt sent to rider's email." });
+            }
         } catch {
-            toast({ title: "Failed to send invoice", variant: "destructive" });
+            toast({
+                title: isUnpaid ? "Failed to send payable invoice" : "Failed to send invoice",
+                variant: "destructive",
+            });
         } finally {
             setSending(false);
         }
@@ -427,7 +446,7 @@ export default function RideInvoice({ rideId, status }: Props) {
              *  for the main action, outline for the secondary download. */}
             <button onClick={handleSend} disabled={sending}
                 className="flex items-center gap-1.5 text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 px-3 py-1.5 rounded-lg shadow-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-                <Send className="h-3.5 w-3.5" /> {sending ? "Sending..." : "Send Invoice"}
+                <Send className="h-3.5 w-3.5" /> {sending ? "Sending..." : isUnpaid ? "Send Payable Invoice" : "Send Invoice"}
             </button>
             <button onClick={handleDownload} disabled={downloading}
                 className="flex items-center gap-1.5 text-xs font-semibold border border-emerald-300 text-emerald-700 hover:bg-emerald-50 dark:border-emerald-800 dark:text-emerald-400 dark:hover:bg-emerald-900/20 px-3 py-1.5 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed">

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -447,6 +447,13 @@ export const sendRideInvoice = (rideId: string) =>
     request<any>(`/api/admin/rides/${rideId}/send-receipt`, {
         method: "POST",
     });
+// Payable Stripe Invoice for a stuck unpaid ride — Stripe emails the rider a
+// hosted pay page; invoice.paid settles the ride. Returns { invoice_url }.
+export const sendPayableRideInvoice = (rideId: string) =>
+    request<{ invoice_url?: string; stripe_invoice_id?: string }>(
+        `/api/admin/rides/${rideId}/send-invoice`,
+        { method: "POST" },
+    );
 export const getFlags = (opts: {
     limit?: number;
     offset?: number;

--- a/backend/migrations/176_ride_stripe_invoice.sql
+++ b/backend/migrations/176_ride_stripe_invoice.sql
@@ -1,0 +1,34 @@
+-- Migration 176: ride payable-invoice fields for the admin "Send Invoice" flow
+--
+-- Rollback:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_rides_stripe_invoice_id;
+--   ALTER TABLE rides DROP COLUMN IF EXISTS stripe_invoice_id;
+--   ALTER TABLE rides DROP COLUMN IF EXISTS invoice_url;
+--   ALTER TABLE rides DROP COLUMN IF EXISTS invoice_sent_at;
+--
+-- Why: when a rider's card is rejected at the end of a trip and they cannot
+-- pay in-app, an admin can send a real Stripe Invoice to the rider's email
+-- (collection_method=send_invoice). The rider pays the hosted invoice and the
+-- invoice.paid webhook flips the ride to payment_status='paid' and credits the
+-- driver via the financial_events ledger — no manual "mark paid"/waive.
+--
+-- These columns are backend-written only (the service role bypasses RLS); they
+-- carry no new user-writable surface, so the existing rides RLS policies cover
+-- them and no new policy is required. The add is forward-compatible with
+-- in-flight traffic: all three are nullable with no default backfill.
+--
+-- The index supports the webhook's lookup of a ride by the Stripe invoice id
+-- (the webhook receives the invoice, not the ride id, when metadata is absent)
+-- and the reconciliation join; it is partial so it only covers invoiced rides.
+-- It is built CONCURRENTLY (no SHARE lock on the hot rides table). The runner
+-- (backend/scripts/migrate.py) detects "CONCURRENTLY" and applies the whole
+-- file in autocommit, executing each statement individually — same pattern as
+-- migration 156.
+
+ALTER TABLE rides ADD COLUMN IF NOT EXISTS stripe_invoice_id TEXT;
+ALTER TABLE rides ADD COLUMN IF NOT EXISTS invoice_url TEXT;
+ALTER TABLE rides ADD COLUMN IF NOT EXISTS invoice_sent_at TIMESTAMPTZ;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_rides_stripe_invoice_id
+    ON rides (stripe_invoice_id)
+    WHERE stripe_invoice_id IS NOT NULL;

--- a/backend/migrations/177_ride_stripe_invoice.sql
+++ b/backend/migrations/177_ride_stripe_invoice.sql
@@ -1,4 +1,4 @@
--- Migration 176: ride payable-invoice fields for the admin "Send Invoice" flow
+-- Migration 177: ride payable-invoice fields for the admin "Send Invoice" flow
 --
 -- Rollback:
 --   DROP INDEX CONCURRENTLY IF EXISTS idx_rides_stripe_invoice_id;

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1449,8 +1449,14 @@ async def admin_send_payable_invoice(
             status_code=409,
             detail=f"Invoice is only for completed rides; ride is '{ride.get('status')}'",
         )
-    if ride.get("payment_status") in ("paid", "waived_admin"):
-        raise HTTPException(status_code=409, detail="Ride is already settled — nothing to invoice")
+    # Terminal payment states must never be re-invoiced. 'refunded' is set by the
+    # charge.refunded webhook — re-collecting an intentionally refunded fare would
+    # be a chargeback/PR incident. 'paid'/'waived_admin' are already settled.
+    if ride.get("payment_status") in ("paid", "waived_admin", "refunded"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Ride is in terminal payment state '{ride.get('payment_status')}' — cannot invoice",
+        )
     if ride.get("payment_status") == "processing":
         # An in-app charge is mid-flight (or captured-but-unconfirmed). Sending
         # an invoice now risks collecting twice. Make the admin retry shortly.
@@ -1480,6 +1486,7 @@ async def admin_send_payable_invoice(
 
     # Ensure the rider has a Stripe customer (an invoice must target one).
     customer_id = rider.get("stripe_customer_id")
+    claimed_sentinel: Optional[str] = None  # set once THIS request wins the CAS claim
     try:
         if not customer_id:
             customer = await db_supabase.run_sync(
@@ -1492,8 +1499,11 @@ async def admin_send_payable_invoice(
             customer_id = customer.id
             await db_supabase.update_one("users", {"id": rider_id}, {"stripe_customer_id": customer_id})
 
-        # Re-send an existing OPEN invoice instead of creating a duplicate.
+        # Re-send an existing OPEN invoice instead of creating a duplicate. A
+        # 'pending:' sentinel means a concurrent request is mid-creation.
         existing_id = ride.get("stripe_invoice_id")
+        if existing_id and str(existing_id).startswith("pending:"):
+            raise HTTPException(status_code=409, detail="An invoice is already being created for this ride")
         if existing_id:
             existing = await db_supabase.run_sync(lambda: stripe.Invoice.retrieve(existing_id, api_key=stripe_secret))
             if existing.get("status") == "paid":
@@ -1510,6 +1520,22 @@ async def admin_send_payable_invoice(
                     "invoice_url": existing.get("hosted_invoice_url"),
                     "resent": True,
                 }
+
+        # Atomic compare-and-swap claim so two concurrent admin requests can't
+        # each create a separate payable invoice (which would leave the rider
+        # with multiple open pay links and a refund owed if both are paid). Only
+        # the request that flips stripe_invoice_id from its observed value to a
+        # 'pending:' sentinel proceeds; the loser gets a 409. On Stripe failure
+        # the sentinel is released below so a later retry can re-claim.
+        invoice_claim_sentinel = f"pending:{uuid.uuid4()}"
+        claim = await db_supabase.update_one(
+            "rides",
+            {"id": ride_id, "stripe_invoice_id": existing_id},
+            {"stripe_invoice_id": invoice_claim_sentinel},
+        )
+        if claim is None:
+            raise HTTPException(status_code=409, detail="An invoice is already being created for this ride")
+        claimed_sentinel = invoice_claim_sentinel
 
         ride_code = ride.get("ride_code") or ride_id[:8].upper()
         # Create the invoice first (auto_advance off, exclude any unrelated
@@ -1543,6 +1569,22 @@ async def admin_send_payable_invoice(
     except HTTPException:
         raise
     except Exception as e:
+        # Release the creation claim (CAS on our own sentinel so a concurrent
+        # write is never clobbered) so a later retry can re-claim the ride.
+        if claimed_sentinel:
+            try:
+                await db_supabase.update_one(
+                    "rides",
+                    {"id": ride_id, "stripe_invoice_id": claimed_sentinel},
+                    {"stripe_invoice_id": None},
+                )
+            except Exception:
+                logger.error(
+                    "admin_send_payable_invoice: failed to release invoice claim for ride %s",
+                    ride_id,
+                    exc_info=True,
+                    extra={"domain": "payments", "ride_id": ride_id},
+                )
         logger.error(
             "admin_send_payable_invoice failed ride_id=%s: %s",
             ride_id,

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1572,10 +1572,22 @@ async def admin_send_payable_invoice(
             existing_status = getattr(existing, "status", None)
             if existing_status == "paid":
                 raise HTTPException(status_code=409, detail="Invoice already paid — webhook will settle the ride")
+            if existing_status == "draft":
+                # A prior request crashed after we persisted the id but before
+                # finalize. Defence: only finalize a draft that actually carries
+                # the fare — never finalize a $0/underfunded draft into a
+                # collectible invoice that invoice.paid would settle for nothing.
+                draft_amount = getattr(existing, "amount_due", None)
+                if draft_amount is None:
+                    draft_amount = getattr(existing, "total", 0) or 0
+                if int(draft_amount) <= 0:
+                    # Broken draft (no fare line) — delete it and fall through to
+                    # the CAS below, which swaps this dead id for a fresh invoice.
+                    await db_supabase.run_sync(lambda: stripe.Invoice.delete(existing_id, api_key=stripe_secret))
+                    existing_status = None
             if existing_status in ("open", "draft"):
                 # 'open' → already finalized+sent, just resend the email.
-                # 'draft' → a prior request crashed after we persisted the id but
-                # before finalize; finalize it now so it becomes collectible.
+                # 'draft' (with a fare line) → finalize so it becomes collectible.
                 if existing_status == "draft":
                     finalized = await db_supabase.run_sync(
                         lambda: stripe.Invoice.finalize_invoice(existing_id, api_key=stripe_secret)
@@ -1642,21 +1654,10 @@ async def admin_send_payable_invoice(
             )
         )
         created_invoice_id = invoice.id
-        # Persist the REAL invoice id BEFORE finalizing. The draft is not yet
-        # collectible, so if any later step (or the process) dies, the row holds
-        # the real id (recoverable via the 'draft' resend branch above) — never a
-        # 'pending:' sentinel masking a *payable* invoice. This is what makes the
-        # age-based sentinel reclaim safe: a bare sentinel ⇒ no collectible invoice.
-        id_written = await db_supabase.update_one(
-            "rides",
-            {"id": ride_id, "stripe_invoice_id": claimed_sentinel},
-            {"stripe_invoice_id": invoice.id},
-        )
-        if id_written is None:
-            # Our sentinel was changed underneath us — abandon: delete the draft
-            # (never finalized → not collectible) and let the rollback clear up.
-            raise HTTPException(status_code=409, detail="Invoice claim changed during creation")
-        claimed_sentinel = None  # the row now holds the real id, not our sentinel
+        # Attach the fare line item BEFORE persisting the id. Persisting only
+        # after the line exists guarantees the 'draft' resend path can never
+        # finalize a $0/underfunded invoice (which invoice.paid would then settle
+        # without collecting the fare).
         await db_supabase.run_sync(
             lambda: stripe.InvoiceItem.create(
                 customer=customer_id,
@@ -1670,6 +1671,36 @@ async def admin_send_payable_invoice(
                 idempotency_key=f"ride-invoiceitem-{invoice.id}",
             )
         )
+        # Persist the REAL invoice id BEFORE finalizing. The draft (now carrying
+        # the fare line) is not yet collectible, so if any later step (or the
+        # process) dies, the row holds the real id (recoverable via the 'draft'
+        # resend branch above) — never a 'pending:' sentinel masking a *payable*
+        # invoice. This is what makes the age-based sentinel reclaim safe: a bare
+        # sentinel ⇒ no collectible invoice.
+        id_written = await db_supabase.update_one(
+            "rides",
+            {"id": ride_id, "stripe_invoice_id": claimed_sentinel},
+            {"stripe_invoice_id": invoice.id},
+        )
+        if id_written is None:
+            # Our sentinel changed underneath us (should not happen). The draft is
+            # not finalized → not collectible; delete it so it can never be resent,
+            # and leave the row alone (the value is no longer ours to clear). This
+            # cleanup is inline because the HTTPException below bypasses the generic
+            # rollback handler (which only runs for non-HTTPException errors).
+            try:
+                await db_supabase.run_sync(lambda: stripe.Invoice.delete(invoice.id, api_key=stripe_secret))
+            except Exception:
+                logger.error(
+                    "admin_send_payable_invoice: failed to delete orphan draft %s for ride %s",
+                    invoice.id,
+                    ride_id,
+                    exc_info=True,
+                    extra={"domain": "payments", "ride_id": ride_id},
+                )
+            created_invoice_id = None  # handled here; don't double-clean in rollback
+            raise HTTPException(status_code=409, detail="Invoice claim changed during creation")
+        claimed_sentinel = None  # the row now holds the real id, not our sentinel
         finalized = await db_supabase.run_sync(
             lambda: stripe.Invoice.finalize_invoice(invoice.id, api_key=stripe_secret)
         )
@@ -1689,9 +1720,7 @@ async def admin_send_payable_invoice(
                     )
                 else:
                     # Still a draft → delete it outright.
-                    await db_supabase.run_sync(
-                        lambda: stripe.Invoice.delete(created_invoice_id, api_key=stripe_secret)
-                    )
+                    await db_supabase.run_sync(lambda: stripe.Invoice.delete(created_invoice_id, api_key=stripe_secret))
             except Exception:
                 logger.error(
                     "admin_send_payable_invoice: failed to roll back Stripe invoice %s for ride %s",

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -59,6 +59,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# A `pending:<epoch>:<uuid>` value in rides.stripe_invoice_id is a transient CAS
+# claim held while admin_send_payable_invoice creates the Stripe invoice. If the
+# request crashes after writing the sentinel (and the release also fails), it
+# would otherwise block all future invoicing AND in-app retries forever. A claim
+# older than this window is considered abandoned and may be reclaimed.
+_INVOICE_CLAIM_STALE_SECONDS = 300
+
+
+def _invoice_claim_age_seconds(sentinel: str) -> Optional[float]:
+    """Age (seconds) of a `pending:<epoch>:<uuid>` claim, or None if unparseable.
+
+    Returns None for legacy `pending:<uuid>` sentinels (no embedded timestamp) so
+    the caller treats them conservatively (not auto-reclaimable)."""
+    try:
+        parts = str(sentinel).split(":")
+        if len(parts) < 3:
+            return None
+        return (datetime.now(timezone.utc) - datetime.fromtimestamp(float(parts[1]), tz=timezone.utc)).total_seconds()
+    except (ValueError, OverflowError, OSError):
+        return None
+
 
 # ---------- Rides ----------
 
@@ -1504,11 +1525,23 @@ async def admin_send_payable_invoice(
             await db_supabase.update_one("users", {"id": rider_id}, {"stripe_customer_id": customer_id})
 
         # Re-send an existing OPEN invoice instead of creating a duplicate. A
-        # 'pending:' sentinel means a concurrent request is mid-creation.
+        # 'pending:' sentinel means a concurrent request is mid-creation — unless
+        # it is stale (a crashed request that never released the claim), in which
+        # case we let the CAS below reclaim it rather than blocking forever.
         existing_id = ride.get("stripe_invoice_id")
         if existing_id and str(existing_id).startswith("pending:"):
-            raise HTTPException(status_code=409, detail="An invoice is already being created for this ride")
-        if existing_id:
+            age = _invoice_claim_age_seconds(existing_id)
+            if age is None or age < _INVOICE_CLAIM_STALE_SECONDS:
+                raise HTTPException(status_code=409, detail="An invoice is already being created for this ride")
+            logger.warning(
+                "admin_send_payable_invoice: reclaiming stale invoice sentinel for ride %s (age %.0fs)",
+                ride_id,
+                age,
+                extra={"domain": "payments", "ride_id": ride_id},
+            )
+            # Fall through: the CAS claim filters on this stale sentinel value, so
+            # only one caller wins the reclaim; others get a 409 on the CAS.
+        if existing_id and not str(existing_id).startswith("pending:"):
             existing = await db_supabase.run_sync(lambda: stripe.Invoice.retrieve(existing_id, api_key=stripe_secret))
             # stripe-python v5+ returns typed model objects — use attribute access.
             existing_status = getattr(existing, "status", None)
@@ -1533,7 +1566,7 @@ async def admin_send_payable_invoice(
         # the request that flips stripe_invoice_id from its observed value to a
         # 'pending:' sentinel proceeds; the loser gets a 409. On Stripe failure
         # the sentinel is released below so a later retry can re-claim.
-        invoice_claim_sentinel = f"pending:{uuid.uuid4()}"
+        invoice_claim_sentinel = f"pending:{datetime.now(timezone.utc).timestamp()}:{uuid.uuid4()}"
         claim = await db_supabase.update_one(
             "rides",
             {"id": ride_id, "stripe_invoice_id": existing_id},

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1487,6 +1487,29 @@ async def admin_send_payable_invoice(
         # an invoice now risks collecting twice. Make the admin retry shortly.
         raise HTTPException(status_code=409, detail="Payment is currently processing — try again in a moment")
 
+    # A payable Stripe invoice bills the rider's PERSONAL card. Corporate
+    # (company_allowance) and wallet rides settle through the allowance /
+    # master-wallet / balance paths — invoicing the rider personally would
+    # bypass corporate billing policy and double-bill. Only card rides qualify.
+    _pmethod = (ride.get("payment_method") or "card").lower()
+    if _pmethod != "card":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Payable invoices are only for card rides; this ride uses '{_pmethod}'. "
+            "Use the corporate/wallet remediation path.",
+        )
+
+    # An open pre-authorization hold (authorized / fare_only) is still captureable
+    # by the preauth-capture sweeper after the tip window. Emailing an invoice now
+    # would let BOTH the captured hold and the hosted invoice collect. Block until
+    # the hold is terminal (captured → paid, or released).
+    _auth_status = (ride.get("auth_status") or "").lower()
+    if _auth_status in ("authorized", "fare_only"):
+        raise HTTPException(
+            status_code=409,
+            detail="Ride has an open pre-authorization hold pending capture — cannot invoice yet",
+        )
+
     rider_id = ride.get("rider_id")
     rider = await db_supabase.get_user_by_id(rider_id) if rider_id else None
     if not rider or not rider.get("email"):
@@ -1512,6 +1535,8 @@ async def admin_send_payable_invoice(
     # Ensure the rider has a Stripe customer (an invoice must target one).
     customer_id = rider.get("stripe_customer_id")
     claimed_sentinel: Optional[str] = None  # set once THIS request wins the CAS claim
+    created_invoice_id: Optional[str] = None  # set once the Stripe invoice exists
+    finalized_done = False  # True once finalize succeeds (→ void on rollback, else delete)
     try:
         if not customer_id:
             customer = await db_supabase.run_sync(
@@ -1547,7 +1572,15 @@ async def admin_send_payable_invoice(
             existing_status = getattr(existing, "status", None)
             if existing_status == "paid":
                 raise HTTPException(status_code=409, detail="Invoice already paid — webhook will settle the ride")
-            if existing_status == "open":
+            if existing_status in ("open", "draft"):
+                # 'open' → already finalized+sent, just resend the email.
+                # 'draft' → a prior request crashed after we persisted the id but
+                # before finalize; finalize it now so it becomes collectible.
+                if existing_status == "draft":
+                    finalized = await db_supabase.run_sync(
+                        lambda: stripe.Invoice.finalize_invoice(existing_id, api_key=stripe_secret)
+                    )
+                    existing = finalized
                 await db_supabase.run_sync(lambda: stripe.Invoice.send_invoice(existing_id, api_key=stripe_secret))
                 await log_admin_action(
                     admin_user, "resend_ride_invoice", "ride", ride_id, {"stripe_invoice_id": existing_id}
@@ -1559,6 +1592,8 @@ async def admin_send_payable_invoice(
                     "invoice_url": getattr(existing, "hosted_invoice_url", None),
                     "resent": True,
                 }
+            # 'void' / 'uncollectible' → fall through; the CAS below swaps this dead
+            # id for a sentinel and a fresh invoice is created.
 
         # Atomic compare-and-swap claim so two concurrent admin requests can't
         # each create a separate payable invoice (which would leave the rider
@@ -1567,9 +1602,19 @@ async def admin_send_payable_invoice(
         # 'pending:' sentinel proceeds; the loser gets a 409. On Stripe failure
         # the sentinel is released below so a later retry can re-claim.
         invoice_claim_sentinel = f"pending:{datetime.now(timezone.utc).timestamp()}:{uuid.uuid4()}"
+        # The claim also asserts the ride is still in an unpaid, non-processing
+        # state. Without this, an in-app /process-payment that flips the ride to
+        # 'processing' AFTER our pre-read but BEFORE this CAS would race us: both
+        # the in-app charge and the emailed invoice could collect. Asserting the
+        # payment_status here (mirrored by stripe_invoice_id=NULL in the in-app
+        # claim) makes the two paths mutually exclusive.
         claim = await db_supabase.update_one(
             "rides",
-            {"id": ride_id, "stripe_invoice_id": existing_id},
+            {
+                "id": ride_id,
+                "stripe_invoice_id": existing_id,
+                "payment_status": {"$nin": ["processing", "paid", "waived_admin", "refunded"]},
+            },
             {"stripe_invoice_id": invoice_claim_sentinel},
         )
         if claim is None:
@@ -1577,8 +1622,8 @@ async def admin_send_payable_invoice(
         claimed_sentinel = invoice_claim_sentinel
 
         ride_code = ride.get("ride_code") or ride_id[:8].upper()
-        # Create the invoice first (auto_advance off, exclude any unrelated
-        # pending items), then attach exactly one line item scoped to it.
+        # Create a DRAFT invoice (auto_advance off → NOT collectible until we
+        # finalize), excluding any unrelated pending items.
         invoice = await db_supabase.run_sync(
             lambda: stripe.Invoice.create(
                 customer=customer_id,
@@ -1591,6 +1636,22 @@ async def admin_send_payable_invoice(
                 api_key=stripe_secret,
             )
         )
+        created_invoice_id = invoice.id
+        # Persist the REAL invoice id BEFORE finalizing. The draft is not yet
+        # collectible, so if any later step (or the process) dies, the row holds
+        # the real id (recoverable via the 'draft' resend branch above) — never a
+        # 'pending:' sentinel masking a *payable* invoice. This is what makes the
+        # age-based sentinel reclaim safe: a bare sentinel ⇒ no collectible invoice.
+        id_written = await db_supabase.update_one(
+            "rides",
+            {"id": ride_id, "stripe_invoice_id": claimed_sentinel},
+            {"stripe_invoice_id": invoice.id},
+        )
+        if id_written is None:
+            # Our sentinel was changed underneath us — abandon: delete the draft
+            # (never finalized → not collectible) and let the rollback clear up.
+            raise HTTPException(status_code=409, detail="Invoice claim changed during creation")
+        claimed_sentinel = None  # the row now holds the real id, not our sentinel
         await db_supabase.run_sync(
             lambda: stripe.InvoiceItem.create(
                 customer=customer_id,
@@ -1604,17 +1665,43 @@ async def admin_send_payable_invoice(
         finalized = await db_supabase.run_sync(
             lambda: stripe.Invoice.finalize_invoice(invoice.id, api_key=stripe_secret)
         )
+        finalized_done = True
         await db_supabase.run_sync(lambda: stripe.Invoice.send_invoice(invoice.id, api_key=stripe_secret))
     except HTTPException:
         raise
     except Exception as e:
-        # Release the creation claim (CAS on our own sentinel so a concurrent
-        # write is never clobbered) so a later retry can re-claim the ride.
-        if claimed_sentinel:
+        # Roll back so the ride is fully recoverable: no collectible invoice left
+        # in Stripe AND no stuck id/sentinel on the row.
+        if created_invoice_id:
+            try:
+                if finalized_done:
+                    # Finalized (possibly sent) → void so it can never be paid.
+                    await db_supabase.run_sync(
+                        lambda: stripe.Invoice.void_invoice(created_invoice_id, api_key=stripe_secret)
+                    )
+                else:
+                    # Still a draft → delete it outright.
+                    await db_supabase.run_sync(
+                        lambda: stripe.Invoice.delete(created_invoice_id, api_key=stripe_secret)
+                    )
+            except Exception:
+                logger.error(
+                    "admin_send_payable_invoice: failed to roll back Stripe invoice %s for ride %s",
+                    created_invoice_id,
+                    ride_id,
+                    exc_info=True,
+                    extra={"domain": "payments", "ride_id": ride_id},
+                )
+        # Clear whichever value is on the row (the real id if we got that far,
+        # else our sentinel) — CAS on the exact value so a concurrent write is
+        # never clobbered — so a later retry can re-claim the ride.
+        for _stale_val in (created_invoice_id, claimed_sentinel):
+            if not _stale_val:
+                continue
             try:
                 await db_supabase.update_one(
                     "rides",
-                    {"id": ride_id, "stripe_invoice_id": claimed_sentinel},
+                    {"id": ride_id, "stripe_invoice_id": _stale_val},
                     {"stripe_invoice_id": None},
                 )
             except Exception:

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1634,6 +1634,11 @@ async def admin_send_payable_invoice(
                 metadata={"ride_id": ride_id, "source": "admin_send_invoice"},
                 description=f"Spinr ride {ride_code}",
                 api_key=stripe_secret,
+                # Per-attempt key (the unique CAS sentinel) so a network-timeout
+                # retry of THIS request dedupes, while a later reclaim (new
+                # sentinel) still mints a fresh invoice instead of replaying a
+                # voided one — keying on ride+amount would do the latter wrongly.
+                idempotency_key=f"ride-invoice-{invoice_claim_sentinel}",
             )
         )
         created_invoice_id = invoice.id
@@ -1660,6 +1665,9 @@ async def admin_send_payable_invoice(
                 currency="cad",
                 description=f"Spinr ride {ride_code}",
                 api_key=stripe_secret,
+                # Keyed to this invoice so a retry can't attach a duplicate line
+                # item (which would double the amount due).
+                idempotency_key=f"ride-invoiceitem-{invoice.id}",
             )
         )
         finalized = await db_supabase.run_sync(

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Dict, Optional
 
 import stripe
@@ -1422,6 +1422,149 @@ async def admin_send_ride_receipt(
         # Email provider rejected/failed — 502 so the operator knows it didn't go.
         raise HTTPException(status_code=502, detail="Receipt could not be sent — email provider unavailable")
     return {"sent": True, "ride_id": ride_id}
+
+
+@router.post("/rides/{ride_id}/send-invoice")
+async def admin_send_payable_invoice(
+    ride_id: str,
+    admin_user: dict = Depends(get_admin_user),
+):
+    """Email the rider a *payable* Stripe Invoice for a stuck unpaid ride.
+
+    Remediation for the card-rejected-at-trip-end loop: when the rider can't
+    pay in-app, an admin sends a real Stripe Invoice (collection_method=
+    send_invoice). Stripe emails a hosted invoice + pay page; on payment the
+    invoice.paid webhook flips the ride to paid and credits the driver via the
+    financial_events ledger. No manual "mark paid" / waive.
+
+    Idempotent: re-sending a ride that already has an open invoice re-sends THAT
+    invoice rather than creating a second one (which could be paid twice).
+    """
+    ride = await db_supabase.get_ride(ride_id)
+    if not ride:
+        raise HTTPException(status_code=404, detail="Ride not found")
+
+    if ride.get("status") != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail=f"Invoice is only for completed rides; ride is '{ride.get('status')}'",
+        )
+    if ride.get("payment_status") in ("paid", "waived_admin"):
+        raise HTTPException(status_code=409, detail="Ride is already settled — nothing to invoice")
+
+    rider_id = ride.get("rider_id")
+    rider = await db_supabase.get_user_by_id(rider_id) if rider_id else None
+    if not rider or not rider.get("email"):
+        raise HTTPException(status_code=422, detail="Rider has no email address on file")
+
+    settings = await get_app_settings()
+    stripe_secret = (settings or {}).get("stripe_secret_key", "")
+    if not stripe_secret:
+        raise HTTPException(status_code=503, detail="Stripe is not configured")
+
+    # Amount = grand_total (excl. tip) + any tip already attached to the ride,
+    # matching process_payment's total_charge. Decimal-only to the cents boundary.
+    grand = ride.get("grand_total")
+    if grand is None:
+        grand = ride.get("total_fare", 0)
+    total = (Decimal(str(grand or 0)) + Decimal(str(ride.get("tip_amount") or 0))).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
+    amount_cents = int(total * 100)
+    if amount_cents <= 0:
+        raise HTTPException(status_code=409, detail="Ride total is $0 — nothing to invoice")
+
+    # Ensure the rider has a Stripe customer (an invoice must target one).
+    customer_id = rider.get("stripe_customer_id")
+    try:
+        if not customer_id:
+            customer = await db_supabase.run_sync(
+                lambda: stripe.Customer.create(
+                    email=rider["email"],
+                    metadata={"user_id": rider_id},
+                    api_key=stripe_secret,
+                )
+            )
+            customer_id = customer.id
+            await db_supabase.update_one("users", {"id": rider_id}, {"stripe_customer_id": customer_id})
+
+        # Re-send an existing OPEN invoice instead of creating a duplicate.
+        existing_id = ride.get("stripe_invoice_id")
+        if existing_id:
+            existing = await db_supabase.run_sync(lambda: stripe.Invoice.retrieve(existing_id, api_key=stripe_secret))
+            if existing.get("status") == "paid":
+                raise HTTPException(status_code=409, detail="Invoice already paid — webhook will settle the ride")
+            if existing.get("status") == "open":
+                await db_supabase.run_sync(lambda: stripe.Invoice.send_invoice(existing_id, api_key=stripe_secret))
+                await log_admin_action(
+                    admin_user, "resend_ride_invoice", "ride", ride_id, {"stripe_invoice_id": existing_id}
+                )
+                return {
+                    "sent": True,
+                    "ride_id": ride_id,
+                    "stripe_invoice_id": existing_id,
+                    "invoice_url": existing.get("hosted_invoice_url"),
+                    "resent": True,
+                }
+
+        ride_code = ride.get("ride_code") or ride_id[:8].upper()
+        # Create the invoice first (auto_advance off, exclude any unrelated
+        # pending items), then attach exactly one line item scoped to it.
+        invoice = await db_supabase.run_sync(
+            lambda: stripe.Invoice.create(
+                customer=customer_id,
+                collection_method="send_invoice",
+                days_until_due=7,
+                auto_advance=False,
+                pending_invoice_items_behavior="exclude",
+                metadata={"ride_id": ride_id, "source": "admin_send_invoice"},
+                description=f"Spinr ride {ride_code}",
+                api_key=stripe_secret,
+            )
+        )
+        await db_supabase.run_sync(
+            lambda: stripe.InvoiceItem.create(
+                customer=customer_id,
+                invoice=invoice.id,
+                amount=amount_cents,
+                currency="cad",
+                description=f"Spinr ride {ride_code}",
+                api_key=stripe_secret,
+            )
+        )
+        finalized = await db_supabase.run_sync(
+            lambda: stripe.Invoice.finalize_invoice(invoice.id, api_key=stripe_secret)
+        )
+        await db_supabase.run_sync(lambda: stripe.Invoice.send_invoice(invoice.id, api_key=stripe_secret))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(
+            "admin_send_payable_invoice failed ride_id=%s: %s",
+            ride_id,
+            e,
+            exc_info=True,
+            extra={"domain": "payments", "ride_id": ride_id},
+        )
+        raise HTTPException(status_code=502, detail="Could not create Stripe invoice") from e
+
+    invoice_url = finalized.get("hosted_invoice_url")
+    await db_supabase.update_ride(
+        ride_id,
+        {
+            "stripe_invoice_id": invoice.id,
+            "invoice_url": invoice_url,
+            "invoice_sent_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    await log_admin_action(
+        admin_user,
+        "send_ride_invoice",
+        "ride",
+        ride_id,
+        {"stripe_invoice_id": invoice.id, "amount_cents": amount_cents},
+    )
+    return {"sent": True, "ride_id": ride_id, "stripe_invoice_id": invoice.id, "invoice_url": invoice_url}
 
 
 @router.get("/rides/{ride_id}/route-map.png")

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1567,9 +1567,34 @@ async def admin_send_payable_invoice(
             # Fall through: the CAS claim filters on this stale sentinel value, so
             # only one caller wins the reclaim; others get a 409 on the CAS.
         if existing_id and not str(existing_id).startswith("pending:"):
-            existing = await db_supabase.run_sync(lambda: stripe.Invoice.retrieve(existing_id, api_key=stripe_secret))
-            # stripe-python v5+ returns typed model objects — use attribute access.
-            existing_status = getattr(existing, "status", None)
+            try:
+                existing = await db_supabase.run_sync(
+                    lambda: stripe.Invoice.retrieve(existing_id, api_key=stripe_secret)
+                )
+                # stripe-python v5+ returns typed model objects — attribute access.
+                existing_status = getattr(existing, "status", None)
+            except stripe.error.InvalidRequestError as e:
+                # The persisted invoice no longer exists in Stripe (e.g. a prior
+                # rollback deleted the draft but the DB clear failed). Without this,
+                # the retrieve would raise into the generic rollback — which has no
+                # sentinel/created id to clear — stranding the dead id, 502ing every
+                # future attempt and blocking in-app pay forever. Treat a missing
+                # invoice like void/uncollectible: clear the dead id and fall through
+                # to the CAS so a fresh invoice is created.
+                if getattr(e, "code", None) == "resource_missing" or "resource_missing" in str(e).lower():
+                    logger.warning(
+                        "admin_send_payable_invoice: persisted invoice %s missing in Stripe for ride %s — reclaiming",
+                        existing_id,
+                        ride_id,
+                        extra={"domain": "payments", "ride_id": ride_id},
+                    )
+                    await db_supabase.update_one(
+                        "rides", {"id": ride_id, "stripe_invoice_id": existing_id}, {"stripe_invoice_id": None}
+                    )
+                    existing_id = None
+                    existing_status = None
+                else:
+                    raise
             if existing_status == "paid":
                 raise HTTPException(status_code=409, detail="Invoice already paid — webhook will settle the ride")
             if existing_status == "draft":

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -1451,6 +1451,10 @@ async def admin_send_payable_invoice(
         )
     if ride.get("payment_status") in ("paid", "waived_admin"):
         raise HTTPException(status_code=409, detail="Ride is already settled — nothing to invoice")
+    if ride.get("payment_status") == "processing":
+        # An in-app charge is mid-flight (or captured-but-unconfirmed). Sending
+        # an invoice now risks collecting twice. Make the admin retry shortly.
+        raise HTTPException(status_code=409, detail="Payment is currently processing — try again in a moment")
 
     rider_id = ride.get("rider_id")
     rider = await db_supabase.get_user_by_id(rider_id) if rider_id else None

--- a/backend/routes/admin/rides.py
+++ b/backend/routes/admin/rides.py
@@ -27,6 +27,7 @@ try:
         places_new_headers,
     )
     from ...utils.insurance_periods import record_period_transition
+    from ...utils.money import dollars_to_cents
     from ...utils.rate_limiter import default_limiter as limiter
 except ImportError:
     import db_supabase
@@ -47,6 +48,7 @@ except ImportError:
         places_new_headers,
     )
     from utils.insurance_periods import record_period_transition
+    from utils.money import dollars_to_cents
     from utils.rate_limiter import default_limiter as limiter
 
 from .drivers import _batch_fetch_drivers_and_users, _user_display_name
@@ -1425,7 +1427,9 @@ async def admin_send_ride_receipt(
 
 
 @router.post("/rides/{ride_id}/send-invoice")
+@limiter.limit("10/minute")
 async def admin_send_payable_invoice(
+    request: Request,
     ride_id: str,
     admin_user: dict = Depends(get_admin_user),
 ):
@@ -1480,7 +1484,7 @@ async def admin_send_payable_invoice(
     total = (Decimal(str(grand or 0)) + Decimal(str(ride.get("tip_amount") or 0))).quantize(
         Decimal("0.01"), rounding=ROUND_HALF_UP
     )
-    amount_cents = int(total * 100)
+    amount_cents = dollars_to_cents(total)
     if amount_cents <= 0:
         raise HTTPException(status_code=409, detail="Ride total is $0 — nothing to invoice")
 
@@ -1506,9 +1510,11 @@ async def admin_send_payable_invoice(
             raise HTTPException(status_code=409, detail="An invoice is already being created for this ride")
         if existing_id:
             existing = await db_supabase.run_sync(lambda: stripe.Invoice.retrieve(existing_id, api_key=stripe_secret))
-            if existing.get("status") == "paid":
+            # stripe-python v5+ returns typed model objects — use attribute access.
+            existing_status = getattr(existing, "status", None)
+            if existing_status == "paid":
                 raise HTTPException(status_code=409, detail="Invoice already paid — webhook will settle the ride")
-            if existing.get("status") == "open":
+            if existing_status == "open":
                 await db_supabase.run_sync(lambda: stripe.Invoice.send_invoice(existing_id, api_key=stripe_secret))
                 await log_admin_action(
                     admin_user, "resend_ride_invoice", "ride", ride_id, {"stripe_invoice_id": existing_id}
@@ -1517,7 +1523,7 @@ async def admin_send_payable_invoice(
                     "sent": True,
                     "ride_id": ride_id,
                     "stripe_invoice_id": existing_id,
-                    "invoice_url": existing.get("hosted_invoice_url"),
+                    "invoice_url": getattr(existing, "hosted_invoice_url", None),
                     "resent": True,
                 }
 
@@ -1594,15 +1600,28 @@ async def admin_send_payable_invoice(
         )
         raise HTTPException(status_code=502, detail="Could not create Stripe invoice") from e
 
-    invoice_url = finalized.get("hosted_invoice_url")
-    await db_supabase.update_ride(
-        ride_id,
-        {
-            "stripe_invoice_id": invoice.id,
-            "invoice_url": invoice_url,
-            "invoice_sent_at": datetime.now(timezone.utc).isoformat(),
-        },
-    )
+    invoice_url = getattr(finalized, "hosted_invoice_url", None)
+    try:
+        await db_supabase.update_ride(
+            ride_id,
+            {
+                "stripe_invoice_id": invoice.id,
+                "invoice_url": invoice_url,
+                "invoice_sent_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except Exception as db_err:
+        # The Stripe invoice is live and the rider will be emailed. Log at
+        # ERROR so ops can manually reconcile the sentinel vs the real invoice id.
+        logger.error(
+            "admin_send_payable_invoice: Stripe invoice %s created for ride %s but "
+            "DB update failed — sentinel may persist; check rides.stripe_invoice_id. err=%s",
+            invoice.id,
+            ride_id,
+            db_err,
+            exc_info=True,
+            extra={"domain": "payments", "ride_id": ride_id},
+        )
     await log_admin_action(
         admin_user,
         "send_ride_invoice",

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3642,9 +3642,15 @@ async def process_payment(
     # We never unblock by age here — a stuck claim is recovered admin-side (which
     # creates invoices crash-safely), not by silently re-opening in-app charging.
     if ride.get("stripe_invoice_id"):
+        # Structured code so the rider app shows the "pay via emailed invoice"
+        # instruction instead of the generic Change Card/Support alert (which would
+        # just loop back into this same guard on every retry).
         raise HTTPException(
             status_code=409,
-            detail="An invoice has been issued for this ride. Please pay using the link in your email.",
+            detail={
+                "code": "invoice_issued",
+                "message": "An invoice has been emailed for this ride. Please pay using the link in your email.",
+            },
         )
 
     # Validate the tip BEFORE the atomic claim — raising after the claim would

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3583,31 +3583,6 @@ def _record_settlement_metrics(payment_method: str, result, duration_ms: float) 
     _metric_observe("spinr_payment_settlement_duration_ms", duration_ms, {"method": method})
 
 
-# Mirrors admin/rides.py + utils/payment_retry.py. A `pending:<epoch>:<uuid>`
-# value in rides.stripe_invoice_id is a transient invoice-creation CAS claim; a
-# claim older than this window is abandoned (the request crashed before Stripe
-# created the invoice) and must NOT block an in-app charge.
-_INVOICE_CLAIM_STALE_SECONDS = 300
-
-
-def _is_stale_invoice_claim(sentinel: str) -> bool:
-    """True only for an ABANDONED `pending:<epoch>:<uuid>` invoice claim.
-
-    A finalized invoice id (in_*) or a legacy `pending:<uuid>` (no timestamp)
-    returns False — i.e. it still blocks in-app payment."""
-    s = str(sentinel)
-    if not s.startswith("pending:"):
-        return False
-    try:
-        parts = s.split(":")
-        if len(parts) < 3:
-            return False
-        age = (datetime.now(timezone.utc) - datetime.fromtimestamp(float(parts[1]), tz=timezone.utc)).total_seconds()
-        return age >= _INVOICE_CLAIM_STALE_SECONDS
-    except (ValueError, OverflowError, OSError):
-        return False
-
-
 @api_router.post("/{ride_id}/process-payment")
 @payment_action_limit
 async def process_payment(
@@ -3658,18 +3633,18 @@ async def process_payment(
         logger.info(f"[PAYMENT] Ride {ride_id} processing ({_pmethod}) — skipping duplicate charge")
         return {"success": True, "charged_amount": _charged(ride), "already_paid": True}
 
-    # An admin has emailed a payable Stripe invoice for this ride — collection
-    # has moved to the hosted invoice (settled by the invoice.paid webhook).
-    # Charging in-app now would collect a second time alongside the invoice, and
-    # the later invoice.paid would see the ride already paid and skip (no refund
-    # of the extra). Block and point the rider at the emailed link. A finalized
-    # invoice (in_*) always blocks; a fresh 'pending:' creation claim blocks too;
-    # a stale/abandoned 'pending:' claim does not (the invoice was never created).
-    _inv_sid = ride.get("stripe_invoice_id")
-    if _inv_sid and not _is_stale_invoice_claim(_inv_sid):
+    # An admin has emailed (or is creating) a payable Stripe invoice for this
+    # ride — collection has moved to the hosted invoice (settled by the
+    # invoice.paid webhook). Charging in-app while ANY invoice claim is on the
+    # row would collect a second time, and the later invoice.paid would see the
+    # ride already paid and skip (no refund of the extra). Block on any non-null
+    # value: a finalized invoice (in_*) and a 'pending:' creation claim alike.
+    # We never unblock by age here — a stuck claim is recovered admin-side (which
+    # creates invoices crash-safely), not by silently re-opening in-app charging.
+    if ride.get("stripe_invoice_id"):
         raise HTTPException(
             status_code=409,
-            detail="An invoice has been emailed for this ride. Please pay using the link in that email.",
+            detail="An invoice has been issued for this ride. Please pay using the link in your email.",
         )
 
     # Validate the tip BEFORE the atomic claim — raising after the claim would
@@ -3716,7 +3691,11 @@ async def process_payment(
         _claim_states.append("processing")  # only added after the lock is held
     guard_row = await db_supabase.update_one(
         "rides",
-        {"id": ride_id, "payment_status": {"$in": _claim_states}},
+        # stripe_invoice_id=NULL is asserted atomically (mirrors admin send-invoice
+        # asserting payment_status NOT IN processing/paid/...): if an admin claimed
+        # the ride for an invoice between our pre-read invoice-guard above and this
+        # claim, 0 rows match and the rider is not charged in-app alongside it.
+        {"id": ride_id, "payment_status": {"$in": _claim_states}, "stripe_invoice_id": None},
         {
             "payment_status": "processing",
             "updated_at": datetime.now(timezone.utc).isoformat(),

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3583,6 +3583,31 @@ def _record_settlement_metrics(payment_method: str, result, duration_ms: float) 
     _metric_observe("spinr_payment_settlement_duration_ms", duration_ms, {"method": method})
 
 
+# Mirrors admin/rides.py + utils/payment_retry.py. A `pending:<epoch>:<uuid>`
+# value in rides.stripe_invoice_id is a transient invoice-creation CAS claim; a
+# claim older than this window is abandoned (the request crashed before Stripe
+# created the invoice) and must NOT block an in-app charge.
+_INVOICE_CLAIM_STALE_SECONDS = 300
+
+
+def _is_stale_invoice_claim(sentinel: str) -> bool:
+    """True only for an ABANDONED `pending:<epoch>:<uuid>` invoice claim.
+
+    A finalized invoice id (in_*) or a legacy `pending:<uuid>` (no timestamp)
+    returns False — i.e. it still blocks in-app payment."""
+    s = str(sentinel)
+    if not s.startswith("pending:"):
+        return False
+    try:
+        parts = s.split(":")
+        if len(parts) < 3:
+            return False
+        age = (datetime.now(timezone.utc) - datetime.fromtimestamp(float(parts[1]), tz=timezone.utc)).total_seconds()
+        return age >= _INVOICE_CLAIM_STALE_SECONDS
+    except (ValueError, OverflowError, OSError):
+        return False
+
+
 @api_router.post("/{ride_id}/process-payment")
 @payment_action_limit
 async def process_payment(
@@ -3632,6 +3657,20 @@ async def process_payment(
     if _pstatus == "processing" and _pmethod != "wallet":
         logger.info(f"[PAYMENT] Ride {ride_id} processing ({_pmethod}) — skipping duplicate charge")
         return {"success": True, "charged_amount": _charged(ride), "already_paid": True}
+
+    # An admin has emailed a payable Stripe invoice for this ride — collection
+    # has moved to the hosted invoice (settled by the invoice.paid webhook).
+    # Charging in-app now would collect a second time alongside the invoice, and
+    # the later invoice.paid would see the ride already paid and skip (no refund
+    # of the extra). Block and point the rider at the emailed link. A finalized
+    # invoice (in_*) always blocks; a fresh 'pending:' creation claim blocks too;
+    # a stale/abandoned 'pending:' claim does not (the invoice was never created).
+    _inv_sid = ride.get("stripe_invoice_id")
+    if _inv_sid and not _is_stale_invoice_claim(_inv_sid):
+        raise HTTPException(
+            status_code=409,
+            detail="An invoice has been emailed for this ride. Please pay using the link in that email.",
+        )
 
     # Validate the tip BEFORE the atomic claim — raising after the claim would
     # leave payment_status stuck at 'processing' with no charge ever attempted.

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -3564,6 +3564,10 @@ async def add_tip(
 
 class ProcessPaymentRequest(BaseModel):
     tip_amount: Decimal = Field(default=Decimal("0"), ge=0, le=500)
+    # In-app "Change Card" escape: when set, charge THIS card (fresh charge on
+    # a card the rider picked after a decline / no-card failure) instead of the
+    # booking-time card or hold. Card rides only; ignored for wallet/corporate.
+    payment_method_id: Optional[str] = None
 
 
 def _record_settlement_metrics(payment_method: str, result, duration_ms: float) -> None:
@@ -3747,7 +3751,14 @@ async def process_payment(
     elif payment_method == "company_allowance":
         result = await settle_corporate(ride, ride_id, total_charge, tip_rounded)
     else:
-        result = await settle_card(ride, ride_id, current_user["id"], total_charge, tip_rounded)
+        result = await settle_card(
+            ride,
+            ride_id,
+            current_user["id"],
+            total_charge,
+            tip_rounded,
+            payment_method_id_override=req.payment_method_id,
+        )
 
     _record_settlement_metrics(payment_method, result, (_time_mod.monotonic() - _settle_started) * 1000.0)
 

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -143,7 +143,10 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str, 
         )
         raise HTTPException(status_code=500, detail="Ride not found for paid invoice — Stripe will retry")
     _pstatus = ride.get("payment_status")
-    if _pstatus in ("paid", "waived_admin"):
+    # 'refunded' is terminal too: if charge.refunded marked the ride refunded
+    # before a delayed invoice.paid lands, re-settling here would append another
+    # ledger row and flip payment_status back to 'paid', erasing the refund.
+    if _pstatus in ("paid", "waived_admin", "refunded"):
         logger.info(
             "invoice.paid: ride %s already settled (%s) — skipping",
             ride_id,

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -941,6 +941,15 @@ async def stripe_webhook(request: Request):
         invoice = data_object
         _ride_invoice_id = (invoice.get("metadata") or {}).get("ride_id")
         stripe_sub_id = invoice.get("subscription")
+        if not _ride_invoice_id and not stripe_sub_id:
+            # A ride invoice whose metadata.ride_id was stripped/lost still settles:
+            # recover the ride by the persisted stripe_invoice_id (migration 177
+            # indexes it) before treating this as a non-ride invoice and dropping it.
+            _inv_id = invoice.get("id")
+            if _inv_id:
+                _by_inv = await db_supabase.find_one("rides", {"stripe_invoice_id": _inv_id})
+                if _by_inv:
+                    _ride_invoice_id = _by_inv.get("id")
         if _ride_invoice_id:
             # Payable ride invoice (admin "Send Invoice" remediation for a card
             # rejected at trip end). Settle the ride + credit the driver; the

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -62,7 +62,64 @@ _STRIPE_HANDLED_EVENTS = frozenset(
 ALLOWED_STRIPE_EVENTS = _STRIPE_HANDLED_EVENTS
 
 
-async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) -> None:
+def _extract_invoice_payment_intent(invoice: dict, stripe_secret: str = "") -> str | None:
+    """Resolve the PaymentIntent id for a paid invoice across Stripe API versions.
+
+    Under the pinned API version (2025-04-30.basil) the top-level
+    ``invoice.payment_intent`` field is removed — the PI now lives under
+    ``invoice.payments.data[].payment.payment_intent``. We MUST persist this id
+    so later charge.refunded / dispute webhooks (which look rides up by
+    payment_intent_id) can find the ride. Tries, in order:
+      1. legacy top-level ``payment_intent`` (pre-Basil / expanded)
+      2. the Basil ``payments.data[].payment.payment_intent`` shape
+      3. a fresh ``Invoice.retrieve(expand=['payments'])`` (webhook payloads do
+         not expand ``payments`` by default)
+    Returns None only if all three fail (logged by the caller).
+    """
+
+    def _pi_id(val) -> str | None:
+        if not val:
+            return None
+        return val if isinstance(val, str) else (val.get("id") if isinstance(val, dict) else None)
+
+    def _from_payload(inv: dict) -> str | None:
+        pi = _pi_id(inv.get("payment_intent"))
+        if pi:
+            return pi
+        payments = inv.get("payments")
+        data = payments.get("data") if isinstance(payments, dict) else None
+        for entry in data or []:
+            payment = (entry or {}).get("payment") or {}
+            pi = _pi_id(payment.get("payment_intent"))
+            if pi:
+                return pi
+        return None
+
+    pi = _from_payload(invoice)
+    if pi:
+        return pi
+
+    invoice_id = invoice.get("id")
+    if not (invoice_id and stripe_secret):
+        return None
+    try:
+        import stripe as _stripe
+
+        refreshed = _stripe.Invoice.retrieve(invoice_id, expand=["payments"], api_key=stripe_secret)
+        # stripe-python returns a typed object; normalize to a plain dict.
+        as_dict = refreshed.to_dict_recursive() if hasattr(refreshed, "to_dict_recursive") else dict(refreshed)
+        return _from_payload(as_dict)
+    except Exception:
+        logger.error(
+            "invoice.paid: could not retrieve invoice %s to resolve payment_intent",
+            invoice_id,
+            exc_info=True,
+            extra={"domain": "payments"},
+        )
+        return None
+
+
+async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str, stripe_secret: str = "") -> None:
     """Settle a ride paid via an admin-sent payable Stripe Invoice.
 
     Mirrors settle_card's success bookkeeping (financial_events ledger row +
@@ -72,13 +129,19 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) 
     """
     ride = await db_supabase.get_ride(ride_id)
     if not ride:
+        # The rider's invoice payment succeeded but the ride row is unreadable
+        # (transient DB failure, or a genuinely missing ride). Do NOT ack the
+        # event — raise so processed_at stays NULL and the stuck-event
+        # reconciliation path surfaces it (webhooks dispatch contract). Silently
+        # returning here would take the rider's money while leaving the ride
+        # unpaid and the driver uncredited.
         logger.error(
-            "invoice.paid for unknown ride %s (invoice %s)",
+            "invoice.paid for unknown ride %s (invoice %s) — not acking; reconcile required",
             ride_id,
             invoice.get("id"),
             extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
         )
-        return
+        raise HTTPException(status_code=500, detail="Ride not found for paid invoice — Stripe will retry")
     _pstatus = ride.get("payment_status")
     if _pstatus in ("paid", "waived_admin"):
         logger.info(
@@ -107,7 +170,17 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) 
     amount_cents = invoice.get("amount_paid")
     if amount_cents is None:
         amount_cents = invoice.get("amount_due") or 0
-    payment_intent_id = invoice.get("payment_intent")
+    payment_intent_id = _extract_invoice_payment_intent(invoice, stripe_secret)
+    if not payment_intent_id:
+        # No PI means later refund/dispute webhooks (keyed on payment_intent_id)
+        # cannot find this ride. Surface loudly rather than writing a half-record.
+        logger.error(
+            "invoice.paid: could not resolve payment_intent for ride %s (invoice %s) — "
+            "refund/dispute lookups will fail",
+            ride_id,
+            invoice.get("id"),
+            extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
+        )
     tip_amount = Decimal(str(ride.get("tip_amount") or 0))
 
     try:
@@ -862,7 +935,7 @@ async def stripe_webhook(request: Request):
             # Payable ride invoice (admin "Send Invoice" remediation for a card
             # rejected at trip end). Settle the ride + credit the driver; the
             # subscription path below is untouched.
-            await _handle_ride_invoice_paid(invoice, _ride_invoice_id, event_id)
+            await _handle_ride_invoice_paid(invoice, _ride_invoice_id, event_id, stripe_secret)
         elif not stripe_sub_id:
             logger.info(
                 "invoice.paid without subscription id — skipping",

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -79,11 +79,26 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) 
             extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
         )
         return
-    if ride.get("payment_status") in ("paid", "waived_admin"):
+    _pstatus = ride.get("payment_status")
+    if _pstatus in ("paid", "waived_admin"):
         logger.info(
             "invoice.paid: ride %s already settled (%s) — skipping",
             ride_id,
-            ride.get("payment_status"),
+            _pstatus,
+            extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
+        )
+        return
+    if _pstatus == "processing":
+        # An in-app settlement holds the atomic 'processing' claim (or a card
+        # charge was captured-but-unconfirmed). Settling the invoice here too
+        # would double-credit the driver and double-write the ledger. Skip and
+        # let the in-app finalize / Stripe reconcile decide the truth. ERROR so
+        # the concurrent-charge anomaly surfaces (the invoice may have collected
+        # alongside an in-app charge — a refund may be owed).
+        logger.error(
+            "invoice.paid for ride %s while payment_status='processing' — possible "
+            "concurrent in-app charge; skipping invoice settlement, reconcile required",
+            ride_id,
             extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
         )
         return
@@ -142,10 +157,15 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) 
             )
         except Exception:
             logger.warning("invoice.paid: WS payment_completed push failed", exc_info=True)
+        # Re-fetch so the receipt reflects the just-written paid status / PI /
+        # invoice id rather than the pre-update snapshot. The receipt is the
+        # rider's tax document — a send failure is logged at ERROR (it may hide
+        # a broken email pipeline), not swallowed at warning.
+        updated_ride = await db_supabase.get_ride(ride_id) or ride
         try:
-            await send_ride_receipt(ride, rider_id, tip_amount)
+            await send_ride_receipt(updated_ride, rider_id, tip_amount)
         except Exception:
-            logger.warning("invoice.paid: receipt email failed", exc_info=True)
+            logger.error("invoice.paid: receipt email failed for ride %s", ride_id, exc_info=True)
 
 
 def _invoice_period_end_iso(invoice: dict) -> str | None:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -154,17 +154,20 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str, 
     if _pstatus == "processing":
         # An in-app settlement holds the atomic 'processing' claim (or a card
         # charge was captured-but-unconfirmed). Settling the invoice here too
-        # would double-credit the driver and double-write the ledger. Skip and
-        # let the in-app finalize / Stripe reconcile decide the truth. ERROR so
-        # the concurrent-charge anomaly surfaces (the invoice may have collected
-        # alongside an in-app charge — a refund may be owed).
+        # would double-credit the driver and double-write the ledger. Do NOT ack
+        # the event: a bare return would stamp processed_at and permanently drop
+        # this paid invoice (driver never credited) if the in-app charge later
+        # fails. Raise so processed_at stays NULL — once the 'processing' claim
+        # resolves (→ paid: idempotent skip; → failed: invoice settles) a replay
+        # settles correctly. ERROR so the concurrent-charge anomaly surfaces (a
+        # refund may be owed if the in-app charge also collected).
         logger.error(
             "invoice.paid for ride %s while payment_status='processing' — possible "
-            "concurrent in-app charge; skipping invoice settlement, reconcile required",
+            "concurrent in-app charge; deferring invoice settlement, reconcile required",
             ride_id,
             extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
         )
-        return
+        raise HTTPException(status_code=500, detail="Ride payment is processing — deferring invoice settlement")
 
     rider_id = ride.get("rider_id")
     amount_cents = invoice.get("amount_paid")

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -173,14 +173,18 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str, 
     payment_intent_id = _extract_invoice_payment_intent(invoice, stripe_secret)
     if not payment_intent_id:
         # No PI means later refund/dispute webhooks (keyed on payment_intent_id)
-        # cannot find this ride. Surface loudly rather than writing a half-record.
+        # cannot find this ride. This is usually a transient Stripe-retrieve
+        # failure in the expand fallback. Do NOT write a half-settled ride
+        # (payment_status=paid with payment_intent_id=NULL); raise so the event
+        # is not acked (processed_at stays NULL) and the retry/reconciliation
+        # path re-resolves the PI. Matches the missing-ride contract above.
         logger.error(
-            "invoice.paid: could not resolve payment_intent for ride %s (invoice %s) — "
-            "refund/dispute lookups will fail",
+            "invoice.paid: could not resolve payment_intent for ride %s (invoice %s) — not settling; Stripe will retry",
             ride_id,
             invoice.get("id"),
             extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
         )
+        raise HTTPException(status_code=500, detail="Could not resolve invoice payment_intent — Stripe will retry")
     tip_amount = Decimal(str(ride.get("tip_amount") or 0))
 
     try:

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -111,9 +111,9 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) 
     tip_amount = Decimal(str(ride.get("tip_amount") or 0))
 
     try:
-        from ..services.payment_service import record_payment_event, send_ride_receipt
+        from ..services.payment_service import _tip_ride_update, record_payment_event, send_ride_receipt
     except ImportError:
-        from services.payment_service import record_payment_event, send_ride_receipt  # type: ignore
+        from services.payment_service import _tip_ride_update, record_payment_event, send_ride_receipt  # type: ignore
 
     # Ledger first (recovery record exists even if the ride update fails).
     await record_payment_event(
@@ -131,6 +131,9 @@ async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) 
             "payment_intent_id": payment_intent_id,
             "stripe_invoice_id": invoice.get("id"),
             "updated_at": datetime.now(timezone.utc).isoformat(),
+            # Mirror settle_card: apply tip delta so driver_earnings reflects any
+            # tip that was captured before the original card decline.
+            **_tip_ride_update(ride, tip_amount),
         },
     )
     logger.info(

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -62,6 +62,92 @@ _STRIPE_HANDLED_EVENTS = frozenset(
 ALLOWED_STRIPE_EVENTS = _STRIPE_HANDLED_EVENTS
 
 
+async def _handle_ride_invoice_paid(invoice: dict, ride_id: str, event_id: str) -> None:
+    """Settle a ride paid via an admin-sent payable Stripe Invoice.
+
+    Mirrors settle_card's success bookkeeping (financial_events ledger row +
+    payment_status='paid' + WS push + receipt) so the driver is credited the
+    same way as an in-app charge. Idempotent: a ride already paid/waived is a
+    no-op, so a duplicate or replayed invoice.paid never double-credits.
+    """
+    ride = await db_supabase.get_ride(ride_id)
+    if not ride:
+        logger.error(
+            "invoice.paid for unknown ride %s (invoice %s)",
+            ride_id,
+            invoice.get("id"),
+            extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
+        )
+        return
+    if ride.get("payment_status") in ("paid", "waived_admin"):
+        logger.info(
+            "invoice.paid: ride %s already settled (%s) — skipping",
+            ride_id,
+            ride.get("payment_status"),
+            extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
+        )
+        return
+
+    rider_id = ride.get("rider_id")
+    amount_cents = invoice.get("amount_paid")
+    if amount_cents is None:
+        amount_cents = invoice.get("amount_due") or 0
+    payment_intent_id = invoice.get("payment_intent")
+    tip_amount = Decimal(str(ride.get("tip_amount") or 0))
+
+    try:
+        from ..services.payment_service import record_payment_event, send_ride_receipt
+    except ImportError:
+        from services.payment_service import record_payment_event, send_ride_receipt  # type: ignore
+
+    # Ledger first (recovery record exists even if the ride update fails).
+    await record_payment_event(
+        ride_id=ride_id,
+        user_id=rider_id,
+        amount_cents=int(amount_cents),
+        payment_intent_id=payment_intent_id,
+        ride=ride,
+        tip_amount=tip_amount,
+    )
+    await db_supabase.update_ride(
+        ride_id,
+        {
+            "payment_status": "paid",
+            "payment_intent_id": payment_intent_id,
+            "stripe_invoice_id": invoice.get("id"),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
+    logger.info(
+        "Ride %s settled via Stripe invoice %s",
+        ride_id,
+        invoice.get("id"),
+        extra={"domain": "payments", "ride_id": ride_id, "event_id": event_id},
+    )
+
+    # Best-effort: nudge the rider's app out of the stuck payment screen.
+    if rider_id:
+        try:
+            from ..socket_manager import manager as _manager
+        except ImportError:
+            from socket_manager import manager as _manager  # type: ignore
+        try:
+            await _manager.send_personal_message(
+                {
+                    "type": "payment_completed",
+                    "ride_id": ride_id,
+                    "charged_amount": str(cents_to_dollars(int(amount_cents))),
+                },
+                f"rider_{rider_id}",
+            )
+        except Exception:
+            logger.warning("invoice.paid: WS payment_completed push failed", exc_info=True)
+        try:
+            await send_ride_receipt(ride, rider_id, tip_amount)
+        except Exception:
+            logger.warning("invoice.paid: receipt email failed", exc_info=True)
+
+
 def _invoice_period_end_iso(invoice: dict) -> str | None:
     """Extract the billing-period end (ISO UTC) from a Stripe Invoice.
 
@@ -747,8 +833,14 @@ async def stripe_webhook(request: Request):
         # invoice's period end — idempotent for both subscription_create and
         # subscription_cycle.
         invoice = data_object
+        _ride_invoice_id = (invoice.get("metadata") or {}).get("ride_id")
         stripe_sub_id = invoice.get("subscription")
-        if not stripe_sub_id:
+        if _ride_invoice_id:
+            # Payable ride invoice (admin "Send Invoice" remediation for a card
+            # rejected at trip end). Settle the ride + credit the driver; the
+            # subscription path below is untouched.
+            await _handle_ride_invoice_paid(invoice, _ride_invoice_id, event_id)
+        elif not stripe_sub_id:
             logger.info(
                 "invoice.paid without subscription id — skipping",
                 extra={"domain": "drivers", "event_id": event_id},

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -539,49 +539,66 @@ async def settle_card(
     rider_id: str,
     total_charge: Decimal,
     tip_amount: Decimal,
+    payment_method_id_override: Optional[str] = None,
 ) -> PaymentResult:
     """Charge rider's card via Stripe.
 
     Prefers capturing a booking-time pre-authorization hold (one Stripe fee,
     lets a within-buffer tip ride on the same PaymentIntent). Falls back to a
     fresh charge when there is no usable hold or the hold could not be captured.
+
+    ``payment_method_id_override`` is the in-app "Change Card" escape: when the
+    booking-time card was declined (or none was on file), the rider picks a
+    different card and we charge THAT card with a fresh PaymentIntent — never
+    the booking-time hold, which sits on the rejected card.
     """
     rider_user = await db_supabase.get_user_by_id(rider_id)
     stripe_customer_id = (rider_user or {}).get("stripe_customer_id")
-    payment_method_id = ride.get("payment_method_id") or (rider_user or {}).get("default_payment_method")
 
-    # Settle against a pre-authorized hold when one is open. ``auth_status``
-    # distinguishes a manual-capture hold from a prior 3DS auto-capture PI that
-    # also lives in ``payment_intent_id`` — only the former is captured here.
-    held_pi = ride.get("payment_intent_id")
-    auth_status = (ride.get("auth_status") or "").lower()
-    authorized = _round(_d(ride.get("authorized_amount") or 0))
-    # Default fresh-charge confirm target: a stored PI is only reused for the
-    # 3DS-retry case (no open hold). After an unusable hold we must NOT reconfirm
-    # the dead hold PI — pass None so charge_ride creates a fresh PaymentIntent.
-    confirm_pi = held_pi
-    if held_pi and auth_status in ("authorized", "fare_only") and authorized > 0:
-        held_result = await _settle_against_hold(
-            ride,
-            ride_id,
-            rider_id,
-            total_charge,
-            tip_amount,
-            held_pi=held_pi,
-            authorized=authorized,
-            stripe_customer_id=stripe_customer_id,
-            payment_method_id=payment_method_id,
-        )
-        if held_result is not None:
-            return held_result
-        confirm_pi = None  # hold unusable → fresh charge, not a reconfirm
+    if payment_method_id_override:
+        # Rider explicitly chose a different card. Skip the hold path entirely
+        # (the hold is on the old, rejected card) and always do a fresh charge.
+        payment_method_id = payment_method_id_override
+        confirm_pi = None
+    else:
+        payment_method_id = ride.get("payment_method_id") or (rider_user or {}).get("default_payment_method")
+
+        # Settle against a pre-authorized hold when one is open. ``auth_status``
+        # distinguishes a manual-capture hold from a prior 3DS auto-capture PI that
+        # also lives in ``payment_intent_id`` — only the former is captured here.
+        held_pi = ride.get("payment_intent_id")
+        auth_status = (ride.get("auth_status") or "").lower()
+        authorized = _round(_d(ride.get("authorized_amount") or 0))
+        # Default fresh-charge confirm target: a stored PI is only reused for the
+        # 3DS-retry case (no open hold). After an unusable hold we must NOT reconfirm
+        # the dead hold PI — pass None so charge_ride creates a fresh PaymentIntent.
+        confirm_pi = held_pi
+        if held_pi and auth_status in ("authorized", "fare_only") and authorized > 0:
+            held_result = await _settle_against_hold(
+                ride,
+                ride_id,
+                rider_id,
+                total_charge,
+                tip_amount,
+                held_pi=held_pi,
+                authorized=authorized,
+                stripe_customer_id=stripe_customer_id,
+                payment_method_id=payment_method_id,
+            )
+            if held_result is not None:
+                return held_result
+            confirm_pi = None  # hold unusable → fresh charge, not a reconfirm
 
     if not payment_method_id:
         await db_supabase.update_ride(ride_id, {"payment_status": "pending"})
+        # Structured code (was a bare 400) so the rider app can surface the
+        # Change Card / Add Card escape instead of a dead-end "Payment error".
         return PaymentResult(
             success=False,
+            error_code="no_payment_method",
             error="No payment method on file. Please add a card.",
-            status_code=400,
+            status_code=402,
+            extra={"suggested_action": "change_card"},
         )
 
     outcome = await charge_ride(
@@ -611,6 +628,9 @@ async def settle_card(
                     "payment_status": "paid",
                     "payment_intent_id": outcome.payment_intent_id,
                     "updated_at": datetime.now(timezone.utc).isoformat(),
+                    # Re-point the ride to the card actually charged so a later
+                    # retry/receipt reflects the new card, not the rejected one.
+                    **({"payment_method_id": payment_method_id} if payment_method_id_override else {}),
                     **_tip_ride_update(ride, tip_amount),
                 },
             )

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -630,7 +630,14 @@ async def settle_card(
                     "updated_at": datetime.now(timezone.utc).isoformat(),
                     # Re-point the ride to the card actually charged so a later
                     # retry/receipt reflects the new card, not the rejected one.
-                    **({"payment_method_id": payment_method_id} if payment_method_id_override else {}),
+                    # Also clear the cached card brand/last4 from the old (declined)
+                    # card so the admin ride-detail resolver re-derives them from
+                    # the new PaymentIntent instead of showing the rejected card.
+                    **(
+                        {"payment_method_id": payment_method_id, "card_brand": None, "card_last4": None}
+                        if payment_method_id_override
+                        else {}
+                    ),
                     **_tip_ride_update(ride, tip_amount),
                 },
             )

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -18,7 +18,7 @@ try:
     from ..services import corporate_allowance_service, corporate_wallet_service
     from ..services.corporate_policy_service import evaluate_policy
     from ..socket_manager import manager
-    from ..utils.stripe_charge import capture_ride, charge_ride
+    from ..utils.stripe_charge import cancel_authorization, capture_ride, charge_ride
 except ImportError:
     import db_supabase  # type: ignore
     from services import corporate_allowance_service, corporate_wallet_service  # type: ignore
@@ -555,11 +555,20 @@ async def settle_card(
     rider_user = await db_supabase.get_user_by_id(rider_id)
     stripe_customer_id = (rider_user or {}).get("stripe_customer_id")
 
+    override_hold_released = False
     if payment_method_id_override:
         # Rider explicitly chose a different card. Skip the hold path entirely
         # (the hold is on the old, rejected card) and always do a fresh charge.
         payment_method_id = payment_method_id_override
         confirm_pi = None
+        # Release the old card's uncaptured pre-auth hold so the rider's funds
+        # aren't reserved on the rejected card until Stripe's ~7-day auth expiry
+        # while the new card is charged. Best-effort; we only mark the hold
+        # 'released' in the DB if Stripe confirms the cancel.
+        _old_hold_pi = ride.get("payment_intent_id")
+        _old_auth = (ride.get("auth_status") or "").lower()
+        if _old_hold_pi and _old_auth in ("authorized", "fare_only"):
+            override_hold_released = await cancel_authorization(ride_id=ride_id, payment_intent_id=_old_hold_pi)
     else:
         payment_method_id = ride.get("payment_method_id") or (rider_user or {}).get("default_payment_method")
 
@@ -638,6 +647,9 @@ async def settle_card(
                         if payment_method_id_override
                         else {}
                     ),
+                    # Record the old hold as released only when Stripe confirmed the
+                    # cancel, so auth_status reflects reality.
+                    **({"auth_status": "released"} if override_hold_released else {}),
                     **_tip_ride_update(ride, tip_amount),
                 },
             )

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -556,19 +556,20 @@ async def settle_card(
     stripe_customer_id = (rider_user or {}).get("stripe_customer_id")
 
     override_hold_released = False
+    override_hold_pi_to_release: Optional[str] = None
     if payment_method_id_override:
         # Rider explicitly chose a different card. Skip the hold path entirely
         # (the hold is on the old, rejected card) and always do a fresh charge.
         payment_method_id = payment_method_id_override
         confirm_pi = None
-        # Release the old card's uncaptured pre-auth hold so the rider's funds
-        # aren't reserved on the rejected card until Stripe's ~7-day auth expiry
-        # while the new card is charged. Best-effort; we only mark the hold
-        # 'released' in the DB if Stripe confirms the cancel.
+        # DEFER releasing the old card's hold until the new card actually charges
+        # (Codex P1): cancelling the guaranteed authorization up front would lose
+        # collectable fare if the new card then declines. We record the hold here
+        # and release it in the success path only.
         _old_hold_pi = ride.get("payment_intent_id")
         _old_auth = (ride.get("auth_status") or "").lower()
         if _old_hold_pi and _old_auth in ("authorized", "fare_only"):
-            override_hold_released = await cancel_authorization(ride_id=ride_id, payment_intent_id=_old_hold_pi)
+            override_hold_pi_to_release = _old_hold_pi
     else:
         payment_method_id = ride.get("payment_method_id") or (rider_user or {}).get("default_payment_method")
 
@@ -622,6 +623,14 @@ async def settle_card(
     )
 
     if outcome.status == "succeeded":
+        # New card charged successfully — NOW it's safe to release the old card's
+        # hold (deferred from the override branch so a decline couldn't have lost
+        # the guaranteed authorization). Best-effort; only mark 'released' in the
+        # DB if Stripe confirms the cancel.
+        if override_hold_pi_to_release:
+            override_hold_released = await cancel_authorization(
+                ride_id=ride_id, payment_intent_id=override_hold_pi_to_release
+            )
         await record_payment_event(
             ride_id=ride_id,
             user_id=rider_id,

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -352,6 +352,66 @@ class TestAdminSendPayableInvoice:
         final = update_ride_mock.await_args.args[1]
         assert final["stripe_invoice_id"] == "in_new_1"
 
+    def test_fresh_pending_sentinel_blocks_but_stale_reclaims(self):
+        """Codex P2 (62i9): a fresh `pending:` claim 409s (concurrent creation),
+        but a stale one (crashed request) is reclaimed via the CAS instead of
+        blocking the ride forever."""
+        from datetime import timedelta
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+
+        from backend.routes.admin import rides as admin_rides
+
+        rider = {"id": RIDER_ID, "email": "rider@spinr.ca", "stripe_customer_id": "cus_1"}
+
+        # Fresh sentinel → 409, no Stripe calls.
+        fresh_ts = datetime.now(timezone.utc).timestamp()
+        fresh_ride = _ride("completed", payment_status="failed", stripe_invoice_id=f"pending:{fresh_ts}:u1")
+        with (
+            patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=fresh_ride)),
+            patch("backend.routes.admin.rides.db_supabase.get_user_by_id", AsyncMock(return_value=rider)),
+            patch("backend.routes.admin.rides.get_app_settings", self._settings()),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    admin_rides.admin_send_payable_invoice(
+                        request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER
+                    )
+                )
+        assert exc.value.status_code == 409
+
+        # Stale sentinel (10 min old) → reclaimed; a new invoice is created.
+        stale_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp()
+        stale_ride = _ride(
+            "completed", payment_status="failed", stripe_invoice_id=f"pending:{stale_ts}:u1", grand_total="18.50"
+        )
+
+        async def _run_sync(fn):
+            return fn()
+
+        inv = MagicMock(id="in_reclaim_1")
+        fin = MagicMock()
+        fin.hosted_invoice_url = "https://pay.stripe/reclaim"
+        with (
+            patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=stale_ride)),
+            patch("backend.routes.admin.rides.db_supabase.get_user_by_id", AsyncMock(return_value=rider)),
+            patch("backend.routes.admin.rides.get_app_settings", self._settings()),
+            patch("backend.routes.admin.rides.db_supabase.update_one", AsyncMock(return_value={"id": RIDE_ID})),
+            patch("backend.routes.admin.rides.db_supabase.update_ride", AsyncMock()),
+            patch("backend.routes.admin.rides.db_supabase.run_sync", _run_sync),
+            patch("backend.routes.admin.rides.log_admin_action", AsyncMock()),
+            patch("stripe.Invoice.create", MagicMock(return_value=inv)),
+            patch("stripe.InvoiceItem.create", MagicMock(return_value=MagicMock())),
+            patch("stripe.Invoice.finalize_invoice", MagicMock(return_value=fin)),
+            patch("stripe.Invoice.send_invoice", MagicMock(return_value=MagicMock())),
+        ):
+            result = asyncio.run(
+                admin_rides.admin_send_payable_invoice(request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER)
+            )
+        assert result["sent"] is True
+        assert result["stripe_invoice_id"] == "in_reclaim_1"
+
 
 class TestAdminGetEarnings:
     def test_returns_earnings_summary(self):

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -262,6 +262,86 @@ class TestAdminCompleteRide:
         assert exc.value.status_code == 400
 
 
+class TestAdminSendPayableInvoice:
+    """POST /admin/rides/{id}/send-invoice — Codex P2 guards."""
+
+    def _settings(self):
+        return AsyncMock(return_value={"stripe_secret_key": "sk_test"})
+
+    def test_rejects_refunded_ride(self):
+        """A refunded ride is terminal — re-invoicing would re-collect a refund."""
+        from fastapi import HTTPException
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="refunded")
+        with patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(admin_rides.admin_send_payable_invoice(ride_id=RIDE_ID, admin_user=ADMIN_USER))
+        assert exc.value.status_code == 409
+        assert "terminal" in str(exc.value.detail).lower()
+
+    def test_concurrent_claim_returns_409(self):
+        """When the atomic CAS claim loses (another request is mid-creation),
+        the endpoint 409s instead of creating a duplicate invoice."""
+        from fastapi import HTTPException
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="failed", stripe_invoice_id=None)
+        rider = {"id": RIDER_ID, "email": "rider@spinr.ca", "stripe_customer_id": "cus_1"}
+
+        with (
+            patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)),
+            patch("backend.routes.admin.rides.db_supabase.get_user_by_id", AsyncMock(return_value=rider)),
+            patch("backend.routes.admin.rides.get_app_settings", self._settings()),
+            # CAS claim loses → update_one returns None.
+            patch("backend.routes.admin.rides.db_supabase.update_one", AsyncMock(return_value=None)),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(admin_rides.admin_send_payable_invoice(ride_id=RIDE_ID, admin_user=ADMIN_USER))
+        assert exc.value.status_code == 409
+        assert "already being created" in str(exc.value.detail).lower()
+
+    def test_happy_path_creates_and_sends_invoice(self):
+        from unittest.mock import MagicMock
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="failed", stripe_invoice_id=None, grand_total="18.50")
+        rider = {"id": RIDER_ID, "email": "rider@spinr.ca", "stripe_customer_id": "cus_1"}
+
+        async def _run_sync(fn):
+            return fn()
+
+        inv = MagicMock(id="in_new_1")
+        fin = MagicMock()
+        fin.get = lambda k, d=None: {"hosted_invoice_url": "https://pay.stripe/x"}.get(k, d)
+        update_ride_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)),
+            patch("backend.routes.admin.rides.db_supabase.get_user_by_id", AsyncMock(return_value=rider)),
+            patch("backend.routes.admin.rides.get_app_settings", self._settings()),
+            patch("backend.routes.admin.rides.db_supabase.update_one", AsyncMock(return_value={"id": RIDE_ID})),
+            patch("backend.routes.admin.rides.db_supabase.update_ride", update_ride_mock),
+            patch("backend.routes.admin.rides.db_supabase.run_sync", _run_sync),
+            patch("backend.routes.admin.rides.log_admin_action", AsyncMock()),
+            patch("stripe.Invoice.create", MagicMock(return_value=inv)),
+            patch("stripe.InvoiceItem.create", MagicMock(return_value=MagicMock())),
+            patch("stripe.Invoice.finalize_invoice", MagicMock(return_value=fin)),
+            patch("stripe.Invoice.send_invoice", MagicMock(return_value=MagicMock())),
+        ):
+            result = asyncio.run(admin_rides.admin_send_payable_invoice(ride_id=RIDE_ID, admin_user=ADMIN_USER))
+
+        assert result["sent"] is True
+        assert result["stripe_invoice_id"] == "in_new_1"
+        assert result["invoice_url"] == "https://pay.stripe/x"
+        # Final write persists the real invoice id (replacing the sentinel).
+        final = update_ride_mock.await_args.args[1]
+        assert final["stripe_invoice_id"] == "in_new_1"
+
+
 class TestAdminGetEarnings:
     def test_returns_earnings_summary(self):
         from backend.routes.admin import rides as admin_rides

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -8,11 +8,22 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 ADMIN_USER = {"id": "admin_1", "role": "admin", "email": "admin@spinr.ca"}
+
+
+def _fake_request():
+    """Minimal FastAPI Request stub for endpoints decorated with @limiter.limit."""
+    req = MagicMock()
+    req.scope = {"type": "http"}
+    req.state = MagicMock()
+    return req
+
+
+_FAKE_REQUEST = _fake_request()
 DRIVER_ID = "driver_admin_ext"
 DRIVER_USER_ID = "user_admin_ext"
 RIDE_ID = "ride_admin_ext"
@@ -277,7 +288,7 @@ class TestAdminSendPayableInvoice:
         ride = _ride("completed", payment_status="refunded")
         with patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)):
             with pytest.raises(HTTPException) as exc:
-                asyncio.run(admin_rides.admin_send_payable_invoice(ride_id=RIDE_ID, admin_user=ADMIN_USER))
+                asyncio.run(admin_rides.admin_send_payable_invoice(request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER))
         assert exc.value.status_code == 409
         assert "terminal" in str(exc.value.detail).lower()
 
@@ -299,7 +310,7 @@ class TestAdminSendPayableInvoice:
             patch("backend.routes.admin.rides.db_supabase.update_one", AsyncMock(return_value=None)),
         ):
             with pytest.raises(HTTPException) as exc:
-                asyncio.run(admin_rides.admin_send_payable_invoice(ride_id=RIDE_ID, admin_user=ADMIN_USER))
+                asyncio.run(admin_rides.admin_send_payable_invoice(request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER))
         assert exc.value.status_code == 409
         assert "already being created" in str(exc.value.detail).lower()
 
@@ -316,7 +327,7 @@ class TestAdminSendPayableInvoice:
 
         inv = MagicMock(id="in_new_1")
         fin = MagicMock()
-        fin.get = lambda k, d=None: {"hosted_invoice_url": "https://pay.stripe/x"}.get(k, d)
+        fin.hosted_invoice_url = "https://pay.stripe/x"
         update_ride_mock = AsyncMock()
 
         with (
@@ -332,7 +343,7 @@ class TestAdminSendPayableInvoice:
             patch("stripe.Invoice.finalize_invoice", MagicMock(return_value=fin)),
             patch("stripe.Invoice.send_invoice", MagicMock(return_value=MagicMock())),
         ):
-            result = asyncio.run(admin_rides.admin_send_payable_invoice(ride_id=RIDE_ID, admin_user=ADMIN_USER))
+            result = asyncio.run(admin_rides.admin_send_payable_invoice(request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER))
 
         assert result["sent"] is True
         assert result["stripe_invoice_id"] == "in_new_1"

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -501,6 +501,56 @@ class TestAdminSendPayableInvoice:
         cleared = [c for c in update_one_calls if c[2].get("stripe_invoice_id") is None]
         assert cleared, "expected the stuck invoice id/sentinel to be cleared to None"
 
+    def test_reclaims_when_persisted_invoice_missing_in_stripe(self):
+        """Codex round-5 (81Sc): if the persisted invoice was deleted in Stripe,
+        retrieve raises resource_missing — the endpoint clears the dead id and
+        creates a fresh invoice rather than 502ing forever."""
+        import stripe
+        from unittest.mock import MagicMock
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="failed", stripe_invoice_id="in_deleted_1", grand_total="18.50")
+        rider = {"id": RIDER_ID, "email": "rider@spinr.ca", "stripe_customer_id": "cus_1"}
+
+        async def _run_sync(fn):
+            return fn()
+
+        inv = MagicMock(id="in_fresh_after_missing")
+        fin = MagicMock()
+        fin.hosted_invoice_url = "https://pay.stripe/fresh"
+        update_one_calls = []
+
+        async def _update_one(table, filters, patch_body):
+            update_one_calls.append((table, filters, patch_body))
+            return {"id": RIDE_ID}
+
+        missing_err = stripe.error.InvalidRequestError("No such invoice", param="id", code="resource_missing")
+
+        with (
+            patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)),
+            patch("backend.routes.admin.rides.db_supabase.get_user_by_id", AsyncMock(return_value=rider)),
+            patch("backend.routes.admin.rides.get_app_settings", self._settings()),
+            patch("backend.routes.admin.rides.db_supabase.update_one", AsyncMock(side_effect=_update_one)),
+            patch("backend.routes.admin.rides.db_supabase.update_ride", AsyncMock()),
+            patch("backend.routes.admin.rides.db_supabase.run_sync", _run_sync),
+            patch("backend.routes.admin.rides.log_admin_action", AsyncMock()),
+            patch("stripe.Invoice.retrieve", MagicMock(side_effect=missing_err)),
+            patch("stripe.Invoice.create", MagicMock(return_value=inv)),
+            patch("stripe.InvoiceItem.create", MagicMock(return_value=MagicMock())),
+            patch("stripe.Invoice.finalize_invoice", MagicMock(return_value=fin)),
+            patch("stripe.Invoice.send_invoice", MagicMock(return_value=MagicMock())),
+        ):
+            result = asyncio.run(
+                admin_rides.admin_send_payable_invoice(request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER)
+            )
+
+        # Dead id cleared, fresh invoice created and sent.
+        assert result["sent"] is True
+        assert result["stripe_invoice_id"] == "in_fresh_after_missing"
+        cleared = [c for c in update_one_calls if c[2].get("stripe_invoice_id") is None]
+        assert cleared, "expected the dead invoice id to be cleared to None"
+
 
 class TestAdminGetEarnings:
     def test_returns_earnings_summary(self):

--- a/backend/tests/test_admin_extended.py
+++ b/backend/tests/test_admin_extended.py
@@ -412,6 +412,95 @@ class TestAdminSendPayableInvoice:
         assert result["sent"] is True
         assert result["stripe_invoice_id"] == "in_reclaim_1"
 
+    def test_rejects_non_card_payment_method(self):
+        """Codex P2 (round-3): a payable Stripe invoice bills the rider's personal
+        card — corporate (company_allowance)/wallet rides must not be invoiced."""
+        from fastapi import HTTPException
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="failed", payment_method="company_allowance")
+        with patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    admin_rides.admin_send_payable_invoice(
+                        request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER
+                    )
+                )
+        assert exc.value.status_code == 409
+        assert "card rides" in str(exc.value.detail).lower()
+
+    def test_rejects_open_preauth_hold(self):
+        """Codex P1 (round-3): an open authorized/fare_only hold is still
+        captureable by the sweeper — invoicing now risks collecting twice."""
+        from fastapi import HTTPException
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="pending", auth_status="authorized")
+        with patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    admin_rides.admin_send_payable_invoice(
+                        request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER
+                    )
+                )
+        assert exc.value.status_code == 409
+        assert "hold" in str(exc.value.detail).lower()
+
+    def test_rollback_voids_invoice_and_clears_id_on_finalize_failure(self):
+        """Codex round-3 (#2): if finalize fails after the real id was persisted,
+        the invoice is voided (never collectible) and the row id is cleared so the
+        ride is fully recoverable — no payable invoice hidden behind a sentinel."""
+        from unittest.mock import MagicMock
+
+        from fastapi import HTTPException
+
+        from backend.routes.admin import rides as admin_rides
+
+        ride = _ride("completed", payment_status="failed", stripe_invoice_id=None, grand_total="18.50")
+        rider = {"id": RIDER_ID, "email": "rider@spinr.ca", "stripe_customer_id": "cus_1"}
+
+        async def _run_sync(fn):
+            return fn()
+
+        inv = MagicMock(id="in_fail_1")
+        void_mock = MagicMock()
+        # Capture every ride update_one so we can assert the id was cleared.
+        update_one_calls = []
+
+        async def _update_one(table, filters, patch_body):
+            update_one_calls.append((table, filters, patch_body))
+            return {"id": RIDE_ID}
+
+        with (
+            patch("backend.routes.admin.rides.db_supabase.get_ride", AsyncMock(return_value=ride)),
+            patch("backend.routes.admin.rides.db_supabase.get_user_by_id", AsyncMock(return_value=rider)),
+            patch("backend.routes.admin.rides.get_app_settings", self._settings()),
+            patch("backend.routes.admin.rides.db_supabase.update_one", AsyncMock(side_effect=_update_one)),
+            patch("backend.routes.admin.rides.db_supabase.update_ride", AsyncMock()),
+            patch("backend.routes.admin.rides.db_supabase.run_sync", _run_sync),
+            patch("backend.routes.admin.rides.log_admin_action", AsyncMock()),
+            patch("stripe.Invoice.create", MagicMock(return_value=inv)),
+            patch("stripe.InvoiceItem.create", MagicMock(return_value=MagicMock())),
+            patch("stripe.Invoice.finalize_invoice", MagicMock(side_effect=Exception("stripe down"))),
+            patch("stripe.Invoice.void_invoice", void_mock),
+            patch("stripe.Invoice.delete", MagicMock()),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(
+                    admin_rides.admin_send_payable_invoice(
+                        request=_FAKE_REQUEST, ride_id=RIDE_ID, admin_user=ADMIN_USER
+                    )
+                )
+
+        assert exc.value.status_code == 502
+        # finalize failed AFTER id-write, so the invoice was finalized? No — it was
+        # still a draft (finalize raised), so it is DELETEd, not voided.
+        # Either way the row id must be cleared back to None for recovery.
+        cleared = [c for c in update_one_calls if c[2].get("stripe_invoice_id") is None]
+        assert cleared, "expected the stuck invoice id/sentinel to be cleared to None"
+
 
 class TestAdminGetEarnings:
     def test_returns_earnings_summary(self):

--- a/backend/tests/test_payment_retry.py
+++ b/backend/tests/test_payment_retry.py
@@ -126,6 +126,53 @@ async def test_retry_skips_ride_with_open_invoice():
 
 
 @pytest.mark.anyio
+async def test_retry_skips_fresh_pending_sentinel_but_retries_stale():
+    """Codex P2 (62i9): a `pending:<epoch>:<uuid>` invoice claim is transient.
+    A FRESH claim (creation in flight) must still be skipped, but a STALE one
+    (crashed mid-creation, no real invoice in Stripe) must be retried in-app so
+    the ride is not stranded forever."""
+    from datetime import timedelta
+
+    # Fresh sentinel — skipped (no claim, no confirm).
+    fresh_ts = datetime.now(timezone.utc).timestamp()
+    fresh = _make_ride(stripe_invoice_id=f"pending:{fresh_ts}:abc")
+    mock_update_fresh = AsyncMock(return_value={"id": RIDE_ID})
+    mock_confirm_fresh = MagicMock()
+    with (
+        patch("utils.payment_retry.db.get_rows", AsyncMock(return_value=[fresh])),
+        patch("utils.payment_retry.get_app_settings", AsyncMock(return_value={"stripe_secret_key": STRIPE_SECRET})),
+        patch("utils.payment_retry.db.update_one", mock_update_fresh),
+        patch("utils.payment_retry.send_push_notification", AsyncMock()),
+        patch("stripe.PaymentIntent.retrieve", MagicMock(return_value=_fake_intent("requires_payment_method"))),
+        patch("stripe.PaymentIntent.confirm", mock_confirm_fresh),
+    ):
+        from utils import payment_retry
+
+        await payment_retry.retry_failed_payments()
+    mock_confirm_fresh.assert_not_called()
+    mock_update_fresh.assert_not_awaited()
+
+    # Stale sentinel (10 min old) — falls through to the normal retry path.
+    stale_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp()
+    stale = _make_ride(stripe_invoice_id=f"pending:{stale_ts}:abc")
+    mock_update_stale = AsyncMock(return_value={"id": RIDE_ID})
+    mock_confirm_stale = MagicMock(return_value=_fake_intent("processing"))
+    with (
+        patch("utils.payment_retry.db.get_rows", AsyncMock(return_value=[stale])),
+        patch("utils.payment_retry.get_app_settings", AsyncMock(return_value={"stripe_secret_key": STRIPE_SECRET})),
+        patch("utils.payment_retry.db.update_one", mock_update_stale),
+        patch("utils.payment_retry.send_push_notification", AsyncMock()),
+        patch("stripe.PaymentIntent.retrieve", MagicMock(return_value=_fake_intent("requires_payment_method"))),
+        patch("stripe.PaymentIntent.confirm", mock_confirm_stale),
+    ):
+        from utils import payment_retry
+
+        await payment_retry.retry_failed_payments()
+    # A stale claim is retried (confirm called) rather than skipped forever.
+    mock_confirm_stale.assert_called_once()
+
+
+@pytest.mark.anyio
 async def test_retry_proceeds_when_stripe_failed():
     """
     When Stripe reports the PI as 'requires_payment_method', the loop must:

--- a/backend/tests/test_payment_retry.py
+++ b/backend/tests/test_payment_retry.py
@@ -208,6 +208,15 @@ async def test_retry_proceeds_when_stripe_failed():
     assert len(processing_calls) == 1
     assert processing_calls[0][0][2]["$set"]["payment_retry_count"] == 2
 
+    # Codex round-5 (81Sa): the atomic 'retrying' claim must assert
+    # stripe_invoice_id IS NULL so an admin send-invoice that wins the row between
+    # the read and the claim excludes this ride from in-app retry.
+    claim_calls = [
+        c for c in mock_db_update.await_args_list if c[0][2].get("$set", {}).get("payment_status") == "retrying"
+    ]
+    assert len(claim_calls) == 1
+    assert claim_calls[0][0][1]["stripe_invoice_id"] is None
+
 
 @pytest.mark.anyio
 async def test_retry_marks_ride_failed_when_retrieve_raises():

--- a/backend/tests/test_payment_retry.py
+++ b/backend/tests/test_payment_retry.py
@@ -126,50 +126,35 @@ async def test_retry_skips_ride_with_open_invoice():
 
 
 @pytest.mark.anyio
-async def test_retry_skips_fresh_pending_sentinel_but_retries_stale():
-    """Codex P2 (62i9): a `pending:<epoch>:<uuid>` invoice claim is transient.
-    A FRESH claim (creation in flight) must still be skipped, but a STALE one
-    (crashed mid-creation, no real invoice in Stripe) must be retried in-app so
-    the ride is not stranded forever."""
+async def test_retry_skips_any_invoice_sentinel_fresh_or_stale():
+    """Codex round-3 (#2): the retry loop must NOT re-charge in-app while ANY
+    invoice claim is on the row — a finalized id, a fresh 'pending:' sentinel, or
+    a stale one. Re-opening by age risks collecting alongside a payable invoice;
+    recovery is admin-side (crash-safe creation), not here."""
     from datetime import timedelta
 
-    # Fresh sentinel — skipped (no claim, no confirm).
     fresh_ts = datetime.now(timezone.utc).timestamp()
-    fresh = _make_ride(stripe_invoice_id=f"pending:{fresh_ts}:abc")
-    mock_update_fresh = AsyncMock(return_value={"id": RIDE_ID})
-    mock_confirm_fresh = MagicMock()
-    with (
-        patch("utils.payment_retry.db.get_rows", AsyncMock(return_value=[fresh])),
-        patch("utils.payment_retry.get_app_settings", AsyncMock(return_value={"stripe_secret_key": STRIPE_SECRET})),
-        patch("utils.payment_retry.db.update_one", mock_update_fresh),
-        patch("utils.payment_retry.send_push_notification", AsyncMock()),
-        patch("stripe.PaymentIntent.retrieve", MagicMock(return_value=_fake_intent("requires_payment_method"))),
-        patch("stripe.PaymentIntent.confirm", mock_confirm_fresh),
-    ):
-        from utils import payment_retry
-
-        await payment_retry.retry_failed_payments()
-    mock_confirm_fresh.assert_not_called()
-    mock_update_fresh.assert_not_awaited()
-
-    # Stale sentinel (10 min old) — falls through to the normal retry path.
     stale_ts = (datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp()
-    stale = _make_ride(stripe_invoice_id=f"pending:{stale_ts}:abc")
-    mock_update_stale = AsyncMock(return_value={"id": RIDE_ID})
-    mock_confirm_stale = MagicMock(return_value=_fake_intent("processing"))
-    with (
-        patch("utils.payment_retry.db.get_rows", AsyncMock(return_value=[stale])),
-        patch("utils.payment_retry.get_app_settings", AsyncMock(return_value={"stripe_secret_key": STRIPE_SECRET})),
-        patch("utils.payment_retry.db.update_one", mock_update_stale),
-        patch("utils.payment_retry.send_push_notification", AsyncMock()),
-        patch("stripe.PaymentIntent.retrieve", MagicMock(return_value=_fake_intent("requires_payment_method"))),
-        patch("stripe.PaymentIntent.confirm", mock_confirm_stale),
-    ):
-        from utils import payment_retry
+    for sid in (f"pending:{fresh_ts}:abc", f"pending:{stale_ts}:abc", "in_admin_real"):
+        ride = _make_ride(stripe_invoice_id=sid)
+        mock_update = AsyncMock(return_value={"id": RIDE_ID})
+        mock_confirm = MagicMock()
+        with (
+            patch("utils.payment_retry.db.get_rows", AsyncMock(return_value=[ride])),
+            patch(
+                "utils.payment_retry.get_app_settings",
+                AsyncMock(return_value={"stripe_secret_key": STRIPE_SECRET}),
+            ),
+            patch("utils.payment_retry.db.update_one", mock_update),
+            patch("utils.payment_retry.send_push_notification", AsyncMock()),
+            patch("stripe.PaymentIntent.retrieve", MagicMock(return_value=_fake_intent("requires_payment_method"))),
+            patch("stripe.PaymentIntent.confirm", mock_confirm),
+        ):
+            from utils import payment_retry
 
-        await payment_retry.retry_failed_payments()
-    # A stale claim is retried (confirm called) rather than skipped forever.
-    mock_confirm_stale.assert_called_once()
+            await payment_retry.retry_failed_payments()
+        mock_confirm.assert_not_called()
+        mock_update.assert_not_awaited()
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_payment_retry.py
+++ b/backend/tests/test_payment_retry.py
@@ -98,6 +98,34 @@ async def test_retry_skips_when_stripe_already_succeeded():
 
 
 @pytest.mark.anyio
+async def test_retry_skips_ride_with_open_invoice():
+    """Codex P1: once an admin has sent a payable Stripe invoice
+    (stripe_invoice_id set), the retry loop must NOT confirm the stored PI on
+    the old card — that would collect twice alongside the invoice. The ride is
+    skipped entirely (no claim, no confirm)."""
+    ride = _make_ride(stripe_invoice_id="in_admin_123")
+
+    mock_db_update = AsyncMock(return_value={"id": RIDE_ID})
+    mock_confirm = MagicMock()
+    fake_settings = {"stripe_secret_key": STRIPE_SECRET}
+
+    with (
+        patch("utils.payment_retry.db.get_rows", AsyncMock(return_value=[ride])),
+        patch("utils.payment_retry.get_app_settings", AsyncMock(return_value=fake_settings)),
+        patch("utils.payment_retry.db.update_one", mock_db_update),
+        patch("utils.payment_retry.send_push_notification", AsyncMock()),
+        patch("stripe.PaymentIntent.retrieve", MagicMock(return_value=_fake_intent("requires_payment_method"))),
+        patch("stripe.PaymentIntent.confirm", mock_confirm),
+    ):
+        from utils import payment_retry
+
+        await payment_retry.retry_failed_payments()
+
+    mock_confirm.assert_not_called()
+    mock_db_update.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_retry_proceeds_when_stripe_failed():
     """
     When Stripe reports the PI as 'requires_payment_method', the loop must:

--- a/backend/tests/test_process_payment_card.py
+++ b/backend/tests/test_process_payment_card.py
@@ -352,22 +352,22 @@ class TestOpenInvoiceGuard:
                 await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
         assert exc.value.status_code == 409
 
-    def test_stale_claim_helper_is_not_blocking(self):
-        """The staleness helper: only an abandoned `pending:<epoch>:<uuid>` claim
-        (>5 min) is stale (non-blocking). A finalized invoice, a fresh claim, and
-        a legacy timestamp-less sentinel all still block in-app payment."""
+    async def test_stale_pending_claim_also_blocks(self):
+        """Codex round-3 (#2): in-app charging must NOT unblock by claim age — a
+        stale 'pending:' sentinel blocks just like a fresh one. Recovery is
+        admin-side (crash-safe), never by silently re-opening the in-app charge."""
         from datetime import datetime, timedelta, timezone
 
         from backend.routes import rides as rides_mod
 
-        now = datetime.now(timezone.utc)
-        stale = f"pending:{(now - timedelta(minutes=10)).timestamp()}:u1"
-        fresh = f"pending:{now.timestamp()}:u1"
-
-        assert rides_mod._is_stale_invoice_claim(stale) is True
-        assert rides_mod._is_stale_invoice_claim(fresh) is False
-        assert rides_mod._is_stale_invoice_claim("in_admin_123") is False
-        assert rides_mod._is_stale_invoice_claim("pending:legacynouuid") is False
+        stale = _completed_ride(
+            stripe_invoice_id=f"pending:{(datetime.now(timezone.utc) - timedelta(minutes=10)).timestamp()}:u1"
+        )
+        with patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=stale)):
+            req = rides_mod.ProcessPaymentRequest(tip_amount=Decimal("0"))
+            with pytest.raises(HTTPException) as exc:
+                await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
+        assert exc.value.status_code == 409
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_process_payment_card.py
+++ b/backend/tests/test_process_payment_card.py
@@ -323,6 +323,54 @@ class TestIdempotencyGuards:
 
 
 @pytest.mark.asyncio
+class TestOpenInvoiceGuard:
+    """Codex P1 (62i3): once an admin emails a payable invoice, in-app charging
+    must be blocked so the rider can't be collected twice. The guard raises
+    before any Stripe call, so only get_ride needs stubbing."""
+
+    async def test_finalized_invoice_blocks_in_app_charge(self):
+        from backend.routes import rides as rides_mod
+
+        ride = _completed_ride(stripe_invoice_id="in_admin_123")
+        with patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride)):
+            req = rides_mod.ProcessPaymentRequest(tip_amount=Decimal("0"))
+            with pytest.raises(HTTPException) as exc:
+                await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
+
+        assert exc.value.status_code == 409
+        assert "invoice" in str(exc.value.detail).lower()
+
+    async def test_fresh_pending_claim_blocks(self):
+        from datetime import datetime, timezone
+
+        from backend.routes import rides as rides_mod
+
+        fresh = _completed_ride(stripe_invoice_id=f"pending:{datetime.now(timezone.utc).timestamp()}:u1")
+        with patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=fresh)):
+            req = rides_mod.ProcessPaymentRequest(tip_amount=Decimal("0"))
+            with pytest.raises(HTTPException) as exc:
+                await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
+        assert exc.value.status_code == 409
+
+    def test_stale_claim_helper_is_not_blocking(self):
+        """The staleness helper: only an abandoned `pending:<epoch>:<uuid>` claim
+        (>5 min) is stale (non-blocking). A finalized invoice, a fresh claim, and
+        a legacy timestamp-less sentinel all still block in-app payment."""
+        from datetime import datetime, timedelta, timezone
+
+        from backend.routes import rides as rides_mod
+
+        now = datetime.now(timezone.utc)
+        stale = f"pending:{(now - timedelta(minutes=10)).timestamp()}:u1"
+        fresh = f"pending:{now.timestamp()}:u1"
+
+        assert rides_mod._is_stale_invoice_claim(stale) is True
+        assert rides_mod._is_stale_invoice_claim(fresh) is False
+        assert rides_mod._is_stale_invoice_claim("in_admin_123") is False
+        assert rides_mod._is_stale_invoice_claim("pending:legacynouuid") is False
+
+
+@pytest.mark.asyncio
 class TestAuthorization:
     async def test_other_rider_cannot_pay_for_this_ride(self):
         from backend.routes import rides as rides_mod

--- a/backend/tests/test_process_payment_card.py
+++ b/backend/tests/test_process_payment_card.py
@@ -338,7 +338,10 @@ class TestOpenInvoiceGuard:
                 await rides_mod.process_payment(ride_id=RIDE_ID, req=req, current_user={"id": RIDER_ID})
 
         assert exc.value.status_code == 409
-        assert "invoice" in str(exc.value.detail).lower()
+        # Codex round-5 (81SZ): structured code so the rider app shows the
+        # pay-by-email instruction instead of looping on Change Card.
+        assert isinstance(exc.value.detail, dict)
+        assert exc.value.detail["code"] == "invoice_issued"
 
     async def test_fresh_pending_claim_blocks(self):
         from datetime import datetime, timezone

--- a/backend/tests/test_settle_card_capture.py
+++ b/backend/tests/test_settle_card_capture.py
@@ -230,6 +230,12 @@ class TestChangeCardOverride:
         # Ride re-pointed to the card actually charged.
         assert _last(updates, "payment_method_id") == "pm_NEW"
         assert _last(updates, "payment_status") == "paid"
+        # Codex P2 (62jG): the cached brand/last4 of the OLD declined card are
+        # cleared so the admin ride-detail resolver re-derives them from the new
+        # PaymentIntent instead of showing the rejected card.
+        paid_update = next(u for u in reversed(updates) if u.get("payment_status") == "paid")
+        assert paid_update["card_brand"] is None
+        assert paid_update["card_last4"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settle_card_capture.py
+++ b/backend/tests/test_settle_card_capture.py
@@ -249,6 +249,34 @@ class TestChangeCardOverride:
         assert paid_update["card_brand"] is None
         assert paid_update["card_last4"] is None
 
+    async def test_override_decline_does_not_release_old_hold(self):
+        """Codex round-3 (#6 follow-up, P1): the old hold must be released only
+        AFTER the new card charges. If the new card declines, the guaranteed
+        authorization must be left intact (not cancelled) so fare is still
+        collectable."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        # New card declines.
+        declined = _outcome(status="declined", decline_code="card_declined", error_message="Declined")
+        cancel_mock = AsyncMock(return_value=True)
+        patches, updates = _common_patches(charge=declined)
+        patches.append(patch("backend.services.payment_service.capture_ride", AsyncMock()))
+        patches.append(patch("backend.services.payment_service.cancel_authorization", cancel_mock))
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            result = await settle_card(
+                _held_ride(), RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"),
+                payment_method_id_override="pm_NEW",
+            )
+
+        assert result.success is False
+        # The old hold was NOT cancelled — it stays authorized and collectable.
+        cancel_mock.assert_not_awaited()
+
 
 @pytest.mark.asyncio
 class TestNoPaymentMethod:

--- a/backend/tests/test_settle_card_capture.py
+++ b/backend/tests/test_settle_card_capture.py
@@ -211,14 +211,22 @@ class TestChangeCardOverride:
         # Ride HAS an open hold on the old card — override must skip it.
         fresh = _outcome(status="succeeded", payment_intent_id="pi_new", charged_amount=Decimal("30.00"))
         cap_mock = AsyncMock()
+        # Codex round-3 (#6): the old card's uncaptured hold must be cancelled so
+        # the rider's funds aren't reserved until auth expiry.
+        cancel_mock = AsyncMock(return_value=True)
         patches, updates = _common_patches(charge=fresh)
         patches.append(patch("backend.services.payment_service.capture_ride", cap_mock))
+        patches.append(patch("backend.services.payment_service.cancel_authorization", cancel_mock))
 
         with ExitStack() as st:
             ctxs = [st.enter_context(p) for p in patches]
-            charge_mock = ctxs[-2]  # charge_ride is appended before capture_ride here
+            charge_mock = ctxs[-3]  # charge_ride, then capture_ride, then cancel_authorization
             result = await settle_card(
-                _held_ride(), RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"),
+                _held_ride(),
+                RIDE_ID,
+                RIDER_ID,
+                Decimal("30.00"),
+                Decimal("5.00"),
                 payment_method_id_override="pm_NEW",
             )
 
@@ -227,6 +235,10 @@ class TestChangeCardOverride:
         cap_mock.assert_not_called()
         assert charge_mock.call_args.kwargs["payment_method_id"] == "pm_NEW"
         assert charge_mock.call_args.kwargs["payment_intent_id"] is None
+        # The old hold PI was cancelled and the ride marked auth released.
+        cancel_mock.assert_awaited_once()
+        assert cancel_mock.await_args.kwargs["payment_intent_id"] == "pi_hold"
+        assert _last(updates, "auth_status") == "released"
         # Ride re-pointed to the card actually charged.
         assert _last(updates, "payment_method_id") == "pm_NEW"
         assert _last(updates, "payment_status") == "paid"

--- a/backend/tests/test_settle_card_capture.py
+++ b/backend/tests/test_settle_card_capture.py
@@ -198,6 +198,71 @@ class TestCaptureFailureModes:
 
 
 @pytest.mark.asyncio
+class TestChangeCardOverride:
+    """The in-app 'Change Card' escape: payment_method_id_override forces a
+    fresh charge on the chosen card and never captures the booking-time hold
+    (which sits on the rejected card)."""
+
+    async def test_override_fresh_charges_new_card_ignoring_hold(self):
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        # Ride HAS an open hold on the old card — override must skip it.
+        fresh = _outcome(status="succeeded", payment_intent_id="pi_new", charged_amount=Decimal("30.00"))
+        cap_mock = AsyncMock()
+        patches, updates = _common_patches(charge=fresh)
+        patches.append(patch("backend.services.payment_service.capture_ride", cap_mock))
+
+        with ExitStack() as st:
+            ctxs = [st.enter_context(p) for p in patches]
+            charge_mock = ctxs[-2]  # charge_ride is appended before capture_ride here
+            result = await settle_card(
+                _held_ride(), RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("5.00"),
+                payment_method_id_override="pm_NEW",
+            )
+
+        assert result.success is True
+        # Hold never captured; fresh PI (no reconfirm of the dead hold).
+        cap_mock.assert_not_called()
+        assert charge_mock.call_args.kwargs["payment_method_id"] == "pm_NEW"
+        assert charge_mock.call_args.kwargs["payment_intent_id"] is None
+        # Ride re-pointed to the card actually charged.
+        assert _last(updates, "payment_method_id") == "pm_NEW"
+        assert _last(updates, "payment_status") == "paid"
+
+
+@pytest.mark.asyncio
+class TestNoPaymentMethod:
+    async def test_no_card_returns_structured_402_change_card(self):
+        """No override, no ride card, no default → 402 no_payment_method with a
+        change_card hint so the app shows Add Card instead of a dead-end."""
+        from contextlib import ExitStack
+
+        from backend.services.payment_service import settle_card
+
+        ride = _held_ride(auth_status=None, authorized_amount=0, pi=None)
+        ride["payment_method_id"] = None
+        patches, updates = _common_patches()
+        # User has no default payment method either.
+        patches[0] = patch(
+            "backend.services.payment_service.db_supabase.get_user_by_id",
+            AsyncMock(return_value={"stripe_customer_id": "cus_X", "default_payment_method": None}),
+        )
+
+        with ExitStack() as st:
+            for p in patches:
+                st.enter_context(p)
+            result = await settle_card(ride, RIDE_ID, RIDER_ID, Decimal("30.00"), Decimal("0"))
+
+        assert result.success is False
+        assert result.status_code == 402
+        assert result.error_code == "no_payment_method"
+        assert (result.extra or {}).get("suggested_action") == "change_card"
+        assert _last(updates, "payment_status") == "pending"
+
+
+@pytest.mark.asyncio
 class TestNoHoldUnchanged:
     async def test_no_hold_uses_fresh_charge_path(self):
         """A ride with no auth_status hold settles via charge_ride exactly as

--- a/backend/tests/test_stripe_charge.py
+++ b/backend/tests/test_stripe_charge.py
@@ -352,3 +352,50 @@ class TestIdempotencyKey:
         mock_stripe.PaymentIntent.confirm.assert_called_once()
         kwargs = mock_stripe.PaymentIntent.confirm.call_args.kwargs
         assert kwargs["idempotency_key"] == "ride-confirm-ride_helper_1-2550"
+
+
+@pytest.mark.asyncio
+class TestCancelAuthorization:
+    """cancel_authorization releases an uncaptured pre-auth hold on Change Card.
+
+    Exercises the REAL function body (the settle_card test mocks it out, which
+    previously hid a NameError on an undefined run_sync)."""
+
+    async def test_cancels_hold_and_returns_true(self):
+        from backend.utils.stripe_charge import cancel_authorization
+
+        stripe_patch, mock_stripe = _patch_stripe()
+        with _patch_settings(), stripe_patch:
+            ok = await cancel_authorization(ride_id="r1", payment_intent_id="pi_hold")
+
+        assert ok is True
+        mock_stripe.PaymentIntent.cancel.assert_called_once()
+        kwargs = mock_stripe.PaymentIntent.cancel.call_args.kwargs
+        assert kwargs["idempotency_key"] == "ride-cancelauth-r1-pi_hold"
+
+    async def test_returns_false_when_no_payment_intent(self):
+        from backend.utils.stripe_charge import cancel_authorization
+
+        # No Stripe/settings needed — short-circuits on the empty id.
+        ok = await cancel_authorization(ride_id="r1", payment_intent_id="")
+        assert ok is False
+
+    async def test_returns_false_on_stripe_error(self):
+        """A hold already captured/expired (StripeError) is surfaced but not
+        raised — the fresh charge is the real settlement."""
+        from backend.utils.stripe_charge import cancel_authorization
+
+        class _FakeStripeError(Exception):
+            pass
+
+        mock_stripe = MagicMock()
+        mock_stripe.PaymentIntent.cancel.side_effect = _FakeStripeError("already captured")
+
+        with (
+            _patch_settings(),
+            patch("backend.utils.stripe_charge.stripe", mock_stripe),
+            patch("backend.utils.stripe_charge._StripeBaseError", _FakeStripeError),
+        ):
+            ok = await cancel_authorization(ride_id="r1", payment_intent_id="pi_x")
+
+        assert ok is False

--- a/backend/tests/test_stripe_charge.py
+++ b/backend/tests/test_stripe_charge.py
@@ -137,9 +137,10 @@ class TestSuccess:
         assert kwargs["confirm"] is True
         assert kwargs["metadata"]["ride_id"] == "ride_helper_1"
         assert kwargs["metadata"]["rider_id"] == "rider_helper_1"
-        # Idempotency key pins future retries to the same PI; the amount is
-        # part of the key so a re-charge at a different total gets a fresh key.
-        assert kwargs["idempotency_key"] == "ride-charge-ride_helper_1-2550"
+        # Idempotency key pins future retries to the same PI; the amount and the
+        # payment_method are part of the key so a re-charge at a different total
+        # OR on a different card (the Change Card escape) gets a fresh key.
+        assert kwargs["idempotency_key"] == "ride-charge-ride_helper_1-2550-pm_helper"
 
     async def test_amount_rounded_to_cents_correctly(self):
         """Float 19.999 must round to 2000 cents, not 1999 or 2001."""
@@ -310,7 +311,27 @@ class TestIdempotencyKey:
             await charge_ride(**_KW)
 
         keys = [call.kwargs["idempotency_key"] for call in mock_stripe.PaymentIntent.create.call_args_list]
-        assert keys == ["ride-charge-ride_helper_1-2550", "ride-charge-ride_helper_1-2550"]
+        assert keys == [
+            "ride-charge-ride_helper_1-2550-pm_helper",
+            "ride-charge-ride_helper_1-2550-pm_helper",
+        ]
+
+    async def test_different_card_yields_different_idempotency_key(self):
+        """Codex P1: the Change Card escape re-charges the SAME ride+amount on a
+        DIFFERENT card — that must mint a fresh key so Stripe charges the new
+        card instead of replaying the prior card's decline."""
+        from backend.utils.stripe_charge import charge_ride
+
+        intent = MagicMock(id="pi_1", status="succeeded", client_secret=None)
+        stripe_patch, mock_stripe = _patch_stripe(create_return=intent)
+
+        with _patch_settings(), stripe_patch:
+            await charge_ride(**_KW)
+            await charge_ride(**{**_KW, "payment_method_id": "pm_NEWCARD"})
+
+        keys = [call.kwargs["idempotency_key"] for call in mock_stripe.PaymentIntent.create.call_args_list]
+        assert keys[0] != keys[1]
+        assert keys[1] == "ride-charge-ride_helper_1-2550-pm_NEWCARD"
 
     async def test_confirm_path_carries_idempotency_key(self):
         """The retry/3DS confirm path must be idempotent too: two replicas

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1499,6 +1499,38 @@ class TestRideInvoicePaid:
         record_mock.assert_not_awaited()
         update_ride_mock.assert_not_awaited()
 
+    def test_ride_invoice_paid_skips_when_refunded(self):
+        """Codex round-4 (P2): a ride already 'refunded' (by charge.refunded) is
+        terminal — a delayed invoice.paid must NOT re-settle it (which would
+        append a ledger row and flip payment_status back to 'paid', erasing the
+        refund)."""
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        data_obj = {"id": "in_ride_ref", "metadata": {"ride_id": "ride_ref"}, "amount_paid": 402}
+        event_obj = self._event(data_obj, event_id="evt_ride_inv_ref")
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.get_ride",
+                AsyncMock(return_value={"id": "ride_ref", "rider_id": "u1", "payment_status": "refunded"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        record_mock.assert_not_awaited()
+        update_ride_mock.assert_not_awaited()
+
     def test_ride_invoice_paid_defers_when_processing(self):
         """A ride mid in-app charge (payment_status='processing') must NOT also be
         settled by the invoice path (double-credit). It must also NOT ack the

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1499,10 +1499,14 @@ class TestRideInvoicePaid:
         record_mock.assert_not_awaited()
         update_ride_mock.assert_not_awaited()
 
-    def test_ride_invoice_paid_skips_when_processing(self):
-        """A ride mid in-app charge (payment_status='processing') must NOT also
-        be settled by the invoice path — that would double-credit the driver."""
+    def test_ride_invoice_paid_defers_when_processing(self):
+        """A ride mid in-app charge (payment_status='processing') must NOT also be
+        settled by the invoice path (double-credit). It must also NOT ack the
+        event — a bare return would stamp processed_at and permanently drop this
+        paid invoice if the in-app charge later fails. So it RAISES (processed_at
+        stays NULL) for a later replay once 'processing' resolves."""
         import stripe
+        from fastapi import HTTPException
 
         from backend.routes import webhooks as wh
 
@@ -1524,9 +1528,11 @@ class TestRideInvoicePaid:
             patch("backend.services.payment_service.record_payment_event", record_mock),
             patch("services.payment_service.record_payment_event", record_mock),
         ):
-            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(wh.stripe_webhook(request=self._req()))
 
-        assert result["received"] is True
+        assert exc.value.status_code == 500
+        # No settlement happened, and the event was not acked.
         record_mock.assert_not_awaited()
         update_ride_mock.assert_not_awaited()
 

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1499,6 +1499,46 @@ class TestRideInvoicePaid:
         record_mock.assert_not_awaited()
         update_ride_mock.assert_not_awaited()
 
+    def test_ride_invoice_paid_recovers_ride_by_invoice_id_without_metadata(self):
+        """Codex round-5 (81SX): a paid ride invoice whose metadata.ride_id was
+        stripped still settles — the handler falls back to looking up the ride by
+        stripe_invoice_id (no subscription id, no metadata)."""
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        # No metadata.ride_id, no subscription → would otherwise be dropped.
+        data_obj = {"id": "in_ride_nometa", "amount_paid": 402, "payment_intent": "pi_nm_1"}
+        event_obj = self._event(data_obj, event_id="evt_ride_nometa")
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+        # find_one("rides", {"stripe_invoice_id": "in_ride_nometa"}) → the ride.
+        ride_row = {"id": "ride_nm", "rider_id": "u1", "payment_status": "failed", "tip_amount": "0"}
+
+        async def _get_ride(rid):
+            return ride_row if rid == "ride_nm" else None
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.find_one", AsyncMock(return_value=ride_row)),
+            patch("backend.routes.webhooks.db_supabase.get_ride", AsyncMock(side_effect=_get_ride)),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+            patch("services.payment_service.record_payment_event", record_mock),
+            patch("backend.services.payment_service.send_ride_receipt", AsyncMock(return_value=True)),
+            patch("services.payment_service.send_ride_receipt", AsyncMock(return_value=True)),
+            patch("backend.socket_manager.manager.send_personal_message", AsyncMock()),
+            patch("socket_manager.manager.send_personal_message", AsyncMock()),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        upd = update_ride_mock.await_args.args[1]
+        assert upd["payment_status"] == "paid"
+
     def test_ride_invoice_paid_skips_when_refunded(self):
         """Codex round-4 (P2): a ride already 'refunded' (by charge.refunded) is
         terminal — a delayed invoice.paid must NOT re-settle it (which would

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1529,3 +1529,82 @@ class TestRideInvoicePaid:
         assert result["received"] is True
         record_mock.assert_not_awaited()
         update_ride_mock.assert_not_awaited()
+
+    def test_ride_invoice_paid_extracts_pi_from_basil_payments(self):
+        """Codex P2: under the pinned API version (2025-04-30.basil) the
+        top-level invoice.payment_intent is gone — the PI lives under
+        payments.data[].payment.payment_intent. The ride must still be written
+        with a payment_intent_id so refund/dispute webhooks can find it."""
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        data_obj = {
+            "id": "in_ride_basil",
+            "metadata": {"ride_id": "ride_basil"},
+            "amount_paid": 402,
+            # No top-level payment_intent — Basil shape only.
+            "payments": {"data": [{"payment": {"payment_intent": "pi_basil_1"}}]},
+        }
+        event_obj = self._event(data_obj, event_id="evt_ride_basil")
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.get_ride",
+                AsyncMock(
+                    return_value={"id": "ride_basil", "rider_id": "u1", "payment_status": "failed", "tip_amount": "0"}
+                ),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+            patch("services.payment_service.record_payment_event", record_mock),
+            patch("backend.services.payment_service.send_ride_receipt", AsyncMock(return_value=True)),
+            patch("services.payment_service.send_ride_receipt", AsyncMock(return_value=True)),
+            patch("backend.socket_manager.manager.send_personal_message", AsyncMock()),
+            patch("socket_manager.manager.send_personal_message", AsyncMock()),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        upd = update_ride_mock.await_args.args[1]
+        assert upd["payment_intent_id"] == "pi_basil_1"
+
+    def test_ride_invoice_paid_raises_when_ride_missing(self):
+        """Codex P1: an invoice.paid whose ride_id no longer resolves must NOT be
+        acked — raising keeps processed_at NULL so the stuck-event reconciliation
+        path catches it instead of silently taking the rider's money."""
+        import stripe
+        from fastapi import HTTPException
+
+        from backend.routes import webhooks as wh
+
+        data_obj = {
+            "id": "in_ride_missing",
+            "metadata": {"ride_id": "ride_gone"},
+            "amount_paid": 402,
+            "payment_intent": "pi_missing_1",
+        }
+        event_obj = self._event(data_obj, event_id="evt_ride_missing")
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch("backend.routes.webhooks.db_supabase.get_ride", AsyncMock(return_value=None)),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+            patch("services.payment_service.record_payment_event", record_mock),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert exc.value.status_code == 500
+        # No ledger write for a ride we couldn't load.
+        record_mock.assert_not_awaited()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1395,3 +1395,95 @@ class TestStripeWebhookInvoiceRecovery:
         assert result["received"] is True
         record_mock.assert_awaited_once()
         assert record_mock.await_args.kwargs["stripe_invoice_id"] == "in_r"
+
+
+class TestRideInvoicePaid:
+    """invoice.paid carrying metadata.ride_id settles a stuck ride paid via the
+    admin 'Send Invoice' remediation (not a subscription)."""
+
+    def _event(self, data_object, event_id="evt_ride_inv_1"):
+        raw = _make_stripe_event("invoice.paid", data_object, event_id=event_id)
+        obj = MagicMock()
+        obj.get = lambda k, d=None: raw.get(k, d)
+        obj.to_dict_recursive = lambda: raw
+        return obj
+
+    def _settings(self):
+        async def f():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        return f
+
+    def _req(self):
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+        return req
+
+    def test_ride_invoice_paid_settles_ride(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        data_obj = {
+            "id": "in_ride_1",
+            "metadata": {"ride_id": "ride_xyz"},
+            "amount_paid": 402,
+            "payment_intent": "pi_inv_1",
+        }
+        event_obj = self._event(data_obj)
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.get_ride",
+                AsyncMock(return_value={"id": "ride_xyz", "rider_id": "u1", "payment_status": "failed", "tip_amount": "0"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+            patch("services.payment_service.record_payment_event", record_mock),
+            patch("backend.services.payment_service.send_ride_receipt", AsyncMock(return_value=True)),
+            patch("services.payment_service.send_ride_receipt", AsyncMock(return_value=True)),
+            patch("backend.socket_manager.manager.send_personal_message", AsyncMock()),
+            patch("socket_manager.manager.send_personal_message", AsyncMock()),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        upd = update_ride_mock.await_args.args[1]
+        assert upd["payment_status"] == "paid"
+        assert upd["stripe_invoice_id"] == "in_ride_1"
+        assert upd["payment_intent_id"] == "pi_inv_1"
+        record_mock.assert_awaited_once()
+
+    def test_ride_invoice_paid_idempotent_when_already_paid(self):
+        from backend.routes import webhooks as wh
+        import stripe
+
+        data_obj = {"id": "in_ride_2", "metadata": {"ride_id": "ride_paid"}, "amount_paid": 402}
+        event_obj = self._event(data_obj, event_id="evt_ride_inv_2")
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.get_ride",
+                AsyncMock(return_value={"id": "ride_paid", "rider_id": "u1", "payment_status": "paid"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
+        # Already settled — no ledger write, no ride update (no double-credit).
+        record_mock.assert_not_awaited()
+        update_ride_mock.assert_not_awaited()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1006,8 +1006,9 @@ class TestStripeWebhookRecurringSubscription:
     def test_invoice_paid_renews_and_notifies_on_cycle(self):
         from datetime import datetime, timedelta, timezone
 
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         period_end = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
         data_obj = {
@@ -1046,8 +1047,9 @@ class TestStripeWebhookRecurringSubscription:
         push_mock.assert_awaited_once()
 
     def test_invoice_payment_failed_marks_past_due_and_notifies(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         data_obj = {"id": "in_2", "subscription": "sub_456"}
         event_obj = self._event("invoice.payment_failed", data_obj)
@@ -1076,8 +1078,9 @@ class TestStripeWebhookRecurringSubscription:
         push_mock.assert_awaited_once()
 
     def test_subscription_updated_canceled_cancels_row(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         data_obj = {"id": "sub_789", "status": "canceled"}
         event_obj = self._event("customer.subscription.updated", data_obj)
@@ -1100,8 +1103,9 @@ class TestStripeWebhookRecurringSubscription:
         assert update_mock.await_args.args[2]["status"] == "cancelled"
 
     def test_invoice_paid_no_matching_row_acks(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         data_obj = {"id": "in_3", "subscription": "sub_orphan", "lines": {"data": []}}
         event_obj = self._event("invoice.paid", data_obj)
@@ -1146,8 +1150,9 @@ class TestStripeWebhookSubscriptionDeleted:
         return req
 
     def test_deleted_matches_by_subscription_id(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         event_obj = self._event({"id": "sub_del_1", "customer": "cus_x"})
         update_mock = AsyncMock()
@@ -1199,12 +1204,11 @@ class TestStripeWebhookInvoicePaidCancelledGuard:
         return req
 
     def test_invoice_paid_ignored_for_cancelled_row(self):
-        from backend.routes import webhooks as wh
         import stripe
 
-        event_obj = self._event(
-            {"id": "in_x", "subscription": "sub_cancelled", "billing_reason": "subscription_cycle"}
-        )
+        from backend.routes import webhooks as wh
+
+        event_obj = self._event({"id": "in_x", "subscription": "sub_cancelled", "billing_reason": "subscription_cycle"})
         update_mock = AsyncMock()
 
         with (
@@ -1248,8 +1252,9 @@ class TestStripeWebhookSubscriptionUpdatedGuard:
         return req
 
     def test_active_update_does_not_reactivate_cancelled_row(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         event_obj = self._event({"id": "sub_g", "status": "active"})
         update_mock = AsyncMock()
@@ -1296,8 +1301,9 @@ class TestStripeWebhookInvoiceLedger:
     def test_invoice_paid_records_ledger_payment(self):
         from datetime import datetime, timedelta, timezone
 
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         period_end = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
         data_obj = {
@@ -1360,8 +1366,9 @@ class TestStripeWebhookInvoiceRecovery:
     def test_invoice_paid_recovers_row_via_subscription_metadata(self):
         from datetime import datetime, timedelta, timezone
 
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         period_end = int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp())
         data_obj = {
@@ -1421,8 +1428,9 @@ class TestRideInvoicePaid:
         return req
 
     def test_ride_invoice_paid_settles_ride(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         data_obj = {
             "id": "in_ride_1",
@@ -1441,7 +1449,9 @@ class TestRideInvoicePaid:
             patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
             patch(
                 "backend.routes.webhooks.db_supabase.get_ride",
-                AsyncMock(return_value={"id": "ride_xyz", "rider_id": "u1", "payment_status": "failed", "tip_amount": "0"}),
+                AsyncMock(
+                    return_value={"id": "ride_xyz", "rider_id": "u1", "payment_status": "failed", "tip_amount": "0"}
+                ),
             ),
             patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
             patch("backend.services.payment_service.record_payment_event", record_mock),
@@ -1461,8 +1471,9 @@ class TestRideInvoicePaid:
         record_mock.assert_awaited_once()
 
     def test_ride_invoice_paid_idempotent_when_already_paid(self):
-        from backend.routes import webhooks as wh
         import stripe
+
+        from backend.routes import webhooks as wh
 
         data_obj = {"id": "in_ride_2", "metadata": {"ride_id": "ride_paid"}, "amount_paid": 402}
         event_obj = self._event(data_obj, event_id="evt_ride_inv_2")
@@ -1485,5 +1496,36 @@ class TestRideInvoicePaid:
 
         assert result["received"] is True
         # Already settled — no ledger write, no ride update (no double-credit).
+        record_mock.assert_not_awaited()
+        update_ride_mock.assert_not_awaited()
+
+    def test_ride_invoice_paid_skips_when_processing(self):
+        """A ride mid in-app charge (payment_status='processing') must NOT also
+        be settled by the invoice path — that would double-credit the driver."""
+        import stripe
+
+        from backend.routes import webhooks as wh
+
+        data_obj = {"id": "in_ride_3", "metadata": {"ride_id": "ride_proc"}, "amount_paid": 402}
+        event_obj = self._event(data_obj, event_id="evt_ride_inv_3")
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.get_ride",
+                AsyncMock(return_value={"id": "ride_proc", "rider_id": "u1", "payment_status": "processing"}),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+            patch("services.payment_service.record_payment_event", record_mock),
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert result["received"] is True
         record_mock.assert_not_awaited()
         update_ride_mock.assert_not_awaited()

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -1575,6 +1575,46 @@ class TestRideInvoicePaid:
         upd = update_ride_mock.await_args.args[1]
         assert upd["payment_intent_id"] == "pi_basil_1"
 
+    def test_ride_invoice_paid_raises_when_pi_unresolved(self):
+        """Codex round-3 (#4): if the PI can't be resolved (no payload field and
+        the expand-retrieve fallback fails), do NOT mark the ride paid with a NULL
+        payment_intent_id — raise so Stripe retries; refund/dispute lookups depend
+        on that id."""
+        import stripe
+        from fastapi import HTTPException
+
+        from backend.routes import webhooks as wh
+
+        # No top-level payment_intent and no payments shape.
+        data_obj = {"id": "in_ride_nopi", "metadata": {"ride_id": "ride_nopi"}, "amount_paid": 402}
+        event_obj = self._event(data_obj, event_id="evt_ride_nopi")
+        update_ride_mock = AsyncMock()
+        record_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", self._settings()),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()),
+            patch(
+                "backend.routes.webhooks.db_supabase.get_ride",
+                AsyncMock(
+                    return_value={"id": "ride_nopi", "rider_id": "u1", "payment_status": "failed", "tip_amount": "0"}
+                ),
+            ),
+            patch("backend.routes.webhooks.db_supabase.update_ride", update_ride_mock),
+            patch("backend.services.payment_service.record_payment_event", record_mock),
+            patch("services.payment_service.record_payment_event", record_mock),
+            # The expand-retrieve fallback also fails to yield a PI.
+            patch("stripe.Invoice.retrieve", MagicMock(side_effect=Exception("stripe down"))),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(wh.stripe_webhook(request=self._req()))
+
+        assert exc.value.status_code == 500
+        # No half-settled ride: the paid write never happened.
+        update_ride_mock.assert_not_awaited()
+
     def test_ride_invoice_paid_raises_when_ride_missing(self):
         """Codex P1: an invoice.paid whose ride_id no longer resolves must NOT be
         acked — raising keeps processed_at NULL so the stuck-event reconciliation

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -54,6 +54,26 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Mirrors admin/rides.py::_INVOICE_CLAIM_STALE_SECONDS. A `pending:<epoch>:<uuid>`
+# claim older than this is an abandoned invoice-creation attempt (the request
+# crashed before Stripe created the invoice), so an in-app retry is safe.
+_INVOICE_CLAIM_STALE_SECONDS = 300
+
+
+def _invoice_claim_is_stale(sentinel: str) -> bool:
+    """True if a `pending:<epoch>:<uuid>` invoice claim is old enough to reclaim.
+
+    Legacy `pending:<uuid>` sentinels (no embedded timestamp) return False — they
+    are treated conservatively and left for manual ops cleanup."""
+    try:
+        parts = str(sentinel).split(":")
+        if len(parts) < 3:
+            return False
+        age = (datetime.now(timezone.utc) - datetime.fromtimestamp(float(parts[1]), tz=timezone.utc)).total_seconds()
+        return age >= _INVOICE_CLAIM_STALE_SECONDS
+    except (ValueError, OverflowError, OSError):
+        return False
+
 
 async def _alert_admins_payment_exhausted(ride: dict) -> None:
     """Notify admins when a ride's payment retries are exhausted."""
@@ -213,17 +233,24 @@ async def retry_failed_payments():
         _invoice_sid = ride.get("stripe_invoice_id")
         if _invoice_sid:
             if str(_invoice_sid).startswith("pending:"):
-                # Admin request crashed after writing the CAS sentinel but before
-                # Stripe created the invoice. The sentinel has no TTL and will block
-                # all retries indefinitely. Alert ops to investigate.
-                logger.error(
-                    "payment_retry: ride %s has stuck pending invoice sentinel '%s' — "
-                    "all automatic retries are blocked; ops must clear rides.stripe_invoice_id manually",
-                    ride_id,
-                    _invoice_sid,
-                    extra={"domain": "payments", "ride_id": ride_id},
-                )
-            continue
+                # Transient CAS claim from admin_send_payable_invoice. A claim that
+                # never cleared (crashed mid-creation) is reclaimable once stale —
+                # mirror admin/rides.py: a stale claim means Stripe almost certainly
+                # never created the invoice, so an in-app retry is safe and unblocks
+                # the ride. A fresh claim is left alone (real creation in flight).
+                if _invoice_claim_is_stale(_invoice_sid):
+                    logger.warning(
+                        "payment_retry: ride %s has a STALE pending invoice sentinel '%s' — "
+                        "retrying in-app (creation never completed)",
+                        ride_id,
+                        _invoice_sid,
+                        extra={"domain": "payments", "ride_id": ride_id},
+                    )
+                    # fall through to the normal retry path
+                else:
+                    continue
+            else:
+                continue
 
         if retry_count >= MAX_RETRIES:
             if not ride.get("admin_alerted_payment_exhausted"):

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -191,7 +191,7 @@ async def retry_failed_payments():
             columns=(
                 "id,rider_id,driver_id,payment_status,payment_retry_count,"
                 "payment_intent_id,admin_alerted_payment_exhausted,total_fare,"
-                "created_at,updated_at"
+                "stripe_invoice_id,created_at,updated_at"
             ),
         )
     except Exception as e:
@@ -205,6 +205,13 @@ async def retry_failed_payments():
         ride_id = ride["id"]
         retry_count = ride.get("payment_retry_count", 0)
         current_status = ride.get("payment_status", "failed")
+
+        # An admin sent a payable Stripe invoice for this ride — collection has
+        # moved to the hosted invoice (settled by the invoice.paid webhook).
+        # Retrying the stored PaymentIntent on the old card here would collect a
+        # second time alongside the invoice. Leave it to the invoice path.
+        if ride.get("stripe_invoice_id"):
+            continue
 
         if retry_count >= MAX_RETRIES:
             if not ride.get("admin_alerted_payment_exhausted"):

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -210,7 +210,19 @@ async def retry_failed_payments():
         # moved to the hosted invoice (settled by the invoice.paid webhook).
         # Retrying the stored PaymentIntent on the old card here would collect a
         # second time alongside the invoice. Leave it to the invoice path.
-        if ride.get("stripe_invoice_id"):
+        _invoice_sid = ride.get("stripe_invoice_id")
+        if _invoice_sid:
+            if str(_invoice_sid).startswith("pending:"):
+                # Admin request crashed after writing the CAS sentinel but before
+                # Stripe created the invoice. The sentinel has no TTL and will block
+                # all retries indefinitely. Alert ops to investigate.
+                logger.error(
+                    "payment_retry: ride %s has stuck pending invoice sentinel '%s' — "
+                    "all automatic retries are blocked; ops must clear rides.stripe_invoice_id manually",
+                    ride_id,
+                    _invoice_sid,
+                    extra={"domain": "payments", "ride_id": ride_id},
+                )
             continue
 
         if retry_count >= MAX_RETRIES:

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -226,31 +226,25 @@ async def retry_failed_payments():
         retry_count = ride.get("payment_retry_count", 0)
         current_status = ride.get("payment_status", "failed")
 
-        # An admin sent a payable Stripe invoice for this ride — collection has
-        # moved to the hosted invoice (settled by the invoice.paid webhook).
+        # An admin sent (or is creating) a payable Stripe invoice for this ride —
+        # collection has moved to the hosted invoice (settled by invoice.paid).
         # Retrying the stored PaymentIntent on the old card here would collect a
-        # second time alongside the invoice. Leave it to the invoice path.
+        # second time alongside the invoice, so skip ANY non-null claim (a
+        # finalized in_* id or a 'pending:' creation sentinel alike). We never
+        # re-open retries by age — a stuck claim is recovered admin-side (which
+        # creates invoices crash-safely), not by silently re-charging here.
         _invoice_sid = ride.get("stripe_invoice_id")
         if _invoice_sid:
-            if str(_invoice_sid).startswith("pending:"):
-                # Transient CAS claim from admin_send_payable_invoice. A claim that
-                # never cleared (crashed mid-creation) is reclaimable once stale —
-                # mirror admin/rides.py: a stale claim means Stripe almost certainly
-                # never created the invoice, so an in-app retry is safe and unblocks
-                # the ride. A fresh claim is left alone (real creation in flight).
-                if _invoice_claim_is_stale(_invoice_sid):
-                    logger.warning(
-                        "payment_retry: ride %s has a STALE pending invoice sentinel '%s' — "
-                        "retrying in-app (creation never completed)",
-                        ride_id,
-                        _invoice_sid,
-                        extra={"domain": "payments", "ride_id": ride_id},
-                    )
-                    # fall through to the normal retry path
-                else:
-                    continue
-            else:
-                continue
+            if str(_invoice_sid).startswith("pending:") and _invoice_claim_is_stale(_invoice_sid):
+                # Surface a long-lived bare sentinel so ops can re-send admin-side.
+                logger.error(
+                    "payment_retry: ride %s has a stale pending invoice sentinel '%s' — "
+                    "in-app retry is blocked; admin must re-send the invoice to recover",
+                    ride_id,
+                    _invoice_sid,
+                    extra={"domain": "payments", "ride_id": ride_id},
+                )
+            continue
 
         if retry_count >= MAX_RETRIES:
             if not ride.get("admin_alerted_payment_exhausted"):

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -289,6 +289,11 @@ async def retry_failed_payments():
                 "id": ride_id,
                 "payment_status": current_status,
                 "payment_retry_count": retry_count,
+                # Mirror /process-payment: assert no invoice claim landed between
+                # the read above and this claim. Without it, an admin send-invoice
+                # that wins the row right here would leave the retry loop confirming
+                # the old PI while the hosted invoice is also collectible.
+                "stripe_invoice_id": None,
             },
             {
                 "$set": {

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -619,3 +619,46 @@ async def capture_ride(
         payment_intent_id=pi_id,
         error_message=f"Unhandled capture PaymentIntent status: {status}",
     )
+
+
+async def cancel_authorization(*, ride_id: str, payment_intent_id: str) -> bool:
+    """Cancel an uncaptured pre-authorization hold so the funds are released.
+
+    Used when a rider abandons the booking-time card (the "Change Card" escape):
+    the new card is charged on a fresh PaymentIntent, so the old hold must be
+    released or the rider's funds stay reserved until Stripe's ~7-day auth
+    expiry. Returns True if the hold is cancelled (or already in a terminal
+    state that cannot/need not be cancelled). Best-effort — never raises; a
+    failure is logged (a stuck hold is a payment-path anomaly) and the caller
+    proceeds, since the fresh charge is the real settlement.
+    """
+    if not payment_intent_id:
+        return False
+    secret = await _resolve_stripe_secret(ride_id)
+    if stripe is None or secret is None:
+        return False
+
+    def _do() -> bool:
+        try:
+            stripe.PaymentIntent.cancel(
+                payment_intent_id,
+                api_key=secret,
+                idempotency_key=f"ride-cancelauth-{ride_id}-{payment_intent_id}",
+            )
+            return True
+        except _StripeBaseError as e:
+            # Already captured/canceled, or a transient ops error. Surface it
+            # (a lingering hold ties up the rider's funds) but don't block the
+            # fresh charge that actually settles the ride.
+            logger.error(
+                "Could not cancel pre-auth hold pi=%s for ride=%s: %s",
+                payment_intent_id,
+                ride_id,
+                e,
+            )
+            return False
+        except Exception as e:  # pragma: no cover — defence-in-depth
+            logger.exception("Unexpected error cancelling pre-auth hold ride=%s: %s", ride_id, e)
+            return False
+
+    return await run_sync(_do)

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -33,11 +33,13 @@ Outcome variants
 Idempotency
 -----------
 
-``idempotency_key = "ride-charge-{ride_id}-{amount_cents}"`` on the create
-path and ``"ride-confirm-{ride_id}-{amount_cents}"`` on the confirm
-(retry / 3DS) path — Stripe dedupes identical keys for 24h. The amount is
-part of the key so a legitimate re-charge at a different total (e.g. tip
-updated after a decline) gets a fresh key instead of an IdempotencyError.
+``idempotency_key = "ride-charge-{ride_id}-{amount_cents}-{payment_method_id}"``
+on the create path and ``"ride-confirm-{ride_id}-{amount_cents}"`` on the
+confirm (retry / 3DS) path — Stripe dedupes identical keys for 24h. The amount
+is part of the key so a legitimate re-charge at a different total (e.g. tip
+updated after a decline) gets a fresh key instead of an IdempotencyError; the
+payment_method is part of the create key so a re-charge on a DIFFERENT card
+(the "Change Card" escape) is not replayed as the prior card's decline.
 payment_retry.py uses the same ride-confirm key scheme so both confirm
 code paths share Stripe-side deduplication. Combined with the caller's
 atomic ``payment_status = 'processing'`` DB lock, a double-tap or retry
@@ -160,13 +162,16 @@ async def charge_ride(
     ride_id = ride.get("id") or ""
     amount_cents = dollars_to_cents(total_amount)
 
-    # Idempotency: a retry of the SAME ride for the SAME amount must not
-    # double-charge — same key → Stripe returns the original PaymentIntent.
-    # The amount (cents) is part of the key so that a legitimate re-charge at a
-    # DIFFERENT total (e.g. the rider updated their tip after a declined
-    # attempt) gets a fresh key instead of an IdempotencyError, which would
-    # otherwise leave the ride stuck in 'processing'.
-    idempotency_key = f"ride-charge-{ride_id}-{amount_cents}"
+    # Idempotency: a retry of the SAME ride for the SAME amount on the SAME card
+    # must not double-charge — same key → Stripe returns the original
+    # PaymentIntent. The amount (cents) is part of the key so a legitimate
+    # re-charge at a DIFFERENT total (e.g. the rider updated their tip after a
+    # declined attempt) gets a fresh key. The payment_method is ALSO part of the
+    # key: when the rider picks a DIFFERENT card after a decline (the in-app
+    # "Change Card" escape), the same ride+amount on a new card must mint a fresh
+    # key — otherwise Stripe replays the prior decline / raises a parameter
+    # mismatch and the new card is never charged.
+    idempotency_key = f"ride-charge-{ride_id}-{amount_cents}-{payment_method_id}"
 
     fare_amount = Decimal(str(ride.get("total_fare", 0) or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
     tip = Decimal(str(total_amount)) - fare_amount

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -638,27 +638,26 @@ async def cancel_authorization(*, ride_id: str, payment_intent_id: str) -> bool:
     if stripe is None or secret is None:
         return False
 
-    def _do() -> bool:
-        try:
-            stripe.PaymentIntent.cancel(
-                payment_intent_id,
-                api_key=secret,
-                idempotency_key=f"ride-cancelauth-{ride_id}-{payment_intent_id}",
-            )
-            return True
-        except _StripeBaseError as e:
-            # Already captured/canceled, or a transient ops error. Surface it
-            # (a lingering hold ties up the rider's funds) but don't block the
-            # fresh charge that actually settles the ride.
-            logger.error(
-                "Could not cancel pre-auth hold pi=%s for ride=%s: %s",
-                payment_intent_id,
-                ride_id,
-                e,
-            )
-            return False
-        except Exception as e:  # pragma: no cover — defence-in-depth
-            logger.exception("Unexpected error cancelling pre-auth hold ride=%s: %s", ride_id, e)
-            return False
-
-    return await run_sync(_do)
+    # Call Stripe directly (same pattern as capture_ride / authorize_ride in this
+    # module) — there is no run_sync helper here.
+    try:
+        stripe.PaymentIntent.cancel(
+            payment_intent_id,
+            api_key=secret,
+            idempotency_key=f"ride-cancelauth-{ride_id}-{payment_intent_id}",
+        )
+        return True
+    except _StripeBaseError as e:
+        # Already captured/canceled, or a transient ops error. Surface it
+        # (a lingering hold ties up the rider's funds) but don't block the
+        # fresh charge that actually settles the ride.
+        logger.error(
+            "Could not cancel pre-auth hold pi=%s for ride=%s: %s",
+            payment_intent_id,
+            ride_id,
+            e,
+        )
+        return False
+    except Exception as e:  # pragma: no cover — defence-in-depth
+        logger.exception("Unexpected error cancelling pre-auth hold ride=%s: %s", ride_id, e)
+        return False

--- a/rider-app/app/manage-cards.tsx
+++ b/rider-app/app/manage-cards.tsx
@@ -28,7 +28,12 @@ export default function ManageCardsScreen() {
   // When opened from a stuck ride-payment ("Change Card" escape), forPayment=1
   // and rideId is set: picking/adding a card bounces back to ride-completed to
   // re-charge that trip on the chosen card.
-  const { rideId, forPayment } = useLocalSearchParams<{ rideId?: string; forPayment?: string }>();
+  const { rideId, forPayment, tip, rated } = useLocalSearchParams<{
+    rideId?: string;
+    forPayment?: string;
+    tip?: string;
+    rated?: string;
+  }>();
   const payForRide = forPayment === '1' && !!rideId;
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
@@ -120,9 +125,19 @@ export default function ManageCardsScreen() {
     }
   };
 
-  // Return to the stuck ride and re-charge it on the chosen card.
+  // Return to the stuck ride and re-charge it on the chosen card. Carry the tip
+  // and rated flag through so the re-charge collects the same tip and doesn't
+  // re-rate the driver (Codex 62i6).
   const payRideWithCard = (cardId: string) => {
-    router.replace({ pathname: '/ride-completed', params: { rideId: rideId as string, payWithCard: cardId } } as any);
+    router.replace({
+      pathname: '/ride-completed',
+      params: {
+        rideId: rideId as string,
+        payWithCard: cardId,
+        ...(typeof tip === 'string' ? { tip } : {}),
+        ...(typeof rated === 'string' ? { rated } : {}),
+      },
+    } as any);
   };
 
   const handleSetDefault = async (cardId: string) => {

--- a/rider-app/app/manage-cards.tsx
+++ b/rider-app/app/manage-cards.tsx
@@ -4,7 +4,7 @@ import {
   Platform, ActivityIndicator, KeyboardAvoidingView,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRouter } from 'expo-router';
+import { useRouter, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { CardField, CardFieldInput, useStripe } from '@stripe/stripe-react-native';
 import { StripeKeyContext } from './_layout';
@@ -25,6 +25,11 @@ interface Card {
 
 export default function ManageCardsScreen() {
   const router = useRouter();
+  // When opened from a stuck ride-payment ("Change Card" escape), forPayment=1
+  // and rideId is set: picking/adding a card bounces back to ride-completed to
+  // re-charge that trip on the chosen card.
+  const { rideId, forPayment } = useLocalSearchParams<{ rideId?: string; forPayment?: string }>();
+  const payForRide = forPayment === '1' && !!rideId;
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const stripeKey = useContext(StripeKeyContext);
@@ -100,6 +105,12 @@ export default function ManageCardsScreen() {
       await api.post('/payments/cards', { payment_method_id: paymentMethod.id });
       setShowAdd(false);
       resetForm();
+      // Paying for a stuck ride: charge the freshly added card immediately.
+      if (payForRide) {
+        showToast('Card Added', 'Charging your ride…', 'success');
+        payRideWithCard(paymentMethod.id);
+        return;
+      }
       fetchCards();
       showToast('Card Added', 'Card added successfully', 'success');
     } catch (err: any) {
@@ -107,6 +118,11 @@ export default function ManageCardsScreen() {
     } finally {
       setSaving(false);
     }
+  };
+
+  // Return to the stuck ride and re-charge it on the chosen card.
+  const payRideWithCard = (cardId: string) => {
+    router.replace({ pathname: '/ride-completed', params: { rideId: rideId as string, payWithCard: cardId } } as any);
   };
 
   const handleSetDefault = async (cardId: string) => {
@@ -168,10 +184,16 @@ export default function ManageCardsScreen() {
         <Text style={styles.cardExpiry}>Expires {String(item.exp_month).padStart(2, '0')}/{item.exp_year}</Text>
       </View>
       <View style={styles.cardActions}>
-        {!item.is_default && (
-          <TouchableOpacity style={styles.setDefaultBtn} onPress={() => handleSetDefault(item.id)}>
-            <Text style={styles.setDefaultText}>Set Default</Text>
+        {payForRide ? (
+          <TouchableOpacity style={styles.payWithBtn} onPress={() => payRideWithCard(item.id)}>
+            <Text style={styles.payWithText}>Use &amp; Pay</Text>
           </TouchableOpacity>
+        ) : (
+          !item.is_default && (
+            <TouchableOpacity style={styles.setDefaultBtn} onPress={() => handleSetDefault(item.id)}>
+              <Text style={styles.setDefaultText}>Set Default</Text>
+            </TouchableOpacity>
+          )
         )}
         <TouchableOpacity onPress={() => handleDeleteCard(item.id)}>
           <Ionicons name="trash-outline" size={20} color={colors.textDim} />
@@ -187,9 +209,16 @@ export default function ManageCardsScreen() {
         <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
           <Ionicons name="arrow-back" size={24} color={colors.text} />
         </TouchableOpacity>
-        <Text style={styles.headerTitle}>Payment Methods</Text>
+        <Text style={styles.headerTitle}>{payForRide ? 'Choose a Card' : 'Payment Methods'}</Text>
         <View style={{ width: 44 }} />
       </View>
+
+      {payForRide && (
+        <View style={styles.payBanner}>
+          <Ionicons name="card" size={16} color={colors.primary} />
+          <Text style={styles.payBannerText}>Pick or add a card to pay for your trip.</Text>
+        </View>
+      )}
 
       {loading ? (
         <View style={styles.loadingWrap}>
@@ -326,6 +355,17 @@ function createStyles(colors: ThemeColors) {
       backgroundColor: colors.border,
     },
     setDefaultText: { fontSize: 11, fontWeight: '600', color: colors.textDim },
+    payWithBtn: {
+      paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8,
+      backgroundColor: colors.primary,
+    },
+    payWithText: { fontSize: 12, fontWeight: '700', color: '#FFF' },
+    payBanner: {
+      flexDirection: 'row', alignItems: 'center', gap: 8,
+      paddingHorizontal: 20, paddingVertical: 12,
+      backgroundColor: '#FEF2F2',
+    },
+    payBannerText: { fontSize: 13, fontWeight: '600', color: colors.text },
 
     // Empty
     emptyState: { alignItems: 'center', paddingVertical: 40 },

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -35,7 +35,9 @@ const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
 
 function RideCompletedScreenContent() {
   const router = useRouter();
-  const { rideId } = useLocalSearchParams<{ rideId: string }>();
+  // payWithCard is set when the rider returns from the "Change Card" escape
+  // (manage-cards) having picked a different card for this stuck trip.
+  const { rideId, payWithCard } = useLocalSearchParams<{ rideId: string; payWithCard?: string }>();
   const { currentRide, currentDriver, fetchRide, rateRide, clearRide } = useRideStore();
 
   // P0-5: confirmPayment is called when the backend returns
@@ -181,11 +183,24 @@ function RideCompletedScreenContent() {
    * confirmSheet shape (with onPress handlers). Split from the attempt
    * itself so the attempt stays pure-data and unit-testable.
    */
+  // handleSubmit is defined below but referenced by the Retry button here;
+  // a ref breaks the definition cycle without reordering the whole component.
+  const handleSubmitRef = useRef<(overrideCardId?: string) => void>(() => {});
+
   const showPaymentAlert = (alert: NonNullable<Awaited<ReturnType<typeof attemptRidePayment>>['alert']>) => {
     const buttons = (alert.buttons || []).map((b: PaymentAlertButton) => ({
       text: b.text,
       style: (b.kind === 'cancel' ? 'cancel' : 'default') as 'default' | 'cancel',
-      onPress: b.kind === 'change_card' ? () => router.push('/manage-cards' as any) : undefined,
+      onPress:
+        b.kind === 'change_card'
+          // Carry the ride so manage-cards can re-charge THIS trip on the new card.
+          ? () => router.push(`/manage-cards?rideId=${rideId}&forPayment=1` as any)
+          : b.kind === 'support'
+            // Pre-fill support with the stuck ride + a payment-failed topic.
+            ? () => router.push(`/support?rideId=${rideId}&topic=payment_failed` as any)
+            : b.kind === 'retry'
+              ? () => handleSubmitRef.current?.()
+              : undefined,
     }));
     setConfirmSheet({
       visible: true,
@@ -196,7 +211,7 @@ function RideCompletedScreenContent() {
     });
   };
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (overrideCardId?: string) => {
     if (isSubmitting) return; // prevent double tap
     setIsSubmitting(true);
     setSubmitPhase('rating');
@@ -220,6 +235,7 @@ function RideCompletedScreenContent() {
           stripe: { confirmPayment },
           rideId: rideId as string,
           tipAmount,
+          paymentMethodId: overrideCardId,
         });
         paymentOk = result.ok;
         chargedAmount = result.charged;
@@ -257,6 +273,18 @@ function RideCompletedScreenContent() {
       setSubmitPhase('idle');
     }
   };
+  handleSubmitRef.current = handleSubmit;
+
+  // Returned from the "Change Card" escape with a card chosen for this trip —
+  // auto-retry the charge on it once. The ref guard stops a re-run on every
+  // re-render while the param is still in the route.
+  const retriedCardRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!payWithCard || alreadyPaid) return;
+    if (retriedCardRef.current === payWithCard) return;
+    retriedCardRef.current = payWithCard;
+    handleSubmit(payWithCard);
+  }, [payWithCard, alreadyPaid]);
 
   // Google Pay path — presents the Stripe PaymentSheet modal so riders can
   // pay without re-entering a card. Only shown for card payment rides on
@@ -675,7 +703,7 @@ function RideCompletedScreenContent() {
         )}
         <TouchableOpacity
           style={styles.submitBtn}
-          onPress={handleSubmit}
+          onPress={() => handleSubmit()}
           disabled={isSubmitting || sheetLoading}
           activeOpacity={0.8}
           accessibilityRole="button"

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -186,6 +186,14 @@ function RideCompletedScreenContent() {
   // handleSubmit is defined below but referenced by the Retry button here;
   // a ref breaks the definition cycle without reordering the whole component.
   const handleSubmitRef = useRef<(overrideCardId?: string) => void>(() => {});
+  // The card the rider chose via "Change Card" — Retry must re-charge on THIS
+  // card, not silently fall back to the booking/default card (Codex P2).
+  const activeOverrideCardRef = useRef<string | undefined>(undefined);
+  // Rating + tip is posted to /rate, which ACCUMULATES tip into driver_earnings
+  // on every call. Across a retry (button or auto card-change) we must post it
+  // at most once or the driver is over-credited while only one tip is charged
+  // (Codex P1). This latches after the first attempt.
+  const hasRatedRef = useRef(false);
 
   const showPaymentAlert = (alert: NonNullable<Awaited<ReturnType<typeof attemptRidePayment>>['alert']>) => {
     const buttons = (alert.buttons || []).map((b: PaymentAlertButton) => ({
@@ -199,7 +207,7 @@ function RideCompletedScreenContent() {
             // Pre-fill support with the stuck ride + a payment-failed topic.
             ? () => router.push(`/support?rideId=${rideId}&topic=payment_failed` as any)
             : b.kind === 'retry'
-              ? () => handleSubmitRef.current?.()
+              ? () => handleSubmitRef.current?.(activeOverrideCardRef.current)
               : undefined,
     }));
     setConfirmSheet({
@@ -213,16 +221,22 @@ function RideCompletedScreenContent() {
 
   const handleSubmit = async (overrideCardId?: string) => {
     if (isSubmitting) return; // prevent double tap
+    if (overrideCardId) activeOverrideCardRef.current = overrideCardId;
     setIsSubmitting(true);
     setSubmitPhase('rating');
     try {
       const tipAmount = selectedTip || (customTip ? parseFloat(customTip) || 0 : 0);
 
-      // 1. Rate the driver first — this is fire-and-forget because
-      //    rating may fail if already rated (idempotent upstream).
-      try {
-        await rateRide(rideId as string, rating, comment || undefined, tipAmount > 0 ? tipAmount : undefined);
-      } catch { /* rating may fail if already rated */ }
+      // 1. Rate the driver first — fire-and-forget, and ONLY once across
+      //    retries. /rate accumulates tip into driver_earnings on every call,
+      //    so re-rating on a card-change retry would over-credit the driver
+      //    while the eventual payment charges a single tip (Codex P1).
+      if (!hasRatedRef.current) {
+        try {
+          await rateRide(rideId as string, rating, comment || undefined, tipAmount > 0 ? tipAmount : undefined);
+        } catch { /* rating may fail if already rated */ }
+        hasRatedRef.current = true;
+      }
 
       // 2. Process payment. If the rider has already paid (came back to
       //    this screen), skip the attempt entirely.

--- a/rider-app/app/ride-completed.tsx
+++ b/rider-app/app/ride-completed.tsx
@@ -36,8 +36,17 @@ const GOOGLE_MAPS_API_KEY = process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY;
 function RideCompletedScreenContent() {
   const router = useRouter();
   // payWithCard is set when the rider returns from the "Change Card" escape
-  // (manage-cards) having picked a different card for this stuck trip.
-  const { rideId, payWithCard } = useLocalSearchParams<{ rideId: string; payWithCard?: string }>();
+  // (manage-cards) having picked a different card for this stuck trip. tip/rated
+  // are carried back so the remounted screen re-charges the SAME tip the rider
+  // already chose (and was credited to the driver via /rate on the first
+  // attempt) instead of resetting to 0, and skips re-rating (which would
+  // overwrite the original stars/comment). See Codex 62i6.
+  const { rideId, payWithCard, tip: tipParam, rated: ratedParam } = useLocalSearchParams<{
+    rideId: string;
+    payWithCard?: string;
+    tip?: string;
+    rated?: string;
+  }>();
   const { currentRide, currentDriver, fetchRide, rateRide, clearRide } = useRideStore();
 
   // P0-5: confirmPayment is called when the backend returns
@@ -53,7 +62,11 @@ function RideCompletedScreenContent() {
   const [rating, setRating] = useState(5);
   const [comment, setComment] = useState('');
   const [selectedTip, setSelectedTip] = useState<number | null>(null);
-  const [customTip, setCustomTip] = useState('');
+  // Rehydrate the tip the rider chose before the Change Card detour so the
+  // re-charge collects it and the receipt matches (Codex 62i6).
+  const [customTip, setCustomTip] = useState(
+    typeof tipParam === 'string' && parseFloat(tipParam) > 0 ? tipParam : '',
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitPhase, setSubmitPhase] = useState<'idle' | 'rating' | 'confirming'>('idle');
   const [alreadyPaid, setAlreadyPaid] = useState(false);
@@ -193,7 +206,10 @@ function RideCompletedScreenContent() {
   // on every call. Across a retry (button or auto card-change) we must post it
   // at most once or the driver is over-credited while only one tip is charged
   // (Codex P1). This latches after the first attempt.
-  const hasRatedRef = useRef(false);
+  // Seed from the route: if the first attempt already posted /rate before its
+  // payment failed, the remounted screen must NOT re-rate (re-rating overwrites
+  // the rider's original stars/comment and /rate accumulates driver_earnings).
+  const hasRatedRef = useRef(ratedParam === '1');
 
   const showPaymentAlert = (alert: NonNullable<Awaited<ReturnType<typeof attemptRidePayment>>['alert']>) => {
     const buttons = (alert.buttons || []).map((b: PaymentAlertButton) => ({
@@ -201,8 +217,14 @@ function RideCompletedScreenContent() {
       style: (b.kind === 'cancel' ? 'cancel' : 'default') as 'default' | 'cancel',
       onPress:
         b.kind === 'change_card'
-          // Carry the ride so manage-cards can re-charge THIS trip on the new card.
-          ? () => router.push(`/manage-cards?rideId=${rideId}&forPayment=1` as any)
+          // Carry the ride + the already-chosen tip + whether we've rated so the
+          // re-charge collects the same tip and doesn't re-rate (Codex 62i6).
+          ? () => {
+              const _tip = selectedTip || (customTip ? parseFloat(customTip) || 0 : 0);
+              router.push(
+                `/manage-cards?rideId=${rideId}&forPayment=1&tip=${_tip}&rated=${hasRatedRef.current ? 1 : 0}` as any,
+              );
+            }
           : b.kind === 'support'
             // Pre-fill support with the stuck ride + a payment-failed topic.
             ? () => router.push(`/support?rideId=${rideId}&topic=payment_failed` as any)

--- a/rider-app/app/support.tsx
+++ b/rider-app/app/support.tsx
@@ -1,6 +1,22 @@
 import React from 'react';
+import { useLocalSearchParams } from 'expo-router';
 import SupportScreen from '@shared/components/SupportScreen';
 
 export default function RiderSupportScreen() {
-  return <SupportScreen role="rider" />;
+  // Opened from the stuck end-of-ride payment screen with ?rideId=&topic=
+  // payment_failed — drop the rider straight into a pre-filled Contact ticket.
+  const { rideId, topic } = useLocalSearchParams<{ rideId?: string; topic?: string }>();
+  const isPaymentIssue = topic === 'payment_failed';
+  return (
+    <SupportScreen
+      role="rider"
+      initialTab={isPaymentIssue ? 'contact' : 'faq'}
+      initialCategory={isPaymentIssue ? 'payment_failed' : 'general'}
+      initialIssue={
+        isPaymentIssue
+          ? `I couldn't complete payment for my ride${rideId ? ` (ride ${rideId})` : ''}. My card was declined and I'm unable to pay or change cards.`
+          : ''
+      }
+    />
+  );
 }

--- a/rider-app/utils/__tests__/attemptRidePayment.test.ts
+++ b/rider-app/utils/__tests__/attemptRidePayment.test.ts
@@ -195,7 +195,8 @@ describe('attemptRidePayment', () => {
       expect(result.alert?.message).toContain('insufficient funds');
       const buttonKinds = (result.alert?.buttons || []).map((b) => b.kind);
       expect(buttonKinds).toContain('change_card');
-      expect(buttonKinds).toContain('cancel');
+      // The screen blocks back nav — every failure must offer a support escape.
+      expect(buttonKinds).toContain('support');
     });
 
     it('also handles flat (non-detail-wrapped) 402 bodies', async () => {
@@ -242,8 +243,56 @@ describe('attemptRidePayment', () => {
       expect(result.ok).toBe(false);
       expect(result.alert?.variant).toBe('warning');
       expect(result.alert?.title).toMatch(/can't process payment/i);
-      // No change-card CTA — this is an ops issue, not a card issue
-      expect(result.alert?.buttons).toBeFalsy();
+      const kinds = (result.alert?.buttons || []).map((b) => b.kind);
+      // No change-card CTA — this is an ops issue, not a card issue …
+      expect(kinds).not.toContain('change_card');
+      // … but still offer Retry + Support so the rider isn't trapped.
+      expect(kinds).toContain('retry');
+      expect(kinds).toContain('support');
+    });
+  });
+
+  describe('change-card escape (override + no-card + 400)', () => {
+    it('forwards payment_method_id when the rider picks a different card', async () => {
+      const api = makeApi(async () => ({ data: { success: true, charged_amount: 9.99 } }));
+      const result = await attemptRidePayment({
+        api,
+        stripe: makeStripe(),
+        rideId: 'r1',
+        tipAmount: 1,
+        paymentMethodId: 'pm_NEW',
+      });
+      expect(result.ok).toBe(true);
+      expect(api.post).toHaveBeenCalledWith('/rides/r1/process-payment', {
+        tip_amount: 1,
+        payment_method_id: 'pm_NEW',
+      });
+    });
+
+    it('maps 402 no_payment_method to an Add Card alert with support', async () => {
+      const err: any = new Error('no card');
+      err.response = {
+        status: 402,
+        data: { detail: { code: 'no_payment_method', message: 'No payment method on file.' } },
+      };
+      const api = { post: jest.fn().mockRejectedValue(err) };
+      const result = await attemptRidePayment({ api, stripe: makeStripe(), rideId: 'r1', tipAmount: 0 });
+      expect(result.ok).toBe(false);
+      expect(result.alert?.title).toBe('Add a payment method');
+      const kinds = (result.alert?.buttons || []).map((b) => b.kind);
+      expect(kinds).toContain('change_card');
+      expect(kinds).toContain('support');
+    });
+
+    it('turns a 400 dead-end into a Change Card + Support escape', async () => {
+      const err: any = new Error('bad request');
+      err.response = { status: 400, data: { detail: 'No payment method on file. Please add a card.' } };
+      const api = { post: jest.fn().mockRejectedValue(err) };
+      const result = await attemptRidePayment({ api, stripe: makeStripe(), rideId: 'r1', tipAmount: 0 });
+      expect(result.ok).toBe(false);
+      const kinds = (result.alert?.buttons || []).map((b) => b.kind);
+      expect(kinds).toContain('change_card');
+      expect(kinds).toContain('support');
     });
   });
 

--- a/rider-app/utils/attemptRidePayment.ts
+++ b/rider-app/utils/attemptRidePayment.ts
@@ -14,7 +14,7 @@ export type AlertVariant = 'info' | 'success' | 'warning' | 'danger';
 
 export interface PaymentAlertButton {
   text: string;
-  kind?: 'change_card' | 'retry' | 'cancel';
+  kind?: 'change_card' | 'retry' | 'cancel' | 'support';
 }
 
 export interface PaymentAlert {
@@ -50,38 +50,54 @@ export interface PaymentAttemptDeps {
   stripe: StripeLike | null;
   rideId: string;
   tipAmount: number;
+  /**
+   * In-app "Change Card" escape: the card the rider picked after a decline /
+   * no-card failure. Forwarded to the backend so the failed ride is re-charged
+   * on THIS card (fresh charge) instead of the booking-time card or hold.
+   */
+  paymentMethodId?: string;
 }
+
+// Every failure on the end-of-ride payment screen must offer a way OUT — the
+// screen blocks the hardware back button, so an alert with only "OK" traps the
+// rider in a retry loop. "Contact Support" is the universal escape; "Change
+// Card" is added wherever a different card can plausibly fix the charge.
+const SUPPORT_BTN: PaymentAlertButton = { text: 'Contact Support', kind: 'support' };
+const CHANGE_CARD_BTN: PaymentAlertButton = { text: 'Change Card', kind: 'change_card' };
 
 const DECLINE_ALERT = (message: string): PaymentAlert => ({
   title: 'Card declined',
   message: message || 'Your card was declined.',
   variant: 'danger',
-  buttons: [
-    { text: 'Change Card', kind: 'change_card' },
-    { text: 'Cancel', kind: 'cancel' },
-  ],
+  buttons: [CHANGE_CARD_BTN, SUPPORT_BTN],
+});
+
+const NO_PAYMENT_METHOD_ALERT = (message: string): PaymentAlert => ({
+  title: 'Add a payment method',
+  message: message || 'There is no card on file for this trip. Add a card to pay.',
+  variant: 'danger',
+  buttons: [{ text: 'Add Card', kind: 'change_card' }, SUPPORT_BTN],
 });
 
 const AUTH_FAILED_ALERT = (message: string): PaymentAlert => ({
   title: 'Authentication failed',
   message: message || 'Card authentication did not complete.',
   variant: 'danger',
-  buttons: [
-    { text: 'Change Card', kind: 'change_card' },
-    { text: 'Try Again', kind: 'retry' },
-  ],
+  buttons: [CHANGE_CARD_BTN, { text: 'Try Again', kind: 'retry' }, SUPPORT_BTN],
 });
 
 const PROCESSOR_ERROR_ALERT: PaymentAlert = {
   title: "Can't process payment right now",
   message: 'Payment service is temporarily unavailable. Please try again shortly.',
   variant: 'warning',
+  buttons: [{ text: 'Try Again', kind: 'retry' }, SUPPORT_BTN],
 };
 
 const UNKNOWN_ERROR_ALERT: PaymentAlert = {
   title: 'Payment error',
-  message: 'Something went wrong. Please try again.',
+  message: "Something went wrong and we couldn't complete the payment. Try a different card, or contact support.",
   variant: 'danger',
+  buttons: [CHANGE_CARD_BTN, SUPPORT_BTN],
 };
 
 const STRIPE_UNAVAILABLE_ALERT: PaymentAlert = {
@@ -115,10 +131,13 @@ export async function attemptRidePayment(
   deps: PaymentAttemptDeps,
   _retryAttempt = 0,
 ): Promise<PaymentAttemptResult> {
-  const { api, stripe, rideId, tipAmount } = deps;
+  const { api, stripe, rideId, tipAmount, paymentMethodId } = deps;
+  const body: Record<string, any> = { tip_amount: tipAmount };
+  // Only include when set so a normal retry keeps charging the booking card.
+  if (paymentMethodId) body.payment_method_id = paymentMethodId;
 
   try {
-    const resp = await api.post(`/rides/${rideId}/process-payment`, { tip_amount: tipAmount });
+    const resp = await api.post(`/rides/${rideId}/process-payment`, body);
     const data = (resp && resp.data) || {};
 
     // Case 1 — straight success or already-paid idempotent return
@@ -148,7 +167,7 @@ export async function attemptRidePayment(
       // the backend side guarantees no double charge.
       const finalize = await api.post(
         `/rides/${rideId}/process-payment`,
-        { tip_amount: tipAmount },
+        body,
       );
       const fin = (finalize && finalize.data) || {};
       if (fin.success === true || fin.already_paid === true) {
@@ -172,8 +191,30 @@ export async function attemptRidePayment(
       return { ok: false, alert: DECLINE_ALERT(message || '') };
     }
 
+    // No card on file for the trip (booking-time card removed / rejected auth
+    // left nothing usable). Backend returns a structured 402; the rider needs
+    // to ADD a card, not just retry.
+    if (status === 402 && code === 'no_payment_method') {
+      return { ok: false, alert: NO_PAYMENT_METHOD_ALERT(message || '') };
+    }
+
+    // Card needs 3DS we couldn't complete off-session, or any other 402 — a
+    // different card is the most likely fix.
+    if (status === 402 && code === 'authentication_required') {
+      return { ok: false, alert: AUTH_FAILED_ALERT(message || '') };
+    }
+    if (status === 402) {
+      return { ok: false, alert: DECLINE_ALERT(message || '') };
+    }
+
     if (status === 502) {
       return { ok: false, alert: PROCESSOR_ERROR_ALERT };
+    }
+
+    // 400 (e.g. legacy no-payment-method, validation) — never a dead end on a
+    // back-blocked screen. Offer Change Card + Contact Support.
+    if (status === 400) {
+      return { ok: false, alert: UNKNOWN_ERROR_ALERT };
     }
 
     if (status === 409 && typeof message === 'string' && message.includes('requires completed state')) {

--- a/rider-app/utils/attemptRidePayment.ts
+++ b/rider-app/utils/attemptRidePayment.ts
@@ -106,6 +106,17 @@ const STRIPE_UNAVAILABLE_ALERT: PaymentAlert = {
   variant: 'danger',
 };
 
+// An admin has emailed a payable invoice for this trip. In-app charging is
+// blocked server-side, so Change Card/Retry would just loop on the same 409 —
+// direct the rider to the emailed pay link instead.
+const INVOICE_ISSUED_ALERT: PaymentAlert = {
+  title: 'Invoice emailed',
+  message:
+    'We’ve emailed you a secure link to pay for this trip. Please use that link to complete payment — there’s nothing more to do here.',
+  variant: 'info',
+  buttons: [SUPPORT_BTN],
+};
+
 /**
  * Attempt to charge the rider's card for a completed ride. Wraps the
  * POST /rides/{id}/process-payment call with 3DS + decline handling.
@@ -215,6 +226,13 @@ export async function attemptRidePayment(
     // back-blocked screen. Offer Change Card + Contact Support.
     if (status === 400) {
       return { ok: false, alert: UNKNOWN_ERROR_ALERT };
+    }
+
+    // An admin has issued a payable invoice for this ride — collection has moved
+    // to the emailed link. Retrying/Change Card would re-hit this 409, so show the
+    // pay-by-email instruction instead of the generic alert.
+    if (status === 409 && code === 'invoice_issued') {
+      return { ok: false, alert: INVOICE_ISSUED_ALERT };
     }
 
     if (status === 409 && typeof message === 'string' && message.includes('requires completed state')) {

--- a/shared/components/SupportScreen.tsx
+++ b/shared/components/SupportScreen.tsx
@@ -81,9 +81,18 @@ interface Props {
   role: Role;
   /** Initial tab when the screen mounts. Defaults to 'faq'. */
   initialTab?: Tab;
+  /** Pre-fill the contact-form issue text (e.g. from a stuck payment screen). */
+  initialIssue?: string;
+  /** Category for a pre-filled ticket. Defaults to 'general'. */
+  initialCategory?: string;
 }
 
-export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
+export default function SupportScreen({
+  role,
+  initialTab = 'faq',
+  initialIssue = '',
+  initialCategory = 'general',
+}: Props) {
   const router = useRouter();
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
@@ -116,7 +125,7 @@ export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
   const conversationIdRef = useRef<string | null>(null);
 
   // Contact form
-  const [issue, setIssue] = useState('');
+  const [issue, setIssue] = useState(initialIssue);
   const [submitting, setSubmitting] = useState(false);
 
   const [alertState, setAlertState] = useState<{
@@ -170,9 +179,9 @@ export default function SupportScreen({ role, initialTab = 'faq' }: Props) {
     setSubmitting(true);
     try {
       await api.post('/support/tickets', {
-        subject: 'App Support Request',
+        subject: initialCategory === 'payment_failed' ? 'Payment Issue' : 'App Support Request',
         message: issue,
-        category: 'general',
+        category: initialCategory,
       });
       setIssue('');
       setAlertState({


### PR DESCRIPTION
When the booking-time card is declined (or none is on file), process_payment
now accepts a payment_method_id override so the rider can pick a different
card and have THIS trip re-charged on it via a fresh PaymentIntent (never the
dead hold on the rejected card). The 'no payment method' case now returns a
structured 402 no_payment_method with suggested_action=change_card instead of
a bare 400, so the rider app can surface an Add Card escape rather than a
dead-end 'Payment error' alert.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AYKnWYeBMZcDX69kHWzrRC

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
