### PR TITLE
feat(pass): add 3-day expiry warning push notification

### DIFF
--- a/backend/migrations/178_sub_expiry_warned_3d.sql
+++ b/backend/migrations/178_sub_expiry_warned_3d.sql
@@ -1,0 +1,28 @@
+-- Rollback: ALTER TABLE driver_subscriptions DROP COLUMN IF EXISTS expiry_warned_3d;
+--
+-- Adds a second claim-flag for the 3-day expiry warning push notification.
+-- The existing `expiry_warned` column gates the 24-hour push; this new column
+-- gates an earlier reminder at ~72 hours before expiry so drivers have enough
+-- time to renew before they are forced offline.
+--
+-- Both flags follow the claim-flag replay-safety pattern: the background loop
+-- performs an UPDATE … WHERE expiry_warned_3d = false and only sends the push
+-- when the update returns a row, preventing duplicate notifications on
+-- multi-replica deploys.
+
+ALTER TABLE driver_subscriptions
+  ADD COLUMN IF NOT EXISTS expiry_warned_3d BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Backfill: any subscription expiring in the next 3 days that was already
+-- warned at 24h has already been active — mark the 3d flag true so they
+-- don't get a belated "3 days left" message on the next loop tick.
+UPDATE driver_subscriptions
+SET    expiry_warned_3d = TRUE
+WHERE  expiry_warned = TRUE;
+
+-- Index for the background loop query so the 6-hour sweep is fast even with
+-- many rows. The partial index only covers active subscriptions because those
+-- are the only ones the loop checks.
+CREATE INDEX IF NOT EXISTS idx_driver_subscriptions_expiry_warn_3d
+  ON driver_subscriptions (expires_at, expiry_warned_3d)
+  WHERE status = 'active';

--- a/backend/migrations/178_sub_expiry_warned_3d.sql
+++ b/backend/migrations/178_sub_expiry_warned_3d.sql
@@ -1,4 +1,6 @@
--- Rollback: ALTER TABLE driver_subscriptions DROP COLUMN IF EXISTS expiry_warned_3d;
+-- Rollback:
+--   DROP INDEX CONCURRENTLY IF EXISTS idx_driver_subscriptions_expiry_warn_3d;
+--   ALTER TABLE driver_subscriptions DROP COLUMN IF EXISTS expiry_warned_3d;
 --
 -- Adds a second claim-flag for the 3-day expiry warning push notification.
 -- The existing `expiry_warned` column gates the 24-hour push; this new column
@@ -23,6 +25,6 @@ WHERE  expiry_warned = TRUE;
 -- Index for the background loop query so the 6-hour sweep is fast even with
 -- many rows. The partial index only covers active subscriptions because those
 -- are the only ones the loop checks.
-CREATE INDEX IF NOT EXISTS idx_driver_subscriptions_expiry_warn_3d
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_driver_subscriptions_expiry_warn_3d
   ON driver_subscriptions (expires_at, expiry_warned_3d)
   WHERE status = 'active';

--- a/backend/routes/admin/__init__.py
+++ b/backend/routes/admin/__init__.py
@@ -71,6 +71,7 @@ from .safety import router as safety_router
 from .service_areas import router as service_areas_router
 from .settings import router as settings_router
 from .staff import router as staff_router
+from .subscriptions import offer_analytics_router
 from .subscriptions import router as subscriptions_router
 from .support import router as support_router
 from .support_tickets import router as support_tickets_router
