### PR TITLE
fix(rider): recover home bottom sheet when 0-height layout race closes it

### DIFF
--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -21,6 +21,7 @@ import { useAuthStore } from '@shared/store/authStore';
 import { useExitOnBackPress } from '@shared/hooks/useExitOnBackPress';
 import api from '@shared/api/client';
 import { useRideStore } from '../../store/rideStore';
+import { useBottomSheetGuard } from '../../hooks/useBottomSheetGuard';
 import { useAiChatStore } from '../../store/aiChatStore';
 import AppMap from '@shared/components/AppMap';
 import CarMarker, { resolveMarkerVariant } from '@shared/components/CarMarker';
@@ -81,19 +82,10 @@ export default function HomeScreen() {
 
   const mapRef = useRef<any>(null);
   const bottomSheetRef = useRef<BottomSheet>(null);
-  // On a fresh install the screen can mount before Reanimated's UI thread is
-  // warm and before the container reports a real height, so the bottom sheet's
-  // mount animation (animateOnMount) is computed against a 0-height container
-  // and the sheet never appears — until the app is killed and reopened warm.
-  // Imperatively snap to index 0 the first time the container measures a real
-  // height so the sheet reliably shows on the very first launch too.
-  const didInitSheet = useRef(false);
-  const handleContainerLayout = useCallback((e: { nativeEvent: { layout: { height: number } } }) => {
-    if (didInitSheet.current || e.nativeEvent.layout.height <= 0) return;
-    didInitSheet.current = true;
-    // Defer one frame so the sheet's own internal measurement has settled.
-    requestAnimationFrame(() => bottomSheetRef.current?.snapToIndex(0));
-  }, []);
+  // The sheet must never be off-screen on Home, but 0-height layout races
+  // (cold start, tab detach/re-attach) can silently resolve it to "closed".
+  // The guard hook snaps it back — see useBottomSheetGuard for the full story.
+  const { handleSheetChange, handleContainerLayout } = useBottomSheetGuard(bottomSheetRef);
   const lastFetchedAt = useRef<number>(0);
   const snapPoints = useMemo(() => ['28%', '45%'], []);
 
@@ -517,6 +509,7 @@ export default function HomeScreen() {
         <BottomSheet
           ref={bottomSheetRef}
           index={0}
+          onChange={handleSheetChange}
           snapPoints={snapPoints}
           backgroundStyle={styles.bottomSheetBg}
           handleIndicatorStyle={styles.sheetHandle}

--- a/rider-app/hooks/__tests__/useBottomSheetGuard.test.tsx
+++ b/rider-app/hooks/__tests__/useBottomSheetGuard.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * useBottomSheetGuard — regression for the "Home screen loses the bottom
+ * sheet" bug. @gorhom/bottom-sheet resolves percentage snap points against
+ * its container height; a transient 0-height layout pass (cold start, tab
+ * detach/re-attach) can resolve the sheet to index -1 (closed) and it then
+ * stays off-screen forever because pan-down-to-close is disabled and nothing
+ * re-opens it.
+ *
+ * The guard must: snap on first real-height layout, treat onChange(-1) as
+ * the layout race and snap back to the last user-chosen index, and re-assert
+ * on layout/focus while the sheet reports closed — without touching the
+ * sheet when it is healthy.
+ */
+
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { useBottomSheetGuard } from '../useBottomSheetGuard';
+
+let focusCallback: undefined | (() => void);
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => void) => {
+    focusCallback = cb;
+  },
+}));
+
+// Run rAF-deferred snaps synchronously so assertions see them immediately.
+beforeAll(() => {
+  jest.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+});
+afterAll(() => (globalThis.requestAnimationFrame as jest.Mock).mockRestore());
+
+const layoutEvent = (height: number) => ({ nativeEvent: { layout: { height } } });
+
+function setup() {
+  const snapToIndex = jest.fn();
+  const sheetRef = { current: { snapToIndex } as any };
+  let handlers: ReturnType<typeof useBottomSheetGuard>;
+  function Harness() {
+    handlers = useBottomSheetGuard(sheetRef);
+    return null;
+  }
+  let renderer!: TestRenderer.ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(<Harness />);
+  });
+  return { snapToIndex, handlers: handlers!, renderer };
+}
+
+beforeEach(() => {
+  focusCallback = undefined;
+});
+
+describe('useBottomSheetGuard', () => {
+  it('snaps to the initial index on the first real-height layout only', () => {
+    const { snapToIndex, handlers } = setup();
+
+    handlers.handleContainerLayout(layoutEvent(0));
+    expect(snapToIndex).not.toHaveBeenCalled();
+
+    handlers.handleContainerLayout(layoutEvent(800));
+    expect(snapToIndex).toHaveBeenCalledTimes(1);
+    expect(snapToIndex).toHaveBeenCalledWith(0);
+
+    // Healthy sheet + repeat layouts → no re-snap churn.
+    handlers.handleSheetChange(0);
+    handlers.handleContainerLayout(layoutEvent(800));
+    expect(snapToIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers immediately when onChange reports -1, restoring the last user index', () => {
+    const { snapToIndex, handlers } = setup();
+    handlers.handleContainerLayout(layoutEvent(800));
+    snapToIndex.mockClear();
+
+    // User expanded to the 45% detent (index 1), then the layout race closes it.
+    handlers.handleSheetChange(1);
+    handlers.handleSheetChange(-1);
+    expect(snapToIndex).toHaveBeenCalledWith(1);
+  });
+
+  it('re-asserts on a real-height layout while the sheet reports closed', () => {
+    const { snapToIndex, handlers } = setup();
+    handlers.handleContainerLayout(layoutEvent(800));
+    handlers.handleSheetChange(0);
+    snapToIndex.mockClear();
+
+    handlers.handleSheetChange(-1); // race closed it (snap attempt may be dropped)
+    snapToIndex.mockClear();
+
+    handlers.handleContainerLayout(layoutEvent(800));
+    expect(snapToIndex).toHaveBeenCalledWith(0);
+  });
+
+  it('re-asserts on tab focus while closed, but not while healthy', () => {
+    const { snapToIndex, handlers } = setup();
+    handlers.handleContainerLayout(layoutEvent(800));
+    handlers.handleSheetChange(0);
+    snapToIndex.mockClear();
+
+    focusCallback?.();
+    expect(snapToIndex).not.toHaveBeenCalled();
+
+    handlers.handleSheetChange(-1);
+    snapToIndex.mockClear();
+    focusCallback?.();
+    expect(snapToIndex).toHaveBeenCalledWith(0);
+  });
+
+  it('does nothing on focus before the container has ever measured', () => {
+    const { snapToIndex } = setup();
+    focusCallback?.();
+    expect(snapToIndex).not.toHaveBeenCalled();
+  });
+});

--- a/rider-app/hooks/useBottomSheetGuard.ts
+++ b/rider-app/hooks/useBottomSheetGuard.ts
@@ -1,0 +1,72 @@
+import { useCallback, useRef, type RefObject } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import type BottomSheet from '@gorhom/bottom-sheet';
+
+type LayoutEvent = { nativeEvent: { layout: { height: number } } };
+
+/**
+ * Keeps a permanently-visible bottom sheet (enablePanDownToClose={false})
+ * from getting stuck off-screen.
+ *
+ * @gorhom/bottom-sheet resolves percentage snap points against its host
+ * container's measured height. Two layout races can hand it a 0-height
+ * container:
+ *
+ *  1. Cold start / fresh install — the screen mounts before the container
+ *     reports a real height, so the mount animation targets garbage detents
+ *     and the sheet never appears.
+ *  2. Tab detach/re-attach — with react-native-screens, leaving the tab (or
+ *     backgrounding the app) can fire a transient 0-height layout pass on
+ *     the hidden scene. All detents collapse, the sheet's current index
+ *     resolves to -1 (closed), and on the next container resize the library
+ *     re-evaluates from that index and pins the sheet to its *closed*
+ *     position — permanently, with no gesture to bring it back.
+ *
+ * Recovery layers (each snaps back to the last user-chosen index):
+ *  - first real-height layout → initial snap (fixes race 1)
+ *  - onChange(-1) → immediate snap; with pan-down-to-close disabled the
+ *    sheet can never legitimately close, so -1 is always the layout race
+ *  - real-height layout while the sheet reports closed → snap (a -1 that
+ *    happened while the scene was hidden)
+ *  - tab focus while the sheet reports closed → snap (re-attach passes that
+ *    fire no layout event at all)
+ */
+export function useBottomSheetGuard(
+  sheetRef: RefObject<BottomSheet | null>,
+  initialIndex = 0,
+) {
+  const lastGoodIndex = useRef(initialIndex);
+  const isClosed = useRef(false);
+  const didInit = useRef(false);
+
+  const snapBack = useCallback(() => {
+    // Defer one frame so the sheet's own internal measurement has settled.
+    requestAnimationFrame(() => sheetRef.current?.snapToIndex(lastGoodIndex.current));
+  }, [sheetRef]);
+
+  const handleSheetChange = useCallback((index: number) => {
+    if (index === -1) {
+      isClosed.current = true;
+      snapBack();
+      return;
+    }
+    isClosed.current = false;
+    lastGoodIndex.current = index;
+  }, [snapBack]);
+
+  const handleContainerLayout = useCallback((e: LayoutEvent) => {
+    if (e.nativeEvent.layout.height <= 0) return;
+    if (!didInit.current || isClosed.current) {
+      didInit.current = true;
+      snapBack();
+    }
+  }, [snapBack]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (didInit.current && isClosed.current) snapBack();
+    }, [snapBack]),
+  );
+
+  return { handleSheetChange, handleContainerLayout };
+}


### PR DESCRIPTION
The home "Where to?" sheet uses percentage snap points, which
@gorhom/bottom-sheet resolves against its container's measured height.
A transient 0-height layout pass — cold start before first measure, or
the tab scene being detached/re-attached by react-native-screens —
collapses all detents, resolves the sheet's index to -1 (closed), and
the library then re-evaluates every later container resize from that
closed index, pinning the sheet off-screen with no gesture to restore
it (pan-down-to-close is disabled). Riders intermittently saw a map
with no booking sheet until the app was killed.

Replace the one-shot first-layout snap with useBottomSheetGuard, which
layers four recoveries: initial snap on first real-height layout,
immediate snap-back when onChange reports -1 (never legitimate here),
re-assert on real-height layouts while closed, and re-assert on tab
focus while closed. The last user-chosen detent is preserved. Healthy
sheets are never touched, so there is no re-snap churn.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GNwNTaVZv3wWpUVcVXzChi

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
