### PR TITLE
fix(webhooks): log routine Stripe lifecycle events at debug, not warning

### DIFF
--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -61,6 +61,40 @@ _STRIPE_HANDLED_EVENTS = frozenset(
 # Public alias exported for tests
 ALLOWED_STRIPE_EVENTS = _STRIPE_HANDLED_EVENTS
 
+# Routine Stripe lifecycle events we knowingly do NOT act on. They fire during
+# normal payment flows (e.g. a manual-capture hold emits
+# payment_intent.amount_capturable_updated; a capture emits charge.succeeded)
+# when the Dashboard webhook is configured to send "all events". They are not
+# bugs and not actionable, so log them at debug rather than warning to keep the
+# signal-to-noise high — a genuinely unexpected event type still logs a warning
+# so a missing handler stands out. Not exhaustive: anything not listed here and
+# not handled still warns, by design.
+_STRIPE_IGNORED_EVENTS = frozenset(
+    {
+        "payment_intent.created",
+        "payment_intent.amount_capturable_updated",
+        "payment_intent.canceled",
+        "payment_intent.processing",
+        "payment_intent.requires_action",
+        "charge.succeeded",
+        "charge.captured",
+        "charge.updated",
+        "charge.pending",
+        "payment_method.attached",
+        "payment_method.detached",
+        "payment_method.updated",
+        "customer.created",
+        "customer.updated",
+        "setup_intent.created",
+        "setup_intent.succeeded",
+        "invoice.created",
+        "invoice.finalized",
+        "invoice.updated",
+        "invoice.payment_succeeded",
+        "payout.created",
+    }
+)
+
 
 def _extract_invoice_payment_intent(invoice: dict, stripe_secret: str = "") -> str | None:
     """Resolve the PaymentIntent id for a paid invoice across Stripe API versions.
@@ -1243,10 +1277,18 @@ async def stripe_webhook(request: Request):
                 event_type,
                 extra={"domain": "payments", "event_id": event_id},
             )
+        elif event_type in _STRIPE_IGNORED_EVENTS:
+            # Routine lifecycle echo we deliberately don't process — debug, not
+            # warning, so it doesn't drown out genuinely unexpected event types.
+            logger.debug(
+                "[WEBHOOK] Ignoring routine Stripe lifecycle event %r (not actionable).",
+                event_type,
+                extra={"domain": "payments", "event_id": event_id},
+            )
         else:
             logger.warning(
                 "[WEBHOOK] Unhandled Stripe event type %r — not in _STRIPE_HANDLED_EVENTS. "
-                "Update Stripe dashboard to send only subscribed events.",
+                "Either add a handler or stop sending it from the Stripe dashboard.",
                 event_type,
                 extra={"domain": "payments", "event_id": event_id},
             )

--- a/backend/tests/test_webhooks_main.py
+++ b/backend/tests/test_webhooks_main.py
@@ -565,6 +565,56 @@ class TestAllowedStripeEvents:
         assert "checkout.session.completed" in ALLOWED_STRIPE_EVENTS
 
 
+class TestStripeWebhookEventLogLevel:
+    """Routine lifecycle events log at debug; truly-unknown ones still warn."""
+
+    def _run(self, event_type: str):
+        from backend.routes import webhooks as wh
+
+        async def mock_get_app_settings():
+            return {"stripe_webhook_secret": "ws", "stripe_secret_key": "sk"}
+
+        raw_event = _make_stripe_event(event_type, {"id": "obj_1"})
+        event_obj = MagicMock()
+        event_obj.get = lambda k, d=None: raw_event.get(k, d)
+        event_obj.to_dict_recursive = lambda: raw_event
+
+        req = MagicMock()
+        req.body = AsyncMock(return_value=b"payload")
+        req.headers = {"stripe-signature": "sig"}
+
+        import stripe
+
+        with (
+            patch("backend.routes.webhooks.get_app_settings", mock_get_app_settings),
+            patch.object(stripe.Webhook, "construct_event", return_value=event_obj),
+            patch("backend.routes.webhooks.claim_stripe_event", AsyncMock(return_value=True)),
+            patch("backend.routes.webhooks.mark_stripe_event_processed", AsyncMock()) as mark,
+            patch("backend.routes.webhooks.logger") as mock_logger,
+        ):
+            result = asyncio.run(wh.stripe_webhook(request=req))
+        return result, mock_logger, mark
+
+    def test_ignored_lifecycle_event_logs_debug_not_warning(self):
+        # The exact events the rider's webhook log was noisy with.
+        for evt in (
+            "payment_intent.created",
+            "payment_intent.amount_capturable_updated",
+            "charge.succeeded",
+        ):
+            result, mock_logger, mark = self._run(evt)
+            assert result.get("unhandled") is True, evt
+            mock_logger.warning.assert_not_called()
+            assert mock_logger.debug.called, evt
+            # Unknown/ignored events stay replayable: processed_at left NULL.
+            mark.assert_not_called()
+
+    def test_truly_unknown_event_still_warns(self):
+        result, mock_logger, _ = self._run("some.brand.new.event")
+        assert result.get("unhandled") is True
+        mock_logger.warning.assert_called()
+
+
 class TestLoopMonitor:
     def test_record_heartbeat(self):
         from backend.utils.loop_monitor import _heartbeats, record_heartbeat


### PR DESCRIPTION
The Stripe webhook endpoint receives all events (Dashboard sends the full set), so routine lifecycle echoes — payment_intent.created, payment_intent.amount_capturable_updated (manual-capture hold placed), charge.succeeded, etc. — were each logged at warning with "Unhandled Stripe event type", drowning out genuinely unexpected types.

Add _STRIPE_IGNORED_EVENTS: known-benign, non-actionable lifecycle events now log at debug. Anything neither handled nor in this set still warns, so a missing handler stands out. Behaviour is otherwise unchanged — these events still return 200 with processed_at left NULL so reconciliation can replay them if they later become actionable.

Regression tests assert the debug-vs-warning routing in test_webhooks_main.py.

Co-developed with Claude Code (claude-sonnet-4-6)


Claude-Session: https://claude.ai/code/session_011bhs7uRvMFejBcBDbT3gbp

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->
