### PR TITLE
feat(backend): email driver T4A and earnings export instead of in-app download

### DIFF
--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -66,7 +66,7 @@ try:
     from ..utils.metrics import inc as _metric_inc
     from ..utils.metrics import observe as _metric_observe
     from ..utils.money import dollars_to_cents, to_decimal
-    from ..utils.rate_limiter import dsar_export_limit
+    from ..utils.rate_limiter import dsar_export_limit, tax_doc_email_limit
     from ..utils.referral_terms import paid_referral_earnings, resolve_referral_terms
     from ..utils.t4a_pdf import generate_t4a_pdf
 except ImportError:
@@ -111,7 +111,7 @@ except ImportError:
     from utils.metrics import inc as _metric_inc  # type: ignore
     from utils.metrics import observe as _metric_observe  # type: ignore
     from utils.money import dollars_to_cents, to_decimal
-    from utils.rate_limiter import dsar_export_limit
+    from utils.rate_limiter import dsar_export_limit, tax_doc_email_limit
     from utils.referral_terms import paid_referral_earnings, resolve_referral_terms  # type: ignore
     from utils.t4a_pdf import generate_t4a_pdf  # noqa: F401 – used in download_t4a_pdf
 
@@ -2978,7 +2978,7 @@ async def _email_driver_document(
     it is logged loudly (never swallowed), mirroring the DSAR export pattern.
     """
     try:
-        await send_email(
+        sent = await send_email(
             to=email,
             subject=subject,
             body=body,
@@ -2987,7 +2987,11 @@ async def _email_driver_document(
             recipient_user_id=user_id,
             log_id=log_id,
         )
-        logger.info("%s emailed for user %s (%s)", log_id, user_id, filename)
+        if sent:
+            logger.info("%s emailed for user %s (%s)", log_id, user_id, filename)
+        else:
+            # Both providers rejected without raising — surface, don't log success.
+            logger.error("%s email NOT sent (provider rejected) for user %s (%s)", log_id, user_id, filename)
     except Exception as exc:
         original = exc.details.get("original") if hasattr(exc, "details") and isinstance(exc.details, dict) else None
         logger.error(
@@ -3052,15 +3056,21 @@ async def _email_earnings_csv(user_id: str, email: str, year: int, csv_data: str
 
 
 @api_router.post("/t4a/{year}/email")
+@tax_doc_email_limit
 async def email_t4a_summary(
     year: int,
     background_tasks: BackgroundTasks,
+    request: Request = None,
     current_user: dict = Depends(get_current_user),
 ):
     """Email the T4A summary PDF to the driver (no in-app download).
 
     Returns immediately; the PDF render and email send happen in a background
     task so the driver does not wait.
+
+    Rate-limited (@tax_doc_email_limit, 6/hour) — each call reads up to 10k
+    rides and sends an email; the cap prevents inbox/SES abuse. SlowAPI needs a
+    parameter named ``request`` typed as starlette Request; do not remove it.
     """
     email = _driver_email_or_400(current_user)
     summary = await get_t4a_summary(year, current_user)
@@ -3069,12 +3079,18 @@ async def email_t4a_summary(
 
 
 @api_router.post("/earnings/export/email")
+@tax_doc_email_limit
 async def email_earnings_export(
     background_tasks: BackgroundTasks,
     year: int = Query(None),
+    request: Request = None,
     current_user: dict = Depends(get_current_user),
 ):
-    """Email the trip-by-trip earnings CSV to the driver (no in-app download)."""
+    """Email the trip-by-trip earnings CSV to the driver (no in-app download).
+
+    Rate-limited (@tax_doc_email_limit, 6/hour). SlowAPI needs a parameter
+    named ``request`` typed as starlette Request; do not remove it.
+    """
     if not year:
         year = datetime.now(timezone.utc).year
     email = _driver_email_or_400(current_user)

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2947,6 +2947,117 @@ async def export_earnings(year: int = Query(None), current_user: dict = Depends(
     return {"data": csv_data, "filename": filename}
 
 
+def _driver_email_or_400(current_user: dict) -> str:
+    """Return the driver's on-file email or raise 400.
+
+    Tax documents are delivered by email only (no in-app download), so a real
+    address is mandatory. Falling back to the phone number would hand a raw
+    phone number to the email provider — it fails to send and risks logging PII.
+    """
+    email = (current_user.get("email") or "").strip()
+    if "@" not in email:
+        raise HTTPException(status_code=400, detail="No email address on file to send the document to.")
+    return email
+
+
+async def _email_t4a_document(user_id: str, email: str, year: int, summary: dict) -> None:
+    """Background task: render the T4A PDF and email it to the driver."""
+    try:
+        pdf_bytes = generate_t4a_pdf(summary)
+        filename = f"T4A_{year}_{user_id[:8]}.pdf"
+        await send_email(
+            to=email,
+            subject=f"Your Spinr T4A summary for {year}",
+            body=(
+                "Hi,\n\n"
+                f"As requested, your T4A earnings summary for the {year} tax year is "
+                f'attached as a PDF ("{filename}").\n\n'
+                "Keep this document for your Canadian tax filing. If you have any "
+                "questions, contact support@spinr.ca.\n\n"
+                "— The Spinr Team"
+            ),
+            attachments=[{"filename": filename, "content": pdf_bytes, "mime": "application/pdf"}],
+            email_type="transactional",
+            recipient_user_id=user_id,
+            log_id="t4a",
+        )
+        logger.info("T4A %s emailed for user %s", year, user_id)
+    except Exception as exc:
+        original = exc.details.get("original") if hasattr(exc, "details") and isinstance(exc.details, dict) else None
+        logger.error(
+            "T4A email failed for user %s year %s: %s%s",
+            user_id,
+            year,
+            exc,
+            f" — {original}" if original else "",
+            exc_info=True,
+        )
+
+
+async def _email_earnings_csv(user_id: str, email: str, year: int, csv_data: str) -> None:
+    """Background task: email the trip-by-trip earnings CSV to the driver."""
+    try:
+        filename = f"earnings_export_{year}.csv"
+        await send_email(
+            to=email,
+            subject=f"Your Spinr earnings export for {year}",
+            body=(
+                "Hi,\n\n"
+                f"As requested, your detailed earnings export for {year} is attached "
+                f'as a CSV ("{filename}").\n\n'
+                "If you have any questions, contact support@spinr.ca.\n\n"
+                "— The Spinr Team"
+            ),
+            attachments=[{"filename": filename, "content": csv_data.encode("utf-8"), "mime": "text/csv"}],
+            email_type="transactional",
+            recipient_user_id=user_id,
+            log_id="earnings",
+        )
+        logger.info("Earnings CSV %s emailed for user %s", year, user_id)
+    except Exception as exc:
+        original = exc.details.get("original") if hasattr(exc, "details") and isinstance(exc.details, dict) else None
+        logger.error(
+            "Earnings CSV email failed for user %s year %s: %s%s",
+            user_id,
+            year,
+            exc,
+            f" — {original}" if original else "",
+            exc_info=True,
+        )
+
+
+@api_router.post("/t4a/{year}/email")
+async def email_t4a_summary(
+    year: int,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(get_current_user),
+):
+    """Email the T4A summary PDF to the driver (no in-app download).
+
+    Returns immediately; the PDF render and email send happen in a background
+    task so the driver does not wait.
+    """
+    email = _driver_email_or_400(current_user)
+    summary = await get_t4a_summary(year, current_user)
+    background_tasks.add_task(_email_t4a_document, current_user["id"], email, year, summary)
+    return {"message": f"Your T4A summary for {year} is on its way. Check your email."}
+
+
+@api_router.post("/earnings/export/email")
+async def email_earnings_export(
+    background_tasks: BackgroundTasks,
+    year: int = Query(None),
+    current_user: dict = Depends(get_current_user),
+):
+    """Email the trip-by-trip earnings CSV to the driver (no in-app download)."""
+    if not year:
+        year = datetime.now(timezone.utc).year
+    email = _driver_email_or_400(current_user)
+    export = await export_earnings(year=year, current_user=current_user)
+    background_tasks.add_task(_email_earnings_csv, current_user["id"], email, year, export["data"])
+    return {"message": f"Your earnings export for {year} is on its way. Check your email."}
+
+
 # Account (users) fields omitted from a data export: credentials and internal
 # session/auth state that are not "personal data about the subject".
 #  - password_hash: credential
@@ -3186,9 +3297,7 @@ async def _upload_export_zip(user_id: str, zip_bytes: bytes, expires_in_seconds:
             {
                 "user_id": user_id,
                 "storage_path": storage_path,
-                "expires_at": (
-                    datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
-                ).isoformat(),
+                "expires_at": (datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)).isoformat(),
             },
         )
     except Exception as exc:
@@ -6592,9 +6701,7 @@ async def get_current_subscription(current_user: dict = Depends(get_current_user
     _window = quota_window_for_sub(sub, tz=_tz)
     _hourly = _pass_is_hourly(sub)
     today_rides = await completed_today(driver["id"], tz=_tz, window_start=_window[0])
-    quota = compute_quota(
-        sub.get("rides_per_day", -1), today_rides, tz=_tz, window=_window, hourly=_hourly
-    )
+    quota = compute_quota(sub.get("rides_per_day", -1), today_rides, tz=_tz, window=_window, hourly=_hourly)
 
     return {
         "has_subscription": True,
@@ -7620,9 +7727,7 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
         # Multi-day pass → local midnight ending its Nth day; 1-day → 24h by hour.
         # Pairs with started_at above (missing duration_days → 30-day fallback) so
         # the row's lifetime is always self-consistent.
-        activate_updates["expires_at"] = compute_pass_expiry(
-            plan.get("duration_days"), now=now, tz=_act_tz
-        ).isoformat()
+        activate_updates["expires_at"] = compute_pass_expiry(plan.get("duration_days"), now=now, tz=_act_tz).isoformat()
 
     # Atomic claim: flip pending→active filtering on status='pending'. Only the
     # caller that wins (webhook vs verify-session can race) gets a row back and

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -2960,70 +2960,95 @@ def _driver_email_or_400(current_user: dict) -> str:
     return email
 
 
+async def _email_driver_document(
+    user_id: str,
+    email: str,
+    *,
+    subject: str,
+    body: str,
+    filename: str,
+    content: bytes,
+    mime: str,
+    log_id: str,
+) -> None:
+    """Background task: email a generated document to the driver as an attachment.
+
+    Shared by the T4A PDF and earnings-CSV senders (and any future tax/document
+    email). Runs off-request, so a send failure can't surface to the client —
+    it is logged loudly (never swallowed), mirroring the DSAR export pattern.
+    """
+    try:
+        await send_email(
+            to=email,
+            subject=subject,
+            body=body,
+            attachments=[{"filename": filename, "content": content, "mime": mime}],
+            email_type="transactional",
+            recipient_user_id=user_id,
+            log_id=log_id,
+        )
+        logger.info("%s emailed for user %s (%s)", log_id, user_id, filename)
+    except Exception as exc:
+        original = exc.details.get("original") if hasattr(exc, "details") and isinstance(exc.details, dict) else None
+        logger.error(
+            "%s email failed for user %s (%s): %s%s",
+            log_id,
+            user_id,
+            filename,
+            exc,
+            f" — {original}" if original else "",
+            exc_info=True,
+        )
+
+
 async def _email_t4a_document(user_id: str, email: str, year: int, summary: dict) -> None:
     """Background task: render the T4A PDF and email it to the driver."""
     try:
         pdf_bytes = generate_t4a_pdf(summary)
-        filename = f"T4A_{year}_{user_id[:8]}.pdf"
-        await send_email(
-            to=email,
-            subject=f"Your Spinr T4A summary for {year}",
-            body=(
-                "Hi,\n\n"
-                f"As requested, your T4A earnings summary for the {year} tax year is "
-                f'attached as a PDF ("{filename}").\n\n'
-                "Keep this document for your Canadian tax filing. If you have any "
-                "questions, contact support@spinr.ca.\n\n"
-                "— The Spinr Team"
-            ),
-            attachments=[{"filename": filename, "content": pdf_bytes, "mime": "application/pdf"}],
-            email_type="transactional",
-            recipient_user_id=user_id,
-            log_id="t4a",
-        )
-        logger.info("T4A %s emailed for user %s", year, user_id)
-    except Exception as exc:
-        original = exc.details.get("original") if hasattr(exc, "details") and isinstance(exc.details, dict) else None
-        logger.error(
-            "T4A email failed for user %s year %s: %s%s",
-            user_id,
-            year,
-            exc,
-            f" — {original}" if original else "",
-            exc_info=True,
-        )
+    except Exception:
+        # Render failure is logged here (not in the shared sender) since it's
+        # specific to PDF generation; nothing is emailed.
+        logger.error("T4A PDF render failed for user %s year %s", user_id, year, exc_info=True)
+        return
+    filename = f"T4A_{year}_{user_id[:8]}.pdf"
+    await _email_driver_document(
+        user_id,
+        email,
+        subject=f"Your Spinr T4A summary for {year}",
+        body=(
+            "Hi,\n\n"
+            f"As requested, your T4A earnings summary for the {year} tax year is "
+            f'attached as a PDF ("{filename}").\n\n'
+            "Keep this document for your Canadian tax filing. If you have any "
+            "questions, contact support@spinr.ca.\n\n"
+            "— The Spinr Team"
+        ),
+        filename=filename,
+        content=pdf_bytes,
+        mime="application/pdf",
+        log_id="t4a",
+    )
 
 
 async def _email_earnings_csv(user_id: str, email: str, year: int, csv_data: str) -> None:
     """Background task: email the trip-by-trip earnings CSV to the driver."""
-    try:
-        filename = f"earnings_export_{year}.csv"
-        await send_email(
-            to=email,
-            subject=f"Your Spinr earnings export for {year}",
-            body=(
-                "Hi,\n\n"
-                f"As requested, your detailed earnings export for {year} is attached "
-                f'as a CSV ("{filename}").\n\n'
-                "If you have any questions, contact support@spinr.ca.\n\n"
-                "— The Spinr Team"
-            ),
-            attachments=[{"filename": filename, "content": csv_data.encode("utf-8"), "mime": "text/csv"}],
-            email_type="transactional",
-            recipient_user_id=user_id,
-            log_id="earnings",
-        )
-        logger.info("Earnings CSV %s emailed for user %s", year, user_id)
-    except Exception as exc:
-        original = exc.details.get("original") if hasattr(exc, "details") and isinstance(exc.details, dict) else None
-        logger.error(
-            "Earnings CSV email failed for user %s year %s: %s%s",
-            user_id,
-            year,
-            exc,
-            f" — {original}" if original else "",
-            exc_info=True,
-        )
+    filename = f"earnings_export_{year}.csv"
+    await _email_driver_document(
+        user_id,
+        email,
+        subject=f"Your Spinr earnings export for {year}",
+        body=(
+            "Hi,\n\n"
+            f"As requested, your detailed earnings export for {year} is attached "
+            f'as a CSV ("{filename}").\n\n'
+            "If you have any questions, contact support@spinr.ca.\n\n"
+            "— The Spinr Team"
+        ),
+        filename=filename,
+        content=csv_data.encode("utf-8"),
+        mime="text/csv",
+        log_id="earnings",
+    )
 
 
 @api_router.post("/t4a/{year}/email")

--- a/backend/tests/test_t4a_email.py
+++ b/backend/tests/test_t4a_email.py
@@ -173,6 +173,19 @@ class TestEmailBackgroundTasks:
         assert att["mime"] == "text/csv"
         assert att["content"] == csv_data.encode("utf-8")
 
+    async def test_t4a_pdf_render_failure_skips_email(self):
+        """A PDF render failure logs and returns — no email is attempted."""
+        from backend.routes.drivers import _email_t4a_document
+
+        with (
+            patch("backend.routes.drivers.generate_t4a_pdf", side_effect=RuntimeError("bad font")),
+            patch("backend.routes.drivers.send_email", AsyncMock(return_value=True)) as send,
+        ):
+            # Must not raise.
+            await _email_t4a_document(DRIVER_USER_ID, DRIVER_EMAIL, 2025, {"year": 2025})
+
+        send.assert_not_awaited()
+
     async def test_send_failure_is_logged_not_raised(self):
         """A provider failure must not escape the background task (already off-request)."""
         from backend.routes.drivers import _email_earnings_csv

--- a/backend/tests/test_t4a_email.py
+++ b/backend/tests/test_t4a_email.py
@@ -1,0 +1,182 @@
+"""
+Driver tax-document email delivery (no in-app download).
+
+Tax documents and earnings exports are delivered by email only — the driver
+app no longer downloads them. These tests pin:
+
+  POST /drivers/t4a/{year}/email          — schedules the T4A PDF email
+  POST /drivers/earnings/export/email     — schedules the earnings CSV email
+  _email_t4a_document  — renders the PDF and attaches it to send_email
+  _email_earnings_csv  — attaches the CSV (utf-8 bytes) to send_email
+
+Both endpoints return immediately and require an email address on file (400
+otherwise — a phone-number fallback would leak PII to the email provider).
+
+Run:
+    pytest backend/tests/test_t4a_email.py -v
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import BackgroundTasks
+
+DRIVER_USER_ID = "driver_user_t4a_email"
+DRIVER_ID = "driver_row_t4a_email"
+DRIVER_EMAIL = "driver@example.com"
+
+
+def _driver_row(**extra) -> dict:
+    return {
+        "id": DRIVER_ID,
+        "user_id": DRIVER_USER_ID,
+        "gst_registered": False,
+        "gst_bn": "",
+        **extra,
+    }
+
+
+def _ride_row(earnings: float = 20.00) -> dict:
+    return {
+        "id": "ride-001",
+        "driver_id": DRIVER_ID,
+        "status": "completed",
+        "driver_earnings": earnings,
+        "tip_amount": 0,
+    }
+
+
+def _user(email: str | None = DRIVER_EMAIL) -> dict:
+    return {"id": DRIVER_USER_ID, "email": email, "first_name": "Pat", "last_name": "Driver"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /drivers/t4a/{year}/email
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestEmailT4ASummary:
+    async def test_schedules_email_and_returns_message(self):
+        from backend.routes.drivers import email_t4a_summary
+
+        bg = BackgroundTasks()
+        with (
+            patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[_driver_row()])),
+            patch(
+                "backend.routes.drivers.db_supabase.get_rides_for_driver",
+                AsyncMock(return_value=[_ride_row()]),
+            ),
+        ):
+            result = await email_t4a_summary(year=2025, background_tasks=bg, current_user=_user())
+
+        assert "email" in result["message"].lower()
+        assert len(bg.tasks) == 1
+        task = bg.tasks[0]
+        assert task.func.__name__ == "_email_t4a_document"
+        # (user_id, email, year, summary)
+        assert task.args[1] == DRIVER_EMAIL
+        assert task.args[2] == 2025
+
+    async def test_no_email_on_file_raises_400(self):
+        from fastapi import HTTPException
+
+        from backend.routes.drivers import email_t4a_summary
+
+        bg = BackgroundTasks()
+        with pytest.raises(HTTPException) as exc_info:
+            await email_t4a_summary(year=2025, background_tasks=bg, current_user=_user(email=None))
+
+        assert exc_info.value.status_code == 400
+        assert bg.tasks == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# POST /drivers/earnings/export/email
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestEmailEarningsExport:
+    async def test_schedules_csv_email(self):
+        from backend.routes.drivers import email_earnings_export
+
+        bg = BackgroundTasks()
+        with (
+            patch("backend.routes.drivers.db_supabase.get_rows", AsyncMock(return_value=[_driver_row()])),
+            patch(
+                "backend.routes.drivers.db_supabase.get_rides_for_driver",
+                AsyncMock(return_value=[_ride_row()]),
+            ),
+        ):
+            result = await email_earnings_export(year=2025, background_tasks=bg, current_user=_user())
+
+        assert "email" in result["message"].lower()
+        assert len(bg.tasks) == 1
+        task = bg.tasks[0]
+        assert task.func.__name__ == "_email_earnings_csv"
+        assert task.args[1] == DRIVER_EMAIL
+        assert task.args[2] == 2025
+        # The CSV payload is the export's "data" string.
+        assert "Total Earnings" in task.args[3]
+
+    async def test_no_email_on_file_raises_400(self):
+        from fastapi import HTTPException
+
+        from backend.routes.drivers import email_earnings_export
+
+        bg = BackgroundTasks()
+        with pytest.raises(HTTPException) as exc_info:
+            await email_earnings_export(year=2025, background_tasks=bg, current_user=_user(email=None))
+
+        assert exc_info.value.status_code == 400
+        assert bg.tasks == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Background tasks — attachment shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+class TestEmailBackgroundTasks:
+    async def test_t4a_document_emails_pdf_attachment(self):
+        from backend.routes.drivers import _email_t4a_document
+
+        summary = {"year": 2025, "total_earnings": "70.00", "total_trips": 3}
+        with (
+            patch("backend.routes.drivers.generate_t4a_pdf", return_value=b"%PDF-1.4 fake"),
+            patch("backend.routes.drivers.send_email", AsyncMock(return_value=True)) as send,
+        ):
+            await _email_t4a_document(DRIVER_USER_ID, DRIVER_EMAIL, 2025, summary)
+
+        send.assert_awaited_once()
+        kwargs = send.await_args.kwargs
+        assert kwargs["to"] == DRIVER_EMAIL
+        att = kwargs["attachments"][0]
+        assert att["filename"].endswith(".pdf")
+        assert att["mime"] == "application/pdf"
+        assert att["content"] == b"%PDF-1.4 fake"
+
+    async def test_csv_emails_utf8_bytes_attachment(self):
+        from backend.routes.drivers import _email_earnings_csv
+
+        csv_data = "Year,Total Earnings\n2025,70.00"
+        with patch("backend.routes.drivers.send_email", AsyncMock(return_value=True)) as send:
+            await _email_earnings_csv(DRIVER_USER_ID, DRIVER_EMAIL, 2025, csv_data)
+
+        send.assert_awaited_once()
+        att = send.await_args.kwargs["attachments"][0]
+        assert att["filename"].endswith(".csv")
+        assert att["mime"] == "text/csv"
+        assert att["content"] == csv_data.encode("utf-8")
+
+    async def test_send_failure_is_logged_not_raised(self):
+        """A provider failure must not escape the background task (already off-request)."""
+        from backend.routes.drivers import _email_earnings_csv
+
+        with patch("backend.routes.drivers.send_email", AsyncMock(side_effect=RuntimeError("ses down"))):
+            # Must not raise.
+            await _email_earnings_csv(DRIVER_USER_ID, DRIVER_EMAIL, 2025, "Year\n2025")

