### PR TITLE
feat(rider-app): Gemini-style animated gradient AI chat screen

### DIFF
--- a/rider-app/app/ai-assistant.tsx
+++ b/rider-app/app/ai-assistant.tsx
@@ -306,7 +306,10 @@ export default function AiAssistantScreen() {
 
   return (
     <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
-      <AiAuroraBackground />
+      {/* Ambient gradient lives on the idle welcome screen; the moment the
+          rider starts typing (or a conversation exists) it fades to plain
+          white, mirroring Gemini's home → chat transition. */}
+      <AiAuroraBackground visible={showWelcome && input.length === 0} />
       <View style={styles.header}>
         <TouchableOpacity
           onPress={() => {

--- a/rider-app/components/AiAuroraBackground.tsx
+++ b/rider-app/components/AiAuroraBackground.tsx
@@ -127,7 +127,7 @@ export default function AiAuroraBackground({ visible = true }: { visible?: boole
 }
 
 const styles = StyleSheet.create({
-  container: { ...StyleSheet.absoluteFillObject, overflow: 'hidden' },
+  container: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden' },
   blob: {
     position: 'absolute',
     width: BLOB,

--- a/rider-app/components/AiAuroraBackground.tsx
+++ b/rider-app/components/AiAuroraBackground.tsx
@@ -73,9 +73,19 @@ function DriftingBlob({ spec, animate }: { spec: BlobSpec; animate: boolean }) {
   );
 }
 
-export default function AiAuroraBackground() {
+export default function AiAuroraBackground({ visible = true }: { visible?: boolean }) {
   const { colors, isDark } = useTheme();
   const [reduceMotion, setReduceMotion] = React.useState(false);
+  const fade = useSharedValue(visible ? 1 : 0);
+
+  useEffect(() => {
+    fade.value = withTiming(visible ? 1 : 0, {
+      duration: 450,
+      easing: Easing.inOut(Easing.ease),
+    });
+  }, [visible, fade]);
+
+  const fadeStyle = useAnimatedStyle(() => ({ opacity: fade.value }));
 
   useEffect(() => {
     let mounted = true;
@@ -102,9 +112,9 @@ export default function AiAuroraBackground() {
   ];
 
   return (
-    <View style={styles.container} pointerEvents="none">
+    <Animated.View style={[styles.container, fadeStyle]} pointerEvents="none">
       {blobs.map((spec, i) => (
-        <DriftingBlob key={i} spec={spec} animate={!reduceMotion} />
+        <DriftingBlob key={i} spec={spec} animate={visible && !reduceMotion} />
       ))}
       {/* Smear the hard circles into a single continuous gradient. */}
       <BlurView
@@ -112,7 +122,7 @@ export default function AiAuroraBackground() {
         tint={isDark ? 'dark' : 'light'}
         style={StyleSheet.absoluteFill}
       />
-    </View>
+    </Animated.View>
   );
 }
 


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Gemini-style animated gradient background + polished welcome state for the rider-app AI assistant screen, fading to plain white when the rider starts typing.
- **Type**: `feat`
- **Linked issue**: none — UI polish requested directly by product owner.
- **Risk**: `low` — purely presentational; no logic, data, or API changes.
- **User-visible change**: `riders` — new ambient gradient + redesigned AI chat welcome/input.
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched**: `[ ]` backend  `[x]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius**: `single-surface`
- **Data schema change**: `none`
- **API contract change**: `none`
- **Background job change**: `none`
- **Feature flag**: `none`
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — revert the commits; no data or schema involved.
- **Dependencies / coordination**: `none` — `expo-blur`, `expo-linear-gradient`, and `react-native-reanimated` v4 were already in `rider-app/package.json`; no new deps.
- **Assumptions**: assumes the rider's `first_name` is available on the auth store (already used elsewhere); greeting gracefully falls back when absent.
- **Not changing but considered**: did not replicate to driver-app's AI screen — can follow up if desired.

## Tier 3 — Compliance flags

_None apply — presentational rider-app UI only, no money/PII/auth/safety surface and no third-party SDK added._

## Tier 4 — Verification

- **Unit tests**: `not-applicable` — purely visual/animation components (drifting gradient blobs, rotating orb, opacity fade); no logic branches, and the screen has no existing snapshot tests.
- **Integration tests**: `not-applicable` — no cross-system behavior.
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: Not captured — the CI/dev container has no `node_modules`, so the RN screen could not be rendered here. Recommend a local `yarn start` (rider-app) to eyeball the aurora motion and the type-to-white fade before merge.
- **Perf numbers**: not applicable — no SLA-critical path touched. Animations run on the UI thread via reanimated worklets and pause/fade out when hidden.

**Pre-merge checklist**:

- [ ] Ran the changed code against real Supabase dev — N/A (frontend-only)
- [ ] Tested with rider + driver + admin accounts — N/A (single-surface, rider-app)
- [ ] Verified the rollback command actually works — N/A (`low` risk, git-revert-safe)
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

---

### Detail

**Behavior** — the moving aurora gradient lives on the idle welcome screen; the moment the rider starts typing (or a conversation exists) it fades (~0.45s) to a plain white background, mirroring Gemini's home → chat transition.

**Changes**
- `components/AiAuroraBackground.tsx` (new) — three slow-drifting colour blobs (red, orange, white) smeared into a continuous aurora by a blur layer. `visible` prop tweens opacity; blob drift pauses while hidden. Honours OS reduce-motion.
- `components/AiWelcomeOrb.tsx` (new) — rotating, breathing gradient sparkle with a soft halo, replacing the static welcome icon. Reduce-motion aware.
- `app/ai-assistant.tsx` — personalised greeting, floating pill input with gradient send button, translucent chips/bubbles, transparent header; gradient visibility wired to `showWelcome && input.length === 0`.

AI-assisted — spinr platform (Claude Code)

https://claude.ai/code/session_01PiQbuKbK8MW1LUj33pU8oJ

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
