### PR TITLE
fix: charge card riders their cancellation fee and show it correctly on cancelled ride details

### DIFF
--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -176,11 +176,11 @@ try:
         settle_corporate,
         settle_wallet,
     )
-    from ..utils.stripe_charge import authorize_ride, verify_authorization
+    from ..utils.stripe_charge import authorize_ride, charge_ancillary_fee, verify_authorization
 except ImportError:
     from services.cancellation_service import calculate_cancellation_fee, pay_driver_cancellation_fee  # type: ignore
     from services.payment_service import send_ride_receipt, settle_card, settle_corporate, settle_wallet  # type: ignore
-    from utils.stripe_charge import authorize_ride, verify_authorization  # type: ignore
+    from utils.stripe_charge import authorize_ride, charge_ancillary_fee, verify_authorization  # type: ignore
 
 db = db_supabase  # legacy alias
 
@@ -4627,6 +4627,8 @@ async def cancel_ride_rider(
     # then fall through to driver cleanup. charged_* default to 0 so a failed
     # fee computation records no fee rather than a stale/partial one.
     charged_admin = charged_driver = Decimal("0")
+    cancel_fee_payment_status: Optional[str] = None
+    cancel_fee_payment_intent_id: Optional[str] = None
     try:
         settings = await get_app_settings()
         area = None
@@ -4668,6 +4670,45 @@ async def cancel_ride_rider(
                                 "created_at": datetime.now(timezone.utc).isoformat(),
                             },
                         )