--- a/backend/tests/test_t4a_email.py
+++ b/backend/tests/test_t4a_email.py
@@ -23,6 +23,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import BackgroundTasks
 
+# Both endpoints are @tax_doc_email_limit (6/hour) in production. The conftest
+# autouse `reset_rate_limiters` fixture sets default_limiter.enabled = False, so
+# these direct handler calls pass request=None and skip the limiter (firing
+# behaviour is not unit-testable under that harness — same as every other
+# @limiter.limit endpoint in the suite).
+
 DRIVER_USER_ID = "driver_user_t4a_email"
 DRIVER_ID = "driver_row_t4a_email"
 DRIVER_EMAIL = "driver@example.com"

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -235,6 +235,13 @@ ride_rating_limit = default_limiter.limit("5/hour")
 # Storage, and sends an email. Tight cap prevents storage fill / SES exhaustion.
 dsar_export_limit = default_limiter.limit("3/hour")
 
+# Tax-document email (T4A PDF / earnings CSV) — each call reads up to 10k rides,
+# renders/builds a document, and sends an email to the driver. Cap prevents
+# inbox-bombing + SES quota / sender-reputation abuse (cf. dsar_export_limit).
+# Applied per-endpoint, so this allows 6 T4A + 6 CSV sends/hour with headroom
+# for retries.
+tax_doc_email_limit = default_limiter.limit("6/hour")
+
 # AI assistant chat — each message triggers LLM spend; per-user daily cap
 # (ai_daily_message_cap) is enforced separately in backend/ai/orchestrator.py
 ai_chat_limit = default_limiter.limit("10/minute")

