### PR TITLE
fix(payments): disable redirect-based methods on server-side PaymentIntents

### DIFF
--- a/backend/routes/corporate_wallet.py
+++ b/backend/routes/corporate_wallet.py
@@ -121,6 +121,10 @@ async def manual_topup(
             payment_method=body.payment_method_id,
             off_session=True,
             confirm=True,
+            # Server-side off_session confirm: disable redirect-based payment
+            # methods so Stripe doesn't demand a `return_url` (it has no browser
+            # to return to) and reject the top-up with invalid_request_error.
+            automatic_payment_methods={"enabled": True, "allow_redirects": "never"},
         )
     # Always set an idempotency key so retries after network timeouts don't
     # create duplicate PaymentIntents. Client may supply one (e.g. a UUID they

--- a/backend/tests/test_ride_preauth.py
+++ b/backend/tests/test_ride_preauth.py
@@ -105,6 +105,12 @@ class TestAuthorize:
         assert kwargs["capture_method"] == "manual"  # HOLD, not charge
         assert kwargs["confirm"] is True
         assert kwargs["off_session"] is False  # rider present at booking
+        # Redirect-based payment methods disabled so a server-side confirm
+        # doesn't require a return_url (Stripe invalid_request_error otherwise).
+        assert kwargs["automatic_payment_methods"] == {
+            "enabled": True,
+            "allow_redirects": "never",
+        }
         assert kwargs["metadata"]["source"] == "ride_booking_authorization"
         assert kwargs["metadata"]["authorized_amount"] == "35.00"
         # amount-pinned idempotency key: a re-auth at a revised estimate gets a

--- a/backend/tests/test_stripe_charge.py
+++ b/backend/tests/test_stripe_charge.py
@@ -135,6 +135,12 @@ class TestSuccess:
         assert kwargs["payment_method"] == "pm_helper"
         assert kwargs["off_session"] is True
         assert kwargs["confirm"] is True
+        # Redirect-based payment methods disabled so a server-side confirm
+        # doesn't require a return_url (Stripe invalid_request_error otherwise).
+        assert kwargs["automatic_payment_methods"] == {
+            "enabled": True,
+            "allow_redirects": "never",
+        }
         assert kwargs["metadata"]["ride_id"] == "ride_helper_1"
         assert kwargs["metadata"]["rider_id"] == "rider_helper_1"
         # Idempotency key pins future retries to the same PI; the amount and the

--- a/backend/utils/corporate_autotopup.py
+++ b/backend/utils/corporate_autotopup.py
@@ -132,6 +132,10 @@ async def _process_one(wallet: dict, stripe_secret: str) -> None:
             payment_method=pm_id,
             off_session=True,
             confirm=True,
+            # Server-side off_session confirm: disable redirect-based payment
+            # methods so Stripe doesn't require a `return_url` and reject the
+            # auto-top-up with invalid_request_error.
+            automatic_payment_methods={"enabled": True, "allow_redirects": "never"},
             metadata={
                 "scope": "corporate_topup",
                 "company_id": company["id"],

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -188,6 +188,14 @@ async def charge_ride(
         # runs the 3DS sheet with the returned client_secret.
         "off_session": True,
         "confirm": True,
+        # Enable payment methods but never the redirect-based ones (e.g.
+        # iDEAL, Klarna) the account may have toggled on in the Stripe
+        # Dashboard. A server-side off_session confirm has no browser to
+        # redirect back to, so without this Stripe rejects the call with
+        # invalid_request_error ("you must provide a `return_url`"), which
+        # broke every ride charge. Card-only keeps the hold/charge path
+        # non-redirecting and return_url-free.
+        "automatic_payment_methods": {"enabled": True, "allow_redirects": "never"},
         "metadata": {
             "ride_id": ride_id,
             "rider_id": rider_id,
@@ -372,6 +380,12 @@ async def authorize_ride(
         "capture_method": "manual",
         "confirm": True,
         "off_session": off_session,
+        # Disable redirect-based payment methods (see charge_ride above):
+        # a confirmed PaymentIntent with redirect methods enabled requires a
+        # `return_url`, which a server-side hold can't supply — Stripe was
+        # rejecting every booking pre-auth with invalid_request_error
+        # ("[preauth] authorization ops error"). Card-only avoids it.
+        "automatic_payment_methods": {"enabled": True, "allow_redirects": "never"},
         "metadata": {
             "ride_id": ride_id,
             "rider_id": rider_id,


### PR DESCRIPTION
Every ride card pre-authorization and completion charge was failing with
Stripe invalid_request_error (HTTP 400): "you must provide a `return_url`".
The PaymentIntents created in authorize_ride / charge_ride use confirm=True
off_session, but the Stripe account has redirect-based payment methods
enabled in the Dashboard, so Stripe's default automatic_payment_methods
demanded a return_url a server-side confirm cannot supply.

Surfaced in Sentry as "[preauth] authorization ops error for ride=..."
(routes/rides.py _preauthorize_ride_card) — the hold then degraded to no
hold and the completion charge failed outright, breaking payments.

Set automatic_payment_methods={"enabled": True, "allow_redirects": "never"}
on all server-side off_session confirms (matching the existing pattern at
routes/payments.py), so card holds/charges no longer require a return_url:
- utils/stripe_charge.py: authorize_ride (hold) + charge_ride (settlement)
- routes/corporate_wallet.py: admin top-up confirm path (same defect)
- utils/corporate_autotopup.py: auto top-up (same defect)

Regression assertions added in test_ride_preauth.py + test_stripe_charge.py.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011bhs7uRvMFejBcBDbT3gbp

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 
