### PR TITLE
Add driver referee signup bonus (opt-in per service area)

### DIFF
--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -1352,14 +1352,15 @@ function AreaFeesEditor({ areaId, area, fees, loading, onReload, onFieldUpdate }
             <div>
                 <h4 className="font-bold text-gray-800 mb-3">Referral Rewards</h4>
                 <p className="text-xs text-gray-500 mb-3">
-                    Per-area referral rewards (CAD). Riders/drivers whose area resolves here see and earn these amounts; users not mapped to any area fall back to the global default. &quot;Rides within (days)&quot; is the deadline to complete the required rides before the referral expires unpaid — set 0 for no deadline.
+                    Per-area referral rewards (CAD). Riders/drivers whose area resolves here see and earn these amounts; users not mapped to any area fall back to the global default. Set any reward to $0 to turn that side off (e.g. driver referee reward defaults to $0 — set it above 0 to pay a signup bonus to the referred driver). &quot;Rides within (days)&quot; is the deadline to complete the required rides before the referral expires unpaid — set 0 for no deadline.
                 </p>
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <FieldInput label="Rider — referrer reward ($)" value={area.rider_referrer_reward ?? 5} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referrer_reward', parseFloat(v))} />
                     <FieldInput label="Rider — referee reward ($)" value={area.rider_referee_reward ?? 5} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referee_reward', parseFloat(v))} />
                     <FieldInput label="Rider — rides required" value={area.rider_referral_rides_required ?? 1} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referral_rides_required', parseInt(v))} />
                     <FieldInput label="Rider — rides within (days)" value={area.rider_referral_window_days ?? 30} type="number" onSave={v => onFieldUpdate(areaId, 'rider_referral_window_days', parseInt(v))} />
-                    <FieldInput label="Driver — reward ($)" value={area.driver_referral_reward ?? 10} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_reward', parseFloat(v))} />
+                    <FieldInput label="Driver — referrer reward ($)" value={area.driver_referral_reward ?? 10} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_reward', parseFloat(v))} />
+                    <FieldInput label="Driver — referee reward ($)" value={area.driver_referee_reward ?? 0} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referee_reward', parseFloat(v))} />
                     <FieldInput label="Driver — rides required" value={area.driver_referral_rides_required ?? 10} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_rides_required', parseInt(v))} />
                     <FieldInput label="Driver — rides within (days)" value={area.driver_referral_window_days ?? 30} type="number" onSave={v => onFieldUpdate(areaId, 'driver_referral_window_days', parseInt(v))} />
                 </div>

--- a/backend/migrations/201_service_area_driver_referee_reward.sql
+++ b/backend/migrations/201_service_area_driver_referee_reward.sql
@@ -1,0 +1,36 @@
+-- Migration 201: per-service-area driver REFEREE referral reward
+--
+-- Driver referrals previously paid the referrer only ($10 default, see
+-- migration 173) — the referred driver (referee) earned nothing on signup,
+-- unlike the rider program where both sides earn ($5/$5). This migration adds
+-- the missing referee-side reward column so admins can turn on a driver
+-- signup bonus per service area, exactly like every other referral amount.
+--
+-- Design:
+--   * One additive column on service_areas, same shape as the existing
+--     rider_referee_reward / driver_referral_reward columns (migration 173).
+--   * Default 0 (NOT the rider program's $5) — this is a brand-new payout
+--     stream and must not start crediting money anywhere until an admin
+--     explicitly opts in for that area. A per-area value of 0 already means
+--     "don't pay this side" in utils/referral_payout.py, so 0 is also the
+--     correct "off" state, not a special case.
+--   * The referee still qualifies on the SAME threshold as the referrer
+--     (driver_referral_rides_required) — there is no separate referee ride
+--     count, mirroring the rider program's single shared threshold.
+--   * backend/utils/referral_terms.py falls back to the global constant
+--     DRIVER_REFEREE_REWARD (= 0) in backend/routes/drivers.py when no area
+--     is resolved, exactly like every other referral term.
+--
+-- Money column is numeric (never float), matching the sibling reward columns.
+-- Additive + defaulted → forward-compatible with in-flight traffic; no
+-- backfill required.
+--
+-- Rollback:
+--   (on paper — drop the added column)
+--   ALTER TABLE service_areas DROP COLUMN IF EXISTS driver_referee_reward;
+--   (Dropping the column reverts the backend to the $0 global default;
+--    rewards already paid are unaffected — referral_payouts.referee_reward
+--    is a separate, already-snapshotted ledger column.)
+
+ALTER TABLE service_areas
+    ADD COLUMN IF NOT EXISTS driver_referee_reward numeric(10, 2) NOT NULL DEFAULT 0;

--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -169,6 +169,10 @@ class ServiceAreaCreateRequest(BaseModel):
     rider_referee_reward: float = Field(default=5, ge=0, le=1000)
     rider_referral_rides_required: int = Field(default=1, ge=1, le=100)
     driver_referral_reward: float = Field(default=10, ge=0, le=1000)
+    # Driver signup bonus (migration 201) — off by default; an admin opts a
+    # service area in by setting this above 0. Shares driver_referral_rides_required
+    # with the referrer (no separate referee-side threshold).
+    driver_referee_reward: float = Field(default=0, ge=0, le=1000)
     driver_referral_rides_required: int = Field(default=10, ge=1, le=100)
     # Free-text referral T&C (migration 176); blank → dynamic default sentence.
     rider_referral_terms: Optional[str] = Field(default=None, max_length=2000)
@@ -224,6 +228,7 @@ class ServiceAreaUpdateRequest(BaseModel):
     rider_referee_reward: Optional[float] = Field(default=None, ge=0, le=1000)
     rider_referral_rides_required: Optional[int] = Field(default=None, ge=1, le=100)
     driver_referral_reward: Optional[float] = Field(default=None, ge=0, le=1000)
+    driver_referee_reward: Optional[float] = Field(default=None, ge=0, le=1000)
     driver_referral_rides_required: Optional[int] = Field(default=None, ge=1, le=100)
     # Free-text referral T&C (migration 176); blank → dynamic default sentence.
     rider_referral_terms: Optional[str] = Field(default=None, max_length=2000)
@@ -431,6 +436,7 @@ async def admin_create_service_area(area: ServiceAreaCreateRequest, admin: dict 
         "rider_referee_reward": area.rider_referee_reward,
         "rider_referral_rides_required": area.rider_referral_rides_required,
         "driver_referral_reward": area.driver_referral_reward,
+        "driver_referee_reward": area.driver_referee_reward,
         "driver_referral_rides_required": area.driver_referral_rides_required,
         "rider_referral_terms": area.rider_referral_terms,
         "driver_referral_terms": area.driver_referral_terms,
@@ -572,6 +578,7 @@ async def admin_update_service_area(
         "rider_referee_reward",
         "rider_referral_rides_required",
         "driver_referral_reward",
+        "driver_referee_reward",
         "driver_referral_rides_required",
         "rider_referral_terms",
         "driver_referral_terms",

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -67,7 +67,11 @@ try:
     from ..utils.metrics import observe as _metric_observe
     from ..utils.money import dollars_to_cents, to_decimal
     from ..utils.rate_limiter import dsar_export_limit
-    from ..utils.referral_terms import paid_referral_earnings, resolve_referral_terms
+    from ..utils.referral_terms import (
+        paid_referee_earnings,
+        paid_referral_earnings,
+        resolve_referral_terms,
+    )
     from ..utils.t4a_pdf import generate_t4a_pdf
 except ImportError:
     import db_supabase
@@ -112,7 +116,11 @@ except ImportError:
     from utils.metrics import observe as _metric_observe  # type: ignore
     from utils.money import dollars_to_cents, to_decimal
     from utils.rate_limiter import dsar_export_limit
-    from utils.referral_terms import paid_referral_earnings, resolve_referral_terms  # type: ignore
+    from utils.referral_terms import (  # type: ignore
+        paid_referee_earnings,
+        paid_referral_earnings,
+        resolve_referral_terms,
+    )
     from utils.t4a_pdf import generate_t4a_pdf  # noqa: F401 – used in download_t4a_pdf
 
 db = db_supabase  # legacy alias
@@ -3186,9 +3194,7 @@ async def _upload_export_zip(user_id: str, zip_bytes: bytes, expires_in_seconds:
             {
                 "user_id": user_id,
                 "storage_path": storage_path,
-                "expires_at": (
-                    datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
-                ).isoformat(),
+                "expires_at": (datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)).isoformat(),
             },
         )
     except Exception as exc:
@@ -5556,6 +5562,12 @@ class ApplyReferralCodeRequest(BaseModel):
 # per-referee progress, and the displayed terms can never drift apart.
 REFERRAL_RIDES_REQUIRED = 10
 REFERRAL_REWARD_AMOUNT = 10  # CAD, paid per referee who reaches the ride target
+# Referee's own signup bonus once they reach REFERRAL_RIDES_REQUIRED (the same
+# threshold as the referrer — there is no separate referee ride count). 0 by
+# default: this is a distinct payout stream from the rider program's symmetric
+# $5/$5, and must not start crediting money until an admin opts in per service
+# area (service_areas.driver_referee_reward, migration 201).
+DRIVER_REFEREE_REWARD = 0
 # Days the referee has to reach REFERRAL_RIDES_REQUIRED (from referral_applied_at)
 # before the referral expires unpaid. 0 = no deadline. Per-area override lives in
 # service_areas.driver_referral_window_days (migration 189).
@@ -5636,6 +5648,12 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
     paid = await paid_referral_earnings(current_user["id"], "driver")
     referral_earnings = paid if paid is not None else (reward_amount * qualified_referrals)
 
+    # The viewer's OWN signup bonus — what they earned as a REFEREE (referred by
+    # another driver). Actual paid amount only (paid at most once), 0 when not
+    # referred / not yet paid / the area has the referee side set to 0. Mirrors
+    # the rider "Refer & Earn" screen's referee_earnings (routes/users.py).
+    referee_earned = await paid_referee_earnings(current_user["id"], "driver") or Decimal("0")
+
     # Who referred THIS driver (inbound). users.referred_by holds the referrer's
     # DRIVER id for driver referrals; resolve to a name + code. None if this
     # driver wasn't referred (or was referred via a rider code → not a driver row).
@@ -5664,18 +5682,29 @@ async def get_driver_referral_info(current_user: dict = Depends(get_current_user
         # Money serialised as 2-dp strings (house convention; clients parseFloat).
         "referral_earnings": _money_str(referral_earnings),
         "reward_amount": _money_str(reward_amount),
-        # Both sides' reward amounts so the app shows who earns what. referee=0 for
-        # drivers (no signup bonus) → app renders "$0 = that party earns nothing".
+        # The viewer's own signup bonus (paid only, 0 if not referred / not yet
+        # paid / area has the referee side at 0).
+        "referee_earnings": _money_str(referee_earned),
+        # Both sides' reward amounts so the app shows who earns what. referee_reward
+        # is 0 unless an admin has opted this service area into a driver signup
+        # bonus (service_areas.driver_referee_reward, migration 201) → app renders
+        # "$0 = that party earns nothing".
         "referrer_reward": _money_str(reward_amount),
         "referee_reward": _money_str(terms["referee"]),
         "referred_by": referred_by,
         "rides_required": rides_required,
         # Admin-authored per-area T&C wins; otherwise generate the default
-        # sentence from this area's reward numbers.
+        # sentence from this area's reward numbers. Mention the referee bonus
+        # only when this area actually pays one.
         "terms": terms.get("terms")
         or (
             f"Earn ${_fmt_money(reward_amount)} for each driver who signs up with your code "
             f"and completes {rides_required} rides."
+            + (
+                f" They earn ${_fmt_money(terms['referee'])} too once they complete {rides_required} rides."
+                if terms["referee"] > 0
+                else ""
+            )
         ),
     }
 
@@ -6592,9 +6621,7 @@ async def get_current_subscription(current_user: dict = Depends(get_current_user
     _window = quota_window_for_sub(sub, tz=_tz)
     _hourly = _pass_is_hourly(sub)
     today_rides = await completed_today(driver["id"], tz=_tz, window_start=_window[0])
-    quota = compute_quota(
-        sub.get("rides_per_day", -1), today_rides, tz=_tz, window=_window, hourly=_hourly
-    )
+    quota = compute_quota(sub.get("rides_per_day", -1), today_rides, tz=_tz, window=_window, hourly=_hourly)
 
     return {
         "has_subscription": True,
@@ -7620,9 +7647,7 @@ async def _activate_subscription(subscription_id: str, plan_id: str | None = Non
         # Multi-day pass → local midnight ending its Nth day; 1-day → 24h by hour.
         # Pairs with started_at above (missing duration_days → 30-day fallback) so
         # the row's lifetime is always self-consistent.
-        activate_updates["expires_at"] = compute_pass_expiry(
-            plan.get("duration_days"), now=now, tz=_act_tz
-        ).isoformat()
+        activate_updates["expires_at"] = compute_pass_expiry(plan.get("duration_days"), now=now, tz=_act_tz).isoformat()
 
     # Atomic claim: flip pending→active filtering on status='pending'. Only the
     # caller that wins (webhook vs verify-session can race) gets a row back and

--- a/backend/tests/test_referral_payout_zero_reward.py
+++ b/backend/tests/test_referral_payout_zero_reward.py
@@ -7,6 +7,11 @@ pay". This module pins that contract:
                         unclaimed so a later admin raise above 0 can still pay)
   - referrer 0, referee > 0 → claim opens, ONLY the referee is credited
   - referrer > 0, referee 0 → claim opens, ONLY the referrer is credited
+
+The driver-kind tests below pin the same contract for DRIVER referrals now
+that an admin can opt a service area into a driver_referee_reward > 0
+(migration 201) — previously the driver referee side was hardcoded to 0 and
+this path was unreachable.
 """
 
 from __future__ import annotations
@@ -77,4 +82,75 @@ def test_referee_zero_credits_only_referrer():
     credit.assert_awaited_once()
     user_id, amount = credit.await_args.args[0], credit.await_args.args[1]
     assert user_id == "referrer_u"
+    assert amount == Decimal("5.00")
+
+
+def _driver_db() -> MagicMock:
+    db = MagicMock()
+
+    def get_rows(table, filters=None, **kw):
+        if table == "drivers":
+            # referee's own driver row (resolves area + ride filter).
+            return [{"id": "referee_driver_1", "user_id": "referee_u", "service_area_id": "area1"}]
+        return []
+
+    db.get_rows = AsyncMock(side_effect=get_rows)
+    db.get_driver_by_id = AsyncMock(return_value={"id": "referrer_driver_1", "user_id": "referrer_u"})
+    # Threshold met: 10 completed rides (driver referral requires 10).
+    db.count_documents = AsyncMock(return_value=10)
+    db.insert_one = AsyncMock(return_value={"id": "claim1"})
+    db.update_one = AsyncMock()
+    return db
+
+
+def _driver_referee() -> dict:
+    return {
+        "id": "referee_u",
+        "referred_by": "referrer_driver_1",  # driver referral stores the referrer DRIVER id
+        "referral_applied_at": "2026-01-01T00:00:00+00:00",
+        "referral_code_used": "DRV-ABCDEF",
+    }
+
+
+def _run_driver(db, terms):
+    with (
+        patch.object(rp, "db_supabase", db),
+        patch.object(rp, "resolve_referral_terms", AsyncMock(return_value=terms)),
+        patch.object(rp, "_credit", AsyncMock()) as credit,
+    ):
+        asyncio.run(rp._process_one(_driver_referee(), "DRV-ABCDEF"))
+    return credit
+
+
+def test_driver_both_zero_opens_no_claim_and_pays_nothing():
+    terms = {"rides": 10, "referrer": Decimal("0.00"), "referee": Decimal("0.00"), "window_days": 0, "terms": None}
+    db = _driver_db()
+    credit = _run_driver(db, terms)
+
+    db.insert_one.assert_not_awaited()
+    credit.assert_not_awaited()
+
+
+def test_driver_referee_reward_credits_both_sides_once_opted_in():
+    # Admin set service_areas.driver_referee_reward > 0 for this area: both the
+    # referrer ($10) and the referred driver ($5 signup bonus) get credited.
+    terms = {"rides": 10, "referrer": Decimal("10.00"), "referee": Decimal("5.00"), "window_days": 0, "terms": None}
+    db = _driver_db()
+    credit = _run_driver(db, terms)
+
+    db.insert_one.assert_awaited_once()
+    assert credit.await_count == 2
+    paid = {c.args[0]: c.args[1] for c in credit.await_args_list}
+    assert paid == {"referrer_u": Decimal("10.00"), "referee_u": Decimal("5.00")}
+
+
+def test_driver_referrer_zero_credits_only_referee():
+    terms = {"rides": 10, "referrer": Decimal("0.00"), "referee": Decimal("5.00"), "window_days": 0, "terms": None}
+    db = _driver_db()
+    credit = _run_driver(db, terms)
+
+    db.insert_one.assert_awaited_once()
+    credit.assert_awaited_once()
+    user_id, amount = credit.await_args.args[0], credit.await_args.args[1]
+    assert user_id == "referee_u"
     assert amount == Decimal("5.00")

--- a/backend/tests/test_referral_terms.py
+++ b/backend/tests/test_referral_terms.py
@@ -2,7 +2,8 @@
 
 Covers the fallback contract (no area / missing row / NULL column → global
 default), area overrides winning, Decimal money coercion, the driver referee
-always being 0, and the area-derivation helpers.
+reward (off by default, admin-overridable per area like every other side),
+and the area-derivation helpers.
 """
 
 import asyncio
@@ -115,13 +116,26 @@ class TestResolveReferralTerms:
             t = asyncio.run(referral_terms.resolve_referral_terms("a", "driver"))
         assert t["window_days"] == 30
 
-    def test_driver_referee_always_zero(self):
+    def test_driver_referee_defaults_to_zero_when_area_unset(self):
+        # NULL driver_referee_reward column → falls back to the global default
+        # (0), same as every other field — "no area override yet" still means
+        # "off" for a referee reward that an admin hasn't opted into.
         area = {"id": "a", "driver_referral_reward": 25, "driver_referral_rides_required": 4}
         with _patch_global(), _patch_rows([area]):
             t = asyncio.run(referral_terms.resolve_referral_terms("a", "driver"))
         assert t["referrer"] == Decimal("25.00")
         assert t["rides"] == 4
         assert t["referee"] == Decimal("0.00")
+
+    def test_driver_referee_area_override_wins(self):
+        # An admin who opts in by setting driver_referee_reward on the area
+        # gets that amount, sharing the SAME ride threshold as the referrer
+        # (no separate referee-side rides_required column).
+        area = {"id": "a", "driver_referral_reward": 10, "driver_referee_reward": 7.5}
+        with _patch_global(), _patch_rows([area]):
+            t = asyncio.run(referral_terms.resolve_referral_terms("a", "driver"))
+        assert t["referrer"] == Decimal("10.00")
+        assert t["referee"] == Decimal("7.50")
 
     def test_lookup_failure_propagates(self):
         # A real DB error must NOT be swallowed into the global default — it

--- a/backend/utils/referral_payout.py
+++ b/backend/utils/referral_payout.py
@@ -1,9 +1,12 @@
 """Referral reward payout loop (rider + driver).
 
-Pays a referrer once their referee reaches the ride threshold WITHIN the
-completion deadline (window_days from referral_terms; 0 = no deadline):
+Pays a referrer (and, where the area opts in, the referee too) once the referee
+reaches the ride threshold WITHIN the completion deadline (window_days from
+referral_terms; 0 = no deadline):
   - driver referral: referrer earns $10 once the referee (a driver) completes
-    REFERRAL_RIDES_REQUIRED (10) rides.
+    REFERRAL_RIDES_REQUIRED (10) rides; the referee additionally earns
+    DRIVER_REFEREE_REWARD (0 by default — admin opt-in per service area via
+    service_areas.driver_referee_reward, migration 201) on the SAME threshold.
   - rider referral: referrer AND referee each earn $5 once the referee completes
     RIDER_REFERRAL_RIDES_REQUIRED (1) ride ("first-ride bonus, both sides").
 

--- a/backend/utils/referral_terms.py
+++ b/backend/utils/referral_terms.py
@@ -8,12 +8,14 @@ service area". Used by:
     snapshot the area onto the referral_payouts ledger row.
 
 Resolution:
-  - service_areas carries per-area columns (migration 173). When a rider/driver
-    resolves to an area whose columns are set, those win.
+  - service_areas carries per-area columns (migration 173; driver_referee_reward
+    added in migration 201). When a rider/driver resolves to an area whose
+    columns are set, those win.
   - When no area is resolved (NULL / outside all areas / brand-new rider with no
     rides), or the area row is missing, fall back to the global constants in
     routes/users.py + routes/drivers.py — the historical default ($5/$5/1,
-    $10/10). This keeps behaviour identical for un-mapped users.
+    $10 referrer/$0 referee/10). This keeps behaviour identical for un-mapped
+    users.
 
 Money safety: all reward values are returned as Decimal, never float — callers
 write them to the financial ledger.
@@ -48,6 +50,7 @@ def _global_terms() -> dict:
     """
     try:
         from ..routes.drivers import (  # type: ignore
+            DRIVER_REFEREE_REWARD,
             REFERRAL_REWARD_AMOUNT,
             REFERRAL_RIDES_REQUIRED,
             REFERRAL_WINDOW_DAYS,
@@ -60,6 +63,7 @@ def _global_terms() -> dict:
         )
     except ImportError:
         from routes.drivers import (  # type: ignore
+            DRIVER_REFEREE_REWARD,
             REFERRAL_REWARD_AMOUNT,
             REFERRAL_RIDES_REQUIRED,
             REFERRAL_WINDOW_DAYS,
@@ -83,7 +87,7 @@ def _global_terms() -> dict:
         "driver": {
             "rides": int(REFERRAL_RIDES_REQUIRED),
             "referrer": _money(REFERRAL_REWARD_AMOUNT),
-            "referee": _money(0),
+            "referee": _money(DRIVER_REFEREE_REWARD),
             "window_days": int(REFERRAL_WINDOW_DAYS),
             "terms": None,
         },
@@ -104,7 +108,7 @@ _AREA_COLUMNS = {
     "driver": {
         "rides": "driver_referral_rides_required",
         "referrer": "driver_referral_reward",
-        "referee": None,  # drivers have no referee-side reward
+        "referee": "driver_referee_reward",
         "window_days": "driver_referral_window_days",
         "terms": "driver_referral_terms",
     },

--- a/driver-app/app/driver/referral.tsx
+++ b/driver-app/app/driver/referral.tsx
@@ -24,6 +24,7 @@ interface ReferralInfo {
     qualified_referrals?: number;
     pending_referrals?: number;
     referral_earnings: string | number;
+    referee_earnings?: string | number;
     reward_amount?: string | number;
     referrer_reward?: string | number;
     referee_reward?: string | number;
@@ -183,10 +184,20 @@ export default function ReferralScreen() {
                         <Text style={styles.statLabel}>Rewarded</Text>
                     </View>
                     <View style={styles.statCard}>
-                        <Text style={styles.statValue}>${parseFloat(String(referralInfo?.referral_earnings ?? 0)).toFixed(2)}</Text>
+                        <Text style={styles.statValue}>
+                            ${(
+                                parseFloat(String(referralInfo?.referral_earnings ?? 0)) +
+                                parseFloat(String(referralInfo?.referee_earnings ?? 0))
+                            ).toFixed(2)}
+                        </Text>
                         <Text style={styles.statLabel}>Earned</Text>
                     </View>
                 </View>
+                {parseFloat(String(referralInfo?.referee_earnings ?? 0)) > 0 ? (
+                    <Text style={styles.referredByText}>
+                        Includes your ${parseFloat(String(referralInfo?.referee_earnings ?? 0)).toFixed(2)} signup bonus
+                    </Text>
+                ) : null}
 
                 {/* Reward amounts — who earns what ($0 = that party earns nothing) */}
                 <View style={styles.statsRow}>


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary**: Enable admins to opt service areas into a driver referee (signup bonus) reward, mirroring the rider program's symmetric payouts. Previously hardcoded to $0; now configurable per area via `service_areas.driver_referee_reward` (migration 201).
- **Type**: `feat`
- **Linked issue**: `none` — feature expansion of existing referral system
- **Risk**: `low` — additive schema column (default 0), backward-compatible payout logic, feature off by default
- **User-visible change**: `drivers` — driver app now displays referee earnings (signup bonus) when the service area opts in; referral screen shows combined earnings and breakdown
- **Scope contract**: `[x]` This PR matches its stated type — no unrelated refactors

## Tier 2 — Impact

- **Surfaces touched**: `[x]` backend `[x]` driver-app `[x]` admin `[ ]` rider-app `[x]` migrations `[ ]` shared `[ ]` infra `[ ]` CI
- **Blast radius**: `multi-surface` — schema change + backend payout logic + admin UI + driver app display
- **Data schema change**: `additive` — new `driver_referee_reward` column on `service_areas` table, default 0, no backfill required
- **API contract change**: `additive` — `GET /drivers/referral-info` response adds optional `referee_earnings` field; existing fields unchanged
- **Background job change**: `modified` — referral payout loop (`backend/utils/referral_payout.py`) now credits both referrer and referee when area opts in
- **Feature flag**: `none` — feature is off by default (reward = $0) and controlled by per-area admin setting
- **Config / secret change**: `none`
- **Rollback plan**: `git-revert-safe` — reverting removes the column (via migration rollback comment) and backend falls back to global `DRIVER_REFEREE_REWARD = 0` constant; already-paid rewards are unaffected (ledger column is immutable)
- **Dependencies / coordination**: `none`
- **Assumptions**: Admin dashboard and backend migrations are deployed together; driver app can safely ignore new `referee_earnings` field (optional, defaults to 0)
- **Not changing but considered**: Rider program's referee reward remains $5 (unchanged); driver referee shares the same ride threshold as referrer (no separate `driver_referee_rides_required` column)

## Tier 3 — Compliance flags

- `[x]` **Money-touching** — New payout stream for driver signup bonuses. Controlled by admin per-area setting; defaults to $0 (off). Ledger column `referral_payouts.referee_reward` snapshots the amount at payout time. Payout logic in `referral_payout.py` mirrors existing rider referee logic.

## Tier 4 — Verification

- **Unit tests**: `added` — 3 new driver referral payout tests (`test_driver_both_zero_opens_no_claim_and_pays_nothing`, `test_driver_referee_reward_credits_both_sides_once_opted_in`, `test_driver_referrer_zero_credits_only_referee`) + 1 new referral terms test (`test_driver_referee_area_override_wins`); existing test renamed for clarity (`test_driver_referee_always_zero` → `test_driver_referee_defaults_to_zero_when_area_unset`)
- **Integration tests**: `not-applicable` — payout loop is tested via unit mocks; admin CRUD for the new field is standard Pydantic validation
- **Metrics / logs introduced**: `none`
- **Screenshots / video**: `not-applicable` — admin dashboard UI change is straightforward form field addition; driver app change is conditional display of existing data
- **Perf numbers**: `not-applicable` — no SLA-critical path touched

**Pre-merge checklist**:

- [x] Ran the changed code against real Supabase dev (schema migration, payout logic, API response)
- [x] Tested with driver

https://claude.ai/code/session_01DgvexhUwKxKbpiPxpJVjKA

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
