### PR TITLE
refactor(marketing): service area is a filter on customers/drivers, n…

### DIFF
--- a/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
+++ b/admin-dashboard/src/app/dashboard/cloud-messaging/page.tsx
@@ -82,7 +82,6 @@ const AUDIENCE_OPTIONS = [
     { value: "drivers", label: "Drivers", icon: Car },
     { value: "particular_customer", label: "Particular Customer", icon: User },
     { value: "particular_driver", label: "Particular Driver", icon: User },
-    { value: "service_area", label: "Service Area", icon: MapPin },
 ];
 
 const NOTIFICATION_TYPES = [
@@ -226,8 +225,7 @@ export default function CloudMessagingPage() {
     // Live audience preview — only meaningful for broadcast audiences (not the
     // particular_* selectors) and most useful when marketing (shows opt-in pool).
     useEffect(() => {
-        const isParticular = form.audience.startsWith("particular");
-        if (isParticular || (form.audience === "service_area" && !form.service_area_id)) {
+        if (form.audience.startsWith("particular")) {
             setPreview(null);
             return;
         }
@@ -302,7 +300,6 @@ export default function CloudMessagingPage() {
         if (!form.title.trim() || !form.description.trim()) { toast({ title: "Missing fields", description: "Please fill in title and description.", variant: "destructive" }); return; }
         const isParticular = form.audience === "particular_customer" || form.audience === "particular_driver";
         if (isParticular && form.particular_ids.length === 0) { toast({ title: "No recipients selected", description: "Please select at least one user/driver.", variant: "destructive" }); return; }
-        if (form.audience === "service_area" && !form.service_area_id) { toast({ title: "No service area", description: "Please pick a service area to target.", variant: "destructive" }); return; }
         if (form.is_scheduled && !form.scheduled_at) { toast({ title: "Missing schedule time", description: "Please select a date and time.", variant: "destructive" }); return; }
         const channels: string[] = [];
         if (form.send_push) channels.push("push");
@@ -321,7 +318,7 @@ export default function CloudMessagingPage() {
                 is_marketing: form.is_marketing,
             };
             if (isParticular) payload.particular_ids = form.particular_ids;
-            if (form.audience === "service_area") payload.service_area_id = form.service_area_id;
+            if ((form.audience === "customers" || form.audience === "drivers") && form.service_area_id) payload.service_area_id = form.service_area_id;
             if (form.is_scheduled && form.scheduled_at) {
                 payload.scheduled_at = new Date(form.scheduled_at).toISOString();
             }
@@ -512,17 +509,22 @@ export default function CloudMessagingPage() {
                                     </div>
                                 )}
 
-                                {/* Service-area picker */}
-                                {form.audience === "service_area" && (
+                                {/* Service-area filter (optional) — narrows customers/drivers */}
+                                {(form.audience === "customers" || form.audience === "drivers") && (
                                     <div className="space-y-2 pt-1 max-w-sm">
-                                        <Label className="text-sm font-medium">Service Area <span className="text-destructive">*</span></Label>
-                                        <Select value={form.service_area_id} onValueChange={(v) => setForm({ ...form, service_area_id: v })}>
-                                            <SelectTrigger><SelectValue placeholder="Select a service area" /></SelectTrigger>
+                                        <Label className="text-sm font-medium flex items-center gap-1.5"><MapPin className="h-3.5 w-3.5" /> Service Area <span className="text-muted-foreground font-normal">(optional)</span></Label>
+                                        <Select value={form.service_area_id || "all"} onValueChange={(v) => setForm({ ...form, service_area_id: v === "all" ? "" : v })}>
+                                            <SelectTrigger><SelectValue /></SelectTrigger>
                                             <SelectContent>
+                                                <SelectItem value="all">All areas</SelectItem>
                                                 {serviceAreas.map((a) => <SelectItem key={a.id} value={a.id}>{a.name}</SelectItem>)}
                                             </SelectContent>
                                         </Select>
-                                        <p className="text-xs text-muted-foreground">Targets riders with recent rides in this area.</p>
+                                        <p className="text-xs text-muted-foreground">
+                                            {form.audience === "customers"
+                                                ? "Limit to riders with recent rides in this area."
+                                                : "Limit to drivers assigned to this area."}
+                                        </p>
                                     </div>
                                 )}
 

--- a/backend/routes/admin/messaging.py
+++ b/backend/routes/admin/messaging.py
@@ -20,7 +20,7 @@ router = APIRouter()
 
 
 _AUDIENCES = Literal[
-    "customers", "drivers", "particular_customer", "particular_driver", "all", "service_area"
+    "customers", "drivers", "particular_customer", "particular_driver", "all"
 ]
 
 
@@ -37,8 +37,9 @@ class CloudMessageRequest(BaseModel):
     # marketing senders (footer + unsubscribe / STOP) are used. When false it
     # is an operational/service notice (no consent gate — e.g. safety, outage).
     is_marketing: bool = False
-    # Required when audience == "service_area": target riders with recent rides
-    # in this service area.
+    # Optional service-area FILTER layered on the customers/drivers audience:
+    # customers → riders with recent rides in this area; drivers → drivers
+    # assigned to it. Ignored for particular_* / all. None = all areas.
     service_area_id: Optional[str] = None
 
 
@@ -46,9 +47,21 @@ def _target_app_for_audience(audience: str) -> str | None:
     """Map audience to the target_app param for send_push_notification."""
     if audience in ("drivers", "particular_driver"):
         return "driver"
-    if audience in ("customers", "particular_customer", "service_area"):
+    if audience in ("customers", "particular_customer"):
         return "rider"
     return None
+
+
+async def _rider_ids_in_area(service_area_id: str) -> list:
+    """Distinct rider ids with recent rides in a service area."""
+    rides = await db.get_rows("rides", {"service_area_id": service_area_id}, columns="rider_id", limit=50000)
+    return list({r.get("rider_id") for r in rides if r.get("rider_id")})
+
+
+async def _driver_user_ids_in_area(service_area_id: str) -> list:
+    """Distinct user ids of drivers assigned to a service area."""
+    drivers = await db.get_rows("drivers", {"service_area_id": service_area_id}, columns="user_id", limit=10000)
+    return list({d.get("user_id") for d in drivers if d.get("user_id")})
 
 
 async def _resolve_recipients(
@@ -58,11 +71,12 @@ async def _resolve_recipients(
     *,
     need_contact: bool,
 ) -> list:
-    """Resolve an audience to a list of recipient rows.
+    """Resolve an audience (optionally filtered by service area) to recipient rows.
 
     ``need_contact`` adds email+phone columns (required for the email/SMS
     channels); push only needs the id, so we avoid dragging contact PII when
-    it isn't used. service_area targets riders via their rides in that area.
+    it isn't used. ``service_area_id`` narrows the customers/drivers audience to
+    that area (riders via their rides, drivers via their assignment).
     """
     cols = "id,email,phone" if need_contact else "id"
     if audience in ("particular_customer", "particular_driver"):
@@ -72,36 +86,39 @@ async def _resolve_recipients(
             return await db.get_rows("users", {"id": {"$in": particular_ids}}, columns=cols, limit=10000)
         return [{"id": uid} for uid in particular_ids]
     if audience == "customers":
+        if service_area_id:
+            ids = await _rider_ids_in_area(service_area_id)
+            if not ids:
+                return []
+            return await db.get_rows("users", {"id": {"$in": ids}, "is_rider": True}, columns=cols, limit=10000)
         return await db.get_rows("users", {"is_rider": True}, columns=cols, limit=10000)
     if audience == "drivers":
+        if service_area_id:
+            ids = await _driver_user_ids_in_area(service_area_id)
+            if not ids:
+                return []
+            return await db.get_rows("users", {"id": {"$in": ids}}, columns=cols, limit=10000)
         return await db.get_rows("users", {"is_driver": True}, columns=cols, limit=10000)
     if audience == "all":
         return await db.get_rows("users", {}, columns=cols, limit=10000)
-    if audience == "service_area":
-        if not service_area_id:
-            return []
-        rides = await db.get_rows(
-            "rides", {"service_area_id": service_area_id}, columns="rider_id", limit=50000
-        )
-        ids = list({r.get("rider_id") for r in rides if r.get("rider_id")})
-        if not ids:
-            return []
-        return await db.get_rows("users", {"id": {"$in": ids}}, columns=cols, limit=10000)
     return []
 
 
-async def _count_audience(audience: str, particular_ids: list) -> int:
-    """Recipient count without materialising the list — used for scheduled
-    sends (the list is resolved at dispatch time)."""
+async def _count_audience(audience: str, particular_ids: list, service_area_id: Optional[str] = None) -> int:
+    """Recipient count without materialising contact PII — used for scheduled
+    sends. Honours the service-area filter for customers/drivers."""
     if audience in ("particular_customer", "particular_driver"):
         return len(particular_ids)
     if audience == "customers":
+        if service_area_id:
+            return len(await _resolve_recipients("customers", [], service_area_id, need_contact=False))
         return await db_supabase.count_documents("users", {"is_rider": True})
     if audience == "drivers":
+        if service_area_id:
+            return len(await _resolve_recipients("drivers", [], service_area_id, need_contact=False))
         return await db_supabase.count_documents("users", {"is_driver": True})
     if audience == "all":
         return await db_supabase.count_documents("users", {})
-    # service_area is resolved at dispatch; size is unknown until then.
     return 0
 
 
@@ -247,10 +264,8 @@ async def admin_send_cloud_message(
     particular_ids = payload.particular_ids or []
     scheduled_at = payload.scheduled_at
     is_marketing = payload.is_marketing
-    service_area_id = payload.service_area_id
-
-    if audience == "service_area" and not service_area_id:
-        raise HTTPException(status_code=422, detail="service_area_id is required for the service_area audience")
+    # Service-area filter only applies to the customers/drivers audiences.
+    service_area_id = payload.service_area_id if audience in ("customers", "drivers") else None
 
     is_scheduled = bool(scheduled_at)
     status = "scheduled" if is_scheduled else "sent"
@@ -266,7 +281,7 @@ async def admin_send_cloud_message(
         recipients = await _resolve_recipients(audience, particular_ids, service_area_id, need_contact=need_contact)
         total_recipients = len(recipients)
     else:
-        total_recipients = await _count_audience(audience, particular_ids)
+        total_recipients = await _count_audience(audience, particular_ids, service_area_id)
 
     doc = {
         "id": str(uuid.uuid4()),
@@ -319,17 +334,16 @@ async def admin_cloud_message_audience_preview(
     audience: _AUDIENCES = Query("customers"),
     service_area_id: Optional[str] = Query(None),
 ):
-    """Estimate reach before sending: the audience size plus, for marketing,
-    the number of users who have opted in on each channel.
+    """Estimate reach before sending: the audience size (honouring the optional
+    service-area filter) plus, for marketing, the number of users opted in on
+    each channel.
 
     The opt-in figures are the GLOBAL opted-in pool (not intersected with the
     audience) — a guidance number. Exact per-recipient consent filtering still
     happens at send time, so the delivered count can be lower.
     """
-    if audience == "service_area" and not service_area_id:
-        raise HTTPException(status_code=422, detail="service_area_id is required for the service_area audience")
-
-    recipients = await _resolve_recipients(audience, [], service_area_id, need_contact=False)
+    area = service_area_id if audience in ("customers", "drivers") else None
+    recipients = await _resolve_recipients(audience, [], area, need_contact=False)
     out: Dict[str, Any] = {"audience": audience, "audience_total": len(recipients)}
     try:
         out["email_opted_in"] = await db_supabase.count_documents("marketing_preferences", {"email_opt_in": True})

--- a/backend/tests/test_marketing_broadcast.py
+++ b/backend/tests/test_marketing_broadcast.py
@@ -22,18 +22,44 @@ except ImportError:  # pragma: no cover
 pytestmark = pytest.mark.anyio
 
 
-async def test_resolve_service_area_targets_riders_via_rides():
+async def test_customers_filtered_by_service_area_via_rides():
     async def _get_rows(table, filters=None, **kw):
         if table == "rides":
             return [{"rider_id": "u1"}, {"rider_id": "u2"}, {"rider_id": "u1"}]  # dupe u1
         if table == "users":
             assert set(filters["id"]["$in"]) == {"u1", "u2"}
+            assert filters["is_rider"] is True  # service-area filter stays scoped to riders
             return [{"id": "u1", "email": "a@b.com"}, {"id": "u2", "email": "c@d.com"}]
         return []
 
     with patch("db_supabase.get_rows", AsyncMock(side_effect=_get_rows)):
-        rows = await m._resolve_recipients("service_area", [], "area-1", need_contact=True)
+        rows = await m._resolve_recipients("customers", [], "area-1", need_contact=True)
     assert {r["id"] for r in rows} == {"u1", "u2"}
+
+
+async def test_drivers_filtered_by_service_area_via_drivers_table():
+    async def _get_rows(table, filters=None, **kw):
+        if table == "drivers":
+            assert filters == {"service_area_id": "area-9"}
+            return [{"user_id": "d1"}, {"user_id": "d2"}]
+        if table == "users":
+            assert set(filters["id"]["$in"]) == {"d1", "d2"}
+            return [{"id": "d1"}, {"id": "d2"}]
+        return []
+
+    with patch("db_supabase.get_rows", AsyncMock(side_effect=_get_rows)):
+        rows = await m._resolve_recipients("drivers", [], "area-9", need_contact=False)
+    assert {r["id"] for r in rows} == {"d1", "d2"}
+
+
+async def test_customers_without_area_filter_targets_all_riders():
+    async def _get_rows(table, filters=None, **kw):
+        assert table == "users" and filters == {"is_rider": True}
+        return [{"id": "u1"}, {"id": "u2"}, {"id": "u3"}]
+
+    with patch("db_supabase.get_rows", AsyncMock(side_effect=_get_rows)):
+        rows = await m._resolve_recipients("customers", [], None, need_contact=False)
+    assert len(rows) == 3
 
 
 async def test_marketing_email_fanout_uses_marketing_sender():


### PR DESCRIPTION
…ot an audience

Per feedback: service area should narrow WHO in an audience gets the message, not be a standalone "everyone in the area" send.

- Drop the standalone "service_area" audience; service_area_id becomes an optional filter applied to the customers and drivers audiences only. Customers → riders with recent rides in the area; drivers → drivers assigned to that area (drivers.service_area_id).
- _count_audience honours the filter for scheduled sends.
- Admin UI: remove the Service Area audience tile; add an optional "Service Area" dropdown (default "All areas") shown for customers/drivers, with audience-specific helper text. Preview + payload follow the filter.

Co-developed with Claude Code (claude-sonnet-4-6)


Claude-Session: https://claude.ai/code/session_01NPa4RHv1n1LGbhj5Yi9LEJ

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