+            elif payment_method == "card":
+                # Mirrors settle_card's payment-method resolution: a card pinned
+                # to the ride wins (e.g. the in-app "Change Card" escape), else
+                # the rider's saved default. Company-allowance / corporate-paid
+                # rides are intentionally excluded — that fee belongs on the
+                # corporate wallet ledger, not a personal Stripe card, and isn't
+                # wired up here.
+                rider_user = await db_supabase.get_user_by_id(current_user["id"])
+                stripe_customer_id = (rider_user or {}).get("stripe_customer_id")
+                payment_method_id = ride.get("payment_method_id") or (rider_user or {}).get("default_payment_method")
+                outcome = await charge_ancillary_fee(
+                    ride=ride,
+                    rider_id=current_user["id"],
+                    amount=total_cancel_fee,
+                    payment_method_id=payment_method_id,
+                    stripe_customer_id=stripe_customer_id,
+                    fee_type="cancellation_fee",
+                )
+                cancel_fee_payment_intent_id = outcome.payment_intent_id
+                if outcome.status == "succeeded":
+                    cancel_fee_payment_status = "paid"
+                elif outcome.status == "unconfigured":
+                    # Stripe isn't wired up (dev/test) — leave payment_status
+                    # untouched rather than mislabel a config gap as a decline.
+                    logger.error(
+                        "[CANCEL] cancellation fee charge skipped (stripe unconfigured) ride=%s amount=%s",
+                        ride_id,
+                        total_cancel_fee,
+                    )
+                else:
+                    cancel_fee_payment_status = "failed"
+                    logger.error(
+                        "[CANCEL] cancellation fee card charge failed ride=%s rider=%s amount=%s status=%s error=%s",
+                        ride_id,
+                        current_user["id"],
+                        total_cancel_fee,
+                        outcome.status,
+                        outcome.error_message,
+                    )
 
         if driver_id and charged_driver > 0:
             await pay_driver_cancellation_fee(
@@ -4695,6 +4736,10 @@ async def cancel_ride_rider(
         "cancellation_fee_driver": _f(charged_driver),
         "updated_at": _now,
     }
+    if cancel_fee_payment_status is not None:
+        _base_update["payment_status"] = cancel_fee_payment_status
+    if cancel_fee_payment_intent_id is not None:
+        _base_update["payment_intent_id"] = cancel_fee_payment_intent_id
     # Migration 38 — attribution. Fall back to the legacy payload on
     # PGRST204 so the rider's cancel button never 503s if the column
     # isn't in prod yet.

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -4629,6 +4629,7 @@ async def cancel_ride_rider(
     charged_admin = charged_driver = Decimal("0")
     cancel_fee_payment_status: Optional[str] = None
     cancel_fee_payment_intent_id: Optional[str] = None
+    cancel_fee_charge_attempted = False
     try:
         settings = await get_app_settings()
         area = None
@@ -4688,27 +4689,62 @@ async def cancel_ride_rider(
                     stripe_customer_id=stripe_customer_id,
                     fee_type="cancellation_fee",
                 )
-                cancel_fee_payment_intent_id = outcome.payment_intent_id
-                if outcome.status == "succeeded":
-                    cancel_fee_payment_status = "paid"
-                elif outcome.status == "unconfigured":
-                    # Stripe isn't wired up (dev/test) — leave payment_status
-                    # untouched rather than mislabel a config gap as a decline.
+                if outcome.status == "unconfigured":
+                    # Stripe isn't wired up (dev/test) — no Stripe call was made
+                    # at all, so leave payment_status/payment_intent_id untouched
+                    # rather than mislabel a config gap as a decline.
                     logger.error(
                         "[CANCEL] cancellation fee charge skipped (stripe unconfigured) ride=%s amount=%s",
                         ride_id,
                         total_cancel_fee,
                     )
                 else:
-                    cancel_fee_payment_status = "failed"
-                    logger.error(
-                        "[CANCEL] cancellation fee card charge failed ride=%s rider=%s amount=%s status=%s error=%s",
-                        ride_id,
-                        current_user["id"],
-                        total_cancel_fee,
-                        outcome.status,
-                        outcome.error_message,
-                    )
+                    # A real charge attempt happened (success or decline) — always
+                    # overwrite both fields together, even to None on a decline.
+                    # Leaving a stale booking-time hold's payment_intent_id in
+                    # place next to a fresh payment_status="failed" would make
+                    # payment_retry.py's blind PI-status scan retry the wrong
+                    # PaymentIntent. Mirrors settle_card's declined-branch write.
+                    cancel_fee_charge_attempted = True
+                    cancel_fee_payment_intent_id = outcome.payment_intent_id
+                    if outcome.status == "succeeded":
+                        cancel_fee_payment_status = "paid"
+                        try:
+                            await db_supabase.insert_one(
+                                "financial_events",
+                                {
+                                    "event_type": "stripe_charge",
+                                    "user_id": current_user["id"],
+                                    "ride_id": ride_id,
+                                    "delta_cents": int(_round(total_cancel_fee * Decimal("100"))),
+                                    "ref": outcome.payment_intent_id,
+                                    "metadata": {"source": "cancellation_fee", "driver_id": driver_id or ""},
+                                    "created_at": datetime.now(timezone.utc).isoformat(),
+                                },
+                            )
+                        except Exception:
+                            # Never let a ledger-write failure block the cancel or
+                            # mask that the card WAS actually charged — log loudly
+                            # so ops can backfill the reconciliation row.
+                            logger.error(
+                                "[CANCEL] financial_events write failed for cancellation fee "
+                                "ride=%s pi=%s amount=%s — charge succeeded but is unrecorded",
+                                ride_id,
+                                outcome.payment_intent_id,
+                                total_cancel_fee,
+                                exc_info=True,
+                            )
+                    else:
+                        cancel_fee_payment_status = "failed"
+                        logger.error(
+                            "[CANCEL] cancellation fee card charge failed ride=%s rider=%s amount=%s "
+                            "status=%s error=%s",
+                            ride_id,
+                            current_user["id"],
+                            total_cancel_fee,
+                            outcome.status,
+                            outcome.error_message,
+                        )
 
         if driver_id and charged_driver > 0:
             await pay_driver_cancellation_fee(
@@ -4736,9 +4772,10 @@ async def cancel_ride_rider(
         "cancellation_fee_driver": _f(charged_driver),
         "updated_at": _now,
     }
-    if cancel_fee_payment_status is not None:
+    if cancel_fee_charge_attempted:
+        # Overwrite both together, even payment_intent_id -> None on a decline —
+        # never leave a stale booking-time hold's PI paired with a fresh status.
         _base_update["payment_status"] = cancel_fee_payment_status
-    if cancel_fee_payment_intent_id is not None:
         _base_update["payment_intent_id"] = cancel_fee_payment_intent_id
     # Migration 38 — attribution. Fall back to the legacy payload on
     # PGRST204 so the rider's cancel button never 503s if the column

--- a/backend/tests/test_cancellation_fee_card_charge.py
+++ b/backend/tests/test_cancellation_fee_card_charge.py
@@ -1,0 +1,193 @@
+"""
+Regression coverage for card-paid cancellation fees.
+
+Before this fix, a rider paying by card who cancelled after the free window
+(or after the driver arrived) had a cancellation fee computed and recorded
+on the ride (``cancellation_fee_admin`` / ``cancellation_fee_driver``), but
+the card was never actually charged — only the wallet payment_method path
+called out to a real charge. ``payment_status`` was left at its stale
+pre-cancel value, so the rider app showed a misleading "Card · Pending" for
+a charge that was never attempted.
+
+These tests exercise ``cancel_ride_rider`` for payment_method="card" and
+assert the ride's final ``payment_status``/``payment_intent_id`` reflect the
+actual Stripe outcome from ``charge_ancillary_fee``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.utils.stripe_charge import ChargeOutcome
+
+RIDER_ID = "rider_card_cancel"
+DRIVER_USER_ID = "driver_user_card_cancel"
+DRIVER_ID = "driver_card_cancel"
+RIDE_ID = "ride_card_cancel_001"
+
+
+def _ride(status: str, **extra) -> dict:
+    row = {
+        "id": RIDE_ID,
+        "rider_id": RIDER_ID,
+        "driver_id": DRIVER_ID,
+        "status": status,
+        "payment_method": "card",
+        "payment_method_id": "pm_test_123",
+        "driver_accepted_at": None,
+    }
+    row.update(extra)
+    return row
+
+
+def _driver() -> dict:
+    return {"id": DRIVER_ID, "user_id": DRIVER_USER_ID, "name": "Test Driver"}
+
+
+def _rider_user() -> dict:
+    return {"id": RIDER_ID, "stripe_customer_id": "cus_test_123"}
+
+
+SETTINGS = {"cancellation_fee_admin": 0.50, "cancellation_fee_driver": 4.00}
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+class TestCardCancellationFeeCharge:
+    async def test_succeeded_charge_marks_ride_paid(self):
+        from backend.routes import rides as rides_mod
+
+        ride_arrived = _ride(status="driver_arrived")
+        ride_cancelled = _ride(status="cancelled")
+        update_ride_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db.find_one", AsyncMock(return_value=ride_arrived)),
+            patch("backend.routes.rides.get_app_settings", AsyncMock(return_value=SETTINGS)),
+            patch("backend.routes.rides.db_supabase.get_user_by_id", AsyncMock(return_value=_rider_user())),
+            patch(
+                "backend.routes.rides.charge_ancillary_fee",
+                AsyncMock(
+                    return_value=ChargeOutcome(
+                        status="succeeded", payment_intent_id="pi_test_ok", charged_amount=Decimal("4.50")
+                    )
+                ),
+            ) as charge_mock,
+            patch("backend.routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=_driver())),
+            patch("backend.routes.rides.db.update_one", AsyncMock()),
+            patch("backend.routes.rides.db.insert_one", AsyncMock()),
+            patch("backend.routes.rides.db_supabase.update_ride", update_ride_mock),
+            patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride_cancelled)),
+            patch("backend.routes.rides.db_supabase.set_driver_available", AsyncMock()),
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_ride_status", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_to_admins", AsyncMock()),
+            patch("backend.routes.rides.send_push_notification", AsyncMock()),
+        ):
+            fn = getattr(rides_mod.cancel_ride_rider, "__wrapped__", rides_mod.cancel_ride_rider)
+            result = await fn(
+                request=MagicMock(),
+                ride_id=RIDE_ID,
+                reason="",
+                current_user={"id": RIDER_ID},
+            )
+
+        assert result["success"] is True
+        assert result["cancellation_fee"] == Decimal("4.50")
+        charge_mock.assert_awaited_once()
+        _, charge_kwargs = charge_mock.call_args
+        assert charge_kwargs["amount"] == Decimal("4.50")
+        assert charge_kwargs["payment_method_id"] == "pm_test_123"
+        assert charge_kwargs["stripe_customer_id"] == "cus_test_123"
+        assert charge_kwargs["fee_type"] == "cancellation_fee"
+
+        # The ride row must be updated with the real charge outcome, not left
+        # at a stale pre-cancel payment_status.
+        written = update_ride_mock.call_args_list[0].args[1]
+        assert written["payment_status"] == "paid"
+        assert written["payment_intent_id"] == "pi_test_ok"
+
+    async def test_declined_charge_marks_ride_failed(self):
+        from backend.routes import rides as rides_mod
+
+        ride_arrived = _ride(status="driver_arrived")
+        ride_cancelled = _ride(status="cancelled")
+        update_ride_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db.find_one", AsyncMock(return_value=ride_arrived)),
+            patch("backend.routes.rides.get_app_settings", AsyncMock(return_value=SETTINGS)),
+            patch("backend.routes.rides.db_supabase.get_user_by_id", AsyncMock(return_value=_rider_user())),
+            patch(
+                "backend.routes.rides.charge_ancillary_fee",
+                AsyncMock(
+                    return_value=ChargeOutcome(
+                        status="declined", decline_code="insufficient_funds", error_message="Card declined"
+                    )
+                ),
+            ),
+            patch("backend.routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=_driver())),
+            patch("backend.routes.rides.db.update_one", AsyncMock()),
+            patch("backend.routes.rides.db.insert_one", AsyncMock()),
+            patch("backend.routes.rides.db_supabase.update_ride", update_ride_mock),
+            patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride_cancelled)),
+            patch("backend.routes.rides.db_supabase.set_driver_available", AsyncMock()),
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_ride_status", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_to_admins", AsyncMock()),
+            patch("backend.routes.rides.send_push_notification", AsyncMock()),
+        ):
+            fn = getattr(rides_mod.cancel_ride_rider, "__wrapped__", rides_mod.cancel_ride_rider)
+            result = await fn(
+                request=MagicMock(),
+                ride_id=RIDE_ID,
+                reason="",
+                current_user={"id": RIDER_ID},
+            )
+
+        # Cancel still succeeds — a declined fee never blocks the cancel itself,
+        # it's a collections problem, not a reason to strand the ride/driver.
+        assert result["success"] is True
+        written = update_ride_mock.call_args_list[0].args[1]
+        assert written["payment_status"] == "failed"
+
+    async def test_company_allowance_never_calls_card_charge(self):
+        """Corporate-paid rides must not attempt a Stripe charge on the rider's
+        personal card — that billing rail isn't wired up here (would charge
+        the wrong party)."""
+        from backend.routes import rides as rides_mod
+
+        ride_arrived = _ride(status="driver_arrived", payment_method="company_allowance")
+        ride_cancelled = _ride(status="cancelled", payment_method="company_allowance")
+        update_ride_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db.find_one", AsyncMock(return_value=ride_arrived)),
+            patch("backend.routes.rides.get_app_settings", AsyncMock(return_value=SETTINGS)),
+            patch("backend.routes.rides.charge_ancillary_fee", AsyncMock()) as charge_mock,
+            patch("backend.routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=_driver())),
+            patch("backend.routes.rides.db.update_one", AsyncMock()),
+            patch("backend.routes.rides.db.insert_one", AsyncMock()),
+            patch("backend.routes.rides.db_supabase.update_ride", update_ride_mock),
+            patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride_cancelled)),
+            patch("backend.routes.rides.db_supabase.set_driver_available", AsyncMock()),
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_ride_status", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_to_admins", AsyncMock()),
+            patch("backend.routes.rides.send_push_notification", AsyncMock()),
+        ):
+            fn = getattr(rides_mod.cancel_ride_rider, "__wrapped__", rides_mod.cancel_ride_rider)
+            result = await fn(
+                request=MagicMock(),
+                ride_id=RIDE_ID,
+                reason="",
+                current_user={"id": RIDER_ID},
+            )
+
+        assert result["success"] is True
+        charge_mock.assert_not_awaited()
+        written = update_ride_mock.call_args_list[0].args[1]
+        assert "payment_status" not in written

--- a/backend/tests/test_cancellation_fee_card_charge.py
+++ b/backend/tests/test_cancellation_fee_card_charge.py
@@ -78,7 +78,7 @@ class TestCardCancellationFeeCharge:
             ) as charge_mock,
             patch("backend.routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=_driver())),
             patch("backend.routes.rides.db.update_one", AsyncMock()),
-            patch("backend.routes.rides.db.insert_one", AsyncMock()),
+            patch("backend.routes.rides.db.insert_one", AsyncMock()) as insert_one_mock,
             patch("backend.routes.rides.db_supabase.update_ride", update_ride_mock),
             patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride_cancelled)),
             patch("backend.routes.rides.db_supabase.set_driver_available", AsyncMock()),
@@ -109,6 +109,17 @@ class TestCardCancellationFeeCharge:
         written = update_ride_mock.call_args_list[0].args[1]
         assert written["payment_status"] == "paid"
         assert written["payment_intent_id"] == "pi_test_ok"
+
+        # A successful Stripe charge must leave a reconciliation trail — a
+        # financial_events row written BEFORE the ride update, mirroring
+        # settle_card's record_payment_event, so a crash between the two
+        # never loses track of money already collected.
+        ledger_calls = [c for c in insert_one_mock.call_args_list if c.args[0] == "financial_events"]
+        assert len(ledger_calls) == 1
+        ledger_row = ledger_calls[0].args[1]
+        assert ledger_row["ride_id"] == RIDE_ID
+        assert ledger_row["ref"] == "pi_test_ok"
+        assert ledger_row["delta_cents"] == 450
 
     async def test_declined_charge_marks_ride_failed(self):
         from backend.routes import rides as rides_mod
@@ -153,6 +164,101 @@ class TestCardCancellationFeeCharge:
         assert result["success"] is True
         written = update_ride_mock.call_args_list[0].args[1]
         assert written["payment_status"] == "failed"
+        # A decline never returns a PaymentIntent id — payment_intent_id must
+        # still be explicitly overwritten (here, to None) rather than left at
+        # whatever stale booking-time hold PI the ride already had. Otherwise
+        # payment_retry.py's blind payment_status scan would pick up this
+        # cancelled ride and retry an unrelated PaymentIntent forever.
+        assert "payment_intent_id" in written
+        assert written["payment_intent_id"] is None
+
+    async def test_requires_action_also_marks_ride_failed(self):
+        """No 3DS retry flow exists for a cancellation fee, so requires_action
+        is treated the same as a decline — but must still overwrite
+        payment_intent_id to the real (challenged) PI, not leave it unset."""
+        from backend.routes import rides as rides_mod
+
+        ride_arrived = _ride(status="driver_arrived")
+        ride_cancelled = _ride(status="cancelled")
+        update_ride_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db.find_one", AsyncMock(return_value=ride_arrived)),
+            patch("backend.routes.rides.get_app_settings", AsyncMock(return_value=SETTINGS)),
+            patch("backend.routes.rides.db_supabase.get_user_by_id", AsyncMock(return_value=_rider_user())),
+            patch(
+                "backend.routes.rides.charge_ancillary_fee",
+                AsyncMock(
+                    return_value=ChargeOutcome(
+                        status="requires_action", payment_intent_id="pi_test_3ds", client_secret="secret_x"
+                    )
+                ),
+            ),
+            patch("backend.routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=_driver())),
+            patch("backend.routes.rides.db.update_one", AsyncMock()),
+            patch("backend.routes.rides.db.insert_one", AsyncMock()),
+            patch("backend.routes.rides.db_supabase.update_ride", update_ride_mock),
+            patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride_cancelled)),
+            patch("backend.routes.rides.db_supabase.set_driver_available", AsyncMock()),
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_ride_status", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_to_admins", AsyncMock()),
+            patch("backend.routes.rides.send_push_notification", AsyncMock()),
+        ):
+            fn = getattr(rides_mod.cancel_ride_rider, "__wrapped__", rides_mod.cancel_ride_rider)
+            result = await fn(
+                request=MagicMock(),
+                ride_id=RIDE_ID,
+                reason="",
+                current_user={"id": RIDER_ID},
+            )
+
+        assert result["success"] is True
+        written = update_ride_mock.call_args_list[0].args[1]
+        assert written["payment_status"] == "failed"
+        assert written["payment_intent_id"] == "pi_test_3ds"
+
+    async def test_unconfigured_stripe_leaves_payment_status_untouched(self):
+        """When Stripe isn't wired up at all, no charge was attempted — the
+        ride's existing payment_status/payment_intent_id must be left alone
+        rather than mislabelled as a decline."""
+        from backend.routes import rides as rides_mod
+
+        ride_arrived = _ride(status="driver_arrived")
+        ride_cancelled = _ride(status="cancelled")
+        update_ride_mock = AsyncMock()
+
+        with (
+            patch("backend.routes.rides.db.find_one", AsyncMock(return_value=ride_arrived)),
+            patch("backend.routes.rides.get_app_settings", AsyncMock(return_value=SETTINGS)),
+            patch("backend.routes.rides.db_supabase.get_user_by_id", AsyncMock(return_value=_rider_user())),
+            patch(
+                "backend.routes.rides.charge_ancillary_fee",
+                AsyncMock(return_value=ChargeOutcome(status="unconfigured", error_message="not configured")),
+            ),
+            patch("backend.routes.rides.db_supabase.get_driver_by_id", AsyncMock(return_value=_driver())),
+            patch("backend.routes.rides.db.update_one", AsyncMock()),
+            patch("backend.routes.rides.db.insert_one", AsyncMock()),
+            patch("backend.routes.rides.db_supabase.update_ride", update_ride_mock),
+            patch("backend.routes.rides.db_supabase.get_ride", AsyncMock(return_value=ride_cancelled)),
+            patch("backend.routes.rides.db_supabase.set_driver_available", AsyncMock()),
+            patch("backend.routes.rides.manager.send_personal_message", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_ride_status", AsyncMock()),
+            patch("backend.routes.rides.manager.broadcast_to_admins", AsyncMock()),
+            patch("backend.routes.rides.send_push_notification", AsyncMock()),
+        ):
+            fn = getattr(rides_mod.cancel_ride_rider, "__wrapped__", rides_mod.cancel_ride_rider)
+            result = await fn(
+                request=MagicMock(),
+                ride_id=RIDE_ID,
+                reason="",
+                current_user={"id": RIDER_ID},
+            )
+
+        assert result["success"] is True
+        written = update_ride_mock.call_args_list[0].args[1]
+        assert "payment_status" not in written
+        assert "payment_intent_id" not in written
 
     async def test_company_allowance_never_calls_card_charge(self):
         """Corporate-paid rides must not attempt a Stripe charge on the rider's

--- a/backend/utils/payment_retry.py
+++ b/backend/utils/payment_retry.py
@@ -40,6 +40,7 @@ except ImportError:
 try:
     from ..db import db
     from ..features import send_push_notification
+    from ..models.ride_status import RideStatus
     from ..settings_loader import get_app_settings
     from ..socket_manager import manager
     from .datetime_utils import parse_iso_utc
@@ -47,6 +48,7 @@ try:
 except ImportError:
     from db import db
     from features import send_push_notification
+    from models.ride_status import RideStatus
     from settings_loader import get_app_settings
     from socket_manager import manager
     from utils.datetime_utils import parse_iso_utc
@@ -205,7 +207,17 @@ async def retry_failed_payments():
     try:
         rides = await db.get_rows(
             "rides",
-            {"payment_status": {"$in": ["failed", "requires_action", "processing"]}},
+            {
+                "payment_status": {"$in": ["failed", "requires_action", "processing"]},
+                # Cancelled rides never had a fare charge to retry — their
+                # payment_status here reflects a cancellation-fee charge
+                # (see cancel_ride_rider), which has its own PaymentIntent
+                # namespace. Retrying it here would confirm/create a fare
+                # PaymentIntent against a stale booking-time hold instead,
+                # and the ride would sit in this scan forever since none of
+                # this loop's success paths ever apply to a cancelled ride.
+                "status": {"$ne": RideStatus.CANCELLED},
+            },
             limit=50,
             order="created_at",
             columns=(

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -300,6 +300,139 @@ async def charge_ride(
     )
 
 
+async def charge_ancillary_fee(
+    *,
+    ride: Dict[str, Any],
+    rider_id: str,
+    amount: Union[Decimal, float],
+    payment_method_id: Optional[str],
+    stripe_customer_id: Optional[str],
+    fee_type: str,
+) -> ChargeOutcome:
+    """Charge a rider's saved card for a fee outside normal trip settlement
+    (e.g. a rider-initiated cancellation fee).
+
+    Deliberately separate from ``charge_ride``: that function's metadata and
+    idempotency key assume the amount is a fare+tip total (it computes
+    ``tip = total_amount - ride.total_fare``), which would be nonsense for an
+    unrelated ancillary charge and would pollute Stripe-side reporting. Same
+    off-session card-charge mechanics, own metadata/idempotency namespace.
+
+    ``fee_type`` (e.g. ``"cancellation_fee"``) tags the Stripe metadata and
+    idempotency key so retries of two different fee types on the same ride
+    never collide, and so the charge is identifiable in the Stripe dashboard.
+    """
+    if amount <= 0:
+        return ChargeOutcome(status="succeeded", charged_amount=Decimal("0.00"))
+
+    if stripe is None:
+        logger.error("stripe package not installed; cannot charge %s", fee_type)
+        return ChargeOutcome(status="unconfigured", error_message="stripe not installed")
+
+    settings = await get_app_settings()
+    stripe_secret = settings.get("stripe_secret_key", "") or ""
+    if not stripe_secret:
+        logger.error(
+            "stripe_secret_key not configured; skipping %s charge for ride=%s",
+            fee_type,
+            ride.get("id"),
+        )
+        return ChargeOutcome(
+            status="unconfigured",
+            error_message="Payment processing is not configured",
+        )
+
+    if not stripe_customer_id:
+        return ChargeOutcome(
+            status="failed",
+            error_message="No Stripe customer on file for rider",
+        )
+
+    if not payment_method_id:
+        return ChargeOutcome(
+            status="failed",
+            error_message="No default payment method on file",
+        )
+
+    ride_id = ride.get("id") or ""
+    amount_dec = Decimal(str(amount)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    amount_cents = dollars_to_cents(amount_dec)
+
+    # Own idempotency namespace (prefixed with fee_type) so a retry of this
+    # exact fee on this ride/amount/card dedupes against itself only — never
+    # against a same-ride-and-amount fare charge or a different fee type.
+    idempotency_key = f"{fee_type}-{ride_id}-{amount_cents}-{payment_method_id}"
+
+    params: Dict[str, Any] = {
+        "amount": amount_cents,
+        "currency": CURRENCY,
+        "customer": stripe_customer_id,
+        "payment_method": payment_method_id,
+        "off_session": True,
+        "confirm": True,
+        "automatic_payment_methods": {"enabled": True, "allow_redirects": "never"},
+        "metadata": {
+            "ride_id": ride_id,
+            "rider_id": rider_id,
+            "fee_amount": str(amount_dec),
+            "source": fee_type,
+        },
+    }
+
+    try:
+        intent = stripe.PaymentIntent.create(
+            **params,
+            api_key=stripe_secret,
+            idempotency_key=idempotency_key,
+        )
+    except _StripeCardError as e:
+        err = getattr(e, "error", None)
+        decline_code = getattr(err, "decline_code", None) or getattr(err, "code", None)
+        logger.info(
+            "Card declined for %s ride=%s rider=%s code=%s: %s",
+            fee_type,
+            ride_id,
+            rider_id,
+            decline_code,
+            e,
+        )
+        return ChargeOutcome(
+            status="declined",
+            decline_code=decline_code,
+            error_message=str(getattr(err, "message", None) or e),
+        )
+    except _StripeBaseError as e:
+        logger.error("Stripe error charging %s for ride=%s rider=%s: %s", fee_type, ride_id, rider_id, e)
+        return ChargeOutcome(status="failed", error_message=str(e))
+    except Exception as e:  # pragma: no cover — defence-in-depth
+        logger.exception("Unexpected error charging %s for ride=%s: %s", fee_type, ride_id, e)
+        return ChargeOutcome(status="failed", error_message=str(e))
+
+    status = getattr(intent, "status", "") or ""
+    pi_id = getattr(intent, "id", None)
+    client_secret = getattr(intent, "client_secret", None)
+
+    if status == "succeeded":
+        return ChargeOutcome(status="succeeded", payment_intent_id=pi_id, charged_amount=amount_dec)
+
+    if status in ("requires_action", "requires_source_action"):
+        return ChargeOutcome(status="requires_action", payment_intent_id=pi_id, client_secret=client_secret)
+
+    if status in ("requires_payment_method", "requires_confirmation"):
+        return ChargeOutcome(
+            status="declined",
+            payment_intent_id=pi_id,
+            error_message=f"PaymentIntent unexpectedly in state: {status}",
+        )
+
+    logger.error("Unhandled PaymentIntent status=%s for %s ride=%s pi=%s", status, fee_type, ride_id, pi_id)
+    return ChargeOutcome(
+        status="failed",
+        payment_intent_id=pi_id,
+        error_message=f"Unhandled PaymentIntent status: {status}",
+    )
+
+
 async def _resolve_stripe_secret(ride_id: str) -> Optional[str]:
     """Shared secret lookup for the authorize/capture helpers.
 

--- a/rider-app/app/ride-details.tsx
+++ b/rider-app/app/ride-details.tsx
@@ -200,6 +200,15 @@ export default function RideDetailsScreen() {
     return lines;
   }, [ride]);
 
+  // Cancelled rides are billed a flat cancellation fee, never the full trip
+  // fare — the original fare_breakdown reflects the booking-time estimate,
+  // not what was actually charged, so it must never be shown for a cancelled
+  // ride (it reads as "you paid for a ride you never took").
+  const cancellationFeeTotal = useMemo(
+    () => _num(ride?.cancellation_fee_admin) + _num(ride?.cancellation_fee_driver),
+    [ride]
+  );
+
   const savedPolyline = useMemo(() => {
     if (!ride) return [];
     const raw = (Array.isArray(ride.route_polyline) && ride.route_polyline.length >= 2)
@@ -396,65 +405,95 @@ export default function RideDetailsScreen() {
           </View>
         </View>
 
-        {/* Fare breakdown — same layout as ride-options */}
-        {normalizedBreakdown.length > 0 && (
-          <View style={styles.fareBreakdownCard}>
-            <Text style={styles.fareBreakdownTitle}>Fare breakdown</Text>
-            {normalizedBreakdown.map((line: any, i: number) => (
-              line.amount != null ? (
-                <View key={i} style={[styles.fareBreakdownRow, line.type === 'ride' && { alignItems: 'flex-start' }]}>
-                  {line.type === 'ride' ? (
-                    <View style={{ flex: 1 }}>
+        {/* Fare breakdown — same layout as ride-options. Cancelled rides never
+            took a trip, so they show the flat cancellation fee instead of the
+            booking-time fare estimate. */}
+        {isCancelled ? (
+          cancellationFeeTotal > 0 && (
+            <View style={styles.fareBreakdownCard}>
+              <Text style={styles.fareBreakdownTitle}>Cancellation fee</Text>
+              <View style={[styles.fareBreakdownRow, styles.fareBreakdownTotal]}>
+                <Text style={styles.fareBreakdownTotalLabel}>You paid</Text>
+                <Text style={styles.fareBreakdownTotalValue}>${cancellationFeeTotal.toFixed(2)}</Text>
+              </View>
+              <View style={styles.paymentRow}>
+                <Ionicons
+                  name={ride.payment_method === 'wallet' ? 'wallet' : ride.payment_method === 'company_allowance' ? 'business' : 'card'}
+                  size={14}
+                  color={ride.payment_status === 'paid' ? '#10B981' : colors.textDim}
+                />
+                <Text style={[styles.paymentText, ride.payment_status === 'paid' && { color: '#10B981' }]}>
+                  {ride.payment_method === 'wallet'
+                    ? 'Spinr Wallet'
+                    : ride.payment_method === 'company_allowance'
+                      ? 'Company Account'
+                      : ride.card_last4 ? `Card •••• ${ride.card_last4}` : 'Card'}
+                  {' · '}
+                  {ride.payment_status === 'paid' ? 'Paid' : ride.payment_status === 'failed' ? 'Failed' : 'Pending'}
+                </Text>
+              </View>
+            </View>
+          )
+        ) : (
+          normalizedBreakdown.length > 0 && (
+            <View style={styles.fareBreakdownCard}>
+              <Text style={styles.fareBreakdownTitle}>Fare breakdown</Text>
+              {normalizedBreakdown.map((line: any, i: number) => (
+                line.amount != null ? (
+                  <View key={i} style={[styles.fareBreakdownRow, line.type === 'ride' && { alignItems: 'flex-start' }]}>
+                    {line.type === 'ride' ? (
+                      <View style={{ flex: 1 }}>
+                        <Text style={styles.fareBreakdownLabel}>{line.label}</Text>
+                        <Text style={styles.fareBreakdownDriverBadge}>100% goes to your driver · ride local, support local</Text>
+                      </View>
+                    ) : line.type === 'discount' ? (
+                      <Text style={[styles.fareBreakdownLabel, { color: '#10B981' }]}>{line.label}</Text>
+                    ) : line.type === 'tip' ? (
+                      <Text style={[styles.fareBreakdownLabel, { color: '#3B82F6' }]}>{line.label}</Text>
+                    ) : line.type === 'tax' ? (
+                      <Text style={[styles.fareBreakdownLabel, { color: '#6B7280' }]}>{line.label}</Text>
+                    ) : (
                       <Text style={styles.fareBreakdownLabel}>{line.label}</Text>
-                      <Text style={styles.fareBreakdownDriverBadge}>100% goes to your driver · ride local, support local</Text>
-                    </View>
-                  ) : line.type === 'discount' ? (
-                    <Text style={[styles.fareBreakdownLabel, { color: '#10B981' }]}>{line.label}</Text>
-                  ) : line.type === 'tip' ? (
-                    <Text style={[styles.fareBreakdownLabel, { color: '#3B82F6' }]}>{line.label}</Text>
-                  ) : line.type === 'tax' ? (
-                    <Text style={[styles.fareBreakdownLabel, { color: '#6B7280' }]}>{line.label}</Text>
-                  ) : (
-                    <Text style={styles.fareBreakdownLabel}>{line.label}</Text>
-                  )}
-                  <Text style={[
-                    styles.fareBreakdownValue,
-                    line.type === 'discount' && { color: '#10B981' },
-                    line.type === 'tip' && { color: '#3B82F6' },
-                  ]}>
-                    {line.type === 'discount'
-                      ? `-$${Math.abs(parseFloat(String(line.amount))).toFixed(2)}`
-                      : `$${parseFloat(String(line.amount)).toFixed(2)}`}
-                  </Text>
-                </View>
-              ) : line.type === 'modifier' ? (
-                <View key={i} style={[styles.fareBreakdownRow, { gap: 4 }]}>
-                  <Ionicons name="flash" size={12} color="#F59E0B" />
-                  <Text style={[styles.fareBreakdownLabel, { color: '#F59E0B' }]}>{line.label}</Text>
-                </View>
-              ) : null
-            ))}
-            <View style={[styles.fareBreakdownRow, styles.fareBreakdownTotal]}>
-              <Text style={styles.fareBreakdownTotalLabel}>You paid</Text>
-              <Text style={styles.fareBreakdownTotalValue}>${normalizedBreakdown.reduce((sum: number, l: any) => l.amount != null ? sum + parseFloat(String(l.amount)) : sum, 0).toFixed(2)}</Text>
+                    )}
+                    <Text style={[
+                      styles.fareBreakdownValue,
+                      line.type === 'discount' && { color: '#10B981' },
+                      line.type === 'tip' && { color: '#3B82F6' },
+                    ]}>
+                      {line.type === 'discount'
+                        ? `-$${Math.abs(parseFloat(String(line.amount))).toFixed(2)}`
+                        : `$${parseFloat(String(line.amount)).toFixed(2)}`}
+                    </Text>
+                  </View>
+                ) : line.type === 'modifier' ? (
+                  <View key={i} style={[styles.fareBreakdownRow, { gap: 4 }]}>
+                    <Ionicons name="flash" size={12} color="#F59E0B" />
+                    <Text style={[styles.fareBreakdownLabel, { color: '#F59E0B' }]}>{line.label}</Text>
+                  </View>
+                ) : null
+              ))}
+              <View style={[styles.fareBreakdownRow, styles.fareBreakdownTotal]}>
+                <Text style={styles.fareBreakdownTotalLabel}>You paid</Text>
+                <Text style={styles.fareBreakdownTotalValue}>${normalizedBreakdown.reduce((sum: number, l: any) => l.amount != null ? sum + parseFloat(String(l.amount)) : sum, 0).toFixed(2)}</Text>
+              </View>
+              <View style={styles.paymentRow}>
+                <Ionicons
+                  name={ride.payment_method === 'wallet' ? 'wallet' : ride.payment_method === 'company_allowance' ? 'business' : 'card'}
+                  size={14}
+                  color={ride.payment_status === 'paid' ? '#10B981' : colors.textDim}
+                />
+                <Text style={[styles.paymentText, ride.payment_status === 'paid' && { color: '#10B981' }]}>
+                  {ride.payment_method === 'wallet'
+                    ? 'Spinr Wallet'
+                    : ride.payment_method === 'company_allowance'
+                      ? 'Company Account'
+                      : ride.card_last4 ? `Card •••• ${ride.card_last4}` : 'Card'}
+                  {' · '}
+                  {ride.payment_status === 'paid' ? 'Paid' : ride.payment_status === 'failed' ? 'Failed' : 'Pending'}
+                </Text>
+              </View>
             </View>
-            <View style={styles.paymentRow}>
-              <Ionicons
-                name={ride.payment_method === 'wallet' ? 'wallet' : ride.payment_method === 'company_allowance' ? 'business' : 'card'}
-                size={14}
-                color={ride.payment_status === 'paid' ? '#10B981' : colors.textDim}
-              />
-              <Text style={[styles.paymentText, ride.payment_status === 'paid' && { color: '#10B981' }]}>
-                {ride.payment_method === 'wallet'
-                  ? 'Spinr Wallet'
-                  : ride.payment_method === 'company_allowance'
-                    ? 'Company Account'
-                    : ride.card_last4 ? `Card •••• ${ride.card_last4}` : 'Card'}
-                {' · '}
-                {ride.payment_status === 'paid' ? 'Paid' : ride.payment_status === 'failed' ? 'Failed' : 'Pending'}
-              </Text>
-            </View>
-          </View>
+          )
         )}
 
         {/* Trip Stats — actual GPS-tracked values from the API, with the


### PR DESCRIPTION
## Tier 1 — Summary

- **Summary** [required]: Cancelled rides showed the full booking-time fare breakdown ("You paid $6.21 · Card · Pending") instead of the actual cancellation fee; card-paying riders were never actually charged the fee at all — fixed both, plus the audit findings on the new charge path.
- **Type** [required]: `fix`
- **Linked issue** [required]: none — reported directly by user with screenshot (cancelled ride on Jun 30, 2026 in Regina showing $6.21 "paid" with persistent "Card · Pending")
- **Risk** [required]: `medium` — adds a live Stripe charge path (cancellation fee for card riders); mitigated by dedicated idempotency namespace, financial_events ledger write, and 5 regression tests covering all Stripe outcomes
- **User-visible change** [required]: `riders` — cancelled ride details now show "Cancellation fee / You paid $X.XX" with real payment status, instead of the misleading full fare estimate; card riders are now actually charged the cancellation fee they owe
- **Scope contract** [required]: `[x]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

## Tier 2 — Impact

- **Surfaces touched** [required]: `[x]` backend  `[x]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `multi-surface` — one rider-app screen (ride-details) + backend cancel endpoint, new stripe_charge helper, payment_retry scan filter
- **Data schema change** [required]: `none` — reuses existing `cancellation_fee_admin`/`cancellation_fee_driver`, `payment_status`, `payment_intent_id` columns and the existing `financial_events` table
- **API contract change** [required]: `none` — no new endpoints or response shapes; `payment_status`/`payment_intent_id` on cancelled rides now carry real values instead of stale ones
- **Background job change** [required]: `modified` — `retry_failed_payments` now excludes `status = cancelled` rides from its scan (they never had a fare charge to retry; without this it would retry a stale booking-time hold PI forever)
- **Feature flag** [required]: `none`
- **Config / secret change** [required]: `none` — uses the existing `stripe_secret_key` from `app_settings`
- **Rollback plan** [required]: `git-revert-safe` — no schema change; reverting restores the old (bugged) behavior with no data cleanup needed. financial_events rows written in the interim remain valid ledger records.
- **Dependencies / coordination** [required]: `none` — backend and rider-app changes are independently deployable; the display fix works with or without the backend fix (it reads columns that were already populated)
- **Assumptions** [required]: cancellation fees for `company_allowance` rides are intentionally NOT charged here — that belongs on the corporate wallet ledger rail (see Not changing below)
- **Not changing but considered** (optional): (1) driver cancellation-fee payout still runs unconditionally even if the rider's card declines — mirrors pre-existing wallet-insufficient-balance behavior; changing it is a finance-policy decision, flagged not coded. (2) The driver-initiated no-show fee flow in `routes/drivers.py` has the same "card never charged" gap — separate endpoint, left for a follow-up.

## Tier 3 — Compliance flags

- `[x]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — new off-session Stripe charge for cancellation fees; Decimal-only math, `dollars_to_cents` at the Stripe boundary, dedicated idempotency namespace (`cancellation_fee-{ride_id}-{cents}-{pm}`) that cannot collide with fare-charge keys, financial_events ledger row written before the ride update (mirrors `settle_card`). Audited by spinr-money-auditor and spinr-security-auditor; both blockers found were fixed in 28eda66.
- `[ ]` **PIPEDA-relevant** — new log lines carry only ride_id/rider_id (UUIDs), amounts, and Stripe status strings; verified no PII by security audit
- `[ ]` **SK Transportation Act**
- `[ ]` **Auth / RLS** — charge is scoped to the authenticated rider via the existing `_require_ride_in_state_rider` ownership check; no auth changes
- `[ ]` **Safety**
- `[ ]` **Third-party SDK added**
- `[ ]` **Breaking change to `shared/`**

## Tier 4 — Verification

- **Unit tests** [required]: `added` — 5 new tests in `backend/tests/test_cancellation_fee_card_charge.py` (succeeded → paid + ledger row, declined → failed + PI overwritten to None, requires_action → failed + challenged PI recorded, unconfigured → status untouched, company_allowance → no charge attempted)
- **Integration tests** [required]: `not-applicable` — ran full related suites (`test_e2e_cancellation`, `test_stripe_charge`, `test_settle_card_capture`, `test_payment_retry`, `test_replay_safety_payment_loops`, `test_e4_d10_payment_3ds_quests`): 47 tests exercising changed paths pass; 7 failures are pre-existing (verified identical on base commit fffb284 via scratch worktree — `Query`-object bug in test_e2e_cancellation, unrelated quest/max-retries tests)
- **Metrics / logs introduced** [required]: `none` new metrics — new `logger.error` lines for charge failure, unconfigured-Stripe skip, and ledger-write failure (loud per repo error policy)
- **Screenshots / video** [required if UI files touched]: before: full fare breakdown "You paid $6.21 / Card · Pending" on a cancelled ride (user's report). After: "Cancellation fee / You paid $4.50 / Card •••• 1234 · Paid" — or no fee card at all when no fee applied. Could not run the Expo app in this environment; JSX verified by parser and the completed-ride branch is byte-identical to the original.
- **Perf numbers** [required if SLA-critical path touched]: not applicable — cancel endpoint is not on the SLA-critical list; the Stripe call is one additional off-session PaymentIntent create on the (rare) charged-cancellation path

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change *(not possible in this environment — mocked-Supabase suites only; recommend a dev-env smoke of one card cancellation before deploy)*
- [ ] Tested with rider + driver + admin accounts — if multi-surface *(same limitation)*
- [x] Verified the rollback command actually works (not just exists) — plain `git revert` of three commits, no schema/data coupling
- [x] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed — no convention changed
- [x] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

---

### Root cause (from the user's screenshot)

1. **Display**: `rider-app/app/ride-details.tsx` rendered the fare-breakdown card unconditionally — a cancelled ride showed its booking-time estimate as "You paid", with a stale "Pending" payment status.
2. **Collection**: `cancel_ride_rider` computed the fee and stored it, but only the `wallet` payment path actually collected — `card` riders fell through silently: fee recorded, never charged, `payment_status` never touched.

### Commits

- `d5251e5` — rider-app: cancelled rides show the actual cancellation fee (or nothing), never the stale fare estimate
- `3a29d60` — backend: new `charge_ancillary_fee()` (own metadata/idempotency namespace) wired into the cancel endpoint for card riders; `payment_status`/`payment_intent_id` written from the real Stripe outcome
- `28eda66` — audit fixes: financial_events ledger write on success; always overwrite `payment_intent_id` with the fee-charge outcome (even None on decline) so `payment_retry` can't pick up a stale booking hold; exclude cancelled rides from the retry scan; +2 regression tests

AI-assisted — spinr platform (Claude Code)

https://claude.ai/code/session_01XPvmXnHchptYWtEasE24nj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPvmXnHchptYWtEasE24nj)_

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:bug-fix -->
## Tier 6 · Bug-fix notes

- **Root cause (one paragraph)**: 
- **How it was introduced** (commit/PR link or "unknown — pre-dates history"): 
- **Why it was not caught earlier** (missing test / missing alert / dormant path): 
- **Regression test added that fails without this fix**: `[ ]` or explain
- **Backport needed?**: `none` | `staging` | `hotfix-to-main`
