### PR TITLE
feat(referral): add window_days columns and expired payout state (migration 189)

### DIFF
--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -1352,14 +1352,16 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
             <div>
                 <h4 className="font-bold text-gray-800 mb-3">Referral Rewards</h4>
                 <p className="text-xs text-gray-500 mb-3">
-                    Per-area referral rewards (CAD). Riders/drivers whose area resolves here see and earn these amounts; users not mapped to any area fall back to the global default.
+                    Per-area referral rewards (CAD). Riders/drivers whose area resolves here see and earn these amounts; users not mapped to any area fall back to the global default. &quot;Rides within (days)&quot; is the deadline to complete the required rides before the referral expires unpaid — set 0 for no deadline.
                 </p>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <FieldInput label="Rider — referrer reward ($)" value={area.rider_referrer_reward ?? 5} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referrer_reward', parseFloat(v))} />
                     <FieldInput label="Rider — referee reward ($)" value={area.rider_referee_reward ?? 5} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referee_reward', parseFloat(v))} />
                     <FieldInput label="Rider — rides required" value={area.rider_referral_rides_required ?? 1} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referral_rides_required', parseInt(v))} />
+                    <FieldInput label="Rider — rides within (days)" value={area.rider_referral_window_days ?? 30} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referral_window_days', parseInt(v))} />
                     <FieldInput label="Driver — reward ($)" value={area.driver_referral_reward ?? 10} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_reward', parseFloat(v))} />
                     <FieldInput label="Driver — rides required" value={area.driver_referral_rides_required ?? 10} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_rides_required', parseInt(v))} />
+                    <FieldInput label="Driver — rides within (days)" value={area.driver_referral_window_days ?? 30} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_window_days', parseInt(v))} />
                 </div>
                 <p className="text-xs text-gray-500 mt-4 mb-2">
                     Referral Terms &amp; Conditions shown on the rider/driver &quot;Refer &amp; Earn&quot; screens. Leave blank to auto-generate the default sentence from the reward amounts above.

--- a/backend/migrations/189_service_area_referral_window_days.sql
+++ b/backend/migrations/189_service_area_referral_window_days.sql
@@ -1,0 +1,49 @@
+-- Migration 189: referral completion deadline (window_days) + 'expired' payout state
+--
+-- Until now a referral reward had only a RIDE-COUNT criterion: the referee had
+-- to complete N completed rides (driver: 10, rider: 1) — with no time limit, so
+-- a driver could take a year to reach the target and the referrer would still
+-- be paid. This migration adds a DEADLINE: the referee must reach the ride
+-- threshold within `window_days` of referral_applied_at, otherwise the referral
+-- expires unpaid. This pushes referred drivers to complete their rides promptly.
+--
+-- Design:
+--   * Two additive columns on service_areas hold each area's deadline, separate
+--     for riders and drivers (their thresholds differ). DEFAULT 30 days applies
+--     a deadline everywhere immediately (admins override per area from the
+--     Service Areas screen; the backend uses the same 30-day global constant for
+--     riders/drivers who resolve to NO area — see utils/referral_terms.py).
+--     A value of 0 disables the deadline for that area (no time limit).
+--   * referral_payouts.status gains 'expired': a terminal, never-paid state the
+--     payout loop records when the window lapses before the threshold is met.
+--     Recording it (rewards 0) reuses the UNIQUE(referee_user_id) claim so the
+--     referee is never re-checked or paid.
+--
+-- All service_areas changes are additive + defaulted → forward-compatible with
+-- in-flight traffic; no backfill of large tables required. The CHECK swap is an
+-- ADD to the allowed set (widening), safe against in-flight writes which only
+-- ever insert the existing states.
+--
+-- Rollback (on paper):
+--   ALTER TABLE service_areas
+--     DROP COLUMN IF EXISTS rider_referral_window_days,
+--     DROP COLUMN IF EXISTS driver_referral_window_days;
+--   ALTER TABLE referral_payouts DROP CONSTRAINT IF EXISTS referral_payouts_status_check;
+--   ALTER TABLE referral_payouts ADD CONSTRAINT referral_payouts_status_check
+--     CHECK (status IN ('processing', 'paid', 'failed'));
+--   (Any rows already in 'expired' must be reconciled before re-adding the
+--    narrower constraint, or the ADD will fail.)
+
+-- ── service_areas: per-area referral completion deadline (days) ──────
+-- 30-day default; 0 = no deadline for that area.
+ALTER TABLE service_areas
+    ADD COLUMN IF NOT EXISTS rider_referral_window_days  integer NOT NULL DEFAULT 30;
+ALTER TABLE service_areas
+    ADD COLUMN IF NOT EXISTS driver_referral_window_days integer NOT NULL DEFAULT 30;
+
+-- ── referral_payouts: add the terminal 'expired' state ──────────────
+ALTER TABLE referral_payouts
+    DROP CONSTRAINT IF EXISTS referral_payouts_status_check;
+ALTER TABLE referral_payouts
+    ADD CONSTRAINT referral_payouts_status_check
+    CHECK (status IN ('processing', 'paid', 'failed', 'expired'));

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5089,6 +5089,10 @@ class ApplyReferralCodeRequest(BaseModel):
 # per-referee progress, and the displayed terms can never drift apart.
 REFERRAL_RIDES_REQUIRED = 10
 REFERRAL_REWARD_AMOUNT = 10  # CAD, paid per referee who reaches the ride target
