### PR TITLE
feat(referral): drop global payout kill-switch; per-area amount (0 = no pay) is the only control

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -63,11 +63,6 @@ class Settings(BaseSettings):
     # Refresh-token TTL in days (30 days "remember this device").
     REFRESH_TOKEN_EXPIRE_DAYS: int = 30
 
-    # Referral reward payouts (rider + driver). The payout loop moves real
-    # wallet money, so it is OFF by default — enable only after verifying the
-    # reward terms and the loop behaviour in staging.
-    REFERRAL_PAYOUTS_ENABLED: bool = False
-
     # ──── Cookie Settings ────
     # HTTP-only cookie flags for secure token storage (P3 HttpOnly migration)
     COOKIE_SECURE: bool = True  # HTTPS only in production

--- a/backend/core/lifespan.py
+++ b/backend/core/lifespan.py
@@ -206,8 +206,8 @@ async def lifespan(app: FastAPI):
 
     # Referral reward payouts — pays referrer/referee rewards once a referee
     # hits the ride threshold. Idempotent via referral_payouts UNIQUE claim.
-    # No-ops unless settings.REFERRAL_PAYOUTS_ENABLED (OFF by default — it moves
-    # real wallet money, enable only after staging verification).
+    # Reward amounts are admin-controlled per service area; a per-area reward of
+    # 0 means that side is simply not paid (no global on/off switch).
     try:
         from utils.referral_payout import referral_payout_loop
 

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -5261,8 +5261,9 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
 
     # Earned total: prefer the snapshotted sum of PAID payouts so it never changes
     # retroactively when area terms or the driver's area change; fall back to the
-    # estimate (reward × qualified) until a payout has actually been paid (the
-    # payout loop is off by default, so this preserves current behaviour).
+    # estimate (reward × qualified) until the payout loop has actually paid this
+    # driver (the loop runs every 5 min, so the snapshot wins shortly after a
+    # referee qualifies).
     paid = await paid_referral_earnings(current_user["id"], "driver")
     referral_earnings = paid if paid is not None else (reward_amount * qualified_referrals)
 

--- a/backend/routes/users.py
+++ b/backend/routes/users.py
@@ -521,8 +521,9 @@ async def _rider_referral_summary(user: dict, *, include_referees: bool) -> dict
     total = len(referred)
     # Earned total: prefer the snapshotted sum of PAID payouts so it never changes
     # retroactively when area terms or the rider's area change; fall back to the