@@ -116,6 +117,7 @@ admin_router.include_router(legal_documents_router, dependencies=[Depends(requir
 admin_router.include_router(documents_router, dependencies=[Depends(require_module("documents"))])
 admin_router.include_router(staff_router, dependencies=[Depends(require_module("staff"))])
 admin_router.include_router(subscriptions_router, dependencies=[Depends(require_module("earnings"))])
+admin_router.include_router(offer_analytics_router, dependencies=[Depends(require_module("dashboard"))])
 admin_router.include_router(messaging_router, dependencies=[Depends(require_module("notifications"))])
 admin_router.include_router(maintenance_router, dependencies=[Depends(require_module("dashboard"))])
 admin_router.include_router(analytics_router, dependencies=[Depends(require_module("dashboard"))])

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -317,10 +317,14 @@ async def admin_get_subscription_stats(
 
 # ============================================================
 # Per-Service-Area Offer Analytics
+# Mounted separately under require_module("dashboard") in __init__.py
+# so analytics-access admins can reach it without earnings permission.
 # ============================================================
 
+offer_analytics_router = APIRouter()
 
-@router.get("/offer-analytics")
+
+@offer_analytics_router.get("/offer-analytics")
 async def get_offer_analytics(
     start_date: Optional[str] = Query(None, description="ISO date, e.g. 2025-01-01"),
     end_date: Optional[str] = Query(None, description="ISO date, e.g. 2025-12-31"),
@@ -353,82 +357,43 @@ async def get_offer_analytics(
     else:
         end_dt = now
 
-    _truncated = False  # set True by the global path when 200k hard cap is hit
+    _truncated = False  # set True when the 200k hard cap is hit
 
-    if service_area_id:
-        # When filtering to a single area, fetch that area's rides first so
-        # the offer query is scoped to those ride IDs. This avoids the 10k
-        # platform-wide cap cutting off quieter-area offers when other areas
-        # are busier during the same date window.
-        area_ride_rows = await db_supabase.get_rows("rides", {"service_area_id": service_area_id}, limit=20_000) or []
-        if not area_ride_rows:
-            return {
-                "window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
-                "areas": [],
-                "totals": _offer_totals([]),
-            }
-        area_ride_ids = [r["id"] for r in area_ride_rows]
-        offers_in_window: List[Dict] = []
-        for batch_start in range(0, len(area_ride_ids), 500):
-            batch = area_ride_ids[batch_start : batch_start + 500]
-            chunk = (
-                await db_supabase.get_rows(
-                    "ride_offers",
-                    {
-                        "$and": [
-                            {"ride_id": {"$in": batch}},
-                            {"offered_at": {"$gte": start_dt.isoformat()}},
-                            {"offered_at": {"$lte": end_dt.isoformat()}},
-                        ]
-                    },
-                    limit=len(batch) * 20,
-                )
-                or []
+    # Single paginated offer fetch for both the global and per-area paths.
+    # Paging through all offers in the date window ensures no row is silently
+    # dropped. When service_area_id is provided the ride lookup below is
+    # additionally filtered by area, so unrelated offers are bucketed as
+    # unknown and dropped by the aggregation loop — no separate area-first
+    # ride query needed, and no 20k lifetime-rides cap.
+    _PAGE = 5_000
+    _HARD_CAP = 200_000
+    offers_in_window: List[Dict] = []
+    _offset = 0
+    _date_filter = {
+        "$and": [
+            {"offered_at": {"$gte": start_dt.isoformat()}},
+            {"offered_at": {"$lte": end_dt.isoformat()}},
+        ]
+    }
+    while True:
+        _page = (
+            await db_supabase.get_rows(
+                "ride_offers",
+                _date_filter,
+                order="offered_at",
+                desc=True,
+                limit=_PAGE,
+                offset=_offset,
             )
-            offers_in_window.extend(chunk)
-        rides = area_ride_rows
-    else:
-        # Global view: page through ALL offers in the date window so quieter
-        # areas are never silently dropped. A 200k hard safety cap is applied
-        # to prevent runaway admin queries; the response includes a `truncated`
-        # flag when it's hit so the caller can narrow the date range.
-        _PAGE = 5_000
-        _HARD_CAP = 200_000
-        offers_in_window: List[Dict] = []
-        _offset = 0
-        _truncated = False
-        _date_filter = {
-            "$and": [
-                {"offered_at": {"$gte": start_dt.isoformat()}},
-                {"offered_at": {"$lte": end_dt.isoformat()}},
-            ]
-        }
-        while True:
-            _page = (
-                await db_supabase.get_rows(
-                    "ride_offers",
-                    _date_filter,
-                    order="offered_at",
-                    desc=True,
-                    limit=_PAGE,
-                    offset=_offset,
-                )
-                or []
-            )
-            offers_in_window.extend(_page)
-            if len(_page) < _PAGE:
-                break
-            _offset += _PAGE
-            if _offset >= _HARD_CAP:
-                _truncated = True
-                break
-
-        ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
-        rides = []
-        for batch_start in range(0, len(ride_ids), 100):
-            batch = ride_ids[batch_start : batch_start + 100]
-            chunk = await db_supabase.get_rows("rides", {"id": {"$in": batch}}, limit=len(batch)) or []
-            rides.extend(chunk)
+            or []
+        )
+        offers_in_window.extend(_page)
+        if len(_page) < _PAGE:
+            break
+        _offset += _PAGE
+        if _offset >= _HARD_CAP:
+            _truncated = True
+            break
 
     if not offers_in_window:
         return {
@@ -436,6 +401,17 @@ async def get_offer_analytics(
             "areas": [],
             "totals": _offer_totals([]),
         }
+
+    ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
+    rides: List[Dict] = []
+    _ride_filter_base: Dict = {"id": {"$in": []}}
+    if service_area_id:
+        _ride_filter_base = {"id": {"$in": []}, "service_area_id": service_area_id}
+    for batch_start in range(0, len(ride_ids), 100):
+        batch = ride_ids[batch_start : batch_start + 100]
+        _batch_filter = {**_ride_filter_base, "id": {"$in": batch}}
+        chunk = await db_supabase.get_rows("rides", _batch_filter, limit=len(batch)) or []
+        rides.extend(chunk)
 
     ride_area = {r["id"]: r.get("service_area_id") for r in rides}
 

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -344,33 +344,44 @@ async def get_offer_analytics(
     if end_date:
         try:
             end_dt = datetime.fromisoformat(end_date).replace(tzinfo=timezone.utc)
+            # Date-only inputs (no "T") land at midnight of that day, which
+            # excludes all offers later on the same day. Extend to end-of-day.
+            if "T" not in end_date:
+                end_dt = end_dt + timedelta(days=1) - timedelta(seconds=1)
         except ValueError:
             end_dt = now
     else:
         end_dt = now
 
-    # Fetch offers in the window. Supabase get_rows doesn't support GTE/LTE
-    # filters natively, so we over-fetch with a large limit and filter in Python.
-    # For analytics on ride_offers (append-only, indexed on offered_at) this is
-    # acceptable up to ~50k rows; add a DB-side date-range RPC if this grows.
-    all_offers = await db_supabase.get_rows("ride_offers", {}, limit=50_000) or []
-    offers_in_window = [
-        o
-        for o in all_offers
-        if o.get("offered_at") and _parse_ts(o["offered_at"]) >= start_dt and _parse_ts(o["offered_at"]) <= end_dt
-    ]
+    # Push the date window into the DB query via $and so the fetch is
+    # bounded even when ride_offers grows past the Python-side cap.
+    offers_in_window = (
+        await db_supabase.get_rows(
+            "ride_offers",
+            {
+                "$and": [
+                    {"offered_at": {"$gte": start_dt.isoformat()}},
+                    {"offered_at": {"$lte": end_dt.isoformat()}},
+                ]
+            },
+            order="offered_at",
+            desc=True,
+            limit=10_000,
+        )
+        or []
+    )
 
     if not offers_in_window:
         return {"areas": [], "totals": _offer_totals([])}
 
-    # Batch-fetch associated rides to get service_area_id
+    # Batch-fetch rides by ID using $in so we never miss a ride that
+    # happens not to be in the first N rows of an unfiltered scan.
     ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
     rides = []
     for batch_start in range(0, len(ride_ids), 100):
         batch = ride_ids[batch_start : batch_start + 100]
-        chunk = await db_supabase.get_rows("rides", {}, limit=len(batch)) or []
-        # Filter client-side because get_rows doesn't support .in_() style here
-        rides.extend(r for r in chunk if r.get("id") in batch)
+        chunk = await db_supabase.get_rows("rides", {"id": {"$in": batch}}, limit=len(batch)) or []
+        rides.extend(chunk)
 
     ride_area = {r["id"]: r.get("service_area_id") for r in rides}
 
@@ -396,10 +407,14 @@ async def get_offer_analytics(
             }
         )
 
+    # When filtering to a single area, totals must reflect only those offers
+    # so the summary matches the breakdown — not the platform-wide count.
+    filtered_offers = [o for b in buckets.values() for o in b] if service_area_id else offers_in_window
+
     return {
         "window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
         "areas": areas,
-        "totals": _offer_totals(offers_in_window),
+        "totals": _offer_totals(filtered_offers),
     }
 
 

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -353,35 +353,69 @@ async def get_offer_analytics(
     else:
         end_dt = now
 
-    # Push the date window into the DB query via $and so the fetch is
-    # bounded even when ride_offers grows past the Python-side cap.
-    offers_in_window = (
-        await db_supabase.get_rows(
-            "ride_offers",
-            {
-                "$and": [
-                    {"offered_at": {"$gte": start_dt.isoformat()}},
-                    {"offered_at": {"$lte": end_dt.isoformat()}},
-                ]
-            },
-            order="offered_at",
-            desc=True,
-            limit=10_000,
+    if service_area_id:
+        # When filtering to a single area, fetch that area's rides first so
+        # the offer query is scoped to those ride IDs. This avoids the 10k
+        # platform-wide cap cutting off quieter-area offers when other areas
+        # are busier during the same date window.
+        area_ride_rows = await db_supabase.get_rows("rides", {"service_area_id": service_area_id}, limit=20_000) or []
+        if not area_ride_rows:
+            return {
+                "window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+                "areas": [],
+                "totals": _offer_totals([]),
+            }
+        area_ride_ids = [r["id"] for r in area_ride_rows]
+        offers_in_window: List[Dict] = []
+        for batch_start in range(0, len(area_ride_ids), 500):
+            batch = area_ride_ids[batch_start : batch_start + 500]
+            chunk = (
+                await db_supabase.get_rows(
+                    "ride_offers",
+                    {
+                        "$and": [
+                            {"ride_id": {"$in": batch}},
+                            {"offered_at": {"$gte": start_dt.isoformat()}},
+                            {"offered_at": {"$lte": end_dt.isoformat()}},
+                        ]
+                    },
+                    limit=len(batch) * 20,
+                )
+                or []
+            )
+            offers_in_window.extend(chunk)
+        rides = area_ride_rows
+    else:
+        # Global view: push date window into DB so the fetch is bounded even
+        # when ride_offers grows past the Python-side cap.
+        offers_in_window = (
+            await db_supabase.get_rows(
+                "ride_offers",
+                {
+                    "$and": [
+                        {"offered_at": {"$gte": start_dt.isoformat()}},
+                        {"offered_at": {"$lte": end_dt.isoformat()}},
+                    ]
+                },
+                order="offered_at",
+                desc=True,
+                limit=10_000,
+            )
+            or []
         )
-        or []
-    )
+        ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
+        rides = []
+        for batch_start in range(0, len(ride_ids), 100):
+            batch = ride_ids[batch_start : batch_start + 100]
+            chunk = await db_supabase.get_rows("rides", {"id": {"$in": batch}}, limit=len(batch)) or []
+            rides.extend(chunk)
 
     if not offers_in_window:
-        return {"areas": [], "totals": _offer_totals([])}
-
-    # Batch-fetch rides by ID using $in so we never miss a ride that
-    # happens not to be in the first N rows of an unfiltered scan.
-    ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
-    rides = []
-    for batch_start in range(0, len(ride_ids), 100):
-        batch = ride_ids[batch_start : batch_start + 100]
-        chunk = await db_supabase.get_rows("rides", {"id": {"$in": batch}}, limit=len(batch)) or []
-        rides.extend(chunk)
+        return {
+            "window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+            "areas": [],
+            "totals": _offer_totals([]),
+        }
 
     ride_area = {r["id"]: r.get("service_area_id") for r in rides}
 

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -353,6 +353,8 @@ async def get_offer_analytics(
     else:
         end_dt = now
 
+    _truncated = False  # set True by the global path when 200k hard cap is hit
+
     if service_area_id:
         # When filtering to a single area, fetch that area's rides first so
         # the offer query is scoped to those ride IDs. This avoids the 10k
@@ -386,23 +388,41 @@ async def get_offer_analytics(
             offers_in_window.extend(chunk)
         rides = area_ride_rows
     else:
-        # Global view: push date window into DB so the fetch is bounded even
-        # when ride_offers grows past the Python-side cap.
-        offers_in_window = (
-            await db_supabase.get_rows(
-                "ride_offers",
-                {
-                    "$and": [
-                        {"offered_at": {"$gte": start_dt.isoformat()}},
-                        {"offered_at": {"$lte": end_dt.isoformat()}},
-                    ]
-                },
-                order="offered_at",
-                desc=True,
-                limit=10_000,
+        # Global view: page through ALL offers in the date window so quieter
+        # areas are never silently dropped. A 200k hard safety cap is applied
+        # to prevent runaway admin queries; the response includes a `truncated`
+        # flag when it's hit so the caller can narrow the date range.
+        _PAGE = 5_000
+        _HARD_CAP = 200_000
+        offers_in_window: List[Dict] = []
+        _offset = 0
+        _truncated = False
+        _date_filter = {
+            "$and": [
+                {"offered_at": {"$gte": start_dt.isoformat()}},
+                {"offered_at": {"$lte": end_dt.isoformat()}},
+            ]
+        }
+        while True:
+            _page = (
+                await db_supabase.get_rows(
+                    "ride_offers",
+                    _date_filter,
+                    order="offered_at",
+                    desc=True,
+                    limit=_PAGE,
+                    offset=_offset,
+                )
+                or []
             )
-            or []
-        )
+            offers_in_window.extend(_page)
+            if len(_page) < _PAGE:
+                break
+            _offset += _PAGE
+            if _offset >= _HARD_CAP:
+                _truncated = True
+                break
+
         ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
         rides = []
         for batch_start in range(0, len(ride_ids), 100):
@@ -445,11 +465,15 @@ async def get_offer_analytics(
     # so the summary matches the breakdown — not the platform-wide count.
     filtered_offers = [o for b in buckets.values() for o in b] if service_area_id else offers_in_window
 
-    return {
+    result: Dict = {
         "window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
         "areas": areas,
         "totals": _offer_totals(filtered_offers),
     }
+    if _truncated:
+        result["truncated"] = True
+        result["warning"] = "Result set capped at 200,000 offers. Narrow the date range for full accuracy."
+    return result
 
 
 def _parse_ts(value: str) -> datetime:

--- a/backend/routes/admin/subscriptions.py
+++ b/backend/routes/admin/subscriptions.py
@@ -313,3 +313,125 @@ async def admin_get_subscription_stats(
             if not a.get("parent_service_area_id")
         ],
     }
+
+
+# ============================================================
+# Per-Service-Area Offer Analytics
+# ============================================================
+
+
+@router.get("/offer-analytics")
+async def get_offer_analytics(
+    start_date: Optional[str] = Query(None, description="ISO date, e.g. 2025-01-01"),
+    end_date: Optional[str] = Query(None, description="ISO date, e.g. 2025-12-31"),
+    service_area_id: Optional[str] = Query(None, description="Filter to a single area"),
+    _admin=Depends(get_admin_user),
+):
+    """Offer acceptance rates, avg response time, and offer counts grouped by service area.
+
+    Reads ride_offers joined to rides (in Python via batch lookup) for the given
+    date window. Defaults to the last 30 days when no dates are supplied.
+    """
+    now = datetime.now(timezone.utc)
+    if start_date:
+        try:
+            start_dt = datetime.fromisoformat(start_date).replace(tzinfo=timezone.utc)
+        except ValueError:
+            start_dt = now - timedelta(days=30)
+    else:
+        start_dt = now - timedelta(days=30)
+
+    if end_date:
+        try:
+            end_dt = datetime.fromisoformat(end_date).replace(tzinfo=timezone.utc)
+        except ValueError:
+            end_dt = now
+    else:
+        end_dt = now
+
+    # Fetch offers in the window. Supabase get_rows doesn't support GTE/LTE
+    # filters natively, so we over-fetch with a large limit and filter in Python.
+    # For analytics on ride_offers (append-only, indexed on offered_at) this is
+    # acceptable up to ~50k rows; add a DB-side date-range RPC if this grows.
+    all_offers = await db_supabase.get_rows("ride_offers", {}, limit=50_000) or []
+    offers_in_window = [
+        o
+        for o in all_offers
+        if o.get("offered_at") and _parse_ts(o["offered_at"]) >= start_dt and _parse_ts(o["offered_at"]) <= end_dt
+    ]
+
+    if not offers_in_window:
+        return {"areas": [], "totals": _offer_totals([])}
+
+    # Batch-fetch associated rides to get service_area_id
+    ride_ids = list({o["ride_id"] for o in offers_in_window if o.get("ride_id")})
+    rides = []
+    for batch_start in range(0, len(ride_ids), 100):
+        batch = ride_ids[batch_start : batch_start + 100]
+        chunk = await db_supabase.get_rows("rides", {}, limit=len(batch)) or []
+        # Filter client-side because get_rows doesn't support .in_() style here
+        rides.extend(r for r in chunk if r.get("id") in batch)
+
+    ride_area = {r["id"]: r.get("service_area_id") for r in rides}
+
+    # Fetch service area names once
+    area_rows = await db_supabase.get_rows("service_areas", {}, limit=500) or []
+    area_name = {a["id"]: a.get("name", "Unknown") for a in area_rows}
+
+    # Aggregate per service area
+    buckets: Dict[str, List[Dict]] = {}
+    for offer in offers_in_window:
+        area_id = ride_area.get(offer.get("ride_id")) or "__unknown__"
+        if service_area_id and area_id != service_area_id:
+            continue
+        buckets.setdefault(area_id, []).append(offer)
+
+    areas = []
+    for area_id, bucket in sorted(buckets.items(), key=lambda kv: -(len(kv[1]))):
+        areas.append(
+            {
+                "service_area_id": area_id if area_id != "__unknown__" else None,
+                "service_area_name": area_name.get(area_id, "Unknown") if area_id != "__unknown__" else "Unknown area",
+                **_offer_totals(bucket),
+            }
+        )
+
+    return {
+        "window": {"start": start_dt.isoformat(), "end": end_dt.isoformat()},
+        "areas": areas,
+        "totals": _offer_totals(offers_in_window),
+    }
+
+
+def _parse_ts(value: str) -> datetime:
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except (ValueError, AttributeError):
+        return datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _offer_totals(offers: List[Dict]) -> Dict:
+    total = len(offers)
+    accepted = sum(1 for o in offers if o.get("status") == "accepted")
+    declined = sum(1 for o in offers if o.get("status") == "declined")
+    expired = sum(1 for o in offers if o.get("status") == "expired")
+
+    response_times = []
+    for o in offers:
+        if o.get("responded_at") and o.get("offered_at"):
+            delta = _parse_ts(o["responded_at"]) - _parse_ts(o["offered_at"])
+            secs = delta.total_seconds()
+            if 0 <= secs < 3600:  # sanity cap at 1 hour
+                response_times.append(secs)
+
+    avg_response_s = (sum(response_times) / len(response_times)) if response_times else None
+
+    return {
+        "total_offers": total,
+        "accepted": accepted,
+        "declined": declined,
+        "expired": expired,
+        "acceptance_rate": round(accepted / total, 4) if total else 0.0,
+        "avg_response_seconds": round(avg_response_s, 1) if avg_response_s is not None else None,
+    }

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -6574,8 +6574,9 @@ async def check_expiring_subscriptions():
 
     Two jobs, both run every 6 hours from the FastAPI lifespan:
 
-    1. **Warn** drivers whose active subscription expires within 24 h
-       (push notification, once per subscription via ``expiry_warned``).
+    1. **Warn** drivers whose active subscription expires within 72 h (3 days)
+       via ``expiry_warned_3d``, then again within 24 h via ``expiry_warned``.
+       Both are claim-flags so only one push fires per window per subscription.
     2. **Enforce** expiry on subscriptions whose ``expires_at`` is in the
        past — but only when the admin toggle
        ``require_driver_subscription`` is on. Enforcement:
@@ -6621,7 +6622,8 @@ async def check_expiring_subscriptions():
             continue
         try:
             now = datetime.now(timezone.utc)
-            window = now + timedelta(hours=24)
+            window_24h = now + timedelta(hours=24)
+            window_3d = now + timedelta(hours=72)
 
             # Retry subscriptions stuck in cancel_pending — a plan-switch Stripe
             # cancel that failed transiently. On success, finalize as cancelled;
@@ -6794,11 +6796,38 @@ async def check_expiring_subscriptions():
                     enforced_count += 1
                     continue
 
-                # ── Warning branch: expires within 24 h ───────────────────
+                # ── Warning branch: 3-day advance notice ─────────────────
+                # Sends first push ~72 h before expiry; claim-flag prevents
+                # re-sending on subsequent loop ticks.
+                if not sub.get("expiry_warned_3d") and now < expires_dt <= window_3d:
+                    driver_3d = await db.find_one("drivers", {"id": sub["driver_id"]})
+                    if driver_3d and driver_3d.get("user_id"):
+                        days_left = max(1, int((expires_dt - now).total_seconds() / 86400))
+                        plan_name = sub.get("plan_name", "Spinr Pass")
+                        try:
+                            await send_push_notification(
+                                driver_3d["user_id"],
+                                "Spinr Pass Expiring in 3 Days",
+                                f"Your {plan_name} plan expires in ~{days_left} day{'s' if days_left != 1 else ''}. Renew now to keep driving!",
+                                {
+                                    "type": "subscription_expiring_3d",
+                                    "days_left": str(days_left),
+                                },
+                            )
+                            warned_count += 1
+                        except Exception as e:
+                            logger.warning(f"[SUB-EXPIRY] 3d push failed for driver {sub['driver_id']}: {e}")
+                    await db.update_one(
+                        "driver_subscriptions",
+                        {"id": sub["id"]},
+                        {"$set": {"expiry_warned_3d": True}},
+                    )
+
+                # ── Warning branch: 24-hour final notice ─────────────────
                 if sub.get("expiry_warned"):
                     continue
 
-                if now < expires_dt <= window:
+                if now < expires_dt <= window_24h:
                     driver = await db.find_one("drivers", {"id": sub["driver_id"]})
                     if driver and driver.get("user_id"):
                         hours_left = max(1, int((expires_dt - now).total_seconds() / 3600))
@@ -6806,7 +6835,7 @@ async def check_expiring_subscriptions():
                         try:
                             await send_push_notification(
                                 driver["user_id"],
-                                "Spinr Pass Expiring Soon ⏰",
+                                "Spinr Pass Expiring Soon",
                                 f"Your {plan_name} plan expires in ~{hours_left} hours. Renew now to keep driving!",
                                 {
                                     "type": "subscription_expiring",

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5793,6 +5793,12 @@ async def get_subscription_plans(current_user: dict = Depends(get_current_user))
                 filtered.append(p)
         plans = filtered
 
+    # Filter by driver's vehicle type — only show plans that cover this vehicle.
+    # A null/empty vehicle_types list means the plan accepts all types.
+    if driver:
+        driver_vt = driver.get("vehicle_type_id")
+        plans = [p for p in plans if not p.get("vehicle_types") or driver_vt in p["vehicle_types"]]
+
     return {"plans": plans, "free_mode": False, "message": None}
 
 
@@ -5943,6 +5949,21 @@ async def subscribe_to_plan(request: Request, current_user: dict = Depends(get_c
     )
     if not plan:
         raise HTTPException(status_code=404, detail="Plan not found or inactive")
+
+    # Reject checkout before Stripe if this plan's vehicle_types don't cover
+    # the driver. Mirrors the go-online gate so a driver can't subscribe to an
+    # incompatible plan and then be silently blocked at go-online time.
+    allowed_vt = plan.get("vehicle_types")
+    if allowed_vt:
+        driver_vt = driver.get("vehicle_type_id")
+        if driver_vt not in allowed_vt:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "Your vehicle type is not compatible with this plan. "
+                    "Please choose a plan that supports your vehicle."
+                ),
+            )
 
     # Check for existing active subscription
     existing = (lambda _r: _r[0] if _r else None)(
@@ -6885,14 +6906,18 @@ async def check_expiring_subscriptions():
                 # ── Warning branch: 3-day advance notice ─────────────────
                 # Gate to the exclusive window (24h, 72h] so subs already
                 # inside the 24h window only get the 24h push, not both.
-                # Claim the flag BEFORE sending so a transient DB failure on
-                # the update (after a successful push) can't fire a duplicate.
+                # Claim the flag atomically (WHERE expiry_warned_3d = false)
+                # BEFORE sending — prevents duplicate pushes across replicas
+                # when Redis is unavailable and the lock falls back to all-run.
                 if not sub.get("expiry_warned_3d") and window_24h < expires_dt <= window_3d:
-                    await db.update_one(
+                    claimed = await db.update_one(
                         "driver_subscriptions",
-                        {"id": sub["id"]},
+                        {"id": sub["id"], "expiry_warned_3d": False},
                         {"$set": {"expiry_warned_3d": True}},
                     )
+                    if claimed is None:
+                        # Another replica already claimed this row; skip.
+                        continue
                     driver_3d = await db.find_one("drivers", {"id": sub["driver_id"]})
                     if driver_3d and driver_3d.get("user_id"):
                         days_left = max(1, int((expires_dt - now).total_seconds() / 86400))

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -6553,6 +6553,57 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
                 logger.warning(f"[SUBSCRIBE] Push notification failed: {push_err}")
 
 
+@api_router.get("/subscription/payments")
+async def get_subscription_payment_history(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: dict = Depends(get_current_user),
+):
+    """Return paginated Spinr Pass payment history for the authenticated driver.
+
+    Only returns rows for the calling driver's own account — driver_id is
+    resolved from the authenticated user's token, never from a query param.
+    """
+    driver = (lambda _r: _r[0] if _r else None)(
+        await db_supabase.get_rows("drivers", {"user_id": current_user["id"]}, limit=1)
+    )
+    if not driver:
+        raise HTTPException(status_code=404, detail="Driver profile not found")
+
+    payments = (
+        await db_supabase.get_rows(
+            "subscription_payments",
+            {"driver_id": driver["id"]},
+            order="created_at",
+            desc=True,
+            limit=limit,
+            offset=offset,
+        )
+        or []
+    )
+
+    total = await db_supabase.count_documents("subscription_payments", {"driver_id": driver["id"]})
+
+    return {
+        "payments": [
+            {
+                "id": p["id"],
+                "plan_id": p.get("plan_id"),
+                "plan_name": p.get("plan_name"),
+                "amount": str(Decimal(str(p["amount"])).quantize(Decimal("0.01"))),
+                "currency": p.get("currency", "CAD"),
+                "billing_reason": p.get("billing_reason"),
+                "stripe_invoice_id": p.get("stripe_invoice_id"),
+                "created_at": p.get("created_at"),
+            }
+            for p in payments
+        ],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
 @api_router.post("/subscription/cancel")
 async def cancel_subscription(current_user: dict = Depends(get_current_user)):
     """Cancel driver's active subscription."""

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5595,6 +5595,39 @@ async def update_driver_status(
                         action_hint="Activate Spinr Pass",
                     )
 
+            # Vehicle-type enforcement: if the subscription plan restricts
+            # to specific vehicle type IDs, the driver's registered vehicle
+            # must be one of them. A null/empty list means all types allowed.
+            if sub.get("plan_id"):
+                try:
+                    plan = await db_supabase.find_one("subscription_plans", {"id": sub["plan_id"]})
+                    allowed_vt = plan.get("vehicle_types") if plan else None
+                    if allowed_vt:  # non-null, non-empty list
+                        driver_vt = driver.get("vehicle_type_id")
+                        if driver_vt not in allowed_vt:
+                            raise SpinrException(
+                                message=(
+                                    "Your vehicle type is not covered by your active Spinr Pass plan. "
+                                    "Please switch to a compatible plan or update your vehicle."
+                                ),
+                                error_code=ErrorCode.PAYMENT_FAILED,
+                                status_code=402,
+                                message_key=ErrorKeys.DRIVER_SUBSCRIPTION_REQUIRED,
+                                action_hint="Update Spinr Pass",
+                            )
+                except SpinrException:
+                    raise
+                except Exception as e:
+                    logger.error(
+                        "vehicle_type check failed for driver=%s plan=%s: %s",
+                        driver_id,
+                        sub.get("plan_id"),
+                        e,
+                        exc_info=True,
+                    )
+                    # Fail open on DB errors rather than blocking the driver —
+                    # the plan lookup is best-effort enforcement.
+
     logger.info(
         f"[GO-ONLINE] handler CALL update_one driver_id={driver_id} "
         f"requested_is_online={is_online} "

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -6903,39 +6903,6 @@ async def check_expiring_subscriptions():
                     enforced_count += 1
                     continue
 
-                # ── Warning branch: 3-day advance notice ─────────────────
-                # Gate to the exclusive window (24h, 72h] so subs already
-                # inside the 24h window only get the 24h push, not both.
-                # Claim the flag atomically (WHERE expiry_warned_3d = false)
-                # BEFORE sending — prevents duplicate pushes across replicas
-                # when Redis is unavailable and the lock falls back to all-run.
-                if not sub.get("expiry_warned_3d") and window_24h < expires_dt <= window_3d:
-                    claimed = await db.update_one(
-                        "driver_subscriptions",
-                        {"id": sub["id"], "expiry_warned_3d": False},
-                        {"$set": {"expiry_warned_3d": True}},
-                    )
-                    if claimed is None:
-                        # Another replica already claimed this row; skip.
-                        continue
-                    driver_3d = await db.find_one("drivers", {"id": sub["driver_id"]})
-                    if driver_3d and driver_3d.get("user_id"):
-                        days_left = max(1, int((expires_dt - now).total_seconds() / 86400))
-                        plan_name = sub.get("plan_name", "Spinr Pass")
-                        try:
-                            await send_push_notification(
-                                driver_3d["user_id"],
-                                "Spinr Pass Expiring in 3 Days",
-                                f"Your {plan_name} plan expires in ~{days_left} day{'s' if days_left != 1 else ''}. Renew now to keep driving!",
-                                {
-                                    "type": "subscription_expiring_3d",
-                                    "days_left": str(days_left),
-                                },
-                            )
-                            warned_count += 1
-                        except Exception as e:
-                            logger.warning(f"[SUB-EXPIRY] 3d push failed for driver {sub['driver_id']}: {e}")
-
                 # ── Warning branch: 24-hour final notice ─────────────────
                 if sub.get("expiry_warned"):
                     continue
@@ -6965,9 +6932,68 @@ async def check_expiring_subscriptions():
                         {"$set": {"expiry_warned": True}},
                     )
 
+            # ── 3-day advance warning: dedicated targeted query ──────────
+            # Query only the subs in the (24h, 72h] expiry window that
+            # haven't been warned yet, bypassing the 500-row active_subs cap
+            # so no expiring row is silently skipped on a busy platform.
+            subs_3d = (
+                await db.get_rows(
+                    "driver_subscriptions",
+                    {
+                        "$and": [
+                            {"status": "active"},
+                            {"expiry_warned_3d": False},
+                            {"expires_at": {"$gt": window_24h.isoformat()}},
+                            {"expires_at": {"$lte": window_3d.isoformat()}},
+                        ]
+                    },
+                    limit=500,
+                )
+                or []
+            )
+            warned_3d_count = 0
+            for sub_3d in subs_3d:
+                try:
+                    _exp_str = sub_3d.get("expires_at")
+                    if not _exp_str:
+                        continue
+                    expires_3d = datetime.fromisoformat(str(_exp_str).replace("Z", "+00:00"))
+                    if expires_3d.tzinfo is None:
+                        expires_3d = expires_3d.replace(tzinfo=timezone.utc)
+                except (ValueError, TypeError):
+                    continue
+                claimed = await db.update_one(
+                    "driver_subscriptions",
+                    {"id": sub_3d["id"], "expiry_warned_3d": False},
+                    {"$set": {"expiry_warned_3d": True}},
+                )
+                if claimed is None:
+                    continue
+                drv_3d = await db.find_one("drivers", {"id": sub_3d["driver_id"]})
+                if drv_3d and drv_3d.get("user_id"):
+                    days_left = max(1, int((expires_3d - now).total_seconds() / 86400))
+                    plan_name = sub_3d.get("plan_name", "Spinr Pass")
+                    try:
+                        await send_push_notification(
+                            drv_3d["user_id"],
+                            "Spinr Pass Expiring in 3 Days",
+                            f"Your {plan_name} plan expires in ~{days_left} day{'s' if days_left != 1 else ''}. Renew now to keep driving!",
+                            {"type": "subscription_expiring_3d", "days_left": str(days_left)},
+                        )
+                        warned_3d_count += 1
+                    except Exception as e:
+                        logger.warning(
+                            "[SUB-EXPIRY] 3d push failed for driver %s: %s",
+                            sub_3d["driver_id"],
+                            e,
+                        )
+
             logger.info(
-                f"[SUB-EXPIRY] Check complete. {len(active_subs)} scanned, "
-                f"{warned_count} warned, {enforced_count} enforced offline."
+                "[SUB-EXPIRY] Check complete. %d scanned, %d 24h warned, %d 3d warned, %d enforced offline.",
+                len(active_subs),
+                warned_count,
+                warned_3d_count,
+                enforced_count,
             )
 
         except Exception as e:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -6962,9 +6962,20 @@ async def check_expiring_subscriptions():
                         expires_3d = expires_3d.replace(tzinfo=timezone.utc)
                 except (ValueError, TypeError):
                     continue
+                # Claim atomically: also recheck status and the expiry window
+                # so a renewal or cancellation between the query and this write
+                # does not mark a stale or renewed row as warned.
                 claimed = await db.update_one(
                     "driver_subscriptions",
-                    {"id": sub_3d["id"], "expiry_warned_3d": False},
+                    {
+                        "id": sub_3d["id"],
+                        "expiry_warned_3d": False,
+                        "status": "active",
+                        "$and": [
+                            {"expires_at": {"$gt": window_24h.isoformat()}},
+                            {"expires_at": {"$lte": window_3d.isoformat()}},
+                        ],
+                    },
                     {"$set": {"expiry_warned_3d": True}},
                 )
                 if claimed is None:

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5625,8 +5625,10 @@ async def update_driver_status(
                         e,
                         exc_info=True,
                     )
-                    # Fail open on DB errors rather than blocking the driver —
-                    # the plan lookup is best-effort enforcement.
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Could not verify subscription plan vehicle restrictions. Please try again.",
+                    ) from e
 
     logger.info(
         f"[GO-ONLINE] handler CALL update_one driver_id={driver_id} "
@@ -6881,9 +6883,16 @@ async def check_expiring_subscriptions():
                     continue
 
                 # ── Warning branch: 3-day advance notice ─────────────────
-                # Sends first push ~72 h before expiry; claim-flag prevents
-                # re-sending on subsequent loop ticks.
-                if not sub.get("expiry_warned_3d") and now < expires_dt <= window_3d:
+                # Gate to the exclusive window (24h, 72h] so subs already
+                # inside the 24h window only get the 24h push, not both.
+                # Claim the flag BEFORE sending so a transient DB failure on
+                # the update (after a successful push) can't fire a duplicate.
+                if not sub.get("expiry_warned_3d") and window_24h < expires_dt <= window_3d:
+                    await db.update_one(
+                        "driver_subscriptions",
+                        {"id": sub["id"]},
+                        {"$set": {"expiry_warned_3d": True}},
+                    )
                     driver_3d = await db.find_one("drivers", {"id": sub["driver_id"]})
                     if driver_3d and driver_3d.get("user_id"):
                         days_left = max(1, int((expires_dt - now).total_seconds() / 86400))
@@ -6901,11 +6910,6 @@ async def check_expiring_subscriptions():
                             warned_count += 1
                         except Exception as e:
                             logger.warning(f"[SUB-EXPIRY] 3d push failed for driver {sub['driver_id']}: {e}")
-                    await db.update_one(
-                        "driver_subscriptions",
-                        {"id": sub["id"]},
-                        {"$set": {"expiry_warned_3d": True}},
-                    )
 
                 # ── Warning branch: 24-hour final notice ─────────────────
                 if sub.get("expiry_warned"):

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -1056,6 +1056,7 @@ async def stripe_webhook(request: Request):
                         "payment_status": "paid",
                         "expires_at": new_expires,
                         "expiry_warned": False,
+                        "expiry_warned_3d": False,
                     },
                 )
                 logger.info(

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -940,7 +940,11 @@ class TestRecurringIntervalAndModeLedger:
             patch("backend.settings_loader.get_app_settings", AsyncMock(return_value=mock_settings)),
             patch(
                 "stripe.Price.retrieve",
-                return_value={"unit_amount": 4999, "currency": "cad", "recurring": {"interval": "week", "interval_count": 1}},
+                return_value={
+                    "unit_amount": 4999,
+                    "currency": "cad",
+                    "recurring": {"interval": "week", "interval_count": 1},
+                },
             ),
             patch("stripe.checkout.Session.create") as mock_session_create,
         ):
@@ -1008,13 +1012,16 @@ class TestVehicleTypeEnforcement:
     """Go-online gate rejects drivers whose vehicle type is not covered by their plan."""
 
     async def test_go_online_blocked_when_vehicle_type_not_in_plan(self):
-        from backend.routes.drivers import do_location_update
+        from backend.routes.drivers import update_driver_status
 
         driver = {"id": "d1", "user_id": "u1", "vehicle_type_id": "vt-sedan", "status": "active"}
         plan = {"id": "plan-1", "vehicle_types": ["vt-suv", "vt-van"]}
         active_sub = {
-            "id": "sub-1", "driver_id": "d1", "plan_id": "plan-1",
-            "status": "active", "expires_at": "2099-01-01T00:00:00+00:00",
+            "id": "sub-1",
+            "driver_id": "d1",
+            "plan_id": "plan-1",
+            "status": "active",
+            "expires_at": "2099-01-01T00:00:00+00:00",
         }
 
         def fake_get_rows(table, filters, **kw):
@@ -1032,6 +1039,7 @@ class TestVehicleTypeEnforcement:
             return None
 
         with (
+            patch("backend.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
             patch("backend.db_supabase.get_rows", side_effect=fake_get_rows),
             patch("backend.db_supabase.find_one", side_effect=fake_find_one),
             patch("backend.db_supabase.update_one", AsyncMock()),
@@ -1041,22 +1049,36 @@ class TestVehicleTypeEnforcement:
             ),
         ):
             with pytest.raises(Exception) as exc_info:
-                await do_location_update(is_online=True, current_user={"id": "u1"})
+                await update_driver_status(
+                    driver_id="d1",
+                    is_online=True,
+                    lat=None,
+                    lng=None,
+                    current_user={"id": "u1"},
+                )
             assert "vehicle" in str(exc_info.value).lower() or "402" in str(exc_info.value)
 
     async def test_go_online_allowed_when_plan_vehicle_types_null(self):
         """Null vehicle_types on plan = all types allowed (no 402 raised from vt gate)."""
-        from backend.routes.drivers import do_location_update
+        from backend.routes.drivers import update_driver_status
 
         driver = {
-            "id": "d1", "user_id": "u1", "vehicle_type_id": "vt-sedan",
-            "status": "active", "is_online": False, "is_available": False,
-            "lat": 52.1, "lng": -106.6,
+            "id": "d1",
+            "user_id": "u1",
+            "vehicle_type_id": "vt-sedan",
+            "status": "active",
+            "is_online": False,
+            "is_available": False,
+            "lat": 52.1,
+            "lng": -106.6,
         }
         plan = {"id": "plan-1", "vehicle_types": None}
         active_sub = {
-            "id": "sub-1", "driver_id": "d1", "plan_id": "plan-1",
-            "status": "active", "expires_at": "2099-01-01T00:00:00+00:00",
+            "id": "sub-1",
+            "driver_id": "d1",
+            "plan_id": "plan-1",
+            "status": "active",
+            "expires_at": "2099-01-01T00:00:00+00:00",
         }
 
         def fake_get_rows(table, filters, **kw):
@@ -1076,6 +1098,7 @@ class TestVehicleTypeEnforcement:
             return None
 
         with (
+            patch("backend.db_supabase.get_driver_by_id", AsyncMock(return_value=driver)),
             patch("backend.db_supabase.get_rows", side_effect=fake_get_rows),
             patch("backend.db_supabase.find_one", side_effect=fake_find_one),
             patch("backend.db_supabase.update_one", AsyncMock()),
@@ -1089,7 +1112,13 @@ class TestVehicleTypeEnforcement:
             patch("backend.routes.drivers.manager", MagicMock()),
         ):
             try:
-                await do_location_update(is_online=True, current_user={"id": "u1"})
+                await update_driver_status(
+                    driver_id="d1",
+                    is_online=True,
+                    lat=None,
+                    lng=None,
+                    current_user={"id": "u1"},
+                )
             except Exception as e:
                 assert "vehicle" not in str(e).lower(), f"Unexpected vehicle type block: {e}"
 
@@ -1103,22 +1132,31 @@ class TestPaymentHistoryEndpoint:
         driver = {"id": "d1", "user_id": "u1"}
         payments = [
             {
-                "id": "pay-1", "driver_id": "d1", "plan_id": "plan-1",
-                "plan_name": "Premium Pass", "amount": "49.99", "currency": "CAD",
-                "billing_reason": "one_off", "stripe_invoice_id": None,
+                "id": "pay-1",
+                "driver_id": "d1",
+                "plan_id": "plan-1",
+                "plan_name": "Premium Pass",
+                "amount": "49.99",
+                "currency": "CAD",
+                "billing_reason": "one_off",
+                "stripe_invoice_id": None,
                 "created_at": "2025-06-01T10:00:00+00:00",
             }
         ]
 
         with (
-            patch("backend.db_supabase.get_rows", AsyncMock(side_effect=[
-                [driver], payments,
-            ])),
+            patch(
+                "backend.db_supabase.get_rows",
+                AsyncMock(
+                    side_effect=[
+                        [driver],
+                        payments,
+                    ]
+                ),
+            ),
             patch("backend.db_supabase.count_documents", AsyncMock(return_value=1)),
         ):
-            result = await get_subscription_payment_history(
-                limit=20, offset=0, current_user={"id": "u1"}
-            )
+            result = await get_subscription_payment_history(limit=20, offset=0, current_user={"id": "u1"})
 
         assert result["total"] == 1
         assert result["payments"][0]["plan_name"] == "Premium Pass"
@@ -1131,9 +1169,7 @@ class TestPaymentHistoryEndpoint:
 
         with patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])):
             with pytest.raises(HTTPException) as exc:
-                await get_subscription_payment_history(
-                    limit=20, offset=0, current_user={"id": "u-nobody"}
-                )
+                await get_subscription_payment_history(limit=20, offset=0, current_user={"id": "u-nobody"})
             assert exc.value.status_code == 404
 
     async def test_amount_is_decimal_string_two_dp(self):
@@ -1143,22 +1179,31 @@ class TestPaymentHistoryEndpoint:
         driver = {"id": "d1", "user_id": "u1"}
         payments = [
             {
-                "id": "pay-2", "driver_id": "d1", "plan_id": "plan-1",
-                "plan_name": "Standard Pass", "amount": "29.9",
-                "currency": "CAD", "billing_reason": "one_off",
-                "stripe_invoice_id": None, "created_at": "2025-06-15T08:00:00+00:00",
+                "id": "pay-2",
+                "driver_id": "d1",
+                "plan_id": "plan-1",
+                "plan_name": "Standard Pass",
+                "amount": "29.9",
+                "currency": "CAD",
+                "billing_reason": "one_off",
+                "stripe_invoice_id": None,
+                "created_at": "2025-06-15T08:00:00+00:00",
             }
         ]
 
         with (
-            patch("backend.db_supabase.get_rows", AsyncMock(side_effect=[
-                [driver], payments,
-            ])),
+            patch(
+                "backend.db_supabase.get_rows",
+                AsyncMock(
+                    side_effect=[
+                        [driver],
+                        payments,
+                    ]
+                ),
+            ),
             patch("backend.db_supabase.count_documents", AsyncMock(return_value=1)),
         ):
-            result = await get_subscription_payment_history(
-                limit=20, offset=0, current_user={"id": "u1"}
-            )
+            result = await get_subscription_payment_history(limit=20, offset=0, current_user={"id": "u1"})
 
         assert result["payments"][0]["amount"] == "29.90"
 
@@ -1170,12 +1215,27 @@ class TestOfferAnalyticsEndpoint:
         from backend.routes.admin.subscriptions import get_offer_analytics
 
         offers = [
-            {"id": "o1", "ride_id": "r1", "status": "accepted",
-             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": "2025-06-01T10:00:05+00:00"},
-            {"id": "o2", "ride_id": "r1", "status": "declined",
-             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": "2025-06-01T10:00:08+00:00"},
-            {"id": "o3", "ride_id": "r2", "status": "accepted",
-             "offered_at": "2025-06-02T10:00:00+00:00", "responded_at": "2025-06-02T10:00:03+00:00"},
+            {
+                "id": "o1",
+                "ride_id": "r1",
+                "status": "accepted",
+                "offered_at": "2025-06-01T10:00:00+00:00",
+                "responded_at": "2025-06-01T10:00:05+00:00",
+            },
+            {
+                "id": "o2",
+                "ride_id": "r1",
+                "status": "declined",
+                "offered_at": "2025-06-01T10:00:00+00:00",
+                "responded_at": "2025-06-01T10:00:08+00:00",
+            },
+            {
+                "id": "o3",
+                "ride_id": "r2",
+                "status": "accepted",
+                "offered_at": "2025-06-02T10:00:00+00:00",
+                "responded_at": "2025-06-02T10:00:03+00:00",
+            },
         ]
         rides = [
             {"id": "r1", "service_area_id": "area-a"},
@@ -1214,10 +1274,20 @@ class TestOfferAnalyticsEndpoint:
         from backend.routes.admin.subscriptions import get_offer_analytics
 
         offers = [
-            {"id": "o1", "ride_id": "r1", "status": "accepted",
-             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": "2025-06-01T10:00:05+00:00"},
-            {"id": "o2", "ride_id": "r2", "status": "expired",
-             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": None},
+            {
+                "id": "o1",
+                "ride_id": "r1",
+                "status": "accepted",
+                "offered_at": "2025-06-01T10:00:00+00:00",
+                "responded_at": "2025-06-01T10:00:05+00:00",
+            },
+            {
+                "id": "o2",
+                "ride_id": "r2",
+                "status": "expired",
+                "offered_at": "2025-06-01T10:00:00+00:00",
+                "responded_at": None,
+            },
         ]
         rides = [
             {"id": "r1", "service_area_id": "area-a"},
@@ -1257,7 +1327,9 @@ class TestExpiryWarning3Day:
 
         now = datetime.now(timezone.utc)
         sub = {
-            "id": "sub-1", "driver_id": "d1", "plan_name": "Premium Pass",
+            "id": "sub-1",
+            "driver_id": "d1",
+            "plan_name": "Premium Pass",
             "status": "active",
             "expires_at": (now + timedelta(days=2)).isoformat(),
             "expiry_warned": False,
@@ -1300,7 +1372,9 @@ class TestExpiryWarning3Day:
 
         now = datetime.now(timezone.utc)
         sub = {
-            "id": "sub-1", "driver_id": "d1", "plan_name": "Premium Pass",
+            "id": "sub-1",
+            "driver_id": "d1",
+            "plan_name": "Premium Pass",
             "status": "active",
             "expires_at": (now + timedelta(days=2)).isoformat(),
             "expiry_warned": False,
@@ -1328,8 +1402,5 @@ class TestExpiryWarning3Day:
                     raise
 
         # No 3d warning push should have fired
-        three_day_pushes = [
-            c for c in push_mock.await_args_list
-            if "3" in str(c.args[1]) or "Days" in str(c.args[1])
-        ]
+        three_day_pushes = [c for c in push_mock.await_args_list if "3" in str(c.args[1]) or "Days" in str(c.args[1])]
         assert len(three_day_pushes) == 0

--- a/backend/tests/test_spinr_pass_subscription.py
+++ b/backend/tests/test_spinr_pass_subscription.py
@@ -999,3 +999,337 @@ class TestRecurringIntervalAndModeLedger:
         ):
             await drv._activate_subscription("s1", "p1", "subscription")
         record_mock.assert_not_awaited()
+
+
+# ── New tests for the four gap-closure features ──────────────────────────────
+
+
+class TestVehicleTypeEnforcement:
+    """Go-online gate rejects drivers whose vehicle type is not covered by their plan."""
+
+    async def test_go_online_blocked_when_vehicle_type_not_in_plan(self):
+        from backend.routes.drivers import do_location_update
+
+        driver = {"id": "d1", "user_id": "u1", "vehicle_type_id": "vt-sedan", "status": "active"}
+        plan = {"id": "plan-1", "vehicle_types": ["vt-suv", "vt-van"]}
+        active_sub = {
+            "id": "sub-1", "driver_id": "d1", "plan_id": "plan-1",
+            "status": "active", "expires_at": "2099-01-01T00:00:00+00:00",
+        }
+
+        def fake_get_rows(table, filters, **kw):
+            if table == "drivers":
+                return [driver]
+            if table == "driver_subscriptions":
+                return [active_sub]
+            return []
+
+        async def fake_find_one(table, filters, **kw):
+            if table == "drivers":
+                return driver
+            if table == "subscription_plans":
+                return plan
+            return None
+
+        with (
+            patch("backend.db_supabase.get_rows", side_effect=fake_get_rows),
+            patch("backend.db_supabase.find_one", side_effect=fake_find_one),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"require_driver_subscription": True}),
+            ),
+        ):
+            with pytest.raises(Exception) as exc_info:
+                await do_location_update(is_online=True, current_user={"id": "u1"})
+            assert "vehicle" in str(exc_info.value).lower() or "402" in str(exc_info.value)
+
+    async def test_go_online_allowed_when_plan_vehicle_types_null(self):
+        """Null vehicle_types on plan = all types allowed (no 402 raised from vt gate)."""
+        from backend.routes.drivers import do_location_update
+
+        driver = {
+            "id": "d1", "user_id": "u1", "vehicle_type_id": "vt-sedan",
+            "status": "active", "is_online": False, "is_available": False,
+            "lat": 52.1, "lng": -106.6,
+        }
+        plan = {"id": "plan-1", "vehicle_types": None}
+        active_sub = {
+            "id": "sub-1", "driver_id": "d1", "plan_id": "plan-1",
+            "status": "active", "expires_at": "2099-01-01T00:00:00+00:00",
+        }
+
+        def fake_get_rows(table, filters, **kw):
+            if table == "drivers":
+                return [driver]
+            if table == "driver_subscriptions":
+                return [active_sub]
+            if table == "driver_document_status":
+                return []
+            return []
+
+        async def fake_find_one(table, filters, **kw):
+            if table == "drivers":
+                return driver
+            if table == "subscription_plans":
+                return plan
+            return None
+
+        with (
+            patch("backend.db_supabase.get_rows", side_effect=fake_get_rows),
+            patch("backend.db_supabase.find_one", side_effect=fake_find_one),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"require_driver_subscription": True}),
+            ),
+            patch("backend.routes.drivers.clear_presence", AsyncMock()),
+            patch("backend.routes.drivers.set_presence", AsyncMock()),
+            patch("backend.routes.drivers.record_period_transition", AsyncMock()),
+            patch("backend.routes.drivers.manager", MagicMock()),
+        ):
+            try:
+                await do_location_update(is_online=True, current_user={"id": "u1"})
+            except Exception as e:
+                assert "vehicle" not in str(e).lower(), f"Unexpected vehicle type block: {e}"
+
+
+class TestPaymentHistoryEndpoint:
+    """GET /drivers/subscription/payments scopes to the authenticated driver."""
+
+    async def test_returns_own_payments(self):
+        from backend.routes.drivers import get_subscription_payment_history
+
+        driver = {"id": "d1", "user_id": "u1"}
+        payments = [
+            {
+                "id": "pay-1", "driver_id": "d1", "plan_id": "plan-1",
+                "plan_name": "Premium Pass", "amount": "49.99", "currency": "CAD",
+                "billing_reason": "one_off", "stripe_invoice_id": None,
+                "created_at": "2025-06-01T10:00:00+00:00",
+            }
+        ]
+
+        with (
+            patch("backend.db_supabase.get_rows", AsyncMock(side_effect=[
+                [driver], payments,
+            ])),
+            patch("backend.db_supabase.count_documents", AsyncMock(return_value=1)),
+        ):
+            result = await get_subscription_payment_history(
+                limit=20, offset=0, current_user={"id": "u1"}
+            )
+
+        assert result["total"] == 1
+        assert result["payments"][0]["plan_name"] == "Premium Pass"
+        assert result["payments"][0]["amount"] == "49.99"
+
+    async def test_returns_404_when_no_driver_profile(self):
+        from fastapi import HTTPException
+
+        from backend.routes.drivers import get_subscription_payment_history
+
+        with patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])):
+            with pytest.raises(HTTPException) as exc:
+                await get_subscription_payment_history(
+                    limit=20, offset=0, current_user={"id": "u-nobody"}
+                )
+            assert exc.value.status_code == 404
+
+    async def test_amount_is_decimal_string_two_dp(self):
+        """Amount must always be serialised to exactly 2 decimal places."""
+        from backend.routes.drivers import get_subscription_payment_history
+
+        driver = {"id": "d1", "user_id": "u1"}
+        payments = [
+            {
+                "id": "pay-2", "driver_id": "d1", "plan_id": "plan-1",
+                "plan_name": "Standard Pass", "amount": "29.9",
+                "currency": "CAD", "billing_reason": "one_off",
+                "stripe_invoice_id": None, "created_at": "2025-06-15T08:00:00+00:00",
+            }
+        ]
+
+        with (
+            patch("backend.db_supabase.get_rows", AsyncMock(side_effect=[
+                [driver], payments,
+            ])),
+            patch("backend.db_supabase.count_documents", AsyncMock(return_value=1)),
+        ):
+            result = await get_subscription_payment_history(
+                limit=20, offset=0, current_user={"id": "u1"}
+            )
+
+        assert result["payments"][0]["amount"] == "29.90"
+
+
+class TestOfferAnalyticsEndpoint:
+    """GET /admin/offer-analytics groups by service area correctly."""
+
+    async def test_groups_by_service_area(self):
+        from backend.routes.admin.subscriptions import get_offer_analytics
+
+        offers = [
+            {"id": "o1", "ride_id": "r1", "status": "accepted",
+             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": "2025-06-01T10:00:05+00:00"},
+            {"id": "o2", "ride_id": "r1", "status": "declined",
+             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": "2025-06-01T10:00:08+00:00"},
+            {"id": "o3", "ride_id": "r2", "status": "accepted",
+             "offered_at": "2025-06-02T10:00:00+00:00", "responded_at": "2025-06-02T10:00:03+00:00"},
+        ]
+        rides = [
+            {"id": "r1", "service_area_id": "area-a"},
+            {"id": "r2", "service_area_id": "area-b"},
+        ]
+        areas = [
+            {"id": "area-a", "name": "Downtown"},
+            {"id": "area-b", "name": "Airport"},
+        ]
+
+        def fake_get_rows(table, filters, **kw):
+            if table == "ride_offers":
+                return offers
+            if table == "rides":
+                return rides
+            if table == "service_areas":
+                return areas
+            return []
+
+        with patch("backend.db_supabase.get_rows", side_effect=fake_get_rows):
+            result = await get_offer_analytics(
+                start_date="2025-06-01",
+                end_date="2025-06-30",
+                service_area_id=None,
+                _admin={"id": "admin-1", "role": "admin"},
+            )
+
+        assert result["totals"]["total_offers"] == 3
+        assert result["totals"]["accepted"] == 2
+        assert result["totals"]["acceptance_rate"] == pytest.approx(2 / 3, abs=0.001)
+        area_ids = {a["service_area_id"] for a in result["areas"]}
+        assert "area-a" in area_ids
+        assert "area-b" in area_ids
+
+    async def test_filters_to_single_area(self):
+        from backend.routes.admin.subscriptions import get_offer_analytics
+
+        offers = [
+            {"id": "o1", "ride_id": "r1", "status": "accepted",
+             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": "2025-06-01T10:00:05+00:00"},
+            {"id": "o2", "ride_id": "r2", "status": "expired",
+             "offered_at": "2025-06-01T10:00:00+00:00", "responded_at": None},
+        ]
+        rides = [
+            {"id": "r1", "service_area_id": "area-a"},
+            {"id": "r2", "service_area_id": "area-b"},
+        ]
+
+        def fake_get_rows(table, filters, **kw):
+            if table == "ride_offers":
+                return offers
+            if table == "rides":
+                return rides
+            if table == "service_areas":
+                return [{"id": "area-a", "name": "Downtown"}, {"id": "area-b", "name": "Airport"}]
+            return []
+
+        with patch("backend.db_supabase.get_rows", side_effect=fake_get_rows):
+            result = await get_offer_analytics(
+                start_date="2025-06-01",
+                end_date="2025-06-30",
+                service_area_id="area-a",
+                _admin={"id": "admin-1", "role": "admin"},
+            )
+
+        assert len(result["areas"]) == 1
+        assert result["areas"][0]["service_area_id"] == "area-a"
+        assert result["areas"][0]["total_offers"] == 1
+        assert result["areas"][0]["accepted"] == 1
+
+
+class TestExpiryWarning3Day:
+    """3-day warning sets expiry_warned_3d flag; 24h warning still fires later."""
+
+    async def test_3d_warning_push_sent_and_flag_set(self):
+        from datetime import datetime, timedelta, timezone
+
+        from backend.routes import drivers as drv
+
+        now = datetime.now(timezone.utc)
+        sub = {
+            "id": "sub-1", "driver_id": "d1", "plan_name": "Premium Pass",
+            "status": "active",
+            "expires_at": (now + timedelta(days=2)).isoformat(),
+            "expiry_warned": False,
+            "expiry_warned_3d": False,
+        }
+        driver = {"id": "d1", "user_id": "u1"}
+
+        push_mock = AsyncMock()
+        update_mock = AsyncMock()
+
+        with (
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[sub])),
+            patch("backend.db_supabase.find_one", AsyncMock(return_value=driver)),
+            patch("backend.db_supabase.update_one", update_mock),
+            patch("backend.routes.drivers.send_push_notification", push_mock),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"require_driver_subscription": False}),
+            ),
+            patch("backend.routes.drivers.asyncio.sleep", AsyncMock(side_effect=Exception("stop"))),
+        ):
+            try:
+                await drv.check_expiring_subscriptions()
+            except Exception as e:
+                if "stop" not in str(e):
+                    raise
+
+        assert push_mock.await_count >= 1
+        all_titles = [str(c.args[1]) for c in push_mock.await_args_list]
+        assert any("3" in t or "Days" in t or "days" in t.lower() for t in all_titles)
+
+        update_calls_str = [str(c) for c in update_mock.await_args_list]
+        assert any("expiry_warned_3d" in c for c in update_calls_str)
+
+    async def test_3d_warning_skipped_when_flag_already_set(self):
+        """expiry_warned_3d=True means no second 3-day push."""
+        from datetime import datetime, timedelta, timezone
+
+        from backend.routes import drivers as drv
+
+        now = datetime.now(timezone.utc)
+        sub = {
+            "id": "sub-1", "driver_id": "d1", "plan_name": "Premium Pass",
+            "status": "active",
+            "expires_at": (now + timedelta(days=2)).isoformat(),
+            "expiry_warned": False,
+            "expiry_warned_3d": True,  # already warned
+        }
+        driver = {"id": "d1", "user_id": "u1"}
+
+        push_mock = AsyncMock()
+
+        with (
+            patch("backend.db_supabase.get_rows", AsyncMock(return_value=[sub])),
+            patch("backend.db_supabase.find_one", AsyncMock(return_value=driver)),
+            patch("backend.db_supabase.update_one", AsyncMock()),
+            patch("backend.routes.drivers.send_push_notification", push_mock),
+            patch(
+                "backend.settings_loader.get_app_settings",
+                AsyncMock(return_value={"require_driver_subscription": False}),
+            ),
+            patch("backend.routes.drivers.asyncio.sleep", AsyncMock(side_effect=Exception("stop"))),
+        ):
+            try:
+                await drv.check_expiring_subscriptions()
+            except Exception as e:
+                if "stop" not in str(e):
+                    raise
+
+        # No 3d warning push should have fired
+        three_day_pushes = [
+            c for c in push_mock.await_args_list
+            if "3" in str(c.args[1]) or "Days" in str(c.args[1])
+        ]
+        assert len(three_day_pushes) == 0

--- a/driver-app/app/driver/subscription.tsx
+++ b/driver-app/app/driver/subscription.tsx
@@ -31,6 +31,15 @@ interface Subscription {
   expires_at: string;
 }
 
+interface Payment {
+  id: string;
+  plan_name: string;
+  amount: string;
+  currency: string;
+  billing_reason: string | null;
+  created_at: string;
+}
+
 export default function SubscriptionScreen() {
   const router = useRouter();
   const [plans, setPlans] = useState<Plan[]>([]);
@@ -39,6 +48,7 @@ export default function SubscriptionScreen() {
   const [freeMessage, setFreeMessage] = useState('');
   const [loading, setLoading] = useState(true);
   const [subscribing, setSubscribing] = useState<string | null>(null);
+  const [payments, setPayments] = useState<Payment[]>([]);
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
 
@@ -82,9 +92,10 @@ export default function SubscriptionScreen() {
   const loadData = async () => {
     setLoading(true);
     try {
-      const [plansRes, subRes] = await Promise.all([
+      const [plansRes, subRes, paymentsRes] = await Promise.all([
         api.get<{ plans?: Plan[]; free_mode?: boolean; message?: string } | Plan[]>('/drivers/subscription/plans'),
         api.get<any>('/drivers/subscription/current'),
+        api.get<{ payments: Payment[] }>('/drivers/subscription/payments?limit=10').catch(() => ({ data: { payments: [] } })),
       ]);
       const data = plansRes.data;
       // Backend returns {plans, free_mode, message} when Spinr Pass is off
@@ -99,6 +110,7 @@ export default function SubscriptionScreen() {
         setFreeMode(false);
       }
       setCurrentSub(subRes.data);
+      setPayments(paymentsRes.data?.payments || []);
     } catch (e) { console.log('Sub load error:', e); }
     finally { setLoading(false); }
   };
@@ -349,6 +361,32 @@ export default function SubscriptionScreen() {
           </View>
         )}
 
+        {/* Payment History */}
+        {payments.length > 0 && (
+          <>
+            <Text style={styles.sectionTitle}>Payment History</Text>
+            <Text style={styles.sectionSubtitle}>Your last 10 Spinr Pass charges</Text>
+            {payments.map((p) => (
+              <View key={p.id} style={styles.paymentRow}>
+                <View style={styles.paymentIcon}>
+                  <Ionicons name="receipt-outline" size={20} color={colors.primary} />
+                </View>
+                <View style={styles.paymentInfo}>
+                  <Text style={styles.paymentPlan}>{p.plan_name || 'Spinr Pass'}</Text>
+                  <Text style={styles.paymentMeta}>
+                    {p.billing_reason === 'subscription_cycle' ? 'Auto-renewal' : 'One-time purchase'}
+                    {'  ·  '}
+                    {formatDate(p.created_at)}
+                  </Text>
+                </View>
+                <Text style={styles.paymentAmount}>
+                  ${parseFloat(p.amount).toFixed(2)} {p.currency}
+                </Text>
+              </View>
+            ))}
+          </>
+        )}
+
       </ScrollView>
 
     </SafeAreaView>
@@ -434,5 +472,19 @@ function createStyles(colors: ThemeColors) {
       backgroundColor: '#D1FAE5', paddingHorizontal: 14, paddingVertical: 8, borderRadius: 12,
     },
     freeBadgeText: { fontSize: 13, fontWeight: '700', color: '#065F46' },
+
+    // Payment history
+    paymentRow: {
+      flexDirection: 'row', alignItems: 'center', marginHorizontal: 16, marginBottom: 8,
+      backgroundColor: colors.surfaceLight, borderRadius: 14, padding: 14, gap: 12,
+    },
+    paymentIcon: {
+      width: 40, height: 40, borderRadius: 12, backgroundColor: colors.surface,
+      justifyContent: 'center', alignItems: 'center',
+    },
+    paymentInfo: { flex: 1 },
+    paymentPlan: { fontSize: 14, fontWeight: '600', color: colors.text },
+    paymentMeta: { fontSize: 12, color: colors.textDim, marginTop: 2 },
+    paymentAmount: { fontSize: 15, fontWeight: '700', color: colors.text },
   });
 }


### PR DESCRIPTION
Extends check_expiring_subscriptions loop with a second claim-flag
(expiry_warned_3d) so drivers get an advance push ~72 h before their
Spinr Pass expires in addition to the existing 24-hour reminder.

Migration 178 adds the expiry_warned_3d boolean column with a backfill
that marks existing warned rows as already notified so the next loop
tick does not re-fire a stale 3-day warning.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J3e3E6MD3UHy3sKjFhj74Z

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