+# Days the referee has to reach REFERRAL_RIDES_REQUIRED (from referral_applied_at)
+# before the referral expires unpaid. 0 = no deadline. Per-area override lives in
+# service_areas.driver_referral_window_days (migration 189).
+REFERRAL_WINDOW_DAYS = 30
 
 
 def _fmt_money(v) -> str:
@@ -6154,9 +6158,7 @@ async def subscription_checkout_return(session_id: str = "", to: str = ""):
 
     _allowed_prefixes = ("spinr-driver://", "exp://")
     _safe = bool(
-        to
-        and any(to.startswith(p) for p in _allowed_prefixes)
-        and _re.fullmatch(r"[A-Za-z0-9:/._%@!$&()*+,;=~-]+", to)
+        to and any(to.startswith(p) for p in _allowed_prefixes) and _re.fullmatch(r"[A-Za-z0-9:/._%@!$&()*+,;=~-]+", to)
     )
     _target = to if _safe else "spinr-driver://subscription/success"
     _sid = session_id if _re.fullmatch(r"[A-Za-z0-9_]+", session_id or "") else ""

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -464,6 +464,10 @@ async def delete_emergency_contact(contact_id: str, current_user: dict = Depends
 RIDER_REFERRAL_RIDES_REQUIRED = 1
 RIDER_REFERRER_REWARD = 5  # CAD — referrer credit once referee takes first ride
 RIDER_REFEREE_REWARD = 5  # CAD — new rider's first-ride credit
+# Days the referee has to reach RIDER_REFERRAL_RIDES_REQUIRED (from
+# referral_applied_at) before the referral expires unpaid. 0 = no deadline.
+# Per-area override lives in service_areas.rider_referral_window_days (migration 189).
+RIDER_REFERRAL_WINDOW_DAYS = 30
 
 
 def _rider_referral_code(user: dict) -> str:

--- a/backend/tests/test_referral_payout_deadline.py
+++ b/backend/tests/test_referral_payout_deadline.py
@@ -1,0 +1,112 @@
+"""Referral completion-deadline enforcement (utils/referral_payout._process_one).
+
+A referred driver must complete the ride threshold WITHIN window_days of
+referral_applied_at:
+  - met in time      → a 'processing' claim is opened and the reward is credited
+  - missed deadline  → a terminal 'expired' claim (rewards 0) is recorded, never paid
+  - still in window  → nothing happens yet; the next tick re-checks
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import utils.referral_payout as rp
+
+_DRIVER_TERMS = {
+    "rides": 10,
+    "referrer": Decimal("10.00"),
+    "referee": Decimal("0.00"),
+    "window_days": 30,
+    "terms": None,
+}
+
+
+def _driver_db(completed: int) -> MagicMock:
+    db = MagicMock()
+    # Resolve the referrer's user id from their driver id.
+    db.get_driver_by_id = AsyncMock(return_value={"user_id": "referrer_u"})
+    # The referee's own driver row (service area for per-area terms).
+    db.get_rows = AsyncMock(return_value=[{"id": "referee_drv", "service_area_id": "area1"}])
+    db.count_documents = AsyncMock(return_value=completed)
+    db.insert_one = AsyncMock(return_value={"id": "claim1"})
+    db.update_one = AsyncMock()
+    return db
+
+
+def _referee(applied_at: str) -> dict:
+    return {
+        "id": "referee_u",
+        "referred_by": "drv_referrer",
+        "referral_applied_at": applied_at,
+        "referral_code_used": "DRV99",
+    }
+
+
+def _run(db, referee):
+    import asyncio
+
+    with (
+        patch.object(rp, "db_supabase", db),
+        patch.object(rp, "resolve_referral_terms", AsyncMock(return_value=dict(_DRIVER_TERMS))),
+        patch.object(rp, "_credit", AsyncMock()) as credit,
+    ):
+        asyncio.run(rp._process_one(referee, "DRV99"))
+    return credit
+
+
+def test_missed_deadline_records_expired_and_does_not_pay():
+    # Applied long ago, under threshold → window closed → expire, never pay.
+    db = _driver_db(completed=3)
+    credit = _run(db, _referee("2020-01-01T00:00:00+00:00"))
+
+    db.insert_one.assert_awaited_once()
+    table, doc = db.insert_one.await_args.args[0], db.insert_one.await_args.args[1]
+    assert table == "referral_payouts"
+    assert doc["status"] == "expired"
+    assert doc["referrer_reward"] == "0.00" and doc["referee_reward"] == "0.00"
+    credit.assert_not_awaited()  # no money moved
+
+
+def test_under_threshold_within_window_waits():
+    # Applied yesterday, under threshold, deadline still in the future → no claim
+    # of any kind yet; the loop re-checks next tick.
+    applied = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    db = _driver_db(completed=3)
+    credit = _run(db, _referee(applied))
+
+    db.insert_one.assert_not_awaited()
+    credit.assert_not_awaited()
+
+
+def test_threshold_met_in_time_opens_claim_and_credits():
+    # Applied yesterday, threshold met before the deadline → normal payout path.
+    applied = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    db = _driver_db(completed=10)
+    credit = _run(db, _referee(applied))
+
+    db.insert_one.assert_awaited_once()
+    doc = db.insert_one.await_args.args[1]
+    assert doc["status"] == "processing"
+    assert doc["referrer_reward"] == "10.00"
+    credit.assert_awaited()  # referrer credited
+
+
+def test_no_deadline_when_window_days_zero():
+    # window_days == 0 disables the deadline: an ancient referral still pays once
+    # the threshold is reached (original "count forever" behaviour).
+    db = _driver_db(completed=10)
+    terms = dict(_DRIVER_TERMS, window_days=0)
+    import asyncio
+
+    with (
+        patch.object(rp, "db_supabase", db),
+        patch.object(rp, "resolve_referral_terms", AsyncMock(return_value=terms)),
+        patch.object(rp, "_credit", AsyncMock()),
+    ):
+        asyncio.run(rp._process_one(_referee("2019-01-01T00:00:00+00:00"), "DRV99"))
+
+    doc = db.insert_one.await_args.args[1]
+    assert doc["status"] == "processing"  # paid despite being years old

--- a/backend/tests/test_referral_terms.py
+++ b/backend/tests/test_referral_terms.py
@@ -14,8 +14,20 @@ from backend.utils import referral_terms
 # Fixed stand-in for the global constants so assertions don't drift if the real
 # RIDER_*/REFERRAL_* constants are later retuned.
 _GLOBAL = {
-    "rider": {"rides": 1, "referrer": Decimal("5.00"), "referee": Decimal("5.00"), "terms": None},
-    "driver": {"rides": 10, "referrer": Decimal("10.00"), "referee": Decimal("0.00"), "terms": None},
+    "rider": {
+        "rides": 1,
+        "referrer": Decimal("5.00"),
+        "referee": Decimal("5.00"),
+        "window_days": 30,
+        "terms": None,
+    },
+    "driver": {
+        "rides": 10,
+        "referrer": Decimal("10.00"),
+        "referee": Decimal("0.00"),
+        "window_days": 30,
+        "terms": None,
+    },
 }
 
 
@@ -82,6 +94,26 @@ class TestResolveReferralTerms:
         with _patch_global(), _patch_rows([area]):
             t = asyncio.run(referral_terms.resolve_referral_terms("a", "driver"))
         assert t["terms"] is None
+
+    def test_window_days_override_wins(self):
+        # A per-area deadline overrides the global default.
+        area = {"id": "a", "driver_referral_window_days": 14}
+        with _patch_global(), _patch_rows([area]):
+            t = asyncio.run(referral_terms.resolve_referral_terms("a", "driver"))
+        assert t["window_days"] == 14
+
+    def test_window_days_zero_is_a_valid_override_not_fallback(self):
+        # 0 means "no deadline for this area" and must NOT fall back to 30.
+        area = {"id": "a", "rider_referral_window_days": 0}
+        with _patch_global(), _patch_rows([area]):
+            t = asyncio.run(referral_terms.resolve_referral_terms("a", "rider"))
+        assert t["window_days"] == 0
+
+    def test_window_days_null_falls_back_to_global(self):
+        area = {"id": "a", "driver_referral_window_days": None}
+        with _patch_global(), _patch_rows([area]):
+            t = asyncio.run(referral_terms.resolve_referral_terms("a", "driver"))
+        assert t["window_days"] == 30
 
     def test_driver_referee_always_zero(self):
         area = {"id": "a", "driver_referral_reward": 25, "driver_referral_rides_required": 4}

--- a/backend/utils/referral_payout.py
+++ b/backend/utils/referral_payout.py
@@ -1,10 +1,15 @@
 """Referral reward payout loop (rider + driver).
 
-Pays a referrer once their referee reaches the ride threshold:
+Pays a referrer once their referee reaches the ride threshold WITHIN the
+completion deadline (window_days from referral_terms; 0 = no deadline):
   - driver referral: referrer earns $10 once the referee (a driver) completes
     REFERRAL_RIDES_REQUIRED (10) rides.
   - rider referral: referrer AND referee each earn $5 once the referee completes
     RIDER_REFERRAL_RIDES_REQUIRED (1) ride ("first-ride bonus, both sides").
+
+If the deadline passes before the threshold is met, the referral is recorded as
+'expired' (rewards 0) and never paid — this forces referred drivers to complete
+their rides promptly.
 
 Money safety:
   - OFF by default (settings.REFERRAL_PAYOUTS_ENABLED) — enable after staging.
@@ -53,6 +58,12 @@ def _d(v) -> Decimal:
 
 def _f(v: Decimal) -> str:
     return str(v)
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp to a tz-aware UTC datetime (assume UTC if naive)."""
+    dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
 async def referral_payout_loop() -> None:
@@ -134,18 +145,17 @@ async def _process_one(referee: dict, code: str) -> None:
     if not referrer_user_id or referrer_user_id == referee_id:
         return  # unresolved or self — nothing to pay
 
-    # Count only rides completed AFTER the referral was applied — never pay
-    # retroactively for rides that predate the referral. (Legacy rows with no
-    # referral_applied_at fall back to lifetime count.)
+    # Never pay retroactively for rides that predate the referral. (Legacy rows
+    # with no referral_applied_at fall back to a lifetime count.)
     applied_at = referee.get("referral_applied_at")
-    since = {"created_at": {"$gte": applied_at}} if applied_at else {}
 
-    # Resolve the referee's service area and its per-area reward terms. The ride
-    # threshold is itself per-area, so this must precede the threshold check.
-    # area_id == None → resolve_referral_terms falls back to the global default.
+    # Resolve the referee's service area + the ride base filter. The ride
+    # threshold AND the completion deadline are both per-area, so resolve terms
+    # before counting. area_id == None → resolve_referral_terms falls back to the
+    # global default.
     if is_rider:
         area_id = await area_id_for_rider(referee_id, applied_at)
-        completed = await db_supabase.count_documents("rides", {"rider_id": referee_id, "status": "completed", **since})
+        ride_filter: dict = {"rider_id": referee_id, "status": "completed"}
     else:
         ref_as_driver = (lambda _r: _r[0] if _r else None)(
             await db_supabase.get_rows("drivers", {"user_id": referee_id}, limit=1)
@@ -153,12 +163,41 @@ async def _process_one(referee: dict, code: str) -> None:
         if not ref_as_driver:
             return
         area_id = ref_as_driver.get("service_area_id")
-        completed = await db_supabase.count_documents(
-            "rides", {"driver_id": ref_as_driver["id"], "status": "completed", **since}
-        )
+        ride_filter = {"driver_id": ref_as_driver["id"], "status": "completed"}
 
     t = await resolve_referral_terms(area_id, kind)
+
+    # Completion deadline: the referee must reach the ride threshold within
+    # window_days of referral_applied_at, or the referral expires unpaid. This is
+    # what forces referred drivers to complete their rides promptly. window_days
+    # <= 0 (or no applied_at, e.g. a legacy referral) → no deadline, preserving
+    # the original "count forever" behaviour.
+    window_days = int(t.get("window_days") or 0)
+    deadline = None
+    if applied_at and window_days > 0:
+        deadline = _parse_iso(applied_at) + timedelta(days=window_days)
+
+    # Count completed rides from referral_applied_at, capped at the deadline so a
+    # ride taken after the window closed can never qualify the referral. The
+    # filter translator honours only one operator per field, so AND the two
+    # bounds via $and (see repositories/_base._apply_filters).
+    bounds = []
+    if applied_at:
+        bounds.append({"created_at": {"$gte": applied_at}})
+    if deadline is not None:
+        bounds.append({"created_at": {"$lte": deadline.isoformat()}})
+    count_filter = dict(ride_filter)
+    if bounds:
+        count_filter["$and"] = bounds
+    completed = await db_supabase.count_documents("rides", count_filter)
+
     if completed < t["rides"]:
+        # Threshold not met. If the window has closed, the referral has expired:
+        # record a terminal 'expired' claim (rewards 0) so it's never paid and the
+        # referee is excluded from every future tick by the same unique claim.
+        # Until the deadline passes, just wait for the next tick.
+        if deadline is not None and datetime.now(timezone.utc) > deadline:
+            await _record_expiry(referee_id, referrer_user_id, kind, area_id)
         return
 
     # resolve_referral_terms already returns Decimal; _d re-quantises defensively.
@@ -236,6 +275,33 @@ async def _process_one(referee: dict, code: str) -> None:
         {"$set": _credit_marks("paid", referrer_paid, referee_paid)},
     )
     logger.info(f"referral_payout: paid {kind} referral reward for referee {referee_id}")
+
+
+async def _record_expiry(referee_id: str, referrer_user_id: str, kind: str, area_id) -> None:
+    """Record a terminal, never-paid 'expired' claim for a referee who missed the
+    completion deadline. Reuses the UNIQUE(referee_user_id) claim (rewards 0) so
+    the referee is excluded from every future tick and is never paid. A duplicate
+    means another replica/tick already finalised this referee — expected, skip."""
+    try:
+        await db_supabase.insert_one(
+            "referral_payouts",
+            {
+                "referee_user_id": referee_id,
+                "referrer_user_id": referrer_user_id,
+                "kind": kind,
+                "service_area_id": area_id,
+                "referrer_reward": _f(_d(0)),
+                "referee_reward": _f(_d(0)),
+                "status": "expired",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+        logger.info(
+            "referral_payout: referral expired unpaid (completion deadline missed)",
+            extra={"referee_id": referee_id, "kind": kind},
+        )
+    except DuplicateRecordError:
+        logger.info(f"referral_payout: claim already exists for referee {referee_id} — skipping expiry")
 
 
 def _credit_marks(status: str, referrer_paid: bool, referee_paid: bool) -> dict:

--- a/backend/utils/referral_terms.py
+++ b/backend/utils/referral_terms.py
@@ -47,17 +47,27 @@ def _global_terms() -> dict:
     risk a circular import.
     """
     try:
-        from ..routes.drivers import REFERRAL_REWARD_AMOUNT, REFERRAL_RIDES_REQUIRED  # type: ignore
+        from ..routes.drivers import (  # type: ignore
+            REFERRAL_REWARD_AMOUNT,
+            REFERRAL_RIDES_REQUIRED,
+            REFERRAL_WINDOW_DAYS,
+        )
         from ..routes.users import (  # type: ignore
             RIDER_REFEREE_REWARD,
             RIDER_REFERRAL_RIDES_REQUIRED,
+            RIDER_REFERRAL_WINDOW_DAYS,
             RIDER_REFERRER_REWARD,
         )
     except ImportError:
-        from routes.drivers import REFERRAL_REWARD_AMOUNT, REFERRAL_RIDES_REQUIRED  # type: ignore
+        from routes.drivers import (  # type: ignore
+            REFERRAL_REWARD_AMOUNT,
+            REFERRAL_RIDES_REQUIRED,
+            REFERRAL_WINDOW_DAYS,
+        )
         from routes.users import (  # type: ignore
             RIDER_REFEREE_REWARD,
             RIDER_REFERRAL_RIDES_REQUIRED,
+            RIDER_REFERRAL_WINDOW_DAYS,
             RIDER_REFERRER_REWARD,
         )
     return {
@@ -65,6 +75,8 @@ def _global_terms() -> dict:
             "rides": int(RIDER_REFERRAL_RIDES_REQUIRED),
             "referrer": _money(RIDER_REFERRER_REWARD),
             "referee": _money(RIDER_REFEREE_REWARD),
+            # Days to reach the threshold before the referral expires; 0 = none.
+            "window_days": int(RIDER_REFERRAL_WINDOW_DAYS),
             # No per-area override → caller generates the dynamic T&C sentence.
             "terms": None,
         },
@@ -72,6 +84,7 @@ def _global_terms() -> dict:
             "rides": int(REFERRAL_RIDES_REQUIRED),
             "referrer": _money(REFERRAL_REWARD_AMOUNT),
             "referee": _money(0),
+            "window_days": int(REFERRAL_WINDOW_DAYS),
             "terms": None,
         },
     }
