### PR TITLE
fix(admin): AI ticket reply reads full mail chain and takes agent guidance

### DIFF
--- a/admin-dashboard/src/app/dashboard/support-tickets/tickets/[id]/page.tsx
+++ b/admin-dashboard/src/app/dashboard/support-tickets/tickets/[id]/page.tsx
@@ -124,6 +124,9 @@ export default function TicketDetailPage() {
     const [sending, setSending] = useState(false);
     const [savingField, setSavingField] = useState(false);
     const [suggesting, setSuggesting] = useState(false);
+    // Optional guidance the agent gives the AI before drafting (what to say /
+    // the decision to convey). Empty = let the AI draft from the ticket alone.
+    const [aiInstruction, setAiInstruction] = useState("");
 
     // Service area (Spinr-local; auto-derived from the contact's ride history
     // when possible, else highlighted for an optional manual assignment).
@@ -216,7 +219,7 @@ export default function TicketDetailPage() {
     const suggestAI = async () => {
         setSuggesting(true);
         try {
-            const { reply: draft } = await aiSuggestDeskReply(id);
+            const { reply: draft } = await aiSuggestDeskReply(id, aiInstruction);
             setReply(textToHtml(draft));
             toast({ title: "Draft ready", description: "Review and edit before sending." });
         } catch (e: any) {
@@ -417,6 +420,19 @@ export default function TicketDetailPage() {
                                 </Button>
                             </CardHeader>
                             <CardContent className="space-y-2">
+                                <div className="space-y-1 rounded-md border border-dashed bg-muted/30 p-2">
+                                    <Label htmlFor="ai-instruction" className="text-xs text-muted-foreground">
+                                        Tell the AI what to say (optional)
+                                    </Label>
+                                    <Textarea
+                                        id="ai-instruction"
+                                        rows={2}
+                                        value={aiInstruction}
+                                        onChange={(e) => setAiInstruction(e.target.value)}
+                                        placeholder="e.g. Apologize for the delay, confirm the refund is approved, and ask for the trip date. The AI reads the full ticket chain — add anything it can't know."
+                                        disabled={suggesting || sending}
+                                    />
+                                </div>
                                 <RichTextEditor
                                     value={reply}
                                     onChange={setReply}

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -2987,8 +2987,15 @@ export const setDeskTicketServiceArea = (id: string, service_area_id: string | n
     });
 
 /* ── AI reply suggestion (draft only; agent reviews + sends) ────────────── */
-export const aiSuggestDeskReply = (id: string) =>
+export const aiSuggestDeskReply = (id: string, instruction?: string) =>
     request<{ reply: string; provider?: string; model?: string }>(
         `/api/admin/support-tickets/tickets/${id}/ai-suggest-reply`,
-        { method: "POST" },
+        {
+            method: "POST",
+            // Optional agent guidance steering the draft. Omit the body when
+            // there's nothing to add so the endpoint behaves exactly as before.
+            ...(instruction && instruction.trim()
+                ? { body: JSON.stringify({ instruction: instruction.trim() }) }
+                : {}),
+        },
     );

--- a/backend/ai/support_assistant.py
+++ b/backend/ai/support_assistant.py
@@ -142,15 +142,24 @@ def build_ticket_context(
     lines.append("Ticket description:")
     lines.append(_truncate(scrub_pii(_plain(ticket.get("description") or "")) or "(empty)"))
 
-    msgs = (thread or [])[-_MAX_THREAD_MESSAGES:]
+    # Keep the most recent messages, then present them newest-first so the model
+    # reads the latest message (the one being replied to) before older context.
+    msgs = list(reversed((thread or [])[-_MAX_THREAD_MESSAGES:]))
     if msgs:
         lines.append("")
-        lines.append("Conversation so far (oldest to newest):")
+        lines.append(
+            "Conversation so far, MOST RECENT FIRST. The first entry below is the "
+            "latest message and is what you are replying to; the entries after it "
+            "are older, for context only:"
+        )
+        is_latest = True  # marks the first message we actually emit, not just msgs[0]
         for m in msgs:
             body = _plain(m.get("content") or m.get("summary") or m.get("plainText") or "")
             if not body:
                 continue
-            lines.append(f"[{_thread_role(m)}] {_truncate(scrub_pii(body), _MAX_FIELD_CHARS)}")
+            marker = " (latest — reply to this)" if is_latest else ""
+            lines.append(f"[{_thread_role(m)}{marker}] {_truncate(scrub_pii(body), _MAX_FIELD_CHARS)}")
+            is_latest = False
 
     if instruction and instruction.strip():
         lines.append("")

--- a/backend/ai/support_assistant.py
+++ b/backend/ai/support_assistant.py
@@ -115,13 +115,21 @@ def _thread_role(m: Dict[str, Any]) -> str:
 
 
 def build_ticket_context(
-    ticket: Dict[str, Any], thread: Optional[List[Dict[str, Any]]], service_area_name: Optional[str]
+    ticket: Dict[str, Any],
+    thread: Optional[List[Dict[str, Any]]],
+    service_area_name: Optional[str],
+    instruction: Optional[str] = None,
 ) -> str:
     """Compose the (PII-scrubbed) user message describing the ticket.
 
     The customer's name is intentionally NOT included — names can't be reliably
     regex-scrubbed, so (like the rider/driver assistant) we don't send them to
     the third-party LLM.
+
+    ``instruction`` is the support agent's own guidance for this reply (what to
+    say, the decision to convey). It is first-party staff input — not customer
+    PII — so it is passed through verbatim (the agent is steering the draft, the
+    same text they'd otherwise type by hand) and only length-bounded.
     """
     lines: List[str] = []
     if service_area_name:
@@ -142,7 +150,17 @@ def build_ticket_context(
             body = _plain(m.get("content") or m.get("summary") or m.get("plainText") or "")
             if not body:
                 continue
-            lines.append(f"[{_thread_role(m)}] {_truncate(scrub_pii(body), 1500)}")
+            lines.append(f"[{_thread_role(m)}] {_truncate(scrub_pii(body), _MAX_FIELD_CHARS)}")
+
+    if instruction and instruction.strip():
+        lines.append("")
+        lines.append(
+            "The support agent handling this ticket gave you specific guidance for "
+            "this reply. Follow it as the intent of the response, while staying "
+            "within the ground rules above (never fabricate facts the guidance does "
+            "not supply):"
+        )
+        lines.append(_truncate(instruction.strip(), _MAX_FIELD_CHARS))
 
     lines.append("")
     lines.append("Draft the reply to send to the customer now.")
@@ -154,6 +172,7 @@ async def suggest_ticket_reply(
     ticket: Dict[str, Any],
     thread: Optional[List[Dict[str, Any]]] = None,
     service_area_name: Optional[str] = None,
+    instruction: Optional[str] = None,
     settings: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Return ``{"reply", "provider", "model"}`` — a draft for a human to send.
@@ -174,7 +193,7 @@ async def suggest_ticket_reply(
     if contact_bits:
         system += f"\n\nSupport contact for sign-off if needed: {', '.join(contact_bits)}."
 
-    user_content = build_ticket_context(ticket, thread, service_area_name)
+    user_content = build_ticket_context(ticket, thread, service_area_name, instruction)
 
     # SEAM: to give the Help Desk its own model, branch here on
     # settings.get("ai_support_model") and pass an override to a model-aware

--- a/backend/ai/support_assistant.py
+++ b/backend/ai/support_assistant.py
@@ -138,19 +138,21 @@ def build_ticket_context(
         lines.append(f"Category: {ticket['category']}")
     # Subjects routinely embed PII ("Re: refund to a@b.com") — scrub like the body.
     lines.append(f"Subject: {scrub_pii(ticket.get('subject') or '(no subject)')}")
-    lines.append("")
-    lines.append("Ticket description:")
-    lines.append(_truncate(scrub_pii(_plain(ticket.get("description") or "")) or "(empty)"))
+
+    description = _truncate(scrub_pii(_plain(ticket.get("description") or "")) or "(empty)")
 
     # Keep the most recent messages, then present them newest-first so the model
     # reads the latest message (the one being replied to) before older context.
+    # Oldest content is bottom-anchored: the ticket description (the original,
+    # oldest message) is shown AFTER the conversation chain, not before it.
     msgs = list(reversed((thread or [])[-_MAX_THREAD_MESSAGES:]))
     if msgs:
         lines.append("")
         lines.append(
             "Conversation so far, MOST RECENT FIRST. The first entry below is the "
             "latest message and is what you are replying to; the entries after it "
-            "are older, for context only:"
+            "(and the original ticket request at the very bottom) are older, for "
+            "context only:"
         )
         is_latest = True  # marks the first message we actually emit, not just msgs[0]
         for m in msgs:
@@ -160,6 +162,15 @@ def build_ticket_context(
             marker = " (latest — reply to this)" if is_latest else ""
             lines.append(f"[{_thread_role(m)}{marker}] {_truncate(scrub_pii(body), _MAX_FIELD_CHARS)}")
             is_latest = False
+        # Oldest message last (bottom-anchored), for context.
+        lines.append("")
+        lines.append("Original ticket request (oldest message, for context):")
+        lines.append(description)
+    else:
+        # No replies yet — the original request IS the message to reply to.
+        lines.append("")
+        lines.append("Ticket request (this is the message you are replying to):")
+        lines.append(description)
 
     if instruction and instruction.strip():
         lines.append("")

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -774,14 +774,20 @@ async def ai_suggest_reply(
     except ImportError:
         from ai.support_assistant import SupportAssistantError, suggest_ticket_reply
 
+    # The ticket, its conversation list, and its (Spinr-local) service area are
+    # independent reads — fetch them concurrently so the agent waits on one
+    # round-trip, not three, before the LLM call. Hydration depends on the
+    # conversation list, so it chains after.
     try:
-        ticket = await zoho.get_ticket(ticket_id)
-        threads = await zoho.get_ticket_threads(ticket_id)
+        ticket, threads, area = await asyncio.gather(
+            zoho.get_ticket(ticket_id),
+            zoho.get_ticket_threads(ticket_id),
+            ticket_area.get_ticket_area(ticket_id),
+        )
         thread = await _hydrate_thread_bodies(ticket_id, (threads or {}).get("data"))
     except ZohoDeskError as e:
         raise _err(e) from e
 
-    area = await ticket_area.get_ticket_area(ticket_id)
     try:
         result = await suggest_ticket_reply(
             ticket=ticket or {},

--- a/backend/routes/admin/support_tickets.py
+++ b/backend/routes/admin/support_tickets.py
@@ -12,6 +12,7 @@ center) is managed here too, but the secret values are write-only:
 GET /config returns presence flags, never the secrets themselves.
 """
 
+import asyncio
 import logging
 import statistics
 from collections import Counter
@@ -658,9 +659,7 @@ async def service_areas(admin: dict = Depends(require_module("support_tickets"))
 
 
 @router.get("/tickets/{ticket_id}/service-area")
-async def get_ticket_service_area(
-    ticket_id: str, admin: dict = Depends(require_module("support_tickets"))
-):
+async def get_ticket_service_area(ticket_id: str, admin: dict = Depends(require_module("support_tickets"))):
     """Current service-area assignment for a ticket. When unassigned, attempts
     an auto-assign from the contact's ride history; if none is found, returns
     ``needs_assignment=True`` so the UI highlights it (assignment is optional).
@@ -713,15 +712,63 @@ async def set_ticket_service_area(
 
 _AI_ERROR_STATUS = {"ai_disabled": 409, "ai_misconfigured": 502, "provider_error": 502, "empty": 502}
 
+# How many of the most recent conversation entries to hydrate with their full
+# body before drafting — matches the assistant's context budget so we never
+# spend a Zoho call (or tokens) on threads the draft won't read.
+try:
+    from ...ai.support_assistant import _MAX_THREAD_MESSAGES as _AI_MAX_THREADS
+except ImportError:  # pragma: no cover - direct module import in tests
+    from ai.support_assistant import _MAX_THREAD_MESSAGES as _AI_MAX_THREADS
+
+
+async def _hydrate_thread_bodies(ticket_id: str, conversations: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]:
+    """Replace each email thread's truncated ``summary`` with its full body.
+
+    Zoho's /conversations list returns only a short ``summary`` per email
+    thread; the complete mail text lives on the per-thread resource. Without
+    this, the AI drafts from snippets and misses the actual conversation. We
+    hydrate only the most recent entries (the ones the assistant keeps) and
+    fetch them concurrently. Comments already carry full content, and any
+    per-thread fetch failure falls back to the summary rather than failing the
+    whole suggestion.
+    """
+    recent = (conversations or [])[-_AI_MAX_THREADS:]
+
+    async def _full(m: Dict[str, Any]) -> Dict[str, Any]:
+        if m.get("type") == "comment":
+            return m
+        thread_id = str(m.get("id") or "")
+        if not thread_id:
+            return m
+        try:
+            full = await zoho.get_thread(ticket_id, thread_id)
+        except ZohoDeskError as e:
+            logger.warning("Could not hydrate thread %s of ticket %s: %s", thread_id, ticket_id, e.message)
+            return m
+        body = (full or {}).get("content") or (full or {}).get("plainText")
+        return {**m, "content": body} if body else m
+
+    return list(await asyncio.gather(*[_full(m) for m in recent]))
+
+
+class AiSuggestRequest(BaseModel):
+    # Optional agent guidance — what the reply should say / the decision to
+    # convey. Steers the draft; the agent still reviews and edits before sending.
+    instruction: Optional[str] = Field(None, max_length=4000)
+
 
 @router.post("/tickets/{ticket_id}/ai-suggest-reply")
 @admin_ai_suggest_limit
 async def ai_suggest_reply(
-    request: Request, ticket_id: str, admin: dict = Depends(require_module("support_tickets"))
+    request: Request,
+    ticket_id: str,
+    payload: Optional[AiSuggestRequest] = None,
+    admin: dict = Depends(require_module("support_tickets")),
 ):
-    """Draft a reply using the AI assistant. Returns the suggestion only — the
-    agent reviews/edits and sends it via the normal /reply endpoint. Nothing is
-    sent to the customer here."""
+    """Draft a reply using the AI assistant. Reads the full ticket mail chain
+    (not just thread summaries) and optionally follows the agent's guidance.
+    Returns the suggestion only — the agent reviews/edits and sends it via the
+    normal /reply endpoint. Nothing is sent to the customer here."""
     try:
         from ...ai.support_assistant import SupportAssistantError, suggest_ticket_reply
     except ImportError:
@@ -730,6 +777,7 @@ async def ai_suggest_reply(
     try:
         ticket = await zoho.get_ticket(ticket_id)
         threads = await zoho.get_ticket_threads(ticket_id)
+        thread = await _hydrate_thread_bodies(ticket_id, (threads or {}).get("data"))
     except ZohoDeskError as e:
         raise _err(e) from e
 
@@ -737,8 +785,9 @@ async def ai_suggest_reply(
     try:
         result = await suggest_ticket_reply(
             ticket=ticket or {},
-            thread=(threads or {}).get("data"),
+            thread=thread,
             service_area_name=area.get("service_area_name"),
+            instruction=payload.instruction if payload else None,
         )
     except SupportAssistantError as e:
         raise HTTPException(status_code=_AI_ERROR_STATUS.get(e.code, 502), detail=e.message) from e
@@ -748,6 +797,10 @@ async def ai_suggest_reply(
         "zoho_desk_ticket_ai_suggest",
         "zoho_desk_ticket",
         ticket_id,
-        {"provider": result.get("provider"), "model": result.get("model")},
+        {
+            "provider": result.get("provider"),
+            "model": result.get("model"),
+            "had_instruction": bool(payload and (payload.instruction or "").strip()),
+        },
     )
     return result

--- a/backend/tests/test_support_assistant.py
+++ b/backend/tests/test_support_assistant.py
@@ -107,6 +107,35 @@ async def test_instruction_steers_draft_and_full_thread_body_used(monkeypatch):
     assert long_body.strip() in user_msg
 
 
+async def test_conversation_presented_newest_first(monkeypatch):
+    """The thread (passed oldest->newest) is presented to the model newest-first,
+    with the latest message flagged as the one to reply to."""
+    fake = _FakeAdapter()
+
+    async def _get_adapter():
+        return fake
+
+    monkeypatch.setattr(sa, "get_adapter", _get_adapter)
+    await sa.suggest_ticket_reply(
+        ticket={"subject": "Help"},
+        thread=[
+            {"type": "thread", "direction": "in", "content": "OLDEST customer message"},
+            {"type": "thread", "direction": "out", "content": "MIDDLE agent reply"},
+            {"type": "thread", "direction": "in", "content": "NEWEST customer message"},
+        ],
+        settings={"ai_assistant_enabled": True},
+    )
+    user_msg = fake.captured["messages"][0]["content"]
+    pos_new = user_msg.index("NEWEST customer message")
+    pos_mid = user_msg.index("MIDDLE agent reply")
+    pos_old = user_msg.index("OLDEST customer message")
+    # Newest appears before middle, which appears before oldest.
+    assert pos_new < pos_mid < pos_old
+    # The latest message is explicitly flagged for the model.
+    assert "(latest — reply to this)" in user_msg
+    assert user_msg.index("(latest — reply to this)") < pos_new + len("NEWEST customer message")
+
+
 async def test_no_instruction_omits_guidance_block(monkeypatch):
     fake = _FakeAdapter()
 

--- a/backend/tests/test_support_assistant.py
+++ b/backend/tests/test_support_assistant.py
@@ -117,7 +117,7 @@ async def test_conversation_presented_newest_first(monkeypatch):
 
     monkeypatch.setattr(sa, "get_adapter", _get_adapter)
     await sa.suggest_ticket_reply(
-        ticket={"subject": "Help"},
+        ticket={"subject": "Help", "description": "ORIGINAL ticket request body"},
         thread=[
             {"type": "thread", "direction": "in", "content": "OLDEST customer message"},
             {"type": "thread", "direction": "out", "content": "MIDDLE agent reply"},
@@ -129,11 +129,32 @@ async def test_conversation_presented_newest_first(monkeypatch):
     pos_new = user_msg.index("NEWEST customer message")
     pos_mid = user_msg.index("MIDDLE agent reply")
     pos_old = user_msg.index("OLDEST customer message")
+    pos_desc = user_msg.index("ORIGINAL ticket request body")
     # Newest appears before middle, which appears before oldest.
     assert pos_new < pos_mid < pos_old
+    # The original ticket request is bottom-anchored: below the whole chain.
+    assert pos_desc > pos_old
     # The latest message is explicitly flagged for the model.
     assert "(latest — reply to this)" in user_msg
     assert user_msg.index("(latest — reply to this)") < pos_new + len("NEWEST customer message")
+
+
+async def test_no_thread_treats_description_as_reply_target(monkeypatch):
+    """With no replies yet, the original request is framed as the message to
+    reply to (not buried as background context)."""
+    fake = _FakeAdapter()
+
+    async def _get_adapter():
+        return fake
+
+    monkeypatch.setattr(sa, "get_adapter", _get_adapter)
+    await sa.suggest_ticket_reply(
+        ticket={"subject": "Help", "description": "Please help me"},
+        settings={"ai_assistant_enabled": True},
+    )
+    user_msg = fake.captured["messages"][0]["content"]
+    assert "this is the message you are replying to" in user_msg
+    assert "Please help me" in user_msg
 
 
 async def test_no_instruction_omits_guidance_block(monkeypatch):

--- a/backend/tests/test_support_assistant.py
+++ b/backend/tests/test_support_assistant.py
@@ -81,6 +81,44 @@ async def test_returns_draft_and_scrubs_pii(monkeypatch):
     assert fake.captured["tools"] == []
 
 
+async def test_instruction_steers_draft_and_full_thread_body_used(monkeypatch):
+    """The agent's guidance reaches the prompt verbatim, and the conversation
+    uses each thread's full body (not a truncated snippet)."""
+    fake = _FakeAdapter()
+
+    async def _get_adapter():
+        return fake
+
+    monkeypatch.setattr(sa, "get_adapter", _get_adapter)
+
+    long_body = "The rider explains in detail. " * 80  # > the old 1500-char clamp
+    out = await sa.suggest_ticket_reply(
+        ticket={"subject": "Help", "description": "see thread"},
+        thread=[{"type": "thread", "direction": "in", "content": long_body}],
+        instruction="Confirm the $25 refund is approved and ask for the trip date.",
+        settings={"ai_assistant_enabled": True},
+    )
+    assert out["reply"] == "Hi Sam, thanks for reaching out."
+
+    user_msg = fake.captured["messages"][0]["content"]
+    # Agent guidance is first-party input — passed through unscrubbed (amounts intact).
+    assert "Confirm the $25 refund is approved" in user_msg
+    # The full mail body is present, not clipped to the old snippet length.
+    assert long_body.strip() in user_msg
+
+
+async def test_no_instruction_omits_guidance_block(monkeypatch):
+    fake = _FakeAdapter()
+
+    async def _get_adapter():
+        return fake
+
+    monkeypatch.setattr(sa, "get_adapter", _get_adapter)
+    await sa.suggest_ticket_reply(ticket={"subject": "Help"}, settings={"ai_assistant_enabled": True})
+    user_msg = fake.captured["messages"][0]["content"]
+    assert "support agent handling this ticket gave you specific guidance" not in user_msg
+
+
 async def test_misconfigured_adapter_raises(monkeypatch):
     from ai.providers.base import AIConfigError
 

--- a/backend/tests/test_support_tickets_ai_suggest.py
+++ b/backend/tests/test_support_tickets_ai_suggest.py
@@ -1,0 +1,69 @@
+"""Tests for the Help Desk AI-suggest route's thread hydration.
+
+The /conversations list Zoho returns only carries a truncated ``summary`` per
+email thread; the route must fetch each recent thread's full body so the AI
+drafts from the whole mail chain, not snippets. A per-thread fetch failure must
+degrade to the summary rather than failing the whole suggestion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import routes.admin.support_tickets as st
+from services.zoho_desk_service import ZohoDeskError
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_hydrate_replaces_summary_with_full_body(monkeypatch):
+    async def _get_thread(ticket_id, thread_id):
+        return {"id": thread_id, "content": f"FULL BODY {thread_id}"}
+
+    monkeypatch.setattr(st.zoho, "get_thread", _get_thread)
+
+    convs = [
+        {"id": "t1", "type": "thread", "direction": "in", "summary": "snippet 1"},
+        {"id": "c1", "type": "comment", "content": "internal note"},
+        {"id": "t2", "type": "thread", "direction": "out", "summary": "snippet 2"},
+    ]
+    out = await st._hydrate_thread_bodies("ticket-1", convs)
+
+    assert out[0]["content"] == "FULL BODY t1"
+    assert out[2]["content"] == "FULL BODY t2"
+    # Comments are not re-fetched; their content is left untouched.
+    assert out[1]["content"] == "internal note"
+
+
+async def test_hydrate_falls_back_to_summary_on_fetch_error(monkeypatch):
+    async def _boom(ticket_id, thread_id):
+        raise ZohoDeskError("Zoho Desk returned 404.", status=502)
+
+    monkeypatch.setattr(st.zoho, "get_thread", _boom)
+
+    convs = [{"id": "t1", "type": "thread", "direction": "in", "summary": "snippet"}]
+    out = await st._hydrate_thread_bodies("ticket-1", convs)
+
+    # No full content added; the summary entry is preserved so the draft still runs.
+    assert out[0].get("content") is None
+    assert out[0]["summary"] == "snippet"
+
+
+async def test_hydrate_only_keeps_recent_window(monkeypatch):
+    calls: list[str] = []
+
+    async def _get_thread(ticket_id, thread_id):
+        calls.append(thread_id)
+        return {"content": f"body {thread_id}"}
+
+    monkeypatch.setattr(st.zoho, "get_thread", _get_thread)
+
+    convs = [
+        {"id": f"t{i}", "type": "thread", "direction": "in", "summary": f"s{i}"}
+        for i in range(st._AI_MAX_THREADS + 5)
+    ]
+    out = await st._hydrate_thread_bodies("ticket-1", convs)
+
+    # Only the most recent window is hydrated (no Zoho call for older threads).
+    assert len(out) == st._AI_MAX_THREADS
+    assert len(calls) == st._AI_MAX_THREADS


### PR DESCRIPTION
The Help Desk "Suggest with AI" drafted from truncated thread summaries and
gave the agent no way to steer the reply.

- Backend route now hydrates the most recent conversation entries with their
  full per-thread body (Zoho /conversations only returns a short `summary`),
  fetched concurrently with a per-thread fallback to the summary on failure.
- Add an optional `instruction` field so the agent can tell the AI what to say;
  it is passed through verbatim (first-party staff input, not customer PII) and
  woven into the prompt as guidance, bounded to 4000 chars.
- Raise the per-thread context clamp so full mail bodies aren't re-truncated.
- Admin UI: add a "Tell the AI what to say (optional)" box above the reply
  editor and thread it through aiSuggestDeskReply.
- Tests for thread hydration (full body, fetch-failure fallback, recent-window
  cap) and for instruction steering / full-body inclusion.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0186PWZzchLXXZ4Ns9vCfV7r

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
