### PR TITLE
Fix rider searching map crash

### DIFF
--- a/rider-app/app/driver-arriving.tsx
+++ b/rider-app/app/driver-arriving.tsx
@@ -106,6 +106,7 @@ function DriverArrivingScreenContent() {
     }
   }, [currentRide?.status]);
 
+  const rideCoords = useMemo(() => getRideMapCoords(currentRide), [currentRide]);
   const cancellationFee = (currentRide as any)?.cancellation_fee ?? 3.0;
 
   // Capture the driver's position the first time valid coords arrive.
@@ -142,19 +143,19 @@ function DriverArrivingScreenContent() {
   // Stable pickup→dropoff refs — ride endpoints never change mid-ride.
   const rideRouteOrigin = useMemo(
     () =>
-      currentRide
-        ? { latitude: currentRide.pickup_lat, longitude: currentRide.pickup_lng }
+      rideCoords
+        ? { latitude: rideCoords.pickupLat, longitude: rideCoords.pickupLng }
         : null,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [currentRide?.id],
+    [currentRide?.id, rideCoords?.pickupLat, rideCoords?.pickupLng],
   );
   const rideRouteDestination = useMemo(
     () =>
-      currentRide
-        ? { latitude: currentRide.dropoff_lat, longitude: currentRide.dropoff_lng }
+      rideCoords
+        ? { latitude: rideCoords.dropoffLat, longitude: rideCoords.dropoffLng }
         : null,
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [currentRide?.id],
+    [currentRide?.id, rideCoords?.dropoffLat, rideCoords?.dropoffLng],
   );
   const freeCancelWindowSeconds = (currentRide as any)?.free_cancel_window_seconds ?? 120;
 
@@ -210,18 +211,18 @@ function DriverArrivingScreenContent() {
 
   // ── Map fitting ──
   useEffect(() => {
-    if (currentRide && mapRef.current) {
+    if (currentRide && rideCoords && mapRef.current) {
       if (currentDriver?.lat != null && currentDriver?.lng != null) {
         mapRef.current.fitToCoordinates(
           [
-            { latitude: currentRide.pickup_lat, longitude: currentRide.pickup_lng },
+            { latitude: rideCoords.pickupLat, longitude: rideCoords.pickupLng },
             { latitude: currentDriver.lat, longitude: currentDriver.lng },
           ],
           { edgePadding: { top: 80, right: 50, bottom: SCREEN_HEIGHT * 0.5, left: 50 }, animated: true },
         );
       }
     }
-  }, [currentDriver?.lat, currentDriver?.lng, currentRide?.id]);
+  }, [currentDriver?.lat, currentDriver?.lng, currentRide?.id, rideCoords?.pickupLat, rideCoords?.pickupLng]);
 
   // ── Cancel handler (fixed: errors are caught, user stays on page) ──
   const performCancel = async (reason?: string) => {
@@ -325,13 +326,13 @@ function DriverArrivingScreenContent() {
   return (
     <View style={styles.container}>
       {/* ═══ Full-screen map ═══ */}
-      {currentRide ? (
+      {currentRide && rideCoords ? (
         <MapView
           ref={mapRef}
           provider={Platform.OS === 'android' ? PROVIDER_GOOGLE : undefined}
           style={StyleSheet.absoluteFill}
           initialRegion={{
-            latitude: currentRide.pickup_lat, longitude: currentRide.pickup_lng,
+            latitude: rideCoords.pickupLat, longitude: rideCoords.pickupLng,
             latitudeDelta: 0.02, longitudeDelta: 0.02,
           }}
         >
@@ -344,7 +345,7 @@ function DriverArrivingScreenContent() {
           {driverOriginSnapshot && activeDriverRouteCoords === null && (
             <MapViewDirections
               origin={driverOriginSnapshot}
-              destination={{ latitude: currentRide.pickup_lat, longitude: currentRide.pickup_lng }}
+              destination={{ latitude: rideCoords.pickupLat, longitude: rideCoords.pickupLng }}
               apikey={process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY || ''}
               strokeWidth={0} strokeColor="transparent"
               onReady={(r: any) => {
@@ -378,12 +379,12 @@ function DriverArrivingScreenContent() {
           {rideRouteCoords.length > 1 && renderGradientPolyline(rideRouteCoords, false)}
 
           {/* Pickup marker */}
-          <Marker coordinate={{ latitude: currentRide.pickup_lat, longitude: currentRide.pickup_lng }} anchor={{ x: 0.5, y: 0.5 }} zIndex={103}>
+          <Marker coordinate={{ latitude: rideCoords.pickupLat, longitude: rideCoords.pickupLng }} anchor={{ x: 0.5, y: 0.5 }} zIndex={103}>
             <View style={styles.markerWrap}><View style={[styles.markerDot, { backgroundColor: '#10B981' }]} /></View>
           </Marker>
 
           {/* Dropoff marker */}
-          <Marker coordinate={{ latitude: currentRide.dropoff_lat, longitude: currentRide.dropoff_lng }} anchor={{ x: 0.5, y: 0.5 }} zIndex={103}>
+          <Marker coordinate={{ latitude: rideCoords.dropoffLat, longitude: rideCoords.dropoffLng }} anchor={{ x: 0.5, y: 0.5 }} zIndex={103}>
             <View style={styles.markerWrap}><View style={[styles.markerDot, { backgroundColor: '#EF4444' }]} /></View>
           </Marker>
 
@@ -405,7 +406,7 @@ function DriverArrivingScreenContent() {
       ) : (
         <View style={styles.mapPlaceholder}>
           <ActivityIndicator size="large" color={colors.primary} />
-          <Text style={styles.loadingText}>Loading ride...</Text>
+          <Text style={styles.loadingText}>{currentRide ? 'Loading map...' : 'Loading ride...'}</Text>
         </View>
       )}
 
@@ -651,6 +652,31 @@ function DriverArrivingScreenContent() {
       />
     </View>
   );
+}
+
+
+type RideMapCoords = {
+  pickupLat: number;
+  pickupLng: number;
+  dropoffLat: number;
+  dropoffLng: number;
+};
+
+function finiteNumber(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(n) ? n : null;
+}
+
+function getRideMapCoords(ride: any): RideMapCoords | null {
+  if (!ride) return null;
+  const pickupLat = finiteNumber(ride.pickup_lat ?? ride.pickup?.lat);
+  const pickupLng = finiteNumber(ride.pickup_lng ?? ride.pickup?.lng);
+  const dropoffLat = finiteNumber(ride.dropoff_lat ?? ride.dropoff?.lat);
+  const dropoffLng = finiteNumber(ride.dropoff_lng ?? ride.dropoff?.lng);
+  if (pickupLat === null || pickupLng === null || dropoffLat === null || dropoffLng === null) {
+    return null;
+  }
+  return { pickupLat, pickupLng, dropoffLat, dropoffLng };
 }
 
 function renderGradientPolyline(coords: any[], dashed: boolean) {


### PR DESCRIPTION
### Motivation
- The rider app was sometimes showing a white screen during booking/searching when the driver-arriving screen attempted to render a MapView with missing or malformed ride coordinates. This change hardens the UI against those invalid payload shapes so the rider sees a loading placeholder instead of a crash. 

### Description
- Added a `getRideMapCoords` helper and `finiteNumber` normaliser to accept either flat (`pickup_lat`) or nested (`pickup.lat`) coordinate shapes and to ensure coordinates are finite numbers before use. 
- Guarded map rendering and related logic so `MapView`, `MapViewDirections`, `fitToCoordinates`, and marker coordinates only run when normalized `rideCoords` are available. 
- Replaced direct `currentRide.pickup_*` / `dropoff_*` usages with `rideCoords.*` where appropriate and updated the map loading text to differentiate between "Loading map..." and "Loading ride...". 
- All changes were made in `rider-app/app/driver-arriving.tsx` and keep existing behaviour when coordinates are valid. 

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch conflicts and it passed. 
- Attempted a TypeScript check with `cd rider-app && npx tsc --noEmit --pretty false` but the check was blocked by missing local dependencies/type definitions (local `node_modules` / Expo tsconfig), so full TS validation could not complete in this environment. 
- Attempted to rebuild the graph with `python3 -c "from graphify.watch import _rebuild_code..."` but this was blocked because the `graphify` package was not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a375f15b8c883308233d144b54922bb)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