@@ -83,6 +96,8 @@ _AREA_COLUMNS = {
         "rides": "rider_referral_rides_required",
         "referrer": "rider_referrer_reward",
         "referee": "rider_referee_reward",
+        # Completion deadline in days (migration 189); NULL → global default.
+        "window_days": "rider_referral_window_days",
         # Free-text T&C override (migration 176); NULL → dynamic default.
         "terms": "rider_referral_terms",
     },
@@ -90,6 +105,7 @@ _AREA_COLUMNS = {
         "rides": "driver_referral_rides_required",
         "referrer": "driver_referral_reward",
         "referee": None,  # drivers have no referee-side reward
+        "window_days": "driver_referral_window_days",
         "terms": "driver_referral_terms",
     },
 }
@@ -128,6 +144,11 @@ async def resolve_referral_terms(service_area_id: Optional[str], kind: str) -> d
     rides_col = cols["rides"]
     rides_val = area.get(rides_col)
 
+    # Completion deadline (days). NULL → global default; 0 is a valid override
+    # meaning "no deadline for this area" and must NOT fall back.
+    window_col = cols.get("window_days")
+    window_val = area.get(window_col) if window_col else None
+
     # Free-text T&C override: a non-blank value wins; blank/NULL → None so the
     # caller falls back to the dynamically generated default sentence.
     terms_col = cols.get("terms")
@@ -138,6 +159,7 @@ async def resolve_referral_terms(service_area_id: Optional[str], kind: str) -> d
         "rides": int(rides_val) if rides_val is not None else fallback["rides"],
         "referrer": _pick("referrer", fallback["referrer"]),
         "referee": _pick("referee", fallback["referee"]),
+        "window_days": int(window_val) if window_val is not None else fallback["window_days"],
         "terms": terms,
     }
 


### PR DESCRIPTION
Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EvvVR7nFUWNdtutemkG8q3

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
