### PR TITLE
Fix driver quest list payload normalization

### DIFF
--- a/driver-app/store/__tests__/questStore.test.ts
+++ b/driver-app/store/__tests__/questStore.test.ts
@@ -96,6 +96,14 @@ describe('questStore — fetchAvailableQuests', () => {
         expect(useQuestStore.getState().availableQuests).toEqual([]);
     });
 
+    it('accepts wrapped available quest payloads from API variants', async () => {
+        mockGet.mockResolvedValue({ data: { quests: [sampleQuest], count: 1 } });
+
+        await useQuestStore.getState().fetchAvailableQuests();
+
+        expect(useQuestStore.getState().availableQuests).toEqual([sampleQuest]);
+    });
+
     it('sets error message on API failure', async () => {
         const err = new Error('Network error');
         mockGet.mockRejectedValue(err);
@@ -136,6 +144,14 @@ describe('questStore — fetchMyQuests', () => {
         await useQuestStore.getState().fetchMyQuests();
 
         expect(useQuestStore.getState().myQuests).toEqual([]);
+    });
+
+    it('accepts wrapped my quest payloads from API variants', async () => {
+        mockGet.mockResolvedValue({ data: { my_quests: [sampleProgress], count: 1 } });
+
+        await useQuestStore.getState().fetchMyQuests();
+
+        expect(useQuestStore.getState().myQuests).toEqual([sampleProgress]);
     });
 
     it('clears isLoadingMine on API failure without setting error', async () => {

--- a/driver-app/store/questStore.ts
+++ b/driver-app/store/questStore.ts
@@ -5,6 +5,24 @@ function isAxiosError(e: unknown): e is { response?: { data?: { detail?: string 
   return typeof e === 'object' && e !== null && ('response' in e || 'message' in e);
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null;
+}
+
+function arrayFromApi<T>(payload: unknown, keys: string[]): T[] {
+  if (Array.isArray(payload)) return payload.filter(Boolean) as T[];
+
+  const record = asRecord(payload);
+  if (!record) return [];
+
+  for (const key of keys) {
+    const candidate = record[key];
+    if (Array.isArray(candidate)) return candidate.filter(Boolean) as T[];
+  }
+
+  return [];
+}
+
 export interface Quest {
   id: string;
   title: string;
@@ -66,8 +84,9 @@ export const useQuestStore = create<QuestState>((set, get) => ({
   fetchAvailableQuests: async () => {
     try {
       set({ isLoadingAvailable: true, error: null });
-      const res = await api.get<Quest[]>('/quests');
-      set({ availableQuests: res.data || [], isLoadingAvailable: false });
+      const res = await api.get<Quest[] | { quests?: Quest[]; available_quests?: Quest[]; data?: Quest[] }>('/quests');
+      const availableQuests = arrayFromApi<Quest>(res.data, ['quests', 'available_quests', 'data']);
+      set({ availableQuests, isLoadingAvailable: false });
     } catch (error: unknown) {
       set({ error: isAxiosError(error) ? (error.message ?? 'Failed to fetch quests') : 'Failed to fetch quests', isLoadingAvailable: false });
     }
@@ -76,8 +95,9 @@ export const useQuestStore = create<QuestState>((set, get) => ({
   fetchMyQuests: async () => {
     try {
       set({ isLoadingMine: true });
-      const res = await api.get<MyQuestProgress[]>('/quests/my-quests');
-      set({ myQuests: res.data || [], isLoadingMine: false });
+      const res = await api.get<MyQuestProgress[] | { quests?: MyQuestProgress[]; my_quests?: MyQuestProgress[]; data?: MyQuestProgress[] }>('/quests/my-quests');
+      const myQuests = arrayFromApi<MyQuestProgress>(res.data, ['quests', 'my_quests', 'data']);
+      set({ myQuests, isLoadingMine: false });
     } catch (error: unknown) {
       set({ isLoadingMine: false });
     }


### PR DESCRIPTION
### Motivation
- Drivers reported the quests screen showing the count but no quest cards because the app expected a bare array from the backend while some API variants return wrapped responses like `{ quests: [...] }` or `{ my_quests: [...] }`.
- Normalize client parsing so different API response shapes don't hide available or joined quests in the UI.

### Description
- Add `arrayFromApi` helper and `asRecord` to `driver-app/store/questStore.ts` and use them to normalize `/quests` and `/quests/my-quests` responses so the store accepts bare arrays or wrapped payloads (`quests`, `available_quests`, `my_quests`, `data`).
- Update TypeScript typing to use `Record<string, unknown>` for the helper and keep existing error handling flows intact.
- Add unit tests in `driver-app/store/__tests__/questStore.test.ts` to cover wrapped `available` and `my_quests` response variants.

### Testing
- Ran the quest store unit tests with `yarn test store/__tests__/questStore.test.ts --runInBand` and all tests passed (16/16).
- Ran `yarn lint` as part of checks but it surfaced pre-existing lint errors elsewhere in the app (these are unrelated to this change and blocked lint success).
- Attempted the repository graph rebuild per project workflow but the `graphify` rebuild step failed due to the environment missing the `graphify` package (external to the code change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39770eaa88833097c858cf68c93fbc)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
