### PR TITLE
fix(auth): recover from foreground/background refresh-token rotation race

### DIFF
--- a/driver-app/__tests__/store/authStore.initialize.test.ts
+++ b/driver-app/__tests__/store/authStore.initialize.test.ts
@@ -79,6 +79,7 @@ jest.mock('../../../shared/api/client', () => ({
   setInMemoryToken: jest.fn(),
   setRefreshCallback: jest.fn(),
   setCsrfToken: jest.fn(),
+  setSuppressRefreshSignOut: jest.fn(),
   getAuthHeader: jest.fn(() => Promise.resolve(null)),
 }));
 

--- a/driver-app/__tests__/store/authStore.refreshRace.test.ts
+++ b/driver-app/__tests__/store/authStore.refreshRace.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Pins the foreground/background refresh-token rotation-race recovery in
+ * shared/store/authStore.ts::refreshTokens.
+ *
+ * Background: the driver app refreshes the access token from TWO independent
+ * JS contexts that share the SecureStore `refresh_token` key —
+ *   • the foreground app (authStore.refreshTokens), and
+ *   • a headless background location task (utils/backgroundLocation.ts).
+ * Refresh tokens are single-use and rotated on every /auth/refresh. When the
+ * background task rotates the token, the foreground's in-memory copy goes
+ * stale; replaying it makes the backend return 401 (a benign rotation race —
+ * NOT a session revocation). Before this fix the foreground reacted to that
+ * 401 by logging the user out, which produced persistent 401s on the
+ * high-frequency pollers (`GET /notifications`, `POST /drivers/location-batch`)
+ * until re-login.
+ *
+ * Fix: refreshTokens() reads the freshest persisted token first and, on a 401,
+ * re-reads storage and retries once with a rotated-forward token before tearing
+ * down the session. It only logs out when the token is genuinely dead.
+ *
+ * Code under test: shared/store/authStore.ts::refreshTokens
+ */
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+}));
+
+jest.mock('../../../shared/config/firebaseConfig', () => ({
+  auth: {},
+}));
+
+jest.mock('firebase/auth', () => ({
+  PhoneAuthProvider: { credential: jest.fn() },
+  signInWithCredential: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+const mockSecureStoreBacking: Record<string, string> = {};
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn((k: string) =>
+    Promise.resolve(mockSecureStoreBacking[k] ?? null),
+  ),
+  setItemAsync: jest.fn((k: string, v: string) => {
+    mockSecureStoreBacking[k] = v;
+    return Promise.resolve();
+  }),
+  deleteItemAsync: jest.fn((k: string) => {
+    delete mockSecureStoreBacking[k];
+    return Promise.resolve();
+  }),
+}));
+
+jest.mock('../../../shared/cache', () => ({
+  appCache: {
+    set: jest.fn().mockResolvedValue(undefined),
+    get: jest.fn().mockResolvedValue(null),
+    remove: jest.fn().mockResolvedValue(undefined),
+    clearUserCache: jest.fn().mockResolvedValue(undefined),
+  },
+  CACHE_KEYS: { USER_PROFILE: 'user', DRIVER_PROFILE: 'driver' },
+  CACHE_CONFIG: { USER_PROFILE_TTL: 120000 },
+}));
+
+jest.mock('../../../shared/api/client', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+  setInMemoryToken: jest.fn(),
+  setRefreshCallback: jest.fn(),
+  setCsrfToken: jest.fn(),
+  setSuppressRefreshSignOut: jest.fn(),
+  getAuthHeader: jest.fn(() => Promise.resolve(null)),
+}));
+
+import apiClient, {
+  setSuppressRefreshSignOut,
+} from '../../../shared/api/client';
+import { useAuthStore } from '../../../shared/store/authStore';
+
+const mockPost = apiClient.post as jest.Mock;
+const mockSetSuppress = setSuppressRefreshSignOut as jest.Mock;
+
+const make401 = () => {
+  const err: any = new Error('refresh token rejected');
+  err.response = { status: 401, data: { detail: 'invalid' } };
+  return err;
+};
+
+beforeEach(() => {
+  Object.keys(mockSecureStoreBacking).forEach((k) => delete mockSecureStoreBacking[k]);
+  mockPost.mockReset();
+  mockSetSuppress.mockClear();
+  useAuthStore.setState({
+    user: null,
+    driver: null,
+    token: null,
+    refreshToken: null,
+    tokenExpiresAt: null,
+    isLoading: false,
+    isInitialized: false,
+    error: null,
+    isDriverMode: false,
+  });
+});
+
+describe('authStore.refreshTokens — rotation-race recovery', () => {
+  it('retries with the background-rotated token instead of logging out', async () => {
+    // Foreground holds a stale in-memory refresh token; the background task has
+    // already rotated SecureStore forward to a fresh value.
+    useAuthStore.setState({ refreshToken: 'stale-foreground' });
+    mockSecureStoreBacking['refresh_token'] = 'fresh-from-background';
+
+    mockPost.mockImplementation((url: string, body: { refresh_token: string }) => {
+      if (url !== '/auth/refresh') throw new Error(`unexpected POST ${url}`);
+      // The stale token (were it sent) is rejected; the background-rotated one
+      // is accepted. Our fix should read storage first and send the fresh one.
+      if (body.refresh_token === 'fresh-from-background') {
+        return Promise.resolve({
+          data: { token: 'access-new', refresh_token: 'refresh-next', expires_in: 900 },
+          status: 200,
+        });
+      }
+      return Promise.reject(make401());
+    });
+
+    const ok = await useAuthStore.getState().refreshTokens();
+
+    expect(ok).toBe(true);
+    expect(useAuthStore.getState().token).toBe('access-new');
+    // Session preserved — no logout.
+    expect(mockSecureStoreBacking['refresh_token']).toBe('refresh-next');
+    // The interceptor sign-out must have been suppressed during the attempt and
+    // reset afterwards.
+    expect(mockSetSuppress).toHaveBeenCalledWith(true);
+    expect(mockSetSuppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it('recovers when the fresher token appears only on the second storage read', async () => {
+    // Simultaneous-refresh window: at the moment of the 401 the winner has not
+    // persisted its rotated token yet; it lands shortly after.
+    mockSecureStoreBacking['refresh_token'] = 'shared-token';
+
+    let firstRefreshSeen = false;
+    mockPost.mockImplementation((url: string, body: { refresh_token: string }) => {
+      if (url !== '/auth/refresh') throw new Error(`unexpected POST ${url}`);
+      if (body.refresh_token === 'shared-token') {
+        // Simulate the other context winning the race and persisting AFTER we
+        // get our 401 back.
+        firstRefreshSeen = true;
+        setTimeout(() => {
+          mockSecureStoreBacking['refresh_token'] = 'winner-rotated';
+        }, 50);
+        return Promise.reject(make401());
+      }
+      if (body.refresh_token === 'winner-rotated') {
+        return Promise.resolve({
+          data: { token: 'access-new', refresh_token: 'refresh-final', expires_in: 900 },
+          status: 200,
+        });
+      }
+      return Promise.reject(make401());
+    });
+
+    const ok = await useAuthStore.getState().refreshTokens();
+
+    expect(firstRefreshSeen).toBe(true);
+    expect(ok).toBe(true);
+    expect(useAuthStore.getState().token).toBe('access-new');
+  });
+
+  it('logs out when the refresh token is genuinely dead (no rotation)', async () => {
+    useAuthStore.setState({ refreshToken: 'dead-token', token: 'old-access' });
+    mockSecureStoreBacking['refresh_token'] = 'dead-token';
+
+    mockPost.mockImplementation((url: string) => {
+      if (url !== '/auth/refresh') throw new Error(`unexpected POST ${url}`);
+      return Promise.reject(make401());
+    });
+
+    const ok = await useAuthStore.getState().refreshTokens();
+
+    expect(ok).toBe(false);
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(mockSecureStoreBacking['refresh_token']).toBeUndefined();
+    // Only one distinct token was ever tried (no spurious extra attempts).
+    expect(mockPost).toHaveBeenCalledWith('/auth/refresh', { refresh_token: 'dead-token' });
+    expect(mockSetSuppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it('keeps the session on a transient (5xx) refresh failure', async () => {
+    useAuthStore.setState({ refreshToken: 'live-token', token: 'old-access' });
+    mockSecureStoreBacking['refresh_token'] = 'live-token';
+
+    mockPost.mockImplementation((url: string) => {
+      if (url !== '/auth/refresh') throw new Error(`unexpected POST ${url}`);
+      const err: any = new Error('service unavailable');
+      err.response = { status: 503 };
+      return Promise.reject(err);
+    });
+
+    const ok = await useAuthStore.getState().refreshTokens();
+
+    expect(ok).toBe(false);
+    // Transient — session and refresh token preserved.
+    expect(mockSecureStoreBacking['refresh_token']).toBe('live-token');
+  });
+});

--- a/driver-app/__tests__/store/authStore.refreshRace.test.ts
+++ b/driver-app/__tests__/store/authStore.refreshRace.test.ts
@@ -85,11 +85,17 @@ import { useAuthStore } from '../../../shared/store/authStore';
 const mockPost = apiClient.post as jest.Mock;
 const mockSetSuppress = setSuppressRefreshSignOut as jest.Mock;
 
+// SpinrApiError-shaped rejection (status on `.response.status` AND `.status`).
 const make401 = () => {
   const err: any = new Error('refresh token rejected');
   err.response = { status: 401, data: { detail: 'invalid' } };
   return err;
 };
+
+// The REAL shape the client rejects with on the /auth/refresh path: a raw
+// fetch Response (HTTP status on `.status`, NO `.response` wrapper). This is
+// what production sends to refreshTokens' catch — the retry must detect it.
+const make401RawResponse = () => ({ status: 401, ok: false });
 
 beforeEach(() => {
   Object.keys(mockSecureStoreBacking).forEach((k) => delete mockSecureStoreBacking[k]);
@@ -138,6 +144,55 @@ describe('authStore.refreshTokens — rotation-race recovery', () => {
     // reset afterwards.
     expect(mockSetSuppress).toHaveBeenCalledWith(true);
     expect(mockSetSuppress).toHaveBeenLastCalledWith(false);
+  });
+
+  it('detects a 401 rejected as a raw fetch Response (status on .status) and retries', async () => {
+    // Pins the production shape: handleApiError rejects the /auth/refresh 401
+    // with the raw Response, whose status is on `.status` (not `.response.status`).
+    // If refreshTokens only read `.response.status` the retry branch would never
+    // fire — the bug this test guards against.
+    mockSecureStoreBacking['refresh_token'] = 'stale-shared';
+
+    let posts = 0;
+    mockPost.mockImplementation((url: string, body: { refresh_token: string }) => {
+      if (url !== '/auth/refresh') throw new Error(`unexpected POST ${url}`);
+      posts += 1;
+      if (body.refresh_token === 'stale-shared') {
+        // First attempt: reject with the RAW Response shape and have the other
+        // context land its rotated token in storage right after.
+        mockSecureStoreBacking['refresh_token'] = 'rotated-forward';
+        return Promise.reject(make401RawResponse());
+      }
+      if (body.refresh_token === 'rotated-forward') {
+        return Promise.resolve({
+          data: { token: 'access-new', refresh_token: 'refresh-final', expires_in: 900 },
+          status: 200,
+        });
+      }
+      return Promise.reject(make401RawResponse());
+    });
+
+    const ok = await useAuthStore.getState().refreshTokens();
+
+    expect(ok).toBe(true);
+    expect(posts).toBe(2);
+    expect(useAuthStore.getState().token).toBe('access-new');
+  });
+
+  it('logs out on a raw-Response 401 when the token is genuinely dead', async () => {
+    useAuthStore.setState({ refreshToken: 'dead', token: 'old-access' });
+    mockSecureStoreBacking['refresh_token'] = 'dead';
+
+    mockPost.mockImplementation((url: string) => {
+      if (url !== '/auth/refresh') throw new Error(`unexpected POST ${url}`);
+      return Promise.reject(make401RawResponse());
+    });
+
+    const ok = await useAuthStore.getState().refreshTokens();
+
+    expect(ok).toBe(false);
+    expect(useAuthStore.getState().token).toBeNull();
+    expect(mockSecureStoreBacking['refresh_token']).toBeUndefined();
   });
 
   it('recovers when the fresher token appears only on the second storage read', async () => {

--- a/shared/api/client.ts
+++ b/shared/api/client.ts
@@ -130,6 +130,17 @@ export function setSignOutCallback(fn: () => Promise<void>): void {
   _signOutCallback = fn;
 }
 
+// While the auth layer (authStore.refreshTokens) runs its OWN controlled
+// refresh attempt, a 401 from /auth/refresh must NOT trigger the hard
+// sign-out below — the auth layer decides whether to retry with a
+// fresher stored token (foreground/background refresh-token rotation race)
+// or actually tear down the session. refreshTokens sets this true for the
+// duration of that controlled attempt and resets it in a finally.
+let _suppressRefreshSignOut = false;
+export function setSuppressRefreshSignOut(v: boolean): void {
+  _suppressRefreshSignOut = v;
+}
+
 export function setRefreshCallback(fn: RefreshFn): void {
   _refreshCallback = fn;
 }
@@ -616,6 +627,16 @@ const handleApiError = async (response: Response, method: string, url: string, r
   // expired or revoked. Sign the user out immediately to clear invalid state
   // rather than letting every queued request spin and eventually time-out.
   if (response.status === 401 && url.includes('/auth/refresh')) {
+    // Controlled retry in progress: the refresh token the foreground sent may
+    // simply have been rotated forward by the driver app's background location
+    // task (both share the SecureStore `refresh_token`). The backend treats
+    // replaying that just-rotated token as a benign rotation race and returns
+    // 401 WITHOUT revoking the session. Let authStore.refreshTokens re-read the
+    // freshest stored token and retry before any sign-out — do NOT log out here.
+    if (_suppressRefreshSignOut) {
+      _refreshSubscribers = [];
+      return Promise.reject(response) as Promise<never>;
+    }
     console.log('[API] Refresh token rejected (401) — signing out');
     if (_signOutCallback) {
       await _signOutCallback().catch(() => {});

--- a/shared/api/client.ts
+++ b/shared/api/client.ts
@@ -134,11 +134,19 @@ export function setSignOutCallback(fn: () => Promise<void>): void {
 // refresh attempt, a 401 from /auth/refresh must NOT trigger the hard
 // sign-out below — the auth layer decides whether to retry with a
 // fresher stored token (foreground/background refresh-token rotation race)
-// or actually tear down the session. refreshTokens sets this true for the
-// duration of that controlled attempt and resets it in a finally.
-let _suppressRefreshSignOut = false;
+// or actually tear down the session. refreshTokens acquires this for the
+// duration of that controlled attempt and releases it in a finally.
+//
+// Reference-counted, NOT a plain boolean: refreshTokens can be invoked
+// concurrently from paths that don't share the interceptor's _refreshPromise
+// dedup (e.g. a cold-start initialize() refresh racing a 401-triggered one).
+// With a boolean, the first caller's `finally` reset would drop suppression
+// while the second is still mid-retry. The counter keeps suppression active
+// until the LAST controlled caller releases it.
+let _suppressRefreshSignOutDepth = 0;
 export function setSuppressRefreshSignOut(v: boolean): void {
-  _suppressRefreshSignOut = v;
+  if (v) _suppressRefreshSignOutDepth++;
+  else _suppressRefreshSignOutDepth = Math.max(0, _suppressRefreshSignOutDepth - 1);
 }
 
 export function setRefreshCallback(fn: RefreshFn): void {
@@ -633,8 +641,14 @@ const handleApiError = async (response: Response, method: string, url: string, r
     // replaying that just-rotated token as a benign rotation race and returns
     // 401 WITHOUT revoking the session. Let authStore.refreshTokens re-read the
     // freshest stored token and retry before any sign-out — do NOT log out here.
-    if (_suppressRefreshSignOut) {
-      _refreshSubscribers = [];
+    //
+    // Do NOT touch _refreshSubscribers here. This 401 is the NESTED
+    // /auth/refresh call made from inside refreshTokens(); the OUTER refresh
+    // handler below flushes subscribers via _onRefreshed once refreshTokens
+    // resolves (with the new token on success, or '' on a dead session).
+    // Wiping the queue here would strand every request that piggy-backed on
+    // the in-flight refresh until its 15s request timeout.
+    if (_suppressRefreshSignOutDepth > 0) {
       return Promise.reject(response) as Promise<never>;
     }
     console.log('[API] Refresh token rejected (401) — signing out');

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import * as SecureStore from 'expo-secure-store';
 import { Platform } from 'react-native';
-import api, { setCsrfToken, setInMemoryToken, setRefreshCallback } from '../api/client';
+import api, { setCsrfToken, setInMemoryToken, setRefreshCallback, setSuppressRefreshSignOut } from '../api/client';
 import { appCache, CACHE_KEYS } from '../cache';
 
 // Last-known profile is cached with a long TTL so the driver/rider still sees
@@ -249,26 +249,67 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   refreshTokens: async (): Promise<boolean> => {
-    const storedRefresh = get().refreshToken ?? await storage.getItem('refresh_token');
-    if (!storedRefresh) return false;
+    // Prefer the freshest persisted refresh token over the in-memory copy.
+    // On the driver app a headless background location task rotates the shared
+    // SecureStore `refresh_token` independently of this foreground context;
+    // reading storage first lets the foreground pick up a rotation the
+    // background already performed instead of replaying a stale in-memory
+    // token (which the backend then 401s as a benign rotation race).
+    let candidate = (await storage.getItem('refresh_token')) ?? get().refreshToken ?? null;
+    if (!candidate) return false;
+
+    // Own the sign-out decision: a 401 from /auth/refresh during this attempt
+    // must not auto-sign-out at the interceptor (see setSuppressRefreshSignOut)
+    // until we've checked for a fresher rotated-forward token below.
+    setSuppressRefreshSignOut(true);
     try {
-      const res = await api.post('/auth/refresh', { refresh_token: storedRefresh });
-      const { token, refresh_token: newRefresh, expires_in, csrf_token } = res.data as RefreshTokenResponse;
-      await get().setTokens(token, newRefresh, expires_in, csrf_token);
-      return true;
-    } catch (e: unknown) {
-      // Only wipe the session when the server explicitly rejects the refresh
-      // token (401). Network errors, timeouts, and 5xx are transient — keeping
-      // the refresh token lets the next app launch / request try again instead
-      // of forcing the user back to the OTP screen on a flaky connection.
-      const status = isApiError(e) ? e.response?.status : undefined;
-      if (status === 401) {
-        console.log('[Auth] Refresh token rejected (401) — logging out');
-        await get().logout();
-      } else {
-        console.log('[Auth] Token refresh failed transiently, keeping session:', status ?? (isApiError(e) ? e.message : String(e)));
+      // Up to 2 attempts: the first uses the freshest token we have; on a 401
+      // we re-read storage and, if another context rotated the token forward in
+      // the meantime, retry once with that value. A short wait covers the
+      // simultaneous-refresh window where the winner hasn't persisted yet.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          const res = await api.post('/auth/refresh', { refresh_token: candidate });
+          const { token, refresh_token: newRefresh, expires_in, csrf_token } = res.data as RefreshTokenResponse;
+          await get().setTokens(token, newRefresh, expires_in, csrf_token);
+          return true;
+        } catch (e: unknown) {
+          const status = isApiError(e) ? e.response?.status : undefined;
+          if (status !== 401) {
+            // Network errors, timeouts, and 5xx are transient — keep the refresh
+            // token so the next app launch / request can try again instead of
+            // forcing the user back to the OTP screen on a flaky connection.
+            console.log('[Auth] Token refresh failed transiently, keeping session:', status ?? (isApiError(e) ? e.message : String(e)));
+            return false;
+          }
+          // 401: the token we sent was rejected. Before tearing down the
+          // session, check whether another context (the background task) has
+          // rotated the shared refresh token forward in secure storage. If so,
+          // this is the foreground/background rotation race — retry once with
+          // the fresher value rather than logging the user out.
+          if (attempt === 0) {
+            let latest = await storage.getItem('refresh_token');
+            if (!latest || latest === candidate) {
+              // The winner may not have persisted its rotated token yet — give
+              // it a brief moment, then re-read once more.
+              await new Promise((r) => setTimeout(r, 200));
+              latest = await storage.getItem('refresh_token');
+            }
+            if (latest && latest !== candidate) {
+              candidate = latest;
+              continue;
+            }
+          }
+          // Genuinely rejected (token unchanged, or the retry also failed):
+          // the session is dead — revoked, expired, or post-cascade. Clear it.
+          console.log('[Auth] Refresh token rejected (401) — logging out');
+          await get().logout();
+          return false;
+        }
       }
       return false;
+    } finally {
+      setSuppressRefreshSignOut(false);
     }
   },
 

--- a/shared/store/authStore.ts
+++ b/shared/store/authStore.ts
@@ -274,7 +274,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           await get().setTokens(token, newRefresh, expires_in, csrf_token);
           return true;
         } catch (e: unknown) {
-          const status = isApiError(e) ? e.response?.status : undefined;
+          // The /auth/refresh path rejects with a raw fetch Response (HTTP
+          // status on `.status`); all other client errors throw SpinrApiError
+          // (status on both `.status` and `.response.status`). Read both shapes
+          // so a 401 is detected no matter which path rejected — otherwise the
+          // retry below never fires and a dead session never logs out.
+          const err = e as { status?: number; response?: { status?: number } };
+          const status = (typeof err?.status === 'number' ? err.status : undefined) ?? err?.response?.status;
           if (status !== 401) {
             // Network errors, timeouts, and 5xx are transient — keep the refresh
             // token so the next app launch / request can try again instead of
@@ -288,14 +294,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           // this is the foreground/background rotation race — retry once with
           // the fresher value rather than logging the user out.
           if (attempt === 0) {
-            let latest = await storage.getItem('refresh_token');
-            if (!latest || latest === candidate) {
-              // The winner may not have persisted its rotated token yet — give
-              // it a brief moment, then re-read once more.
-              await new Promise((r) => setTimeout(r, 200));
-              latest = await storage.getItem('refresh_token');
+            // The winner of the race may not have persisted its rotated token
+            // yet; poll storage a few times (immediate, then short backoffs)
+            // so we still recover on slower hardware instead of a single fixed
+            // wait. Retry the moment a fresher token appears.
+            let latest = candidate;
+            for (const waitMs of [0, 150, 300]) {
+              if (waitMs) await new Promise((r) => setTimeout(r, waitMs));
+              const v = await storage.getItem('refresh_token');
+              if (v && v !== candidate) { latest = v; break; }
             }
-            if (latest && latest !== candidate) {
+            if (latest !== candidate) {
               candidate = latest;
               continue;
             }


### PR DESCRIPTION
Mobile rider/driver endpoints (GET /notifications, POST /drivers/location-batch)
were returning 401 Unauthorized while admin and public endpoints stayed 200 OK.

Root cause: the access token is memory-only, so every cold start and 15-min
expiry must re-mint it via /auth/refresh. Refresh tokens are single-use and
rotated on every call, but TWO independent contexts share the SecureStore
`refresh_token`: the foreground app and the driver app's headless background
location task. When one rotates the token, the other replays the now-stale
value; the backend correctly classifies that as a benign rotation race (no
cascade) but still returns 401, and the client reacted to a refresh-401 by
signing the user out — producing persistent 401s on the high-frequency pollers
until re-login.

Fix (client-side only; no change to backend theft detection):
- authStore.refreshTokens now reads the freshest persisted refresh token first
  (picking up a rotation the background task already performed) and, on a 401,
  re-reads storage and retries once with a rotated-forward token before tearing
  down the session. It only logs out when the token is genuinely dead.
- A suppress flag lets the auth layer own the sign-out decision so the
  interceptor's /auth/refresh-401 handler no longer signs out mid-recovery.

Adds 4 regression tests for the race recovery (retry with background-rotated
token, second-read recovery, genuine-dead logout, transient-5xx preservation)
and updates the client mock in the existing initialize suite.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GxV1k49jqsr6jj7zZDb8zU

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