-    # estimate (current reward × qualified) until any payout has actually been paid
-    # (the payout loop is off by default, so this is the current behaviour).
+    # estimate (current reward × qualified) until the payout loop has actually
+    # paid this referrer (the loop runs every 5 min, so the snapshot wins shortly
+    # after a referee qualifies).
     paid = await paid_referral_earnings(user["id"], "rider")
     earnings = paid if paid is not None else (referrer_reward * qualified)
     summary = {

--- a/backend/tests/test_referral_payout_zero_reward.py
+++ b/backend/tests/test_referral_payout_zero_reward.py
@@ -1,0 +1,80 @@
+"""Per-area 0 reward = "don't pay this side" (utils/referral_payout._process_one).
+
+Referral reward amounts are admin-controlled per service area. There is no
+global on/off flag: setting an area's reward to 0 is how an admin says "don't
+pay". This module pins that contract:
+  - both sides 0      → no claim is opened and no money moves (the referee stays
+                        unclaimed so a later admin raise above 0 can still pay)
+  - referrer 0, referee > 0 → claim opens, ONLY the referee is credited
+  - referrer > 0, referee 0 → claim opens, ONLY the referrer is credited
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import utils.referral_payout as rp
+
+
+def _rider_db() -> MagicMock:
+    db = MagicMock()
+    # Threshold met: one completed ride (rider referral requires 1).
+    db.count_documents = AsyncMock(return_value=1)
+    db.insert_one = AsyncMock(return_value={"id": "claim1"})
+    db.update_one = AsyncMock()
+    return db
+
+
+def _referee() -> dict:
+    return {
+        "id": "referee_u",
+        "referred_by": "referrer_u",  # rider referral stores the referrer USER id
+        "referral_applied_at": "2026-01-01T00:00:00+00:00",
+        "referral_code_used": "RIDEABCD1234",
+    }
+
+
+def _run(db, terms):
+    with (
+        patch.object(rp, "db_supabase", db),
+        patch.object(rp, "area_id_for_rider", AsyncMock(return_value="area1")),
+        patch.object(rp, "resolve_referral_terms", AsyncMock(return_value=terms)),
+        patch.object(rp, "_credit", AsyncMock()) as credit,
+    ):
+        asyncio.run(rp._process_one(_referee(), "RIDEABCD1234"))
+    return credit
+
+
+def test_both_zero_opens_no_claim_and_pays_nothing():
+    terms = {"rides": 1, "referrer": Decimal("0.00"), "referee": Decimal("0.00"), "window_days": 0, "terms": None}
+    db = _rider_db()
+    credit = _run(db, terms)
+
+    db.insert_one.assert_not_awaited()  # claim NOT burned — re-payable if admin raises it
+    credit.assert_not_awaited()  # no money moved
+
+
+def test_referrer_zero_credits_only_referee():
+    terms = {"rides": 1, "referrer": Decimal("0.00"), "referee": Decimal("5.00"), "window_days": 0, "terms": None}
+    db = _rider_db()
+    credit = _run(db, terms)
+
+    db.insert_one.assert_awaited_once()  # claim opened for the payable side
+    credit.assert_awaited_once()
+    user_id, amount = credit.await_args.args[0], credit.await_args.args[1]
+    assert user_id == "referee_u"
+    assert amount == Decimal("5.00")
+
+
+def test_referee_zero_credits_only_referrer():
+    terms = {"rides": 1, "referrer": Decimal("5.00"), "referee": Decimal("0.00"), "window_days": 0, "terms": None}
+    db = _rider_db()
+    credit = _run(db, terms)
+
+    db.insert_one.assert_awaited_once()
+    credit.assert_awaited_once()
+    user_id, amount = credit.await_args.args[0], credit.await_args.args[1]
+    assert user_id == "referrer_u"
+    assert amount == Decimal("5.00")

--- a/backend/utils/referral_payout.py
+++ b/backend/utils/referral_payout.py
@@ -12,7 +12,9 @@ If the deadline passes before the threshold is met, the referral is recorded as
 their rides promptly.
 
 Money safety:
-  - OFF by default (settings.REFERRAL_PAYOUTS_ENABLED) — enable after staging.
+  - Reward amounts are admin-controlled per service area (see referral_terms).
+    A per-area reward of 0 means that side is not paid — there is no global
+    on/off flag; "don't pay" is expressed by setting the amount to 0.
   - Idempotent: a payout is claimed by INSERTing a referral_payouts row whose
     UNIQUE(referee_user_id) makes a duplicate/concurrent claim fail, so each
     referral is paid at most once even across replicas and retries.
@@ -31,7 +33,6 @@ from decimal import ROUND_HALF_UP, Decimal
 
 try:
     from .. import db_supabase  # type: ignore
-    from ..core.config import settings  # type: ignore
     from ..utils.error_handling import DuplicateRecordError  # type: ignore
     from ..utils.referral_terms import (  # type: ignore
         area_id_for_rider,
@@ -39,7 +40,6 @@ try:
     )
 except ImportError:
     import db_supabase  # type: ignore
-    from core.config import settings  # type: ignore
     from utils.error_handling import DuplicateRecordError  # type: ignore
     from utils.referral_terms import (  # type: ignore
         area_id_for_rider,
@@ -77,9 +77,6 @@ async def referral_payout_loop() -> None:
 
 
 async def _tick() -> None:
-    if not settings.REFERRAL_PAYOUTS_ENABLED:
-        return
-
     # Reclaim crash-stranded claims: a row stuck 'processing' past the grace
     # window means a replica died between claiming and finalising. We can't tell
     # whether the credit landed, so mark it 'failed' for manual review rather
@@ -205,6 +202,14 @@ async def _process_one(referee: dict, code: str) -> None:
     referee_reward = _d(t["referee"])
     now_iso = datetime.now(timezone.utc).isoformat()
 
+    # Admin set BOTH sides to 0 for this area → there is nothing to pay. Don't
+    # burn the UNIQUE(referee_user_id) claim on a $0 row: leaving the referee
+    # unclaimed means that if an admin later raises the area's reward above 0,
+    # this referral becomes payable again on a future tick. (A one-sided 0 still
+    # claims-and-pays the non-zero side below.)
+    if referrer_reward <= 0 and referee_reward <= 0:
+        return
+
     # Atomic claim: the UNIQUE(referee_user_id) means only one replica/tick wins
     # this INSERT; a duplicate raises and we skip (already being handled).
     try:
@@ -231,10 +236,11 @@ async def _process_one(referee: dict, code: str) -> None:
     # the outer handler in _tick, which logs it as an error rather than silently
     # treating it as 'already claimed'.
 
-    # Credit the referrer, then the referee (when their reward > 0). _credit
-    # routes DRIVER rewards to the payable driver_bonuses ledger (append-only
-    # insert) and RIDER rewards to the wallet (self-atomic: reverses its own
-    # increment if the ledger write fails, so money is never left unrecorded).
+    # Credit each side only when its admin-configured reward is > 0 (a per-area
+    # reward of 0 means "don't pay this side"). _credit routes DRIVER rewards to
+    # the payable driver_bonuses ledger (append-only insert) and RIDER rewards to
+    # the wallet (self-atomic: reverses its own increment if the ledger write
+    # fails, so money is never left unrecorded).
     # On ANY credit failure we mark the claim
     # 'failed' and stop: we deliberately do NOT delete/retry, because the claim
     # row staying in place is exactly what prevents a re-claim and a double
@@ -251,8 +257,9 @@ async def _process_one(referee: dict, code: str) -> None:
     referrer_paid = False
     referee_paid = False
     try:
-        await _credit(referrer_user_id, referrer_reward, kind, referee_id, "referral_reward", meta)
-        referrer_paid = True
+        if referrer_reward > 0:
+            await _credit(referrer_user_id, referrer_reward, kind, referee_id, "referral_reward", meta)
+            referrer_paid = True
         if referee_reward > 0:
             await _credit(referee_id, referee_reward, kind, referee_id, "referral_bonus", meta)
             referee_paid = True

--- a/backend/utils/referral_terms.py
+++ b/backend/utils/referral_terms.py
@@ -172,9 +172,9 @@ async def paid_referral_earnings(referrer_user_id: str, kind: str) -> Optional[D
     recomputed from today's area terms, so a referrer's historical earned total
     can't change retroactively when an admin edits an area's reward/threshold or
     the user moves service areas. Returns None — not 0 — when there are no paid
-    rows so callers fall back to the pre-payout estimate (the payout loop is off
-    by default; until it runs there are no paid rows and the estimate is the only
-    available signal).
+    rows so callers fall back to the pre-payout estimate (until the payout loop
+    pays this referrer there are no paid rows and the estimate is the only
+    available signal; the loop runs every 5 min).
     """
     rows = await db_supabase.get_rows(
         "referral_payouts",


### PR DESCRIPTION
The referral payout loop was gated behind REFERRAL_PAYOUTS_ENABLED (off by
default), so wallets were never credited even though the app shows referral
rewards. Reward amounts are already admin-controlled per service area, so the
global flag was redundant: removing it makes the per-area amount the single
control, and a per-area reward of 0 means "don't pay that side".

- Remove REFERRAL_PAYOUTS_ENABLED from config/lifespan and the _tick gate;
  the loop now always runs (replay-safe via the existing UNIQUE(referee_user_id)
  claim).
- _process_one: both-side-zero returns before claiming (so a later admin raise
  above 0 stays payable); credit each side only when its reward > 0.
- Add test_referral_payout_zero_reward.py covering both-zero / one-sided-zero.
- Refresh stale "loop is off by default" comments (users, drivers, referral_terms).

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nez3YxuGkgASK999NvWAfU

<!-- spinr-expanded:background-job -->
## Tier 5 · Background-loop details

- **Replay-safety mechanism** (claim flag / idempotency key / atomic DB claim / Redis leader lock) — pick one and name it: 
- **Loop interval**: `N s` — justify if < 30 s
- **Shutdown-safe** — in-flight work either finishes or is resumable next tick: `[ ]`
- **Metric emitted per tick** (`spinr.<domain>.<metric>`): 
- **Failure mode** — what happens if the tick throws? (Sentry only? retry next tick? backoff?)