--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -8,7 +8,6 @@ import {
     Platform,
     TextInput,
     ActivityIndicator,
-    Linking,
     KeyboardAvoidingView,
 } from 'react-native';
 import { showToast } from '../../hooks/useToast';
@@ -214,50 +213,31 @@ function PayoutScreen() {
         }
     };
 
-    const handleDownloadT4A = async () => {
+    const handleEmailT4A = async () => {
         setDownloadingT4A(true);
         try {
             // CRA T4A is generated per tax year — default to the most recently
             // completed year so drivers don't get an in-progress year's partial total.
             const year = new Date().getFullYear() - 1;
-            const res = await api.get<{ url?: string; file_url?: string; total_earnings?: string; year?: number; total_trips?: number; net_earnings?: string }>(`/drivers/t4a/${year}`);
-            const url = res.data?.url || res.data?.file_url;
-            if (url) {
-                await Linking.openURL(url);
-            } else if (res.data?.total_earnings != null) {
-                showToast(
-                    'info',
-                    `T4A Summary — ${res.data.year}`,
-                    `Total earnings: $${Number(res.data.total_earnings).toFixed(2)}\nTotal trips: ${res.data.total_trips}\nNet earnings: $${Number(res.data.net_earnings).toFixed(2)}\n\nA downloadable PDF will be available once tax documents are finalized.`,
-                );
-            } else {
-                showToast('info', 'Unavailable', 'T4A document is not yet available. Please try again later.');
-            }
+            // Tax documents are delivered by email only (no in-app download); the
+            // backend renders the PDF and emails it as an attachment.
+            const res = await api.post<{ message?: string }>(`/drivers/t4a/${year}/email`);
+            showToast('success', 'Check Your Email', res.data?.message || `Your T4A summary for ${year} is on its way.`);
         } catch (err: any) {
-            showToast('error', 'Download Failed', err.response?.data?.detail || 'Could not download T4A. Please try again.');
+            showToast('error', 'Send Failed', err.response?.data?.detail || 'Could not send your T4A. Please try again.');
         } finally {
             setDownloadingT4A(false);
         }
     };
 
-    const handleDownloadCSV = async () => {
+    const handleEmailCSV = async () => {
         setDownloadingCSV(true);
         try {
             const year = new Date().getFullYear();
-            const res = await api.get<{ url?: string; file_url?: string; data?: string }>(`/drivers/earnings/export?year=${year}`);
-            const url = res.data?.url || res.data?.file_url;
-            if (url) {
-                await Linking.openURL(url);
-            } else if (res.data?.data) {
-                // Backend returns { data: <csv-string>, filename }. Open a data: URL
-                // so the OS share sheet can hand it to Mail/Drive/Files.
-                const encoded = encodeURIComponent(res.data.data);
-                await Linking.openURL(`data:text/csv;charset=utf-8,${encoded}`);
-            } else {
-                showToast('info', 'Unavailable', 'Earnings CSV is not yet available. Please try again later.');
-            }
+            const res = await api.post<{ message?: string }>(`/drivers/earnings/export/email?year=${year}`);
+            showToast('success', 'Check Your Email', res.data?.message || `Your earnings export for ${year} is on its way.`);
         } catch (err: any) {
-            showToast('error', 'Download Failed', err.response?.data?.detail || 'Could not download earnings CSV. Please try again.');
+            showToast('error', 'Send Failed', err.response?.data?.detail || 'Could not send your earnings export. Please try again.');
         } finally {
             setDownloadingCSV(false);
         }
@@ -640,20 +620,20 @@ function PayoutScreen() {
                     <View style={styles.payoutCard}>
                         <TouchableOpacity
                             style={[styles.docRow, downloadingT4A && styles.docRowDisabled]}
-                            onPress={handleDownloadT4A}
+                            onPress={handleEmailT4A}
                             disabled={downloadingT4A}
                         >
                             <View style={styles.docRowLeft}>
                                 <Ionicons name="document-text-outline" size={22} color={colors.primary} />
                                 <View style={{ marginLeft: 12 }}>
-                                    <Text style={styles.docRowTitle}>Download T4A</Text>
-                                    <Text style={styles.docRowSub}>Annual earnings slip for tax filing</Text>
+                                    <Text style={styles.docRowTitle}>Email T4A</Text>
+                                    <Text style={styles.docRowSub}>Annual earnings slip sent to your email</Text>
                                 </View>
                             </View>
                             {downloadingT4A ? (
                                 <ActivityIndicator size="small" color={colors.primary} />
                             ) : (
-                                <Ionicons name="download-outline" size={20} color={colors.primary} />
+                                <Ionicons name="mail-outline" size={20} color={colors.primary} />
                             )}
                         </TouchableOpacity>
 
@@ -661,20 +641,20 @@ function PayoutScreen() {
 
                         <TouchableOpacity
                             style={[styles.docRow, downloadingCSV && styles.docRowDisabled]}
-                            onPress={handleDownloadCSV}
+                            onPress={handleEmailCSV}
                             disabled={downloadingCSV}
                         >
                             <View style={styles.docRowLeft}>
                                 <Ionicons name="grid-outline" size={22} color={colors.primary} />
                                 <View style={{ marginLeft: 12 }}>
-                                    <Text style={styles.docRowTitle}>Download Earnings CSV</Text>
-                                    <Text style={styles.docRowSub}>Detailed trip-by-trip earnings export</Text>
+                                    <Text style={styles.docRowTitle}>Email Earnings CSV</Text>
+                                    <Text style={styles.docRowSub}>Trip-by-trip earnings export sent to your email</Text>
                                 </View>
                             </View>
                             {downloadingCSV ? (
                                 <ActivityIndicator size="small" color={colors.primary} />
                             ) : (
-                                <Ionicons name="download-outline" size={20} color={colors.primary} />
+                                <Ionicons name="mail-outline" size={20} color={colors.primary} />
                             )}
                         </TouchableOpacity>
                     </View>

--- a/driver-app/app/driver/payout.tsx
+++ b/driver-app/app/driver/payout.tsx
@@ -45,8 +45,8 @@ function PayoutScreen() {
     // Hosted Stripe onboarding opens in the system browser, so track the brief
     // "opening…" state while we mint the AccountLink and hand off.
     const [stripeOnboarding, setStripeOnboarding] = useState(false);
-    const [downloadingT4A, setDownloadingT4A] = useState(false);
-    const [downloadingCSV, setDownloadingCSV] = useState(false);
+    const [sendingT4A, setSendingT4A] = useState(false);
+    const [sendingCSV, setSendingCSV] = useState(false);
     // gst_bn (CRA Business Number) is the canonical column on the driver row
     // served by useDriverMe and accepted by PUT /drivers/me — keep a local form
     // state for the input but seed it from the cached server value (also
@@ -214,7 +214,7 @@ function PayoutScreen() {
     };
 
     const handleEmailT4A = async () => {
-        setDownloadingT4A(true);
+        setSendingT4A(true);
         try {
             // CRA T4A is generated per tax year — default to the most recently
             // completed year so drivers don't get an in-progress year's partial total.
@@ -226,12 +226,12 @@ function PayoutScreen() {
         } catch (err: any) {
             showToast('error', 'Send Failed', err.response?.data?.detail || 'Could not send your T4A. Please try again.');
         } finally {
-            setDownloadingT4A(false);
+            setSendingT4A(false);
         }
     };
 
     const handleEmailCSV = async () => {
-        setDownloadingCSV(true);
+        setSendingCSV(true);
         try {
             const year = new Date().getFullYear();
             const res = await api.post<{ message?: string }>(`/drivers/earnings/export/email?year=${year}`);
@@ -239,7 +239,7 @@ function PayoutScreen() {
         } catch (err: any) {
             showToast('error', 'Send Failed', err.response?.data?.detail || 'Could not send your earnings export. Please try again.');
         } finally {
-            setDownloadingCSV(false);
+            setSendingCSV(false);
         }
     };
 
@@ -619,9 +619,9 @@ function PayoutScreen() {
                     <Text style={styles.sectionTitle}>Tax Documents</Text>
                     <View style={styles.payoutCard}>
                         <TouchableOpacity
-                            style={[styles.docRow, downloadingT4A && styles.docRowDisabled]}
+                            style={[styles.docRow, sendingT4A && styles.docRowDisabled]}
                             onPress={handleEmailT4A}
-                            disabled={downloadingT4A}
+                            disabled={sendingT4A}
                         >
                             <View style={styles.docRowLeft}>
                                 <Ionicons name="document-text-outline" size={22} color={colors.primary} />
@@ -630,7 +630,7 @@ function PayoutScreen() {
                                     <Text style={styles.docRowSub}>Annual earnings slip sent to your email</Text>
                                 </View>
                             </View>
-                            {downloadingT4A ? (
+                            {sendingT4A ? (
                                 <ActivityIndicator size="small" color={colors.primary} />
                             ) : (
                                 <Ionicons name="mail-outline" size={20} color={colors.primary} />
@@ -640,9 +640,9 @@ function PayoutScreen() {
                         <View style={styles.docDivider} />
 
                         <TouchableOpacity
-                            style={[styles.docRow, downloadingCSV && styles.docRowDisabled]}
+                            style={[styles.docRow, sendingCSV && styles.docRowDisabled]}
                             onPress={handleEmailCSV}
-                            disabled={downloadingCSV}
+                            disabled={sendingCSV}
                         >
                             <View style={styles.docRowLeft}>
                                 <Ionicons name="grid-outline" size={22} color={colors.primary} />
@@ -651,7 +651,7 @@ function PayoutScreen() {
                                     <Text style={styles.docRowSub}>Trip-by-trip earnings export sent to your email</Text>
                                 </View>
                             </View>
-                            {downloadingCSV ? (
+                            {sendingCSV ? (
                                 <ActivityIndicator size="small" color={colors.primary} />
                             ) : (
                                 <Ionicons name="mail-outline" size={20} color={colors.primary} />

--- a/driver-app/app/driver/settings.tsx
+++ b/driver-app/app/driver/settings.tsx
@@ -407,7 +407,7 @@ export default function SettingsScreen() {
                             disabled={exportingData}
                         >
                             <View style={[styles.settingIcon, { backgroundColor: `${colors.primary}12` }]}>
-                                <Ionicons name="download-outline" size={18} color={colors.primary} />
+                                <Ionicons name="mail-outline" size={18} color={colors.primary} />
                             </View>
                             <Text style={styles.settingLabel}>{t('settings.downloadData')}</Text>
                             {exportingData ? (

--- a/driver-app/app/driver/tax-documents.tsx
+++ b/driver-app/app/driver/tax-documents.tsx
@@ -34,7 +34,7 @@ function TaxDocumentsScreen() {
     const [documents, setDocuments] = useState<TaxDocument[]>([]);
     const [loading, setLoading] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
-    const [downloadingId, setDownloadingId] = useState<string | null>(null);
+    const [sendingId, setSendingId] = useState<string | null>(null);
 
     useEffect(() => {
         fetchDocuments();
@@ -44,9 +44,9 @@ function TaxDocumentsScreen() {
         try {
             // There is no server-side listing endpoint for tax documents yet —
             // T4A summaries are generated per-year on demand via
-            // GET /drivers/t4a/{year}. Synthesize a list client-side for the
-            // last three completed tax years; the actual summary is fetched
-            // when the driver taps Download.
+            // POST /drivers/t4a/{year}/email. Synthesize a list client-side for
+            // the last three completed tax years; the actual PDF is emailed
+            // when the driver taps the row.
             const now = new Date();
             const latestCompletedYear = now.getFullYear() - 1;
             const years = [latestCompletedYear, latestCompletedYear - 1, latestCompletedYear - 2];
@@ -72,7 +72,7 @@ function TaxDocumentsScreen() {
     };
 
     const handleEmail = async (doc: TaxDocument) => {
-        setDownloadingId(doc.id);
+        setSendingId(doc.id);
         try {
             // Tax documents are delivered by email only (no in-app download); the
             // backend renders the PDF and emails it as an attachment.
@@ -85,7 +85,7 @@ function TaxDocumentsScreen() {
         } catch (err: any) {
             showToast('error', 'Send Failed', err?.response?.data?.detail || 'Could not send the document. Please try again.');
         } finally {
-            setDownloadingId(null);
+            setSendingId(null);
         }
     };
 
@@ -113,7 +113,7 @@ function TaxDocumentsScreen() {
     };
 
     const renderDocumentItem = ({ item }: { item: TaxDocument }) => {
-        const isDownloading = downloadingId === item.id;
+        const isSending = sendingId === item.id;
         return (
             <View style={styles.docCard}>
                 <View style={styles.docIcon}>
@@ -127,11 +127,11 @@ function TaxDocumentsScreen() {
                     )}
                 </View>
                 <TouchableOpacity
-                    style={[styles.downloadBtn, isDownloading && styles.downloadBtnDisabled]}
+                    style={[styles.emailBtn, isSending && styles.emailBtnDisabled]}
                     onPress={() => handleEmail(item)}
-                    disabled={isDownloading}
+                    disabled={isSending}
                 >
-                    {isDownloading ? (
+                    {isSending ? (
                         <ActivityIndicator size="small" color="#fff" />
                     ) : (
                         <Ionicons name="mail-outline" size={18} color="#fff" />
@@ -277,7 +277,7 @@ function createStyles(colors: ThemeColors) {
             marginTop: 2,
         },
 
-        downloadBtn: {
+        emailBtn: {
             backgroundColor: colors.primary,
             width: 40,
             height: 40,
@@ -285,7 +285,7 @@ function createStyles(colors: ThemeColors) {
             justifyContent: 'center',
             alignItems: 'center',
         },
-        downloadBtnDisabled: {
+        emailBtnDisabled: {
             opacity: 0.6,
         },
 

--- a/driver-app/app/driver/tax-documents.tsx
+++ b/driver-app/app/driver/tax-documents.tsx
@@ -6,7 +6,6 @@ import {
     TouchableOpacity,
     FlatList,
     ActivityIndicator,
-    Linking,
 } from 'react-native';
 import SafeRefreshControl from '../../components/SafeRefreshControl';
 import { showToast } from '../../hooks/useToast';
@@ -72,31 +71,19 @@ function TaxDocumentsScreen() {
         fetchDocuments();
     };
 
-    const handleDownload = async (doc: TaxDocument) => {
+    const handleEmail = async (doc: TaxDocument) => {
         setDownloadingId(doc.id);
         try {
-            if (doc.file_url) {
-                await Linking.openURL(doc.file_url);
-                return;
-            }
-
-            // T4A: fetch the per-year summary and either open the signed URL
-            // (once the PDF generator ships) or display the summary inline.
-            const res = await api.get<{ url?: string; file_url?: string; total_earnings?: string; year?: number; total_trips?: number; net_earnings?: string }>(`/drivers/t4a/${doc.tax_year}`);
-            const url = res.data?.url || res.data?.file_url;
-            if (url) {
-                await Linking.openURL(url);
-            } else if (res.data?.total_earnings != null) {
-                showToast(
-                    'info',
-                    `T4A Summary — ${res.data.year}`,
-                    `Total earnings: $${Number(res.data.total_earnings).toFixed(2)}\nTotal trips: ${res.data.total_trips}\nNet earnings: $${Number(res.data.net_earnings).toFixed(2)}\n\nA downloadable PDF will be available once tax documents are finalized.`,
-                );
-            } else {
-                showToast('info', 'Unavailable', 'This document is not yet available for download.');
-            }
-        } catch (err) {
-            showToast('error', 'Open Failed', 'Could not open the document. Please try again.');
+            // Tax documents are delivered by email only (no in-app download); the
+            // backend renders the PDF and emails it as an attachment.
+            const res = await api.post<{ message?: string }>(`/drivers/t4a/${doc.tax_year}/email`);
+            showToast(
+                'success',
+                'Check Your Email',
+                res.data?.message || `Your T4A summary for ${doc.tax_year} is on its way.`,
+            );
+        } catch (err: any) {
+            showToast('error', 'Send Failed', err?.response?.data?.detail || 'Could not send the document. Please try again.');
         } finally {
             setDownloadingId(null);
         }
@@ -141,13 +128,13 @@ function TaxDocumentsScreen() {
                 </View>
                 <TouchableOpacity
                     style={[styles.downloadBtn, isDownloading && styles.downloadBtnDisabled]}
-                    onPress={() => handleDownload(item)}
+                    onPress={() => handleEmail(item)}
                     disabled={isDownloading}
                 >
                     {isDownloading ? (
                         <ActivityIndicator size="small" color="#fff" />
                     ) : (
-                        <Ionicons name="download-outline" size={18} color="#fff" />
+                        <Ionicons name="mail-outline" size={18} color="#fff" />
                     )}
                 </TouchableOpacity>
             </View>
@@ -193,7 +180,7 @@ function TaxDocumentsScreen() {
                         <View style={styles.infoCard}>
                             <Ionicons name="information-circle" size={20} color={colors.primary} />
                             <Text style={styles.infoText}>
-                                Download your T4A slips and earnings summaries for Canadian tax filing purposes.
+                                Tap to have your T4A slips and earnings summaries emailed to you for Canadian tax filing purposes.
                             </Text>
                         </View>
                     }

--- a/driver-app/i18n/en.json
+++ b/driver-app/i18n/en.json
@@ -312,7 +312,7 @@
         "emergencyServicesMsg": "Call 911 for immediate emergency assistance.",
         "call911": "Call 911",
         "cancel": "Cancel",
-        "downloadData": "Download My Data",
+        "downloadData": "Email My Data",
         "exportRequestedTitle": "Export Requested",
         "exportRequestedMsg": "Your data export is on its way — check your email.",
         "exportFailedTitle": "Export Failed",

--- a/driver-app/i18n/es.json
+++ b/driver-app/i18n/es.json
@@ -261,7 +261,7 @@
         "emergencyServicesMsg": "Llame al 911 para asistencia de emergencia inmediata.",
         "call911": "Llamar al 911",
         "cancel": "Cancelar",
-        "downloadData": "Descargar mis datos",
+        "downloadData": "Enviar mis datos por correo",
         "exportRequestedTitle": "Exportación solicitada",
         "exportRequestedMsg": "Su exportación de datos está en camino — revise su correo.",
         "exportFailedTitle": "Error de exportación",

--- a/driver-app/i18n/fr.json
+++ b/driver-app/i18n/fr.json
@@ -312,7 +312,7 @@
         "emergencyServicesMsg": "Composez le 911 pour une assistance d'urgence immédiate.",
         "call911": "Appeler le 911",
         "cancel": "Annuler",
-        "downloadData": "Télécharger mes données",
+        "downloadData": "Envoyer mes données par e-mail",
         "exportRequestedTitle": "Exportation demandée",
         "exportRequestedMsg": "Votre exportation de données est en route — consultez votre courriel.",
         "exportFailedTitle": "Échec de l'exportation",

--- a/driver-app/store/driverStore.ts
+++ b/driver-app/store/driverStore.ts
@@ -380,7 +380,6 @@ interface DriverState {
     fetchDriverBalance: () => Promise<void>;
     requestPayout: (amount: number) => Promise<{ success: boolean; error?: string }>;
     fetchPayoutHistory: (limit?: number, offset?: number) => Promise<void>;
-    exportEarnings: (year?: number) => Promise<{ data: string; filename: string } | null>;
 
     // T4A Tax Documents
     fetchT4ASummaries: () => Promise<void>;
@@ -1014,16 +1013,6 @@ export const useDriverStore = create<DriverState>((set, get) => ({
             set({ payoutHistory: res.data.payouts || [] });
         } catch (err) {
             console.log('Fetch payout history error:', err);
-        }
-    },
-
-    exportEarnings: async (year?: number): Promise<{ data: string; filename: string } | null> => {
-        try {
-            const res = await api.get<{ data: string; filename: string }>(`/drivers/earnings/export?year=${year || new Date().getFullYear()}`);
-            return { data: res.data.data, filename: res.data.filename };
-        } catch (err) {
-            console.log('Export earnings error:', err);
-            return null;
         }
     },
 


### PR DESCRIPTION
Tax documents and the trip-by-trip earnings export are now delivered by
email only — the driver app no longer downloads them. Adds two endpoints
that render the document and queue the send as a background task:

  POST /drivers/t4a/{year}/email
  POST /drivers/earnings/export/email

Both require an email address on file (400 otherwise — a phone-number
fallback would leak PII to the email provider) and return immediately so
the driver does not wait on PDF render + send. Send failures are logged
loudly (mirrors the DSAR export pattern), never swallowed.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011GAzaemr6QHJXvTYijppRG

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
