### PR TITLE
feat(corporate): company portal — guest booking UI, sections, hardening

### DIFF
--- a/admin-dashboard/next.config.ts
+++ b/admin-dashboard/next.config.ts
@@ -79,6 +79,14 @@ const nextConfig: NextConfig = {
         source: "/api/admin/auth/:path*",
         destination: "/api/admin/auth/:path*",
       },
+      // Company-portal auth routes (set-cookie, verify-otp, refresh, logout)
+      // are Next.js API routes that manage HttpOnly cookies (spinr_company_rt)
+      // and strip the refresh_token from proxied bodies — they must NOT be
+      // proxied to the backend or company login/refresh silently breaks.
+      {
+        source: "/api/company-auth/:path*",
+        destination: "/api/company-auth/:path*",
+      },
       // Proxy everything else to backend
       {
         source: "/api/:path*",

--- a/admin-dashboard/src/app/api/company-auth/_shared.ts
+++ b/admin-dashboard/src/app/api/company-auth/_shared.ts
@@ -14,6 +14,11 @@ export const BACKEND_URL = (() => {
 })();
 
 export const RT_COOKIE = "spinr_company_rt";
+// Per-audience CSRF cookie: the staff admin surface and the company portal are
+// the same browser origin, so a shared `csrf_token` cookie collides when both
+// sessions are active. The company portal uses its own name; the backend CSRF
+// middleware validates the X-CSRF-Token header against either cookie.
+export const CSRF_COOKIE = "csrf_token_company";
 // Middleware-visible presence marker: the access token (company_token) expires
 // in 15 min (rider TTL), but the refresh session lasts 30 days. This flag lets
 // the middleware load the /company-portal shell after access expiry so the
@@ -51,9 +56,10 @@ export function setCompanySession(
     path: "/api/company-auth",
     maxAge: SESSION_MAX_AGE,
   });
-  // Readable csrf_token cookie for the backend double-submit on direct
-  // /api/company/* writes (value echoed to the store as csrfToken).
-  res.cookies.set("csrf_token", csrf, {
+  // Company CSRF cookie for the backend double-submit on direct /api/company/*
+  // writes (value echoed to the store as csrfToken). Distinct name so it never
+  // collides with the staff admin's csrf_token cookie on the shared origin.
+  res.cookies.set(CSRF_COOKIE, csrf, {
     httpOnly: false,
     sameSite: "strict",
     secure: isProduction,
@@ -79,7 +85,7 @@ export function clearCompanySession(res: NextResponse, isProduction: boolean): v
     path: "/api/company-auth",
     maxAge: 0,
   });
-  res.cookies.set("csrf_token", "", {
+  res.cookies.set(CSRF_COOKIE, "", {
     httpOnly: false,
     sameSite: "strict",
     secure: isProduction,

--- a/admin-dashboard/src/app/api/company-auth/_shared.ts
+++ b/admin-dashboard/src/app/api/company-auth/_shared.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Shared helpers for the company-portal auth proxy routes (verify-otp,
+// refresh, logout). Not a route file (underscore prefix) → Next never treats
+// it as an endpoint.
+
+export const BACKEND_URL = (() => {
+  const url =
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
+  if (!url) console.warn("BACKEND_URL env var is required in production.");
+  return url || "http://127.0.0.1:8000";
+})();
+
+export const RT_COOKIE = "spinr_company_rt";
+// Middleware-visible presence marker: the access token (company_token) expires
+// in 15 min (rider TTL), but the refresh session lasts 30 days. This flag lets
+// the middleware load the /company-portal shell after access expiry so the
+// client can silentRefresh, instead of hard-redirecting to /company-login.
+export const SESSION_MARKER = "company_session";
+export const SESSION_MAX_AGE = 30 * 24 * 60 * 60; // 30 days — matches backend RT
+
+/**
+ * Forward the real client IP + user-agent to the backend. Without this the
+ * backend rate limiters (get_ipaddr → X-Forwarded-For) key every proxied OTP
+ * verify / refresh to the Vercel/Railway egress address, so one busy portal
+ * exhausts the shared bucket and 429s unrelated company users.
+ */
+export function forwardedHeaders(req: NextRequest): Record<string, string> {
+  const h: Record<string, string> = { "Content-Type": "application/json" };
+  const xff = req.headers.get("x-forwarded-for");
+  const xri = req.headers.get("x-real-ip");
+  const ua = req.headers.get("user-agent");
+  if (xff) h["x-forwarded-for"] = xff;
+  if (xri) h["x-real-ip"] = xri;
+  if (ua) h["user-agent"] = ua;
+  return h;
+}
+
+export function setCompanySession(
+  res: NextResponse,
+  refreshToken: string,
+  csrf: string,
+  isProduction: boolean
+): void {
+  res.cookies.set(RT_COOKIE, refreshToken, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/api/company-auth",
+    maxAge: SESSION_MAX_AGE,
+  });
+  // Readable csrf_token cookie for the backend double-submit on direct
+  // /api/company/* writes (value echoed to the store as csrfToken).
+  res.cookies.set("csrf_token", csrf, {
+    httpOnly: false,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+  // Non-sensitive presence marker for the middleware (lax so it survives a
+  // top-level navigation/reload into /company-portal).
+  res.cookies.set(SESSION_MARKER, "1", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: isProduction,
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+}
+
+export function clearCompanySession(res: NextResponse, isProduction: boolean): void {
+  res.cookies.set(RT_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/api/company-auth",
+    maxAge: 0,
+  });
+  res.cookies.set("csrf_token", "", {
+    httpOnly: false,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/",
+    maxAge: 0,
+  });
+  res.cookies.set(SESSION_MARKER, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: isProduction,
+    path: "/",
+    maxAge: 0,
+  });
+}

--- a/admin-dashboard/src/app/api/company-auth/logout/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/logout/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const preferredRegion = "yul1";
+
+// Company-portal logout proxy: revoke the rider refresh token server-side so a
+// logged-out shared desk machine can't silent-refresh a new session, then
+// clear the portal's auth cookies. Best-effort — a failed backend revoke must
+// not block the local sign-out.
+const BACKEND_URL = (() => {
+  const url =
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
+  return url || "http://127.0.0.1:8000";
+})();
+
+const RT_COOKIE = "spinr_company_rt";
+
+export async function POST(req: NextRequest) {
+  const isProduction = process.env.NODE_ENV === "production";
+  const rt = req.cookies.get(RT_COOKIE)?.value;
+  const auth = req.headers.get("authorization");
+
+  if (rt) {
+    try {
+      // Backend /auth/logout requires the bearer (get_current_user) and
+      // revokes the refresh token from the body.
+      await fetch(`${BACKEND_URL}/api/v1/auth/logout`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(auth ? { Authorization: auth } : {}),
+        },
+        body: JSON.stringify({ refresh_token: rt }),
+      });
+    } catch {
+      /* best-effort revoke */
+    }
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(RT_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/api/company-auth",
+    maxAge: 0,
+  });
+  res.cookies.set("csrf_token", "", {
+    httpOnly: false,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/",
+    maxAge: 0,
+  });
+  return res;
+}

--- a/admin-dashboard/src/app/api/company-auth/logout/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/logout/route.ts
@@ -1,21 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { BACKEND_URL, RT_COOKIE, forwardedHeaders, clearCompanySession } from "../_shared";
 
 export const preferredRegion = "yul1";
 
 // Company-portal logout proxy: revoke the rider refresh token server-side so a
-// logged-out shared desk machine can't silent-refresh a new session, then
-// clear the portal's auth cookies. Best-effort — a failed backend revoke must
-// not block the local sign-out.
-const BACKEND_URL = (() => {
-  const url =
-    process.env.BACKEND_URL ||
-    process.env.NEXT_PUBLIC_API_URL ||
-    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
-  return url || "http://127.0.0.1:8000";
-})();
-
-const RT_COOKIE = "spinr_company_rt";
-
+// logged-out shared desk machine can't silent-refresh a new session, then clear
+// the portal's auth cookies. Best-effort — a failed backend revoke must not
+// block the local sign-out.
 export async function POST(req: NextRequest) {
   const isProduction = process.env.NODE_ENV === "production";
   const rt = req.cookies.get(RT_COOKIE)?.value;
@@ -28,7 +19,7 @@ export async function POST(req: NextRequest) {
       await fetch(`${BACKEND_URL}/api/v1/auth/logout`, {
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
+          ...forwardedHeaders(req),
           ...(auth ? { Authorization: auth } : {}),
         },
         body: JSON.stringify({ refresh_token: rt }),
@@ -39,19 +30,6 @@ export async function POST(req: NextRequest) {
   }
 
   const res = NextResponse.json({ ok: true });
-  res.cookies.set(RT_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/api/company-auth",
-    maxAge: 0,
-  });
-  res.cookies.set("csrf_token", "", {
-    httpOnly: false,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/",
-    maxAge: 0,
-  });
+  clearCompanySession(res, isProduction);
   return res;
 }

--- a/admin-dashboard/src/app/api/company-auth/refresh/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/refresh/route.ts
@@ -1,48 +1,26 @@
 import { randomBytes } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
+import {
+  BACKEND_URL,
+  RT_COOKIE,
+  forwardedHeaders,
+  setCompanySession,
+  clearCompanySession,
+} from "../_shared";
 
 export const preferredRegion = "yul1";
 
 // Company-portal token refresh proxy. Runs server-side so the backend CSRF
 // middleware (which only enforces on browser-Origin requests) is skipped —
-// this is why refresh works even on a rehydrated page load where no CSRF
-// token exists in JS memory. The refresh token lives only in the HttpOnly
+// this is why refresh works even on a rehydrated page load where no CSRF token
+// exists in JS memory. The refresh token lives only in the HttpOnly
 // spinr_company_rt cookie (SameSite=strict → cross-site POSTs can't carry it,
-// so no CSRF double-submit is needed here); the backend rotates it and we
-// strip the rotated value from the body before returning to the browser.
-const BACKEND_URL = (() => {
-  const url =
-    process.env.BACKEND_URL ||
-    process.env.NEXT_PUBLIC_API_URL ||
-    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
-  return url || "http://127.0.0.1:8000";
-})();
-
-const RT_COOKIE = "spinr_company_rt";
-const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
-
-function clearCookies(res: NextResponse, isProduction: boolean): void {
-  res.cookies.set(RT_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/api/company-auth",
-    maxAge: 0,
-  });
-  res.cookies.set("csrf_token", "", {
-    httpOnly: false,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/",
-    maxAge: 0,
-  });
-}
-
+// so no double-submit is needed here); the backend rotates it and we strip the
+// rotated value from the body before returning to the browser.
 export async function POST(req: NextRequest) {
   const isProduction = process.env.NODE_ENV === "production";
   const rt = req.cookies.get(RT_COOKIE)?.value;
-  // No RT cookie → no session to restore. Clean 401 (not 403) so a fresh page
-  // load doesn't destroy anything.
+  // No RT cookie → no session to restore. Clean 401 (not 403).
   if (!rt) {
     return NextResponse.json({ detail: "No refresh token" }, { status: 401 });
   }
@@ -51,7 +29,7 @@ export async function POST(req: NextRequest) {
   try {
     upstream = await fetch(`${BACKEND_URL}/api/v1/auth/refresh`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: forwardedHeaders(req),
       // Backend reads the refresh token from cookie OR body; we hold it in a
       // route-scoped cookie the backend fetch can't see, so pass it in the body.
       body: JSON.stringify({ refresh_token: rt }),
@@ -64,7 +42,7 @@ export async function POST(req: NextRequest) {
   if (!upstream.ok) {
     const res = NextResponse.json(data, { status: upstream.status });
     // A definitive 401 means the RT is revoked/rotated-away — clear cookies.
-    if (upstream.status === 401) clearCookies(res, isProduction);
+    if (upstream.status === 401) clearCompanySession(res, isProduction);
     return res;
   }
 
@@ -75,19 +53,6 @@ export async function POST(req: NextRequest) {
 
   const csrf = randomBytes(32).toString("hex");
   const res = NextResponse.json({ ...clientData, csrf_token: csrf }, { status: 200 });
-  res.cookies.set(RT_COOKIE, refresh_token, {
-    httpOnly: true,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/api/company-auth",
-    maxAge: SESSION_MAX_AGE,
-  });
-  res.cookies.set("csrf_token", csrf, {
-    httpOnly: false,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/",
-    maxAge: SESSION_MAX_AGE,
-  });
+  setCompanySession(res, refresh_token, csrf, isProduction);
   return res;
 }

--- a/admin-dashboard/src/app/api/company-auth/refresh/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/refresh/route.ts
@@ -1,0 +1,93 @@
+import { randomBytes } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+export const preferredRegion = "yul1";
+
+// Company-portal token refresh proxy. Runs server-side so the backend CSRF
+// middleware (which only enforces on browser-Origin requests) is skipped —
+// this is why refresh works even on a rehydrated page load where no CSRF
+// token exists in JS memory. The refresh token lives only in the HttpOnly
+// spinr_company_rt cookie (SameSite=strict → cross-site POSTs can't carry it,
+// so no CSRF double-submit is needed here); the backend rotates it and we
+// strip the rotated value from the body before returning to the browser.
+const BACKEND_URL = (() => {
+  const url =
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
+  return url || "http://127.0.0.1:8000";
+})();
+
+const RT_COOKIE = "spinr_company_rt";
+const SESSION_MAX_AGE = 30 * 24 * 60 * 60;
+
+function clearCookies(res: NextResponse, isProduction: boolean): void {
+  res.cookies.set(RT_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/api/company-auth",
+    maxAge: 0,
+  });
+  res.cookies.set("csrf_token", "", {
+    httpOnly: false,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/",
+    maxAge: 0,
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const isProduction = process.env.NODE_ENV === "production";
+  const rt = req.cookies.get(RT_COOKIE)?.value;
+  // No RT cookie → no session to restore. Clean 401 (not 403) so a fresh page
+  // load doesn't destroy anything.
+  if (!rt) {
+    return NextResponse.json({ detail: "No refresh token" }, { status: 401 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${BACKEND_URL}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // Backend reads the refresh token from cookie OR body; we hold it in a
+      // route-scoped cookie the backend fetch can't see, so pass it in the body.
+      body: JSON.stringify({ refresh_token: rt }),
+    });
+  } catch {
+    return NextResponse.json({ detail: "Backend unreachable" }, { status: 502 });
+  }
+
+  const data = await upstream.json().catch(() => ({}));
+  if (!upstream.ok) {
+    const res = NextResponse.json(data, { status: upstream.status });
+    // A definitive 401 means the RT is revoked/rotated-away — clear cookies.
+    if (upstream.status === 401) clearCookies(res, isProduction);
+    return res;
+  }
+
+  const { refresh_token, refresh_expires_at: _ignored, ...clientData } = data;
+  if (!refresh_token) {
+    return NextResponse.json({ detail: "Backend protocol error" }, { status: 502 });
+  }
+
+  const csrf = randomBytes(32).toString("hex");
+  const res = NextResponse.json({ ...clientData, csrf_token: csrf }, { status: 200 });
+  res.cookies.set(RT_COOKIE, refresh_token, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/api/company-auth",
+    maxAge: SESSION_MAX_AGE,
+  });
+  res.cookies.set("csrf_token", csrf, {
+    httpOnly: false,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+  return res;
+}

--- a/admin-dashboard/src/app/api/company-auth/set-cookie/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/set-cookie/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+// Company-portal twin of /api/auth/set-cookie: holds the RIDER access token
+// for the edge middleware's exp check on /company-portal/**. Rider access
+// tokens live 15 minutes; silentRefresh() rewrites this cookie on every
+// rotation, so the maxAge only needs to outlive one token's lifetime.
+const COOKIE_NAME = 'company_token';
+const COOKIE_MAX_AGE = 30 * 60;
+
+export async function POST(request: NextRequest) {
+    let token: string | undefined;
+    try {
+        const body = await request.json();
+        token = body?.token;
+    } catch (error) {
+        console.error('[POST /api/company-auth/set-cookie] JSON parse error:', error);
+        return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+    }
+    if (!token || typeof token !== 'string') {
+        return NextResponse.json({ error: 'Missing token' }, { status: 400 });
+    }
+
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set(COOKIE_NAME, token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: COOKIE_MAX_AGE,
+        path: '/',
+    });
+    return response;
+}
+
+export async function DELETE() {
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set(COOKIE_NAME, '', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 0,
+        path: '/',
+    });
+    return response;
+}

--- a/admin-dashboard/src/app/api/company-auth/verify-otp/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/verify-otp/route.ts
@@ -1,0 +1,82 @@
+import { randomBytes } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+// PIPEDA data residency: pin to Canadian (Montreal) Vercel edge region.
+export const preferredRegion = "yul1";
+
+// Company-portal OTP verification proxy. Mirrors the admin login route: the
+// backend's AuthResponse returns the 30-day refresh_token in the JSON body
+// (for mobile clients that have no cookie jar), so a direct browser call
+// would expose the long-lived credential to JS. This route proxies to the
+// backend, strips refresh_token from the body, and holds it in an HttpOnly
+// cookie (spinr_company_rt, scoped to /api/company-auth) instead. The
+// readable csrf_token cookie is what the backend's double-submit middleware
+// checks on the portal's direct /api/company/* writes.
+const BACKEND_URL = (() => {
+  const url =
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
+  if (!url) {
+    console.warn("BACKEND_URL env var is required in production.");
+  }
+  return url || "http://127.0.0.1:8000";
+})();
+
+const RT_COOKIE = "spinr_company_rt";
+const SESSION_MAX_AGE = 30 * 24 * 60 * 60; // 30 days — matches backend RT TTL
+
+export async function POST(req: NextRequest) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ detail: "Invalid JSON" }, { status: 400 });
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${BACKEND_URL}/api/v1/auth/verify-otp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return NextResponse.json({ detail: "Backend unreachable" }, { status: 502 });
+  }
+
+  const data = await upstream.json().catch(() => ({}));
+  if (!upstream.ok) {
+    return NextResponse.json(data, { status: upstream.status });
+  }
+
+  const { refresh_token, refresh_expires_at: _ignored, ...clientData } = data;
+  const isProduction = process.env.NODE_ENV === "production";
+
+  // No refresh_token on a 200 (e.g. requires_reactivation) → no session; relay
+  // the body verbatim with no cookies set.
+  if (!refresh_token) {
+    return NextResponse.json(clientData, { status: 200 });
+  }
+
+  // Self-issued CSRF token: value is echoed in the body (stored in the
+  // company auth store) AND set as the csrf_token cookie, so the backend's
+  // double-submit check (cookie === X-CSRF-Token header) passes on writes.
+  const csrf = randomBytes(32).toString("hex");
+  const res = NextResponse.json({ ...clientData, csrf_token: csrf }, { status: 200 });
+  res.cookies.set(RT_COOKIE, refresh_token, {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/api/company-auth",
+    maxAge: SESSION_MAX_AGE,
+  });
+  res.cookies.set("csrf_token", csrf, {
+    httpOnly: false,
+    sameSite: "strict",
+    secure: isProduction,
+    path: "/",
+    maxAge: SESSION_MAX_AGE,
+  });
+  return res;
+}

--- a/admin-dashboard/src/app/api/company-auth/verify-otp/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/verify-otp/route.ts
@@ -1,31 +1,17 @@
 import { randomBytes } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { BACKEND_URL, forwardedHeaders, setCompanySession } from "../_shared";
 
 // PIPEDA data residency: pin to Canadian (Montreal) Vercel edge region.
 export const preferredRegion = "yul1";
 
-// Company-portal OTP verification proxy. Mirrors the admin login route: the
-// backend's AuthResponse returns the 30-day refresh_token in the JSON body
-// (for mobile clients that have no cookie jar), so a direct browser call
-// would expose the long-lived credential to JS. This route proxies to the
-// backend, strips refresh_token from the body, and holds it in an HttpOnly
-// cookie (spinr_company_rt, scoped to /api/company-auth) instead. The
-// readable csrf_token cookie is what the backend's double-submit middleware
-// checks on the portal's direct /api/company/* writes.
-const BACKEND_URL = (() => {
-  const url =
-    process.env.BACKEND_URL ||
-    process.env.NEXT_PUBLIC_API_URL ||
-    (process.env.NODE_ENV !== "production" ? "http://127.0.0.1:8000" : "");
-  if (!url) {
-    console.warn("BACKEND_URL env var is required in production.");
-  }
-  return url || "http://127.0.0.1:8000";
-})();
-
-const RT_COOKIE = "spinr_company_rt";
-const SESSION_MAX_AGE = 30 * 24 * 60 * 60; // 30 days — matches backend RT TTL
-
+// Company-portal OTP verification proxy. The backend's AuthResponse returns the
+// 30-day refresh_token in the JSON body (for mobile clients that have no cookie
+// jar), so a direct browser call would expose the long-lived credential to JS.
+// This route strips refresh_token from the body and holds it in an HttpOnly
+// spinr_company_rt cookie (scoped to /api/company-auth) instead — mirroring the
+// admin login route. Client IP/UA are forwarded so the backend OTP rate limiter
+// keys on the browser, not the egress address.
 export async function POST(req: NextRequest) {
   let body: unknown;
   try {
@@ -38,7 +24,7 @@ export async function POST(req: NextRequest) {
   try {
     upstream = await fetch(`${BACKEND_URL}/api/v1/auth/verify-otp`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: forwardedHeaders(req),
       body: JSON.stringify(body),
     });
   } catch {
@@ -59,24 +45,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(clientData, { status: 200 });
   }
 
-  // Self-issued CSRF token: value is echoed in the body (stored in the
-  // company auth store) AND set as the csrf_token cookie, so the backend's
-  // double-submit check (cookie === X-CSRF-Token header) passes on writes.
+  // Self-issued CSRF token: echoed in the body (stored in the company auth
+  // store) AND set as the csrf_token cookie, so the backend double-submit
+  // (cookie === X-CSRF-Token header) passes on writes.
   const csrf = randomBytes(32).toString("hex");
   const res = NextResponse.json({ ...clientData, csrf_token: csrf }, { status: 200 });
-  res.cookies.set(RT_COOKIE, refresh_token, {
-    httpOnly: true,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/api/company-auth",
-    maxAge: SESSION_MAX_AGE,
-  });
-  res.cookies.set("csrf_token", csrf, {
-    httpOnly: false,
-    sameSite: "strict",
-    secure: isProduction,
-    path: "/",
-    maxAge: SESSION_MAX_AGE,
-  });
+  setCompanySession(res, refresh_token, csrf, isProduction);
   return res;
 }

--- a/admin-dashboard/src/app/company-login/page.tsx
+++ b/admin-dashboard/src/app/company-login/page.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Building2, Loader2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useCompanyAuthStore } from "@/store/companyAuthStore";
+import {
+    sendCompanyOtp,
+    verifyCompanyOtp,
+    getMyWorkProfiles,
+    acceptCompanyInvite,
+} from "@/lib/companyApi";
+
+/**
+ * Company-portal login (Spinr for Business).
+ *
+ * Company staff sign in with the SAME phone-OTP identity as the rider app —
+ * their corporate membership (invite / email-domain match) is what grants
+ * portal access, so there are no separate business passwords to manage.
+ *
+ * `?invite_token=` deep links accept a member invitation right after OTP
+ * verification, closing the "employee never installed the app" gap in the
+ * invite flow (the app deep link app://join is useless on a desk computer).
+ */
+function CompanyLoginInner() {
+    const router = useRouter();
+    const params = useSearchParams();
+    const completeLogin = useCompanyAuthStore((s) => s.completeLogin);
+    const setMemberships = useCompanyAuthStore((s) => s.setMemberships);
+
+    const [step, setStep] = useState<"phone" | "code">("phone");
+    const [phone, setPhone] = useState("");
+    const [code, setCode] = useState("");
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const normalizedPhone = () => {
+        const digits = phone.replace(/\D/g, "");
+        return digits.length === 10 ? `+1${digits}` : phone.trim();
+    };
+
+    const handleSend = async () => {
+        setBusy(true);
+        setError(null);
+        try {
+            await sendCompanyOtp(normalizedPhone());
+            setStep("code");
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Could not send code");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleVerify = async () => {
+        setBusy(true);
+        setError(null);
+        try {
+            const result = await verifyCompanyOtp(normalizedPhone(), code.trim());
+            await completeLogin({
+                token: result.token,
+                csrfToken: result.csrf_token ?? null,
+                user: result.user,
+            });
+
+            const inviteToken = params.get("invite_token");
+            if (inviteToken) {
+                try {
+                    await acceptCompanyInvite(inviteToken);
+                } catch (e) {
+                    // Already-accepted / expired invites shouldn't block login —
+                    // the membership list below is the source of truth.
+                    console.warn("[company-login] invite accept failed:", e);
+                }
+            }
+
+            const memberships = await getMyWorkProfiles().catch(() => []);
+            setMemberships(memberships);
+
+            if (memberships.length === 0) {
+                setError(
+                    "This phone number has no company memberships. Ask your company admin for an invite link."
+                );
+                setBusy(false);
+                return;
+            }
+
+            const next = params.get("next");
+            if (next && next.startsWith("/company-portal")) {
+                router.replace(next);
+            } else if (memberships.length === 1) {
+                router.replace(`/company-portal/${memberships[0].company.id}/overview`);
+            } else {
+                router.replace("/company-portal");
+            }
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Invalid code");
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-background p-4">
+            <Card className="w-full max-w-md">
+                <CardHeader className="space-y-2 text-center">
+                    <div className="mx-auto rounded-lg bg-emerald-50 p-3 w-fit">
+                        <Building2 className="h-7 w-7 text-emerald-600" />
+                    </div>
+                    <CardTitle className="text-xl">Spinr for Business</CardTitle>
+                    <p className="text-sm text-muted-foreground">
+                        {step === "phone"
+                            ? "Sign in with your phone number to manage your company's rides."
+                            : `Enter the code we texted to ${phone}.`}
+                    </p>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    {step === "phone" ? (
+                        <>
+                            <Input
+                                type="tel"
+                                inputMode="tel"
+                                placeholder="(306) 555-0123"
+                                value={phone}
+                                autoFocus
+                                onChange={(e) => setPhone(e.target.value)}
+                                onKeyDown={(e) => e.key === "Enter" && !busy && phone && handleSend()}
+                            />
+                            <Button className="w-full" onClick={handleSend} disabled={busy || !phone.trim()}>
+                                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                Send code
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Input
+                                type="text"
+                                inputMode="numeric"
+                                placeholder="4-digit code"
+                                maxLength={6}
+                                value={code}
+                                autoFocus
+                                onChange={(e) => setCode(e.target.value)}
+                                onKeyDown={(e) => e.key === "Enter" && !busy && code && handleVerify()}
+                            />
+                            <Button className="w-full" onClick={handleVerify} disabled={busy || !code.trim()}>
+                                {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                Verify &amp; sign in
+                            </Button>
+                            <button
+                                type="button"
+                                className="w-full text-center text-xs text-muted-foreground hover:underline"
+                                onClick={() => {
+                                    setStep("phone");
+                                    setCode("");
+                                    setError(null);
+                                }}
+                            >
+                                Use a different number
+                            </button>
+                        </>
+                    )}
+                    {error && (
+                        <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>
+                    )}
+                    <p className="text-center text-xs text-muted-foreground">
+                        Employees use the same sign-in as the Spinr rider app. Your company
+                        membership controls what you can see here.
+                    </p>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}
+
+export default function CompanyLoginPage() {
+    return (
+        <Suspense fallback={null}>
+            <CompanyLoginInner />
+        </Suspense>
+    );
+}

--- a/admin-dashboard/src/app/company-login/page.tsx
+++ b/admin-dashboard/src/app/company-login/page.tsx
@@ -12,6 +12,7 @@ import {
     verifyCompanyOtp,
     getMyWorkProfiles,
     acceptCompanyInvite,
+    portalHome,
 } from "@/lib/companyApi";
 
 /**
@@ -92,7 +93,8 @@ function CompanyLoginInner() {
             if (next && next.startsWith("/company-portal")) {
                 router.replace(next);
             } else if (memberships.length === 1) {
-                router.replace(`/company-portal/${memberships[0].company.id}/overview`);
+                // Role-appropriate landing: members can't see the admin overview.
+                router.replace(portalHome(memberships[0].company.id, memberships[0].membership.role));
             } else {
                 router.replace("/company-portal");
             }

--- a/admin-dashboard/src/app/company-login/page.tsx
+++ b/admin-dashboard/src/app/company-login/page.tsx
@@ -71,7 +71,10 @@ function CompanyLoginInner() {
                 user: result.user,
             });
 
-            const inviteToken = params.get("invite_token");
+            // Accept both param names: the portal surfaces web links as
+            // ?invite_token=, but the backend also mints app://join?token= deep
+            // links — honour `token` too so either lands the membership.
+            const inviteToken = params.get("invite_token") || params.get("token");
             if (inviteToken) {
                 try {
                     await acceptCompanyInvite(inviteToken);

--- a/admin-dashboard/src/app/company-login/page.tsx
+++ b/admin-dashboard/src/app/company-login/page.tsx
@@ -40,7 +40,11 @@ function CompanyLoginInner() {
 
     const normalizedPhone = () => {
         const digits = phone.replace(/\D/g, "");
-        return digits.length === 10 ? `+1${digits}` : phone.trim();
+        if (digits.length === 10) return `+1${digits}`;
+        // Common 11-digit forms like "+1 (306) 555-0123" / "1-306-555-0123":
+        // the backend send-otp only accepts strict +1XXXXXXXXXX.
+        if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+        return phone.trim();
     };
 
     const handleSend = async () => {

--- a/admin-dashboard/src/app/company-portal/[id]/activity/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/activity/page.tsx
@@ -2,10 +2,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
+import type {
     BillingStatement,
-    getCompanyBillingStatement,
 } from "@/lib/api";
+import {
+    getCompanyBillingStatement,
+} from "@/lib/companyApi";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/admin-dashboard/src/app/company-portal/[id]/allowance-requests/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/allowance-requests/page.tsx
@@ -2,11 +2,13 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
+import type {
     AllowanceRequestRow,
+} from "@/lib/api";
+import {
     decideAllowanceRequest,
     listCompanyAllowanceRequests,
-} from "@/lib/api";
+} from "@/lib/companyApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";

--- a/admin-dashboard/src/app/company-portal/[id]/allowances/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/allowances/page.tsx
@@ -2,13 +2,15 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
+import type {
     AllowanceTypeValue,
     CorporateMember,
+} from "@/lib/api";
+import {
     getMemberAllowance,
     listCompanyMembers,
     putMemberAllowance,
-} from "@/lib/api";
+} from "@/lib/companyApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";

--- a/admin-dashboard/src/app/company-portal/[id]/billing/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/billing/page.tsx
@@ -2,14 +2,16 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
+import type {
     BillingStatement,
     BillingSummary,
     BillingTransactionsPage,
+} from "@/lib/api";
+import {
     getCompanyBillingStatement,
     getCompanyBillingSummary,
     getCompanyBillingTransactions,
-} from "@/lib/api";
+} from "@/lib/companyApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";

--- a/admin-dashboard/src/app/company-portal/[id]/book/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/book/page.tsx
@@ -221,7 +221,12 @@ export default function CompanyBookRidePage() {
         setError(null);
         try {
             const digits = customerPhone.replace(/\D/g, "");
-            const phone = digits.length === 10 ? `+1${digits}` : customerPhone.trim();
+            const phone =
+                digits.length === 10
+                    ? `+1${digits}`
+                    : digits.length === 11 && digits.startsWith("1")
+                      ? `+${digits}`
+                      : customerPhone.trim();
             const res = await createCompanyBooking(companyId, {
                 customer_name: customerName.trim(),
                 customer_phone: phone,

--- a/admin-dashboard/src/app/company-portal/[id]/book/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/book/page.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import { CalendarPlus, CheckCircle2, Loader2, MapPin } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+    companyRequest,
+    companyBookingFareEstimate,
+    createCompanyBooking,
+    getPortalVehicleTypes,
+    CompanyFareEstimate,
+    CreateBookingResult,
+    PortalVehicleType,
+} from "@/lib/companyApi";
+
+/**
+ * Book a ride for a customer (Spinr for Business guest booking).
+ *
+ * Route metrics: pickup/dropoff come from the rider-token maps proxy
+ * (places autocomplete + details); distance/duration use a haversine ×1.3
+ * road-factor approximation. That approximation feeds BOTH the preview and
+ * the booking, so what the booker sees is what the company is charged at
+ * booking time — and completion re-prices on actual GPS distance anyway
+ * (unless fare-lock is on), exactly like rider-app bookings.
+ */
+
+interface PlacePoint {
+    address: string;
+    lat: number;
+    lng: number;
+}
+
+function haversineKm(a: PlacePoint, b: PlacePoint): number {
+    const R = 6371;
+    const dLat = ((b.lat - a.lat) * Math.PI) / 180;
+    const dLng = ((b.lng - a.lng) * Math.PI) / 180;
+    const s =
+        Math.sin(dLat / 2) ** 2 +
+        Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+    return 2 * R * Math.asin(Math.sqrt(s));
+}
+
+interface Suggestion {
+    place_id: string;
+    description: string;
+}
+
+function AddressPicker({
+    label,
+    value,
+    onSelect,
+}: {
+    label: string;
+    value: PlacePoint | null;
+    onSelect: (p: PlacePoint | null) => void;
+}) {
+    const [query, setQuery] = useState(value?.address ?? "");
+    const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+    const [open, setOpen] = useState(false);
+    const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const search = useCallback((text: string) => {
+        if (debounce.current) clearTimeout(debounce.current);
+        if (text.trim().length < 3) {
+            setSuggestions([]);
+            return;
+        }
+        debounce.current = setTimeout(async () => {
+            try {
+                const res = await companyRequest<{ predictions?: Suggestion[] } | Suggestion[]>(
+                    `/api/v1/maps/places/autocomplete?input=${encodeURIComponent(text)}`
+                );
+                const rows = Array.isArray(res) ? res : (res.predictions ?? []);
+                setSuggestions(rows.slice(0, 6));
+                setOpen(true);
+            } catch {
+                setSuggestions([]);
+            }
+        }, 300);
+    }, []);
+
+    const pick = async (s: Suggestion) => {
+        setOpen(false);
+        setQuery(s.description);
+        try {
+            const detail = await companyRequest<{
+                result?: { geometry?: { location?: { lat: number; lng: number } } };
+                lat?: number;
+                lng?: number;
+            }>(`/api/v1/maps/places/details?place_id=${encodeURIComponent(s.place_id)}`);
+            const lat = detail.lat ?? detail.result?.geometry?.location?.lat;
+            const lng = detail.lng ?? detail.result?.geometry?.location?.lng;
+            if (typeof lat === "number" && typeof lng === "number") {
+                onSelect({ address: s.description, lat, lng });
+                return;
+            }
+        } catch {
+            /* fall through to clearing */
+        }
+        onSelect(null);
+    };
+
+    return (
+        <div className="relative">
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">{label}</label>
+            <div className="relative">
+                <MapPin className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                    className="pl-8"
+                    placeholder="Search address…"
+                    value={query}
+                    onChange={(e) => {
+                        setQuery(e.target.value);
+                        onSelect(null);
+                        search(e.target.value);
+                    }}
+                    onFocus={() => suggestions.length > 0 && setOpen(true)}
+                    onBlur={() => setTimeout(() => setOpen(false), 200)}
+                />
+            </div>
+            {open && suggestions.length > 0 && (
+                <div className="absolute z-20 mt-1 w-full rounded-md border bg-background shadow-md">
+                    {suggestions.map((s) => (
+                        <button
+                            key={s.place_id}
+                            type="button"
+                            className="block w-full px-3 py-2 text-left text-sm hover:bg-muted"
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => pick(s)}
+                        >
+                            {s.description}
+                        </button>
+                    ))}
+                </div>
+            )}
+            {value && <p className="mt-1 truncate text-xs text-emerald-700">✓ {value.address}</p>}
+        </div>
+    );
+}
+
+export default function CompanyBookRidePage() {
+    const params = useParams();
+    const companyId = typeof params?.id === "string" ? params.id : "";
+
+    const [customerName, setCustomerName] = useState("");
+    const [customerPhone, setCustomerPhone] = useState("");
+    const [pickup, setPickup] = useState<PlacePoint | null>(null);
+    const [dropoff, setDropoff] = useState<PlacePoint | null>(null);
+    const [vehicleTypes, setVehicleTypes] = useState<PortalVehicleType[]>([]);
+    const [vehicleTypeId, setVehicleTypeId] = useState("");
+    const [when, setWhen] = useState<"now" | "scheduled">("now");
+    const [scheduledTime, setScheduledTime] = useState("");
+    const [notes, setNotes] = useState("");
+    const [estimate, setEstimate] = useState<CompanyFareEstimate | null>(null);
+    const [estimating, setEstimating] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [confirmPhone, setConfirmPhone] = useState(false);
+    const [result, setResult] = useState<CreateBookingResult | null>(null);
+
+    useEffect(() => {
+        getPortalVehicleTypes()
+            .then((rows) => {
+                const active = rows.filter((v) => v.is_active !== false);
+                setVehicleTypes(active);
+                if (active.length > 0) setVehicleTypeId((prev) => prev || active[0].id);
+            })
+            .catch(() => setVehicleTypes([]));
+    }, []);
+
+    const route = useMemo(() => {
+        if (!pickup || !dropoff) return null;
+        const straight = haversineKm(pickup, dropoff);
+        const distance_km = Math.max(0.5, Math.round(straight * 1.3 * 100) / 100);
+        const duration_minutes = Math.max(3, Math.round((distance_km / 30) * 60)); // ~30 km/h city
+        return { distance_km, duration_minutes };
+    }, [pickup, dropoff]);
+
+    useEffect(() => {
+        if (!companyId || !pickup || !dropoff || !vehicleTypeId || !route) {
+            setEstimate(null);
+            return;
+        }
+        let cancelled = false;
+        setEstimating(true);
+        companyBookingFareEstimate(companyId, {
+            pickup_lat: pickup.lat,
+            pickup_lng: pickup.lng,
+            dropoff_lat: dropoff.lat,
+            dropoff_lng: dropoff.lng,
+            distance_km: route.distance_km,
+            duration_minutes: route.duration_minutes,
+            vehicle_type_id: vehicleTypeId,
+        })
+            .then((fare) => !cancelled && setEstimate(fare))
+            .catch(() => !cancelled && setEstimate(null))
+            .finally(() => !cancelled && setEstimating(false));
+        return () => {
+            cancelled = true;
+        };
+    }, [companyId, pickup, dropoff, vehicleTypeId, route]);
+
+    const phoneLooksValid = /^\+?1?\s*\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/.test(customerPhone.trim());
+    const canSubmit =
+        !!customerName.trim() &&
+        phoneLooksValid &&
+        !!pickup &&
+        !!dropoff &&
+        !!vehicleTypeId &&
+        !!route &&
+        (when === "now" || !!scheduledTime) &&
+        confirmPhone &&
+        !submitting;
+
+    const handleSubmit = async () => {
+        if (!pickup || !dropoff || !route) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            const digits = customerPhone.replace(/\D/g, "");
+            const phone = digits.length === 10 ? `+1${digits}` : customerPhone.trim();
+            const res = await createCompanyBooking(companyId, {
+                customer_name: customerName.trim(),
+                customer_phone: phone,
+                pickup_address: pickup.address,
+                pickup_lat: pickup.lat,
+                pickup_lng: pickup.lng,
+                dropoff_address: dropoff.address,
+                dropoff_lat: dropoff.lat,
+                dropoff_lng: dropoff.lng,
+                distance_km: route.distance_km,
+                duration_minutes: route.duration_minutes,
+                vehicle_type_id: vehicleTypeId,
+                scheduled_time: when === "scheduled" ? new Date(scheduledTime).toISOString() : null,
+                rider_notes: notes.trim() || null,
+            });
+            setResult(res);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Booking failed");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    if (result) {
+        return (
+            <Card className="mx-auto max-w-xl">
+                <CardHeader className="text-center">
+                    <CheckCircle2 className="mx-auto h-10 w-10 text-emerald-600" />
+                    <CardTitle>Ride booked</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                    <p>
+                        {result.customer_has_app
+                            ? "The customer has the Spinr app — the ride is already showing there, and they got a push notification."
+                            : "The customer will get an SMS with the trip details, their pickup code, and a live tracking link."}
+                    </p>
+                    {result.tracking_url && (
+                        <p className="break-all rounded bg-muted p-3">
+                            Tracking link:{" "}
+                            <a
+                                href={result.tracking_url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-primary underline"
+                            >
+                                {result.tracking_url}
+                            </a>
+                        </p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                        The pickup code is sent only to the customer — the driver needs it
+                        from them to start the trip.
+                    </p>
+                    <div className="flex gap-2 pt-2">
+                        <Button
+                            className="flex-1"
+                            variant="outline"
+                            onClick={() => {
+                                setResult(null);
+                                setCustomerName("");
+                                setCustomerPhone("");
+                                setPickup(null);
+                                setDropoff(null);
+                                setNotes("");
+                                setConfirmPhone(false);
+                                setEstimate(null);
+                            }}
+                        >
+                            Book another
+                        </Button>
+                        <Button className="flex-1" asChild>
+                            <a href={`/company-portal/${companyId}/bookings`}>View bookings</a>
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <div className="mx-auto max-w-2xl space-y-6">
+            <header>
+                <h1 className="flex items-center gap-2 text-xl font-semibold">
+                    <CalendarPlus className="h-5 w-5" /> Book a ride for a customer
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                    The ride is billed to your company allowance. The customer needs no app —
+                    they get everything by text.
+                </p>
+            </header>
+
+            <Card>
+                <CardContent className="space-y-4 p-5">
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Customer name
+                            </label>
+                            <Input
+                                placeholder="Pat Customer"
+                                value={customerName}
+                                onChange={(e) => setCustomerName(e.target.value)}
+                            />
+                        </div>
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Customer phone
+                            </label>
+                            <Input
+                                type="tel"
+                                placeholder="(306) 555-0123"
+                                value={customerPhone}
+                                onChange={(e) => {
+                                    setCustomerPhone(e.target.value);
+                                    setConfirmPhone(false);
+                                }}
+                            />
+                        </div>
+                    </div>
+
+                    <AddressPicker label="Pickup" value={pickup} onSelect={setPickup} />
+                    <AddressPicker label="Dropoff" value={dropoff} onSelect={setDropoff} />
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Vehicle type
+                            </label>
+                            <select
+                                className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+                                value={vehicleTypeId}
+                                onChange={(e) => setVehicleTypeId(e.target.value)}
+                            >
+                                {vehicleTypes.map((v) => (
+                                    <option key={v.id} value={v.id}>
+                                        {v.name}
+                                        {v.capacity ? ` · ${v.capacity} seats` : ""}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                When
+                            </label>
+                            <div className="flex gap-2">
+                                <select
+                                    className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                                    value={when}
+                                    onChange={(e) => setWhen(e.target.value as "now" | "scheduled")}
+                                >
+                                    <option value="now">Now</option>
+                                    <option value="scheduled">Schedule</option>
+                                </select>
+                                {when === "scheduled" && (
+                                    <Input
+                                        type="datetime-local"
+                                        value={scheduledTime}
+                                        min={new Date(Date.now() + 15 * 60_000).toISOString().slice(0, 16)}
+                                        onChange={(e) => setScheduledTime(e.target.value)}
+                                    />
+                                )}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                            Note for the driver (optional)
+                        </label>
+                        <Input
+                            placeholder="e.g. Customer waiting at the service desk"
+                            maxLength={200}
+                            value={notes}
+                            onChange={(e) => setNotes(e.target.value)}
+                        />
+                    </div>
+
+                    {estimate && (
+                        <div className="rounded-md border bg-muted/40 p-3 text-sm">
+                            <div className="flex items-center justify-between font-medium">
+                                <span>Estimated fare (no surge on company rides)</span>
+                                <span>${Number(estimate.grand_total).toFixed(2)}</span>
+                            </div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                                Fare ${Number(estimate.subtotal).toFixed(2)} · Fees $
+                                {Number(estimate.area_fees_total).toFixed(2)} · Tax $
+                                {Number(estimate.tax_amount).toFixed(2)}
+                                {estimate.service_area ? ` · ${estimate.service_area}` : ""}
+                            </div>
+                        </div>
+                    )}
+                    {estimating && (
+                        <p className="text-xs text-muted-foreground">
+                            <Loader2 className="mr-1 inline h-3 w-3 animate-spin" /> Estimating fare…
+                        </p>
+                    )}
+
+                    <label className="flex items-start gap-2 text-xs text-muted-foreground">
+                        <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={confirmPhone}
+                            onChange={(e) => setConfirmPhone(e.target.checked)}
+                        />
+                        <span>
+                            I&apos;ve double-checked the customer&apos;s phone number
+                            {customerPhone.trim() ? ` (${customerPhone.trim()})` : ""} — the pickup
+                            code and tracking link are texted to it.
+                        </span>
+                    </label>
+
+                    {error && <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+
+                    <Button className="w-full" disabled={!canSubmit} onClick={handleSubmit}>
+                        {submitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        {when === "now" ? "Book ride now" : "Schedule ride"}
+                    </Button>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/book/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/book/page.tsx
@@ -380,7 +380,15 @@ export default function CompanyBookRidePage() {
                                     <Input
                                         type="datetime-local"
                                         value={scheduledTime}
-                                        min={new Date(Date.now() + 15 * 60_000).toISOString().slice(0, 16)}
+                                        min={(() => {
+                                            // datetime-local is LOCAL wall-clock; toISOString() is
+                                            // UTC. Offset to local so the min isn't shifted by the
+                                            // browser's tz (e.g. +6h in Saskatchewan), which would
+                                            // block scheduling for the next several hours.
+                                            const d = new Date(Date.now() + 15 * 60_000);
+                                            d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+                                            return d.toISOString().slice(0, 16);
+                                        })()}
                                         onChange={(e) => setScheduledTime(e.target.value)}
                                     />
                                 )}

--- a/admin-dashboard/src/app/company-portal/[id]/bookings/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/bookings/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { ListChecks, Loader2, RefreshCw } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+    cancelCompanyBooking,
+    listCompanyBookings,
+    CompanyBookingRow,
+} from "@/lib/companyApi";
+import { useCompanyAuthStore } from "@/store/companyAuthStore";
+
+/**
+ * Live company bookings — polls every 12s (v1; a socket feed is overkill for
+ * a desk dashboard). Members see their own bookings; owner/admin see all
+ * (enforced by the backend guard regardless of what this UI shows).
+ */
+
+const POLL_MS = 12_000;
+const PRE_TRIP = new Set(["scheduled", "searching", "driver_assigned", "driver_accepted", "driver_arrived"]);
+
+const STATUS_STYLES: Record<string, string> = {
+    scheduled: "bg-sky-100 text-sky-800",
+    searching: "bg-amber-100 text-amber-800",
+    driver_assigned: "bg-indigo-100 text-indigo-800",
+    driver_accepted: "bg-indigo-100 text-indigo-800",
+    driver_arrived: "bg-violet-100 text-violet-800",
+    in_progress: "bg-emerald-100 text-emerald-800",
+    completed: "bg-emerald-50 text-emerald-700",
+    cancelled: "bg-red-100 text-red-700",
+};
+
+function StatusBadge({ status }: { status: string }) {
+    return (
+        <Badge className={`${STATUS_STYLES[status] ?? "bg-muted text-foreground"} hover:bg-inherit`}>
+            {status.replace(/_/g, " ")}
+        </Badge>
+    );
+}
+
+export default function CompanyBookingsPage() {
+    const params = useParams();
+    const companyId = typeof params?.id === "string" ? params.id : "";
+    const memberships = useCompanyAuthStore((s) => s.memberships);
+    const isCompanyAdmin = useMemo(() => {
+        const m = memberships.find((p) => p.company.id === companyId);
+        return m?.membership.role === "owner" || m?.membership.role === "admin";
+    }, [memberships, companyId]);
+
+    const [rows, setRows] = useState<CompanyBookingRow[]>([]);
+    const [statusFilter, setStatusFilter] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [cancelling, setCancelling] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!companyId) return;
+        try {
+            const res = await listCompanyBookings(companyId, {
+                status: statusFilter || undefined,
+                limit: 100,
+            });
+            setRows(res.bookings);
+            setError(null);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load bookings");
+        } finally {
+            setLoading(false);
+        }
+    }, [companyId, statusFilter]);
+
+    useEffect(() => {
+        setLoading(true);
+        load();
+        const t = setInterval(load, POLL_MS);
+        return () => clearInterval(t);
+    }, [load]);
+
+    const handleCancel = async (rideId: string) => {
+        if (!window.confirm("Cancel this booking? The customer will be notified by text.")) return;
+        setCancelling(rideId);
+        try {
+            await cancelCompanyBooking(companyId, rideId);
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Cancel failed");
+        } finally {
+            setCancelling(null);
+        }
+    };
+
+    return (
+        <div className="space-y-4">
+            <header className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <h1 className="flex items-center gap-2 text-xl font-semibold">
+                        <ListChecks className="h-5 w-5" /> Bookings
+                    </h1>
+                    <p className="text-sm text-muted-foreground">
+                        {isCompanyAdmin
+                            ? "All rides booked by your company. Updates every few seconds."
+                            : "Rides you booked for customers. Updates every few seconds."}
+                    </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <select
+                        className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                        value={statusFilter}
+                        onChange={(e) => setStatusFilter(e.target.value)}
+                    >
+                        <option value="">All statuses</option>
+                        <option value="scheduled">Scheduled</option>
+                        <option value="searching">Finding driver</option>
+                        <option value="driver_accepted">Driver on the way</option>
+                        <option value="in_progress">In progress</option>
+                        <option value="completed">Completed</option>
+                        <option value="cancelled">Cancelled</option>
+                    </select>
+                    <Button variant="outline" size="sm" onClick={() => load()}>
+                        <RefreshCw className="h-4 w-4" />
+                    </Button>
+                    <Button size="sm" asChild>
+                        <Link href={`/company-portal/${companyId}/book`}>Book a ride</Link>
+                    </Button>
+                </div>
+            </header>
+
+            {error && <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+            {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+            <Card>
+                <CardContent className="p-0">
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="border-b bg-muted/40 text-left text-xs text-muted-foreground">
+                                    <th className="px-4 py-2 font-medium">Customer</th>
+                                    <th className="px-4 py-2 font-medium">Trip</th>
+                                    <th className="px-4 py-2 font-medium">Status</th>
+                                    <th className="px-4 py-2 font-medium">Fare</th>
+                                    <th className="px-4 py-2 font-medium">Payment</th>
+                                    <th className="px-4 py-2 font-medium">Booked</th>
+                                    <th className="px-4 py-2" />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {rows.map((r) => (
+                                    <tr key={r.ride_id} className="border-b last:border-0">
+                                        <td className="px-4 py-3">
+                                            <div className="font-medium">
+                                                {r.customer_first_name ?? "Customer"}
+                                            </div>
+                                            <div className="text-xs text-muted-foreground">
+                                                {r.ride_code ?? r.ride_id.slice(0, 8)}
+                                            </div>
+                                        </td>
+                                        <td className="max-w-[280px] px-4 py-3">
+                                            <div className="truncate text-xs">{r.pickup_address}</div>
+                                            <div className="truncate text-xs text-muted-foreground">
+                                                → {r.dropoff_address}
+                                            </div>
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <StatusBadge status={r.status} />
+                                            {r.scheduled_time && r.status === "scheduled" && (
+                                                <div className="mt-1 text-[11px] text-muted-foreground">
+                                                    {new Date(r.scheduled_time).toLocaleString()}
+                                                </div>
+                                            )}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            {r.grand_total != null ? `$${Number(r.grand_total).toFixed(2)}` : "—"}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <span className="text-xs text-muted-foreground">
+                                                {r.payment_status ?? "—"}
+                                            </span>
+                                        </td>
+                                        <td className="px-4 py-3 text-xs text-muted-foreground">
+                                            {r.created_at ? new Date(r.created_at).toLocaleString() : "—"}
+                                        </td>
+                                        <td className="px-4 py-3 text-right">
+                                            {PRE_TRIP.has(r.status) && (
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    disabled={cancelling === r.ride_id}
+                                                    onClick={() => handleCancel(r.ride_id)}
+                                                >
+                                                    {cancelling === r.ride_id ? (
+                                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                                    ) : (
+                                                        "Cancel"
+                                                    )}
+                                                </Button>
+                                            )}
+                                        </td>
+                                    </tr>
+                                ))}
+                                {!loading && rows.length === 0 && (
+                                    <tr>
+                                        <td
+                                            colSpan={7}
+                                            className="px-4 py-10 text-center text-sm text-muted-foreground"
+                                        >
+                                            No bookings yet.{" "}
+                                            <Link
+                                                href={`/company-portal/${companyId}/book`}
+                                                className="text-primary underline"
+                                            >
+                                                Book the first ride
+                                            </Link>
+                                            .
+                                        </td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/layout.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/layout.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import {
     ArrowLeft,
     Building2,
+    CalendarPlus,
     LayoutDashboard,
+    ListChecks,
     Receipt,
     ScrollText,
     Settings,
@@ -14,28 +16,33 @@ import {
     Users,
     Wallet,
 } from "lucide-react";
-import {
-    CorporateAccount,
-    getCorporateAccount,
-} from "@/lib/api";
+import { getMyWorkProfiles } from "@/lib/companyApi";
+import { useCompanyAuthStore, CompanyMembershipProfile } from "@/store/companyAuthStore";
 import { Badge } from "@/components/ui/badge";
 
 interface NavItem {
     href: string;
     label: string;
     icon: React.ComponentType<{ className?: string }>;
+    adminOnly?: boolean;
 }
 
+// Booking is every member's job (that's the product); org management stays
+// owner/admin. The backend guards enforce this regardless — hiding the nav
+// items is UX, not security.
 function buildNav(id: string): NavItem[] {
     return [
-        { href: `/company-portal/${id}/overview`, label: "Overview", icon: LayoutDashboard },
-        { href: `/company-portal/${id}/members`, label: "Members", icon: Users },
-        { href: `/company-portal/${id}/allowances`, label: "Allowances", icon: Wallet },
-        { href: `/company-portal/${id}/allowance-requests`, label: "Requests", icon: ScrollText },
-        { href: `/company-portal/${id}/policy`, label: "Policy", icon: ShieldCheck },
-        { href: `/company-portal/${id}/billing`, label: "Billing", icon: Receipt },
-        { href: `/company-portal/${id}/activity`, label: "Activity", icon: LayoutDashboard },
-        { href: `/company-portal/${id}/settings`, label: "Settings", icon: Settings },
+        { href: `/company-portal/${id}/book`, label: "Book a ride", icon: CalendarPlus },
+        { href: `/company-portal/${id}/bookings`, label: "Bookings", icon: ListChecks },
+        { href: `/company-portal/${id}/overview`, label: "Overview", icon: LayoutDashboard, adminOnly: true },
+        { href: `/company-portal/${id}/members`, label: "Members", icon: Users, adminOnly: true },
+        { href: `/company-portal/${id}/sections`, label: "Sections", icon: Users, adminOnly: true },
+        { href: `/company-portal/${id}/allowances`, label: "Allowances", icon: Wallet, adminOnly: true },
+        { href: `/company-portal/${id}/allowance-requests`, label: "Requests", icon: ScrollText, adminOnly: true },
+        { href: `/company-portal/${id}/policy`, label: "Policy", icon: ShieldCheck, adminOnly: true },
+        { href: `/company-portal/${id}/billing`, label: "Billing", icon: Receipt, adminOnly: true },
+        { href: `/company-portal/${id}/activity`, label: "Activity", icon: LayoutDashboard, adminOnly: true },
+        { href: `/company-portal/${id}/settings`, label: "Settings", icon: Settings, adminOnly: true },
     ];
 }
 
@@ -48,23 +55,32 @@ export default function CompanyPortalLayout({
     const pathname = usePathname();
     const router = useRouter();
     const id = typeof params?.id === "string" ? params.id : "";
-    const [company, setCompany] = useState<CorporateAccount | null>(null);
+    const memberships = useCompanyAuthStore((s) => s.memberships);
+    const setMemberships = useCompanyAuthStore((s) => s.setMemberships);
     const [error, setError] = useState<string | null>(null);
 
+    // Company identity comes from the caller's OWN membership (work-profile),
+    // not the staff corporate-accounts endpoint (403 for rider tokens).
+    const profile: CompanyMembershipProfile | undefined = useMemo(
+        () => memberships.find((m) => m.company.id === id),
+        [memberships, id]
+    );
+
     useEffect(() => {
-        if (!id) return;
-        getCorporateAccount(id)
-            .then(setCompany)
-            .catch((e) => {
-                const msg = e instanceof Error ? e.message : "Failed to load";
-                setError(msg);
-                if (/forbidden|not a company/i.test(msg)) {
+        if (!id || profile) return;
+        getMyWorkProfiles()
+            .then((rows) => {
+                setMemberships(rows);
+                if (!rows.some((m) => m.company.id === id)) {
+                    setError("You are not a member of this company.");
                     router.push("/company-portal");
                 }
-            });
-    }, [id, router]);
+            })
+            .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"));
+    }, [id, profile, router, setMemberships]);
 
-    const nav = buildNav(id);
+    const isCompanyAdmin = profile?.membership.role === "owner" || profile?.membership.role === "admin";
+    const nav = buildNav(id).filter((item) => isCompanyAdmin || !item.adminOnly);
 
     return (
         <div className="flex min-h-screen flex-col md:flex-row">
@@ -82,11 +98,11 @@ export default function CompanyPortalLayout({
                         </div>
                         <div>
                             <div className="font-semibold leading-tight">
-                                {company?.name ?? "Loading…"}
+                                {profile?.company.name ?? "Loading…"}
                             </div>
-                            {company?.status && (
+                            {profile?.membership.role && (
                                 <Badge className="mt-1 text-[10px] bg-emerald-100 text-emerald-800 hover:bg-emerald-100">
-                                    {company.status}
+                                    {profile.membership.role}
                                 </Badge>
                             )}
                         </div>
@@ -116,7 +132,7 @@ export default function CompanyPortalLayout({
             </aside>
 
             <main className="flex-1">
-                {error && !/forbidden|not a company/i.test(error) && (
+                {error && (
                     <div className="m-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                         {error}
                     </div>

--- a/admin-dashboard/src/app/company-portal/[id]/members/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/members/page.tsx
@@ -87,7 +87,15 @@ export default function MembersPage() {
                 email: inviteEmail.trim(),
                 role: inviteRole,
             });
-            setFeedback(`Invite sent — share: ${res.invite_url}`);
+            // The backend mints an app://join?token=… deep link (for the rider
+            // app). Desk employees follow a link in a browser, so surface a
+            // web link to the portal login that carries the same token.
+            const tokenMatch = /[?&]token=([^&]+)/.exec(res.invite_url ?? "");
+            const webLink =
+                tokenMatch && typeof window !== "undefined"
+                    ? `${window.location.origin}/company-login?invite_token=${tokenMatch[1]}`
+                    : res.invite_url;
+            setFeedback(`Invite sent — share this link: ${webLink}`);
             setInviteEmail("");
             await load();
         } catch (e) {

--- a/admin-dashboard/src/app/company-portal/[id]/members/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/members/page.tsx
@@ -2,14 +2,16 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
+import type {
     CorporateMember,
     CorporateMemberRole,
     CorporateMemberStatus,
+} from "@/lib/api";
+import {
     inviteCompanyMember,
     listCompanyMembers,
     updateCompanyMember,
-} from "@/lib/api";
+} from "@/lib/companyApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";

--- a/admin-dashboard/src/app/company-portal/[id]/overview/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/overview/page.tsx
@@ -3,14 +3,16 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import {
+import type {
     BillingSummary,
     CorporateMember,
     AllowanceRequestRow,
+} from "@/lib/api";
+import {
     getCompanyBillingSummary,
     listCompanyMembers,
     listCompanyAllowanceRequests,
-} from "@/lib/api";
+} from "@/lib/companyApi";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {

--- a/admin-dashboard/src/app/company-portal/[id]/policy/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/policy/page.tsx
@@ -2,13 +2,15 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
+import type {
     CorporatePolicy,
     PaymentSourcePolicy,
     TimeWindowPolicy,
+} from "@/lib/api";
+import {
     getCompanyPolicy,
     patchCompanyPolicy,
-} from "@/lib/api";
+} from "@/lib/companyApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";

--- a/admin-dashboard/src/app/company-portal/[id]/sections/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/sections/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { FolderTree, Loader2, Plus } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+    archiveCompanySection,
+    assignMemberSection,
+    createCompanySection,
+    listCompanySections,
+    CompanySection,
+} from "@/lib/companyApi";
+import { listCompanyMembers, CorporateMember } from "@/lib/api";
+
+/**
+ * Sections (departments) — grouping + reporting only; budgets stay
+ * per-member allowances. Owner/admin manage sections and assign members
+ * here; the bookings list filters by section.
+ */
+export default function CompanySectionsPage() {
+    const params = useParams();
+    const companyId = typeof params?.id === "string" ? params.id : "";
+
+    const [sections, setSections] = useState<CompanySection[]>([]);
+    const [members, setMembers] = useState<(CorporateMember & { section_id?: string | null })[]>([]);
+    const [newName, setNewName] = useState("");
+    const [busy, setBusy] = useState(false);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        if (!companyId) return;
+        try {
+            const [sec, mem] = await Promise.all([
+                listCompanySections(companyId),
+                listCompanyMembers(companyId, "active"),
+            ]);
+            setSections(sec.sections);
+            setMembers(mem as (CorporateMember & { section_id?: string | null })[]);
+            setError(null);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load sections");
+        } finally {
+            setLoading(false);
+        }
+    }, [companyId]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const handleCreate = async () => {
+        if (!newName.trim()) return;
+        setBusy(true);
+        setError(null);
+        try {
+            await createCompanySection(companyId, { name: newName.trim() });
+            setNewName("");
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Could not create section");
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const handleArchive = async (sectionId: string) => {
+        if (!window.confirm("Archive this section? Members keep their history; you can reassign them anytime.")) {
+            return;
+        }
+        try {
+            await archiveCompanySection(companyId, sectionId);
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Could not archive section");
+        }
+    };
+
+    const handleAssign = async (memberId: string, sectionId: string) => {
+        try {
+            await assignMemberSection(companyId, memberId, sectionId || null);
+            await load();
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Could not assign section");
+        }
+    };
+
+    const activeSections = sections.filter((s) => s.status === "active");
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="flex items-center gap-2 text-xl font-semibold">
+                    <FolderTree className="h-5 w-5" /> Sections
+                </h1>
+                <p className="text-sm text-muted-foreground">
+                    Organize your team into departments (showroom, service, …) — bookings
+                    and reports filter by section. Budgets stay per-employee allowances.
+                </p>
+            </header>
+
+            {error && <p className="rounded bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+            {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+            <Card>
+                <CardContent className="space-y-4 p-5">
+                    <div className="flex gap-2">
+                        <Input
+                            placeholder="New section name (e.g. Service Department)"
+                            value={newName}
+                            maxLength={80}
+                            onChange={(e) => setNewName(e.target.value)}
+                            onKeyDown={(e) => e.key === "Enter" && !busy && handleCreate()}
+                        />
+                        <Button onClick={handleCreate} disabled={busy || !newName.trim()}>
+                            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                            <span className="ml-1">Add</span>
+                        </Button>
+                    </div>
+
+                    <div className="space-y-2">
+                        {sections.map((s) => (
+                            <div
+                                key={s.id}
+                                className="flex items-center justify-between rounded-md border p-3"
+                            >
+                                <div>
+                                    <span className="font-medium">{s.name}</span>
+                                    <span className="ml-2 text-xs text-muted-foreground">
+                                        {s.member_count ?? 0} member{(s.member_count ?? 0) === 1 ? "" : "s"}
+                                    </span>
+                                    {s.status === "archived" && (
+                                        <Badge className="ml-2 bg-muted text-muted-foreground hover:bg-muted">
+                                            archived
+                                        </Badge>
+                                    )}
+                                </div>
+                                {s.status === "active" && (
+                                    <Button variant="ghost" size="sm" onClick={() => handleArchive(s.id)}>
+                                        Archive
+                                    </Button>
+                                )}
+                            </div>
+                        ))}
+                        {!loading && sections.length === 0 && (
+                            <p className="py-4 text-center text-sm text-muted-foreground">
+                                No sections yet — add your first above.
+                            </p>
+                        )}
+                    </div>
+                </CardContent>
+            </Card>
+
+            <Card>
+                <CardContent className="p-5">
+                    <h2 className="mb-3 text-sm font-semibold">Member assignments</h2>
+                    <div className="space-y-2">
+                        {members.map((m) => (
+                            <div
+                                key={m.id}
+                                className="flex items-center justify-between gap-3 rounded-md border p-3"
+                            >
+                                <div className="min-w-0">
+                                    <div className="truncate text-sm font-medium">
+                                        {m.invited_email ?? m.user_id ?? m.id}
+                                    </div>
+                                    <div className="text-xs text-muted-foreground">{m.role}</div>
+                                </div>
+                                <select
+                                    className="h-8 rounded-md border border-input bg-background px-2 text-sm"
+                                    value={m.section_id ?? ""}
+                                    onChange={(e) => handleAssign(m.id, e.target.value)}
+                                >
+                                    <option value="">No section</option>
+                                    {activeSections.map((s) => (
+                                        <option key={s.id} value={s.id}>
+                                            {s.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+                        ))}
+                        {!loading && members.length === 0 && (
+                            <p className="py-4 text-center text-sm text-muted-foreground">
+                                No active members yet.
+                            </p>
+                        )}
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/admin-dashboard/src/app/company-portal/[id]/sections/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/sections/page.tsx
@@ -14,7 +14,12 @@ import {
     listCompanySections,
     CompanySection,
 } from "@/lib/companyApi";
-import { listCompanyMembers, CorporateMember } from "@/lib/api";
+import type {
+    CorporateMember,
+} from "@/lib/api";
+import {
+    listCompanyMembers,
+} from "@/lib/companyApi";
 
 /**
  * Sections (departments) — grouping + reporting only; budgets stay

--- a/admin-dashboard/src/app/company-portal/[id]/settings/page.tsx
+++ b/admin-dashboard/src/app/company-portal/[id]/settings/page.tsx
@@ -2,24 +2,20 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import {
-    AllowedDomainRow,
-    CorporateAccount,
-    addAllowedDomain,
-    getCorporateAccount,
-    listAllowedDomains,
-    removeAllowedDomain,
-} from "@/lib/api";
+import type { AllowedDomainRow } from "@/lib/api";
+import { addAllowedDomain, listAllowedDomains, removeAllowedDomain } from "@/lib/companyApi";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
 import { Globe, Trash2 } from "lucide-react";
 
+// Company-session settings: allowed email domains only. Company KYB/profile
+// details (legal name, business number, tax region…) are staff-managed and
+// are not exposed via the /company/{id} rider-token endpoints, so they live
+// in the staff dashboard, not this portal.
 export default function SettingsPage() {
     const { id } = useParams<{ id: string }>();
-    const [company, setCompany] = useState<CorporateAccount | null>(null);
     const [domains, setDomains] = useState<AllowedDomainRow[]>([]);
     const [newDomain, setNewDomain] = useState("");
     const [busy, setBusy] = useState(false);
@@ -31,12 +27,7 @@ export default function SettingsPage() {
         if (!id) return;
         setLoading(true);
         try {
-            const [c, d] = await Promise.all([
-                getCorporateAccount(id).catch(() => null),
-                listAllowedDomains(id).catch(() => []),
-            ]);
-            setCompany(c);
-            setDomains(d);
+            setDomains(await listAllowedDomains(id));
         } catch (e) {
             setError(e instanceof Error ? e.message : "Failed to load");
         } finally {
@@ -83,49 +74,16 @@ export default function SettingsPage() {
         <div className="space-y-6">
             <header>
                 <h1 className="text-2xl font-semibold">Settings</h1>
-                <p className="text-muted-foreground">
-                    Company details and approved email domains.
-                </p>
+                <p className="text-muted-foreground">Approved email domains for your team.</p>
             </header>
-
-            <Card>
-                <CardContent className="space-y-2 p-4 text-sm">
-                    {loading ? (
-                        <p className="text-muted-foreground">Loading…</p>
-                    ) : (
-                        <>
-                            <Row label="Name" value={company?.name} />
-                            <Row label="Legal name" value={company?.legal_name} />
-                            <Row label="Business number" value={company?.business_number} />
-                            <Row label="Tax region" value={company?.tax_region} />
-                            <Row
-                                label="Billing email"
-                                value={company?.billing_email ?? "—"}
-                            />
-                            <Row label="Contact name" value={company?.contact_name} />
-                            <Row label="Contact email" value={company?.contact_email} />
-                            <Row label="Contact phone" value={company?.contact_phone} />
-                            <Row label="Size tier" value={company?.size_tier} />
-                            <Row
-                                label="Status"
-                                value={
-                                    <Badge className="bg-emerald-100 text-emerald-800">
-                                        {company?.status}
-                                    </Badge>
-                                }
-                            />
-                        </>
-                    )}
-                </CardContent>
-            </Card>
 
             <Card>
                 <CardContent className="space-y-4 p-4">
                     <div>
                         <h2 className="font-medium">Allowed email domains</h2>
                         <p className="text-xs text-muted-foreground">
-                            Members whose verified email matches an allowed domain can
-                            join without an explicit invite.
+                            Members whose verified email matches an allowed domain can join
+                            without an explicit invite.
                         </p>
                     </div>
 
@@ -141,29 +99,19 @@ export default function SettingsPage() {
                                 onChange={(e) => setNewDomain(e.target.value)}
                             />
                         </div>
-                        <Button
-                            onClick={onAdd}
-                            disabled={busy || !newDomain.trim()}
-                        >
+                        <Button onClick={onAdd} disabled={busy || !newDomain.trim()}>
                             Add
                         </Button>
                     </div>
 
                     {feedback && (
-                        <p className="rounded bg-emerald-50 p-2 text-xs text-emerald-800">
-                            {feedback}
-                        </p>
+                        <p className="rounded bg-emerald-50 p-2 text-xs text-emerald-800">{feedback}</p>
                     )}
-                    {error && (
-                        <p className="rounded bg-red-50 p-2 text-xs text-red-700">{error}</p>
-                    )}
+                    {error && <p className="rounded bg-red-50 p-2 text-xs text-red-700">{error}</p>}
 
                     <ul className="divide-y divide-border">
                         {domains.map((d) => (
-                            <li
-                                key={d.domain}
-                                className="flex items-center justify-between py-2"
-                            >
+                            <li key={d.domain} className="flex items-center justify-between py-2">
                                 <span className="flex items-center gap-2 text-sm">
                                     <Globe className="h-3.5 w-3.5 text-muted-foreground" />
                                     {d.domain}
@@ -186,21 +134,6 @@ export default function SettingsPage() {
                     </ul>
                 </CardContent>
             </Card>
-        </div>
-    );
-}
-
-function Row({
-    label,
-    value,
-}: {
-    label: string;
-    value?: React.ReactNode;
-}) {
-    return (
-        <div className="flex items-center justify-between border-b border-border py-1.5 last:border-b-0">
-            <span className="text-muted-foreground">{label}</span>
-            <span className="font-medium">{value ?? "—"}</span>
         </div>
     );
 }

--- a/admin-dashboard/src/app/company-portal/layout.tsx
+++ b/admin-dashboard/src/app/company-portal/layout.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useCompanyAuthStore } from "@/store/companyAuthStore";
 
 /**
  * Company-portal root gate — bound to the COMPANY session (rider-token
  * companyAuthStore), never the staff admin session. The edge middleware
- * already bounces cookie-less visits to /company-login; this client gate
- * covers in-app state (logout, expired rehydrated session) and restores a
- * rehydrated session's access token via silent refresh.
+ * already lets the shell through when a refreshable session (company_session
+ * marker) exists; this client gate then restores the access token from the
+ * HttpOnly refresh cookie BEFORE deciding to redirect.
  */
 export default function CompanyPortalRootLayout({
     children,
@@ -18,26 +18,33 @@ export default function CompanyPortalRootLayout({
 }) {
     const router = useRouter();
     const { isAuthenticated, isLoading, token, silentRefresh, logout } = useCompanyAuthStore();
+    const attempted = useRef(false);
+    const [checking, setChecking] = useState(true);
 
-    // Rehydrated session (profile persisted, token memory-only): restore the
-    // access token from the HttpOnly refresh cookie before rendering.
+    // Whenever we lack a live authenticated token, try silentRefresh FIRST and
+    // only redirect if it fails. This covers BOTH a rehydrated session
+    // (isAuthenticated, token dropped from memory) AND a fresh tab / bookmark
+    // where sessionStorage is empty (isAuthenticated=false) but the 30-day
+    // refresh cookie the middleware allowed through is still valid — otherwise
+    // that valid session would be treated as logged out.
     useEffect(() => {
-        if (!isLoading && isAuthenticated && !token) {
-            silentRefresh().then((ok) => {
-                if (!ok) {
-                    logout().then(() => router.replace("/company-login?next=/company-portal"));
-                }
-            });
+        if (isLoading) return;
+        if (isAuthenticated && token) {
+            setChecking(false);
+            return;
         }
+        if (attempted.current) return;
+        attempted.current = true;
+        silentRefresh().then((ok) => {
+            if (ok) {
+                setChecking(false);
+            } else {
+                logout().then(() => router.replace("/company-login?next=/company-portal"));
+            }
+        });
     }, [isAuthenticated, isLoading, token, silentRefresh, logout, router]);
 
-    useEffect(() => {
-        if (!isLoading && !isAuthenticated) {
-            router.replace("/company-login?next=/company-portal");
-        }
-    }, [isAuthenticated, isLoading, router]);
-
-    if (isLoading) {
+    if (isLoading || checking) {
         return (
             <div className="flex items-center justify-center min-h-screen bg-background">
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />

--- a/admin-dashboard/src/app/company-portal/layout.tsx
+++ b/admin-dashboard/src/app/company-portal/layout.tsx
@@ -2,19 +2,38 @@
 
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useAuthStore } from "@/store/authStore";
+import { useCompanyAuthStore } from "@/store/companyAuthStore";
 
+/**
+ * Company-portal root gate — bound to the COMPANY session (rider-token
+ * companyAuthStore), never the staff admin session. The edge middleware
+ * already bounces cookie-less visits to /company-login; this client gate
+ * covers in-app state (logout, expired rehydrated session) and restores a
+ * rehydrated session's access token via silent refresh.
+ */
 export default function CompanyPortalRootLayout({
     children,
 }: {
     children: React.ReactNode;
 }) {
     const router = useRouter();
-    const { isAuthenticated, isLoading } = useAuthStore();
+    const { isAuthenticated, isLoading, token, silentRefresh, logout } = useCompanyAuthStore();
+
+    // Rehydrated session (profile persisted, token memory-only): restore the
+    // access token from the HttpOnly refresh cookie before rendering.
+    useEffect(() => {
+        if (!isLoading && isAuthenticated && !token) {
+            silentRefresh().then((ok) => {
+                if (!ok) {
+                    logout().then(() => router.replace("/company-login?next=/company-portal"));
+                }
+            });
+        }
+    }, [isAuthenticated, isLoading, token, silentRefresh, logout, router]);
 
     useEffect(() => {
         if (!isLoading && !isAuthenticated) {
-            router.replace("/login?next=/company-portal");
+            router.replace("/company-login?next=/company-portal");
         }
     }, [isAuthenticated, isLoading, router]);
 

--- a/admin-dashboard/src/app/company-portal/page.tsx
+++ b/admin-dashboard/src/app/company-portal/page.tsx
@@ -2,30 +2,55 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Building2, ChevronRight } from "lucide-react";
-import { getCorporateAccounts, CorporateAccount } from "@/lib/api";
+import { useRouter } from "next/navigation";
+import { Building2, ChevronRight, LogOut } from "lucide-react";
+import { getMyWorkProfiles } from "@/lib/companyApi";
+import { useCompanyAuthStore, CompanyMembershipProfile } from "@/store/companyAuthStore";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 
+/**
+ * Company selector — the caller's OWN memberships (GET /rider/work-profile),
+ * never a staff-wide company list. Auto-enters when there's exactly one.
+ */
 export default function CompanyPortalLandingPage() {
-    const [companies, setCompanies] = useState<CorporateAccount[]>([]);
+    const router = useRouter();
+    const setMemberships = useCompanyAuthStore((s) => s.setMemberships);
+    const logout = useCompanyAuthStore((s) => s.logout);
+    const [profiles, setProfiles] = useState<CompanyMembershipProfile[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        getCorporateAccounts()
-            .then((rows) => setCompanies(rows.filter((c) => c.status === "active")))
+        getMyWorkProfiles()
+            .then((rows) => {
+                setProfiles(rows);
+                setMemberships(rows);
+                if (rows.length === 1) {
+                    router.replace(`/company-portal/${rows[0].company.id}/overview`);
+                }
+            })
             .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
             .finally(() => setLoading(false));
-    }, []);
+    }, [router, setMemberships]);
 
     return (
         <div className="mx-auto max-w-3xl p-6 md:p-10">
-            <header className="mb-8">
-                <h1 className="text-2xl font-semibold">Company Portal</h1>
-                <p className="text-muted-foreground">
-                    Select a company to manage members, policies, and billing.
-                </p>
+            <header className="mb-8 flex items-start justify-between">
+                <div>
+                    <h1 className="text-2xl font-semibold">Company Portal</h1>
+                    <p className="text-muted-foreground">
+                        Select a company to book rides and manage your team.
+                    </p>
+                </div>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => logout().then(() => router.replace("/company-login"))}
+                >
+                    <LogOut className="mr-1 h-4 w-4" /> Sign out
+                </Button>
             </header>
 
             {loading && <p className="text-sm text-muted-foreground">Loading…</p>}
@@ -34,10 +59,10 @@ export default function CompanyPortalLandingPage() {
             )}
 
             <div className="space-y-3">
-                {companies.map((c) => (
+                {profiles.map((p) => (
                     <Link
-                        key={c.id}
-                        href={`/company-portal/${c.id}/overview`}
+                        key={p.company.id}
+                        href={`/company-portal/${p.company.id}/overview`}
                         className="block"
                     >
                         <Card className="transition-colors hover:bg-muted/40">
@@ -47,15 +72,15 @@ export default function CompanyPortalLandingPage() {
                                         <Building2 className="h-5 w-5 text-emerald-600" />
                                     </div>
                                     <div>
-                                        <div className="font-medium">{c.name}</div>
+                                        <div className="font-medium">{p.company.name}</div>
                                         <div className="text-xs text-muted-foreground">
-                                            {c.legal_name ?? c.tax_region ?? c.size_tier}
+                                            Signed in as {p.membership.role}
                                         </div>
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-3">
                                     <Badge className="bg-emerald-100 text-emerald-800 hover:bg-emerald-100">
-                                        {c.status}
+                                        {p.membership.role}
                                     </Badge>
                                     <ChevronRight className="h-4 w-4 text-muted-foreground" />
                                 </div>
@@ -63,10 +88,11 @@ export default function CompanyPortalLandingPage() {
                         </Card>
                     </Link>
                 ))}
-                {!loading && companies.length === 0 && !error && (
+                {!loading && profiles.length === 0 && !error && (
                     <Card>
                         <CardContent className="p-6 text-center text-sm text-muted-foreground">
-                            No active companies found.
+                            No company memberships on this account. Ask your company admin
+                            for an invite link, then sign in here again.
                         </CardContent>
                     </Card>
                 )}

--- a/admin-dashboard/src/app/company-portal/page.tsx
+++ b/admin-dashboard/src/app/company-portal/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Building2, ChevronRight, LogOut } from "lucide-react";
-import { getMyWorkProfiles } from "@/lib/companyApi";
+import { getMyWorkProfiles, portalHome } from "@/lib/companyApi";
 import { useCompanyAuthStore, CompanyMembershipProfile } from "@/store/companyAuthStore";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -28,7 +28,7 @@ export default function CompanyPortalLandingPage() {
                 setProfiles(rows);
                 setMemberships(rows);
                 if (rows.length === 1) {
-                    router.replace(`/company-portal/${rows[0].company.id}/overview`);
+                    router.replace(portalHome(rows[0].company.id, rows[0].membership.role));
                 }
             })
             .catch((e) => setError(e instanceof Error ? e.message : "Failed to load"))
@@ -62,7 +62,7 @@ export default function CompanyPortalLandingPage() {
                 {profiles.map((p) => (
                     <Link
                         key={p.company.id}
-                        href={`/company-portal/${p.company.id}/overview`}
+                        href={portalHome(p.company.id, p.membership.role)}
                         className="block"
                     >
                         <Card className="transition-colors hover:bg-muted/40">

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -4,7 +4,6 @@ const API_BASE = "";
 
 // Import Zustand store for token management
 import { useAuthStore } from "@/store/authStore";
-import { companyRequest } from "./companyApi";
 
 // ─── B-P1-8: typed rate-limit error ──────────────────────────────────
 // Mirrors shared/api/client.ts's RateLimitError so admin login,
@@ -59,14 +58,6 @@ const parseIntHeader = (header: string | null): number | null => {
 };
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-    // Company-portal delegation: /api/company/* and /api/rider/work-profile*
-    // authenticate with the RIDER-token session (companyAuthStore), not the
-    // staff session — and their 401s must bounce to /company-login, never
-    // /login. Routing here keeps the portal pages' existing imports intact.
-    if (path.startsWith("/api/company/") || path.startsWith("/api/rider/work-profile")) {
-        return companyRequest<T>(path, options);
-    }
-
     // Get token from Zustand store
     const store = useAuthStore.getState();
     const token = store.token;
@@ -1468,7 +1459,7 @@ export interface AllowanceRequestRow {
 
 export const listCompanyMembers = (companyId: string, status?: string) =>
     request<CorporateMember[]>(
-        `/api/company/${companyId}/members${status ? `?status=${encodeURIComponent(status)}` : ""}`
+        `/company/${companyId}/members${status ? `?status=${encodeURIComponent(status)}` : ""}`
     );
 
 export const inviteCompanyMember = (
@@ -1476,18 +1467,18 @@ export const inviteCompanyMember = (
     body: { email: string; role: CorporateMemberRole; policy_override?: boolean }
 ) =>
     request<{ member: CorporateMember; invite_url: string }>(
-        `/api/company/${companyId}/members/invite`,
+        `/company/${companyId}/members/invite`,
         { method: "POST", body: JSON.stringify(body) }
     );
 
 export const removeCompanyMember = (companyId: string, memberId: string) =>
-    request<CorporateMember>(`/api/company/${companyId}/members/${memberId}`, {
+    request<CorporateMember>(`/company/${companyId}/members/${memberId}`, {
         method: "DELETE",
     });
 
 export const getMemberAllowance = (companyId: string, memberId: string) =>
     request<CorporateAllowance | Record<string, never>>(
-        `/api/company/${companyId}/members/${memberId}/allowance`
+        `/company/${companyId}/members/${memberId}/allowance`
     );
 
 export const putMemberAllowance = (
@@ -1504,13 +1495,13 @@ export const putMemberAllowance = (
     }
 ) =>
     request<CorporateAllowance>(
-        `/api/company/${companyId}/members/${memberId}/allowance`,
+        `/company/${companyId}/members/${memberId}/allowance`,
         { method: "PUT", body: JSON.stringify(body) }
     );
 
 export const listCompanyAllowanceRequests = (companyId: string, status = "pending") =>
     request<AllowanceRequestRow[]>(
-        `/api/company/${companyId}/allowance-requests?status=${encodeURIComponent(status)}`
+        `/company/${companyId}/allowance-requests?status=${encodeURIComponent(status)}`
     );
 
 export const decideAllowanceRequest = (
@@ -1519,7 +1510,7 @@ export const decideAllowanceRequest = (
     body: { approve: boolean; note?: string }
 ) =>
     request<AllowanceRequestRow>(
-        `/api/company/${companyId}/allowance-requests/${requestId}/decide`,
+        `/company/${companyId}/allowance-requests/${requestId}/decide`,
         { method: "POST", body: JSON.stringify(body) }
     );
 
@@ -1529,7 +1520,7 @@ export const updateCompanyMember = (
     body: { role?: CorporateMemberRole; status?: CorporateMemberStatus; policy_override?: boolean }
 ) =>
     request<CorporateMember>(
-        `/api/company/${companyId}/members/${memberId}`,
+        `/company/${companyId}/members/${memberId}`,
         { method: "PATCH", body: JSON.stringify(body) }
     );
 
@@ -1553,13 +1544,13 @@ export interface CorporatePolicy {
 }
 
 export const getCompanyPolicy = (companyId: string) =>
-    request<CorporatePolicy | Record<string, never>>(`/api/company/${companyId}/policy`);
+    request<CorporatePolicy | Record<string, never>>(`/company/${companyId}/policy`);
 
 export const putCompanyPolicy = (
     companyId: string,
     body: Omit<CorporatePolicy, "id" | "company_id">
 ) =>
-    request<CorporatePolicy>(`/api/company/${companyId}/policy`, {
+    request<CorporatePolicy>(`/company/${companyId}/policy`, {
         method: "PUT",
         body: JSON.stringify(body),
     });
@@ -1568,7 +1559,7 @@ export const patchCompanyPolicy = (
     companyId: string,
     body: Partial<Omit<CorporatePolicy, "id" | "company_id">>
 ) =>
-    request<CorporatePolicy>(`/api/company/${companyId}/policy`, {
+    request<CorporatePolicy>(`/company/${companyId}/policy`, {
         method: "PATCH",
         body: JSON.stringify(body),
     });
@@ -1580,17 +1571,17 @@ export interface AllowedDomainRow {
 }
 
 export const listAllowedDomains = (companyId: string) =>
-    request<AllowedDomainRow[]>(`/api/company/${companyId}/allowed-domains`);
+    request<AllowedDomainRow[]>(`/company/${companyId}/allowed-domains`);
 
 export const addAllowedDomain = (companyId: string, domain: string) =>
-    request<AllowedDomainRow>(`/api/company/${companyId}/allowed-domains`, {
+    request<AllowedDomainRow>(`/company/${companyId}/allowed-domains`, {
         method: "POST",
         body: JSON.stringify({ domain }),
     });
 
 export const removeAllowedDomain = (companyId: string, domain: string) =>
     request<{ status: string }>(
-        `/api/company/${companyId}/allowed-domains/${encodeURIComponent(domain)}`,
+        `/company/${companyId}/allowed-domains/${encodeURIComponent(domain)}`,
         { method: "DELETE" }
     );
 
@@ -1661,12 +1652,12 @@ export interface BillingTransactionsPage {
 
 export const getCompanyBillingSummary = (companyId: string, month?: string) => {
     const qs = month ? `?month=${encodeURIComponent(month)}` : "";
-    return request<BillingSummary>(`/api/company/${companyId}/billing/summary${qs}`);
+    return request<BillingSummary>(`/company/${companyId}/billing/summary${qs}`);
 };
 
 export const getCompanyBillingStatement = (companyId: string, month: string) =>
     request<BillingStatement>(
-        `/api/company/${companyId}/billing/statements/${encodeURIComponent(month)}`
+        `/company/${companyId}/billing/statements/${encodeURIComponent(month)}`
     );
 
 export const getCompanyBillingTransactions = (
@@ -1675,7 +1666,7 @@ export const getCompanyBillingTransactions = (
     limit = 50
 ) =>
     request<BillingTransactionsPage>(
-        `/api/company/${companyId}/billing/transactions?skip=${skip}&limit=${limit}`
+        `/company/${companyId}/billing/transactions?skip=${skip}&limit=${limit}`
     );
 
 /* ── Cloud Messaging (merged with Notifications) ── */

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -4,6 +4,7 @@ const API_BASE = "";
 
 // Import Zustand store for token management
 import { useAuthStore } from "@/store/authStore";
+import { companyRequest } from "./companyApi";
 
 // ─── B-P1-8: typed rate-limit error ──────────────────────────────────
 // Mirrors shared/api/client.ts's RateLimitError so admin login,
@@ -58,6 +59,14 @@ const parseIntHeader = (header: string | null): number | null => {
 };
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+    // Company-portal delegation: /api/company/* and /api/rider/work-profile*
+    // authenticate with the RIDER-token session (companyAuthStore), not the
+    // staff session — and their 401s must bounce to /company-login, never
+    // /login. Routing here keeps the portal pages' existing imports intact.
+    if (path.startsWith("/api/company/") || path.startsWith("/api/rider/work-profile")) {
+        return companyRequest<T>(path, options);
+    }
+
     // Get token from Zustand store
     const store = useAuthStore.getState();
     const token = store.token;
@@ -1459,7 +1468,7 @@ export interface AllowanceRequestRow {
 
 export const listCompanyMembers = (companyId: string, status?: string) =>
     request<CorporateMember[]>(
-        `/company/${companyId}/members${status ? `?status=${encodeURIComponent(status)}` : ""}`
+        `/api/company/${companyId}/members${status ? `?status=${encodeURIComponent(status)}` : ""}`
     );
 
 export const inviteCompanyMember = (
@@ -1467,18 +1476,18 @@ export const inviteCompanyMember = (
     body: { email: string; role: CorporateMemberRole; policy_override?: boolean }
 ) =>
     request<{ member: CorporateMember; invite_url: string }>(
-        `/company/${companyId}/members/invite`,
+        `/api/company/${companyId}/members/invite`,
         { method: "POST", body: JSON.stringify(body) }
     );
 
 export const removeCompanyMember = (companyId: string, memberId: string) =>
-    request<CorporateMember>(`/company/${companyId}/members/${memberId}`, {
+    request<CorporateMember>(`/api/company/${companyId}/members/${memberId}`, {
         method: "DELETE",
     });
 
 export const getMemberAllowance = (companyId: string, memberId: string) =>
     request<CorporateAllowance | Record<string, never>>(
-        `/company/${companyId}/members/${memberId}/allowance`
+        `/api/company/${companyId}/members/${memberId}/allowance`
     );
 
 export const putMemberAllowance = (
@@ -1495,13 +1504,13 @@ export const putMemberAllowance = (
     }
 ) =>
     request<CorporateAllowance>(
-        `/company/${companyId}/members/${memberId}/allowance`,
+        `/api/company/${companyId}/members/${memberId}/allowance`,
         { method: "PUT", body: JSON.stringify(body) }
     );
 
 export const listCompanyAllowanceRequests = (companyId: string, status = "pending") =>
     request<AllowanceRequestRow[]>(
-        `/company/${companyId}/allowance-requests?status=${encodeURIComponent(status)}`
+        `/api/company/${companyId}/allowance-requests?status=${encodeURIComponent(status)}`
     );
 
 export const decideAllowanceRequest = (
@@ -1510,7 +1519,7 @@ export const decideAllowanceRequest = (
     body: { approve: boolean; note?: string }
 ) =>
     request<AllowanceRequestRow>(
-        `/company/${companyId}/allowance-requests/${requestId}/decide`,
+        `/api/company/${companyId}/allowance-requests/${requestId}/decide`,
         { method: "POST", body: JSON.stringify(body) }
     );
 
@@ -1520,7 +1529,7 @@ export const updateCompanyMember = (
     body: { role?: CorporateMemberRole; status?: CorporateMemberStatus; policy_override?: boolean }
 ) =>
     request<CorporateMember>(
-        `/company/${companyId}/members/${memberId}`,
+        `/api/company/${companyId}/members/${memberId}`,
         { method: "PATCH", body: JSON.stringify(body) }
     );
 
@@ -1544,13 +1553,13 @@ export interface CorporatePolicy {
 }
 
 export const getCompanyPolicy = (companyId: string) =>
-    request<CorporatePolicy | Record<string, never>>(`/company/${companyId}/policy`);
+    request<CorporatePolicy | Record<string, never>>(`/api/company/${companyId}/policy`);
 
 export const putCompanyPolicy = (
     companyId: string,
     body: Omit<CorporatePolicy, "id" | "company_id">
 ) =>
-    request<CorporatePolicy>(`/company/${companyId}/policy`, {
+    request<CorporatePolicy>(`/api/company/${companyId}/policy`, {
         method: "PUT",
         body: JSON.stringify(body),
     });
@@ -1559,7 +1568,7 @@ export const patchCompanyPolicy = (
     companyId: string,
     body: Partial<Omit<CorporatePolicy, "id" | "company_id">>
 ) =>
-    request<CorporatePolicy>(`/company/${companyId}/policy`, {
+    request<CorporatePolicy>(`/api/company/${companyId}/policy`, {
         method: "PATCH",
         body: JSON.stringify(body),
     });
@@ -1571,17 +1580,17 @@ export interface AllowedDomainRow {
 }
 
 export const listAllowedDomains = (companyId: string) =>
-    request<AllowedDomainRow[]>(`/company/${companyId}/allowed-domains`);
+    request<AllowedDomainRow[]>(`/api/company/${companyId}/allowed-domains`);
 
 export const addAllowedDomain = (companyId: string, domain: string) =>
-    request<AllowedDomainRow>(`/company/${companyId}/allowed-domains`, {
+    request<AllowedDomainRow>(`/api/company/${companyId}/allowed-domains`, {
         method: "POST",
         body: JSON.stringify({ domain }),
     });
 
 export const removeAllowedDomain = (companyId: string, domain: string) =>
     request<{ status: string }>(
-        `/company/${companyId}/allowed-domains/${encodeURIComponent(domain)}`,
+        `/api/company/${companyId}/allowed-domains/${encodeURIComponent(domain)}`,
         { method: "DELETE" }
     );
 
@@ -1652,12 +1661,12 @@ export interface BillingTransactionsPage {
 
 export const getCompanyBillingSummary = (companyId: string, month?: string) => {
     const qs = month ? `?month=${encodeURIComponent(month)}` : "";
-    return request<BillingSummary>(`/company/${companyId}/billing/summary${qs}`);
+    return request<BillingSummary>(`/api/company/${companyId}/billing/summary${qs}`);
 };
 
 export const getCompanyBillingStatement = (companyId: string, month: string) =>
     request<BillingStatement>(
-        `/company/${companyId}/billing/statements/${encodeURIComponent(month)}`
+        `/api/company/${companyId}/billing/statements/${encodeURIComponent(month)}`
     );
 
 export const getCompanyBillingTransactions = (
@@ -1666,7 +1675,7 @@ export const getCompanyBillingTransactions = (
     limit = 50
 ) =>
     request<BillingTransactionsPage>(
-        `/company/${companyId}/billing/transactions?skip=${skip}&limit=${limit}`
+        `/api/company/${companyId}/billing/transactions?skip=${skip}&limit=${limit}`
     );
 
 /* ── Cloud Messaging (merged with Notifications) ── */

--- a/admin-dashboard/src/lib/companyApi.ts
+++ b/admin-dashboard/src/lib/companyApi.ts
@@ -1,0 +1,275 @@
+// Company-portal API client (Spinr for Business).
+//
+// Same relative-URL/proxy contract as lib/api.ts, but bound to the
+// companyAuthStore rider session: 401s silent-refresh via the HttpOnly
+// refresh cookie and bounce to /company-login (never the staff /login).
+// lib/api.ts's request() delegates any /api/company/* or
+// /api/rider/work-profile* path here, so the existing portal pages keep
+// their imports untouched.
+
+import { useCompanyAuthStore, CompanyMembershipProfile } from "@/store/companyAuthStore";
+
+const API_BASE = "";
+
+export async function companyRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const store = useCompanyAuthStore.getState();
+    const isFormData = typeof FormData !== "undefined" && options.body instanceof FormData;
+    const headers: Record<string, string> = {
+        ...(isFormData ? {} : { "Content-Type": "application/json" }),
+        ...(options.headers as Record<string, string>),
+    };
+    if (store.token && !headers["Authorization"]) {
+        headers["Authorization"] = `Bearer ${store.token}`;
+    }
+    const method = (options.method ?? "GET").toUpperCase();
+    if (!["GET", "HEAD", "OPTIONS"].includes(method) && store.csrfToken) {
+        headers["X-CSRF-Token"] = store.csrfToken;
+    }
+
+    const url = `${API_BASE}${path}`;
+    const res = await fetch(url, { ...options, headers });
+
+    if (res.status === 401) {
+        const refreshed = await store.silentRefresh();
+        if (refreshed) {
+            const newToken = useCompanyAuthStore.getState().token;
+            const retryHeaders = { ...headers, Authorization: `Bearer ${newToken}` };
+            const retryRes = await fetch(url, { ...options, headers: retryHeaders });
+            if (retryRes.ok) return retryRes.json() as T;
+            if (retryRes.status !== 401) {
+                const retryBody = await retryRes.json().catch(() => ({}));
+                throw new Error(
+                    retryBody.detail?.message ?? retryBody.detail ?? retryBody.message ?? retryRes.statusText
+                );
+            }
+        }
+        await useCompanyAuthStore.getState().logout();
+        if (typeof window !== "undefined") {
+            window.location.href = "/company-login";
+        }
+        throw new Error("Unauthorized");
+    }
+
+    if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        const detail = body.detail;
+        const message =
+            (typeof detail === "object" && detail?.message) ||
+            (typeof detail === "string" && detail) ||
+            body.message ||
+            res.statusText;
+        const err = new Error(message) as Error & { status?: number; detail?: unknown };
+        err.status = res.status;
+        err.detail = detail;
+        throw err;
+    }
+    return res.json() as T;
+}
+
+/* ── Portal auth (phone OTP — rider identity) ── */
+
+export const sendCompanyOtp = async (phone: string): Promise<void> => {
+    const res = await fetch("/api/v1/auth/send-otp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone }),
+    });
+    if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail?.message ?? body.detail ?? body.message ?? "Could not send code");
+    }
+};
+
+export interface CompanyOtpVerifyResult {
+    token: string;
+    csrf_token?: string;
+    user: { id: string; phone?: string; first_name?: string; last_name?: string };
+}
+
+export const verifyCompanyOtp = async (phone: string, code: string): Promise<CompanyOtpVerifyResult> => {
+    const res = await fetch("/api/v1/auth/verify-otp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ phone, code }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        throw new Error(body.detail?.message ?? body.detail ?? body.message ?? "Invalid code");
+    }
+    return body as CompanyOtpVerifyResult;
+};
+
+export const getMyWorkProfiles = () =>
+    companyRequest<CompanyMembershipProfile[]>("/api/rider/work-profile");
+
+export const acceptCompanyInvite = (token: string) =>
+    companyRequest<{ membership?: unknown; status?: string }>(
+        "/api/rider/work-profile/accept-invite",
+        { method: "POST", body: JSON.stringify({ token }) }
+    );
+
+/* ── Guest bookings ── */
+
+export interface CompanyBookingRow {
+    ride_id: string;
+    ride_code?: string | null;
+    status: string;
+    guest_booking: boolean;
+    customer_first_name?: string | null;
+    booked_by_member_id?: string | null;
+    booked_by_name?: string | null;
+    section_id?: string | null;
+    pickup_address?: string;
+    dropoff_address?: string;
+    scheduled_time?: string | null;
+    created_at?: string;
+    grand_total?: number | string | null;
+    payment_status?: string | null;
+    cancelled_reason?: string | null;
+}
+
+export interface CreateBookingBody {
+    customer_name: string;
+    customer_phone: string;
+    pickup_address: string;
+    pickup_lat: number;
+    pickup_lng: number;
+    dropoff_address: string;
+    dropoff_lat: number;
+    dropoff_lng: number;
+    distance_km: number;
+    duration_minutes: number;
+    vehicle_type_id: string;
+    scheduled_time?: string | null;
+    rider_notes?: string | null;
+}
+
+export interface CreateBookingResult {
+    success: boolean;
+    booking: CompanyBookingRow;
+    tracking_url?: string | null;
+    customer_has_app?: boolean;
+}
+
+export const createCompanyBooking = (companyId: string, body: CreateBookingBody) =>
+    companyRequest<CreateBookingResult>(`/api/company/${companyId}/bookings`, {
+        method: "POST",
+        body: JSON.stringify(body),
+    });
+
+export const listCompanyBookings = (
+    companyId: string,
+    params: {
+        status?: string;
+        member_id?: string;
+        section_id?: string;
+        from?: string;
+        to?: string;
+        skip?: number;
+        limit?: number;
+    } = {}
+) => {
+    const qs = new URLSearchParams();
+    Object.entries(params).forEach(([k, v]) => {
+        if (v !== undefined && v !== null && v !== "") qs.set(k, String(v));
+    });
+    const q = qs.toString();
+    return companyRequest<{ bookings: CompanyBookingRow[]; skip: number; limit: number }>(
+        `/api/company/${companyId}/bookings${q ? `?${q}` : ""}`
+    );
+};
+
+export const cancelCompanyBooking = (companyId: string, rideId: string) =>
+    companyRequest<{ success?: boolean }>(
+        `/api/company/${companyId}/bookings/${rideId}/cancel`,
+        { method: "POST" }
+    );
+
+export interface CompanyFareEstimate {
+    base_fare: number;
+    distance_fare: number;
+    time_fare: number;
+    booking_fee: number;
+    subtotal: number;
+    area_fees_total: number;
+    tax_amount: number;
+    grand_total: number;
+    service_area?: string | null;
+}
+
+export const companyBookingFareEstimate = (
+    companyId: string,
+    params: {
+        pickup_lat: number;
+        pickup_lng: number;
+        dropoff_lat: number;
+        dropoff_lng: number;
+        distance_km: number;
+        duration_minutes: number;
+        vehicle_type_id: string;
+    }
+) => {
+    const qs = new URLSearchParams(
+        Object.fromEntries(Object.entries(params).map(([k, v]) => [k, String(v)]))
+    );
+    return companyRequest<CompanyFareEstimate>(
+        `/api/company/${companyId}/bookings/fare-estimate?${qs.toString()}`
+    );
+};
+
+/* ── Sections (departments) ── */
+
+export interface CompanySection {
+    id: string;
+    company_id: string;
+    name: string;
+    description?: string | null;
+    status: "active" | "archived";
+    member_count?: number;
+    created_at?: string;
+}
+
+export const listCompanySections = (companyId: string) =>
+    companyRequest<{ sections: CompanySection[] }>(`/api/company/${companyId}/sections`);
+
+export const createCompanySection = (companyId: string, body: { name: string; description?: string }) =>
+    companyRequest<CompanySection>(`/api/company/${companyId}/sections`, {
+        method: "POST",
+        body: JSON.stringify(body),
+    });
+
+export const updateCompanySection = (
+    companyId: string,
+    sectionId: string,
+    body: { name?: string; description?: string; status?: "active" | "archived" }
+) =>
+    companyRequest<CompanySection>(`/api/company/${companyId}/sections/${sectionId}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+    });
+
+export const archiveCompanySection = (companyId: string, sectionId: string) =>
+    companyRequest<CompanySection>(`/api/company/${companyId}/sections/${sectionId}`, {
+        method: "DELETE",
+    });
+
+export const assignMemberSection = (companyId: string, memberId: string, sectionId: string | null) =>
+    companyRequest<unknown>(`/api/company/${companyId}/members/${memberId}`, {
+        method: "PATCH",
+        // Backend contract: empty string clears the assignment (None means
+        // "field not provided" under its exclude_none handling).
+        body: JSON.stringify({ section_id: sectionId ?? "" }),
+    });
+
+export interface PortalVehicleType {
+    id: string;
+    name: string;
+    capacity?: number;
+    is_active?: boolean;
+}
+
+export const getPortalVehicleTypes = async (): Promise<PortalVehicleType[]> => {
+    // Public endpoint — no auth needed, but routing through companyRequest
+    // keeps error shapes consistent.
+    return companyRequest<PortalVehicleType[]>("/api/v1/vehicle-types");
+};

--- a/admin-dashboard/src/lib/companyApi.ts
+++ b/admin-dashboard/src/lib/companyApi.ts
@@ -3,11 +3,23 @@
 // Same relative-URL/proxy contract as lib/api.ts, but bound to the
 // companyAuthStore rider session: 401s silent-refresh via the HttpOnly
 // refresh cookie and bounce to /company-login (never the staff /login).
-// lib/api.ts's request() delegates any /api/company/* or
-// /api/rider/work-profile* path here, so the existing portal pages keep
-// their imports untouched.
+// Portal pages import the company-session helpers below (NOT from @/lib/api,
+// whose identically-pathed helpers run on the staff admin session).
 
 import { useCompanyAuthStore, CompanyMembershipProfile } from "@/store/companyAuthStore";
+import type {
+    CorporateMember,
+    CorporateMemberRole,
+    CorporateMemberStatus,
+    CorporateAllowance,
+    AllowanceTypeValue,
+    AllowanceRequestRow,
+    CorporatePolicy,
+    AllowedDomainRow,
+    BillingSummary,
+    BillingStatement,
+    BillingTransactionsPage,
+} from "@/lib/api";
 
 const API_BASE = "";
 
@@ -32,8 +44,18 @@ export async function companyRequest<T>(path: string, options: RequestInit = {})
     if (res.status === 401) {
         const refreshed = await store.silentRefresh();
         if (refreshed) {
-            const newToken = useCompanyAuthStore.getState().token;
-            const retryHeaders = { ...headers, Authorization: `Bearer ${newToken}` };
+            // Rebuild BOTH auth headers from the refreshed store: the refresh
+            // rotated the csrf_token cookie + value, so reusing the stale
+            // X-CSRF-Token from `headers` would fail the backend double-submit
+            // on write retries (booking/cancel/section).
+            const refreshedStore = useCompanyAuthStore.getState();
+            const retryHeaders: Record<string, string> = {
+                ...headers,
+                Authorization: `Bearer ${refreshedStore.token}`,
+            };
+            if (!["GET", "HEAD", "OPTIONS"].includes(method) && refreshedStore.csrfToken) {
+                retryHeaders["X-CSRF-Token"] = refreshedStore.csrfToken;
+            }
             const retryRes = await fetch(url, { ...options, headers: retryHeaders });
             if (retryRes.ok) return retryRes.json() as T;
             if (retryRes.status !== 401) {
@@ -87,7 +109,11 @@ export interface CompanyOtpVerifyResult {
 }
 
 export const verifyCompanyOtp = async (phone: string, code: string): Promise<CompanyOtpVerifyResult> => {
-    const res = await fetch("/api/v1/auth/verify-otp", {
+    // LOCAL Next route (/api/company-auth/verify-otp) — proxies to the backend
+    // and STRIPS the 30-day refresh_token from the JSON body (it lives only in
+    // the HttpOnly spinr_company_rt cookie), so the long-lived credential never
+    // reaches JS. Mirrors the admin login route.
+    const res = await fetch("/api/company-auth/verify-otp", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phone, code }),
@@ -98,6 +124,15 @@ export const verifyCompanyOtp = async (phone: string, code: string): Promise<Com
     }
     return body as CompanyOtpVerifyResult;
 };
+
+// Role-appropriate landing inside a company: owner/admin get the management
+// overview (which calls admin-only endpoints); a plain member gets the
+// booking flow (the overview would show empty/failed admin metrics for them).
+export function portalHome(companyId: string, role?: string): string {
+    return role === "owner" || role === "admin"
+        ? `/company-portal/${companyId}/overview`
+        : `/company-portal/${companyId}/book`;
+}
 
 export const getMyWorkProfiles = () =>
     companyRequest<CompanyMembershipProfile[]>("/api/rider/work-profile");
@@ -260,6 +295,118 @@ export const assignMemberSection = (companyId: string, memberId: string, section
         // "field not provided" under its exclude_none handling).
         body: JSON.stringify({ section_id: sectionId ?? "" }),
     });
+
+/* ── Company management (portal, COMPANY session) ──
+ *
+ * The /company/{id}/** endpoints are guarded by require_company_admin /
+ * require_company_member (rider JWT + membership). Portal pages MUST call
+ * these company-session versions — the identically-named helpers in @/lib/api
+ * run on the STAFF admin session and would 401 a company user to /login.
+ */
+
+export const listCompanyMembers = (companyId: string, status?: string) =>
+    companyRequest<CorporateMember[]>(
+        `/api/company/${companyId}/members${status ? `?status=${encodeURIComponent(status)}` : ""}`
+    );
+
+export const inviteCompanyMember = (
+    companyId: string,
+    body: { email: string; role: CorporateMemberRole; policy_override?: boolean }
+) =>
+    companyRequest<{ member: CorporateMember; invite_url: string }>(
+        `/api/company/${companyId}/members/invite`,
+        { method: "POST", body: JSON.stringify(body) }
+    );
+
+export const updateCompanyMember = (
+    companyId: string,
+    memberId: string,
+    body: { role?: CorporateMemberRole; status?: CorporateMemberStatus; policy_override?: boolean }
+) =>
+    companyRequest<CorporateMember>(`/api/company/${companyId}/members/${memberId}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+    });
+
+export const getMemberAllowance = (companyId: string, memberId: string) =>
+    companyRequest<CorporateAllowance | Record<string, never>>(
+        `/api/company/${companyId}/members/${memberId}/allowance`
+    );
+
+export const putMemberAllowance = (
+    companyId: string,
+    memberId: string,
+    body: {
+        type: AllowanceTypeValue;
+        amount?: number | null;
+        period_start?: string | null;
+        period_end?: string | null;
+        rollover?: boolean;
+        auto_approve_topup_amount?: number | null;
+        auto_approve_monthly_count?: number | null;
+    }
+) =>
+    companyRequest<CorporateAllowance>(`/api/company/${companyId}/members/${memberId}/allowance`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+    });
+
+export const listCompanyAllowanceRequests = (companyId: string, status = "pending") =>
+    companyRequest<AllowanceRequestRow[]>(
+        `/api/company/${companyId}/allowance-requests?status=${encodeURIComponent(status)}`
+    );
+
+export const decideAllowanceRequest = (
+    companyId: string,
+    requestId: string,
+    body: { approve: boolean; note?: string }
+) =>
+    companyRequest<AllowanceRequestRow>(
+        `/api/company/${companyId}/allowance-requests/${requestId}/decide`,
+        { method: "POST", body: JSON.stringify(body) }
+    );
+
+export const getCompanyPolicy = (companyId: string) =>
+    companyRequest<CorporatePolicy | Record<string, never>>(`/api/company/${companyId}/policy`);
+
+export const patchCompanyPolicy = (
+    companyId: string,
+    body: Partial<Omit<CorporatePolicy, "id" | "company_id">>
+) =>
+    companyRequest<CorporatePolicy>(`/api/company/${companyId}/policy`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+    });
+
+export const listAllowedDomains = (companyId: string) =>
+    companyRequest<AllowedDomainRow[]>(`/api/company/${companyId}/allowed-domains`);
+
+export const addAllowedDomain = (companyId: string, domain: string) =>
+    companyRequest<AllowedDomainRow>(`/api/company/${companyId}/allowed-domains`, {
+        method: "POST",
+        body: JSON.stringify({ domain }),
+    });
+
+export const removeAllowedDomain = (companyId: string, domain: string) =>
+    companyRequest<{ status: string }>(
+        `/api/company/${companyId}/allowed-domains/${encodeURIComponent(domain)}`,
+        { method: "DELETE" }
+    );
+
+export const getCompanyBillingSummary = (companyId: string, month?: string) =>
+    companyRequest<BillingSummary>(
+        `/api/company/${companyId}/billing/summary${month ? `?month=${encodeURIComponent(month)}` : ""}`
+    );
+
+export const getCompanyBillingStatement = (companyId: string, month: string) =>
+    companyRequest<BillingStatement>(
+        `/api/company/${companyId}/billing/statements/${encodeURIComponent(month)}`
+    );
+
+export const getCompanyBillingTransactions = (companyId: string, skip = 0, limit = 50) =>
+    companyRequest<BillingTransactionsPage>(
+        `/api/company/${companyId}/billing/transactions?skip=${skip}&limit=${limit}`
+    );
 
 export interface PortalVehicleType {
     id: string;

--- a/admin-dashboard/src/middleware.ts
+++ b/admin-dashboard/src/middleware.ts
@@ -99,7 +99,7 @@ function isIpAllowed(request: NextRequest): boolean {
   return ALLOWED_IP_ENTRIES.some((entry) => clientIp.startsWith(entry));
 }
 
-const PUBLIC_PATHS = ["/login"];
+const PUBLIC_PATHS = ["/login", "/company-login"];
 const PUBLIC_PREFIXES = ["/register/", "/track/"];
 
 function isPublic(pathname: string): boolean {
@@ -195,6 +195,25 @@ export function middleware(request: NextRequest) {
   // Public page — no auth required
   if (isPublic(pathname)) {
     return passThroughWithNonce(request, nonce);
+  }
+
+  // ── Company portal (Spinr for Business) ────────────────────────────────────
+  // Company users hold RIDER tokens (phone OTP), never staff sessions — the
+  // portal is gated on its own company_token cookie and bounces to
+  // /company-login, keeping the two auth surfaces fully separate.
+  if (pathname === "/company-portal" || pathname.startsWith("/company-portal/")) {
+    const companyToken = request.cookies.get("company_token")?.value;
+    if (companyToken && isTokenValid(companyToken)) {
+      return passThroughWithNonce(request, nonce);
+    }
+    const companyRedirect = request.nextUrl.clone();
+    companyRedirect.pathname = "/company-login";
+    companyRedirect.searchParams.set("next", pathname);
+    const companyResponse = NextResponse.redirect(companyRedirect);
+    if (companyToken) {
+      companyResponse.cookies.set("company_token", "", { path: "/", maxAge: 0 });
+    }
+    return companyResponse;
   }
 
   const token = request.cookies.get("admin_token")?.value;

--- a/admin-dashboard/src/middleware.ts
+++ b/admin-dashboard/src/middleware.ts
@@ -203,6 +203,15 @@ export function middleware(request: NextRequest) {
     if (companyToken && isTokenValid(companyToken)) {
       return passThroughWithNonce(request, nonce);
     }
+    // The access token (company_token) expires in 15 min, but the refresh
+    // session lasts 30 days. When the access token is stale/absent but the
+    // company_session marker shows a refreshable session exists, load the shell
+    // so the client can silentRefresh — otherwise an idle reload would force a
+    // needless re-login. If the refresh fails, the client layout redirects.
+    const hasRefreshableSession = request.cookies.get("company_session")?.value === "1";
+    if (hasRefreshableSession) {
+      return passThroughWithNonce(request, nonce);
+    }
     const companyRedirect = request.nextUrl.clone();
     companyRedirect.pathname = "/company-login";
     companyRedirect.searchParams.set("next", pathname);

--- a/admin-dashboard/src/middleware.ts
+++ b/admin-dashboard/src/middleware.ts
@@ -99,7 +99,10 @@ function isIpAllowed(request: NextRequest): boolean {
   return ALLOWED_IP_ENTRIES.some((entry) => clientIp.startsWith(entry));
 }
 
-const PUBLIC_PATHS = ["/login", "/company-login"];
+// /company-login is handled explicitly before the admin IP allowlist (see
+// middleware()) so it stays reachable for external company users — it does
+// not go through isPublic().
+const PUBLIC_PATHS = ["/login"];
 const PUBLIC_PREFIXES = ["/register/", "/track/"];
 
 function isPublic(pathname: string): boolean {
@@ -184,23 +187,17 @@ export function middleware(request: NextRequest) {
     return handleTrackingHost(request);
   }
 
-  // ── Admin domain below ──────────────────────────────────────────────────────
-  // IP allowlist check — runs before auth so blocked IPs see 403, not /login
-  if (!isIpAllowed(request)) {
-    return new NextResponse("Forbidden", { status: 403 });
-  }
-
   const nonce = generateNonce();
 
-  // Public page — no auth required
-  if (isPublic(pathname)) {
+  // ── Company portal (Spinr for Business) — CUSTOMER-facing surface ───────────
+  // Handled BEFORE the admin IP allowlist: company employees are external
+  // users who must reach /company-login and /company-portal even when
+  // ADMIN_ALLOWED_IPS restricts the STAFF admin surface. Company users hold
+  // RIDER tokens (phone OTP), gated on their own company_token cookie, and
+  // bounce to /company-login — never the staff /login.
+  if (pathname === "/company-login") {
     return passThroughWithNonce(request, nonce);
   }
-
-  // ── Company portal (Spinr for Business) ────────────────────────────────────
-  // Company users hold RIDER tokens (phone OTP), never staff sessions — the
-  // portal is gated on its own company_token cookie and bounces to
-  // /company-login, keeping the two auth surfaces fully separate.
   if (pathname === "/company-portal" || pathname.startsWith("/company-portal/")) {
     const companyToken = request.cookies.get("company_token")?.value;
     if (companyToken && isTokenValid(companyToken)) {
@@ -214,6 +211,18 @@ export function middleware(request: NextRequest) {
       companyResponse.cookies.set("company_token", "", { path: "/", maxAge: 0 });
     }
     return companyResponse;
+  }
+
+  // ── Admin domain below ──────────────────────────────────────────────────────
+  // IP allowlist check — runs before auth so blocked IPs see 403, not /login.
+  // (The company surface above is intentionally exempt — see comment there.)
+  if (!isIpAllowed(request)) {
+    return new NextResponse("Forbidden", { status: 403 });
+  }
+
+  // Public page — no auth required
+  if (isPublic(pathname)) {
+    return passThroughWithNonce(request, nonce);
   }
 
   const token = request.cookies.get("admin_token")?.value;

--- a/admin-dashboard/src/store/companyAuthStore.ts
+++ b/admin-dashboard/src/store/companyAuthStore.ts
@@ -69,6 +69,12 @@ async function writeCompanyCookie(token: string): Promise<void> {
     }
 }
 
+// MUTEX: concurrent silentRefresh callers (root layout on rehydrate + several
+// companyRequest 401s) must share ONE in-flight refresh. Without this the
+// second call presents an already-rotated refresh token; the backend's reuse
+// detection revokes the whole token family → instant logout.
+let _inflightRefresh: Promise<boolean> | null = null;
+
 export const useCompanyAuthStore = create<CompanyAuthState>()(
     persist(
         (set, get) => ({
@@ -93,33 +99,62 @@ export const useCompanyAuthStore = create<CompanyAuthState>()(
             setMemberships: (memberships) => set({ memberships }),
 
             silentRefresh: async () => {
-                // The rider refresh endpoint reads the HttpOnly refresh_token
-                // cookie; rotation re-sets it on the response. Must go through
-                // the /api/v1 catch-all proxy (NOT /api/auth/* — that prefix is
-                // pinned to the staff-auth Next route handlers).
-                try {
-                    const res = await fetch("/api/v1/auth/refresh", {
-                        method: "POST",
-                        headers: { "Content-Type": "application/json" },
-                    });
-                    if (!res.ok) return false;
-                    const data = await res.json().catch(() => ({}));
-                    const newToken: string | undefined = data.token ?? data.access_token;
-                    if (!newToken) return false;
-                    await writeCompanyCookie(newToken);
-                    set({
-                        token: newToken,
-                        csrfToken: data.csrf_token ?? get().csrfToken,
-                        isAuthenticated: true,
-                        isLoading: false,
-                    });
-                    return true;
-                } catch {
-                    return false;
-                }
+                // Share one in-flight refresh across concurrent callers (mutex).
+                if (_inflightRefresh) return _inflightRefresh;
+
+                const doRefresh = async (): Promise<boolean> => {
+                    try {
+                        // LOCAL Next route (see /api/company-auth/refresh): reads
+                        // the HttpOnly spinr_company_rt cookie, proxies to the
+                        // backend server-side (so the CSRF middleware — which only
+                        // fires on browser-Origin requests — is skipped, letting
+                        // refresh work on a rehydrated load with no in-memory CSRF)
+                        // and strips the rotated refresh_token from the body.
+                        const res = await fetch("/api/company-auth/refresh", {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                        });
+                        if (!res.ok) return false;
+                        const data = await res.json().catch(() => ({}));
+                        const newToken: string | undefined = data.token ?? data.access_token;
+                        if (!newToken) return false;
+                        await writeCompanyCookie(newToken);
+                        set({
+                            token: newToken,
+                            csrfToken: data.csrf_token ?? get().csrfToken,
+                            isAuthenticated: true,
+                            isLoading: false,
+                        });
+                        return true;
+                    } catch {
+                        return false;
+                    } finally {
+                        _inflightRefresh = null;
+                    }
+                };
+
+                _inflightRefresh = doRefresh();
+                return _inflightRefresh;
             },
 
             logout: async () => {
+                // Revoke the rider refresh token + clear the HttpOnly
+                // spinr_company_rt / csrf_token cookies server-side FIRST, so a
+                // shared desk machine can't silent-refresh a new session after
+                // sign-out. Then clear the middleware's company_token and local
+                // state. All best-effort — never block the local sign-out.
+                const { token } = get();
+                try {
+                    await fetch("/api/company-auth/logout", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                        },
+                    });
+                } catch {
+                    /* best-effort revoke */
+                }
                 try {
                     await fetch("/api/company-auth/set-cookie", { method: "DELETE" });
                 } catch {

--- a/admin-dashboard/src/store/companyAuthStore.ts
+++ b/admin-dashboard/src/store/companyAuthStore.ts
@@ -1,0 +1,157 @@
+"use client";
+
+/**
+ * Company-portal session (Spinr for Business).
+ *
+ * Company users are RIDER accounts (phone OTP) whose corporate_members rows
+ * grant org access — the backend /company/{id}/** guards authenticate the
+ * rider JWT. This store is fully separate from the staff authStore: mixing
+ * them would send company users to the staff /login on 401 and vice versa.
+ *
+ * Token custody mirrors the admin pattern:
+ *   - access token lives in Zustand memory only (never storage)
+ *   - a company_token HttpOnly cookie (set via /api/company-auth/set-cookie)
+ *     exists solely for the edge middleware's exp check
+ *   - the HttpOnly refresh_token cookie set by the backend at verify-otp
+ *     drives silentRefresh() through POST /api/v1/auth/refresh
+ *   - only the non-sensitive profile/memberships persist to sessionStorage
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+export interface CompanyMembershipProfile {
+    membership: {
+        id: string;
+        role: "owner" | "admin" | "member";
+        status: string;
+        section_id?: string | null;
+        policy_override?: boolean;
+    };
+    company: { id: string; name: string };
+}
+
+export interface CompanyPortalUser {
+    id: string;
+    phone?: string;
+    first_name?: string;
+    last_name?: string;
+}
+
+interface CompanyAuthState {
+    token: string | null;
+    csrfToken: string | null;
+    user: CompanyPortalUser | null;
+    memberships: CompanyMembershipProfile[];
+    isAuthenticated: boolean;
+    isLoading: boolean;
+
+    completeLogin: (opts: {
+        token: string;
+        csrfToken?: string | null;
+        user: CompanyPortalUser;
+    }) => Promise<void>;
+    setMemberships: (memberships: CompanyMembershipProfile[]) => void;
+    silentRefresh: () => Promise<boolean>;
+    logout: () => Promise<void>;
+    markLoaded: () => void;
+}
+
+async function writeCompanyCookie(token: string): Promise<void> {
+    try {
+        await fetch("/api/company-auth/set-cookie", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token }),
+        });
+    } catch (e) {
+        console.error("[companyAuth] set-cookie failed:", e);
+    }
+}
+
+export const useCompanyAuthStore = create<CompanyAuthState>()(
+    persist(
+        (set, get) => ({
+            token: null,
+            csrfToken: null,
+            user: null,
+            memberships: [],
+            isAuthenticated: false,
+            isLoading: true,
+
+            completeLogin: async ({ token, csrfToken, user }) => {
+                await writeCompanyCookie(token);
+                set({
+                    token,
+                    csrfToken: csrfToken ?? null,
+                    user,
+                    isAuthenticated: true,
+                    isLoading: false,
+                });
+            },
+
+            setMemberships: (memberships) => set({ memberships }),
+
+            silentRefresh: async () => {
+                // The rider refresh endpoint reads the HttpOnly refresh_token
+                // cookie; rotation re-sets it on the response. Must go through
+                // the /api/v1 catch-all proxy (NOT /api/auth/* — that prefix is
+                // pinned to the staff-auth Next route handlers).
+                try {
+                    const res = await fetch("/api/v1/auth/refresh", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                    });
+                    if (!res.ok) return false;
+                    const data = await res.json().catch(() => ({}));
+                    const newToken: string | undefined = data.token ?? data.access_token;
+                    if (!newToken) return false;
+                    await writeCompanyCookie(newToken);
+                    set({
+                        token: newToken,
+                        csrfToken: data.csrf_token ?? get().csrfToken,
+                        isAuthenticated: true,
+                        isLoading: false,
+                    });
+                    return true;
+                } catch {
+                    return false;
+                }
+            },
+
+            logout: async () => {
+                try {
+                    await fetch("/api/company-auth/set-cookie", { method: "DELETE" });
+                } catch {
+                    /* cookie clear is best-effort */
+                }
+                set({
+                    token: null,
+                    csrfToken: null,
+                    user: null,
+                    memberships: [],
+                    isAuthenticated: false,
+                    isLoading: false,
+                });
+            },
+
+            markLoaded: () => set({ isLoading: false }),
+        }),
+        {
+            name: "spinr-company-portal",
+            storage: createJSONStorage(() => sessionStorage),
+            // Never persist tokens — memory + HttpOnly cookies only.
+            partialize: (s) => ({
+                user: s.user,
+                memberships: s.memberships,
+                isAuthenticated: s.isAuthenticated,
+            }),
+            onRehydrateStorage: () => (state) => {
+                // A rehydrated "authenticated" session has no in-memory token;
+                // the first companyRequest 401s and silentRefresh restores it
+                // from the refresh cookie. Mark loading done either way.
+                state?.markLoaded();
+            },
+        }
+    )
+);

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -14,6 +14,15 @@ from utils.rate_limiter import default_limiter, rate_limit_exceeded_handler
 
 # ── CSRF double-submit constants ─────────────────────────────────────
 _CSRF_COOKIE = "csrf_token"
+# Per-audience CSRF cookies: the admin dashboard and the company portal are the
+# same browser origin, so a single shared cookie name collides when both
+# sessions are active (whichever logged in last owns `csrf_token`, breaking the
+# other's writes). Each browser surface uses its own cookie name and the
+# double-submit header is validated against whichever one it matches. This does
+# not weaken the protection: an attacker still cannot read either cookie to
+# forge a matching header (SameSite=Strict also blocks cross-site sends).
+_CSRF_COOKIE_COMPANY = "csrf_token_company"
+_CSRF_COOKIES = (_CSRF_COOKIE, _CSRF_COOKIE_COMPANY)
 _CSRF_HEADER = "x-csrf-token"
 _CSRF_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 # Paths that have no established session yet — no CSRF cookie exists.
@@ -332,10 +341,13 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         if not request.headers.get("origin"):
             return await call_next(request)
 
-        csrf_cookie = request.cookies.get(_CSRF_COOKIE)
         csrf_header = request.headers.get(_CSRF_HEADER)
+        # Collect whichever per-audience CSRF cookies are present (admin uses
+        # `csrf_token`, the company portal uses `csrf_token_company`).
+        present_cookies = [(request.cookies.get(name)) for name in _CSRF_COOKIES]
+        present_cookies = [c for c in present_cookies if c]
 
-        if not csrf_cookie or not csrf_header:
+        if not present_cookies or not csrf_header:
             logger.warning("CSRF token missing: %s %s", request.method, path)
             return JSONResponse(
                 status_code=403,
@@ -344,7 +356,10 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
         import hmac as _hmac  # noqa: PLC0415
 
-        if not _hmac.compare_digest(csrf_cookie.encode(), csrf_header.encode()):
+        # Valid if the header matches ANY present CSRF cookie. Constant-time
+        # compare against each; the attacker can read none of them.
+        header_bytes = csrf_header.encode()
+        if not any(_hmac.compare_digest(c.encode(), header_bytes) for c in present_cookies):
             logger.warning(
                 "CSRF token mismatch: %s %s origin=%s",
                 request.method,

--- a/backend/routes/corporate_company.py
+++ b/backend/routes/corporate_company.py
@@ -94,23 +94,15 @@ def _validate_geofence(geofence: Optional[dict]) -> None:
     if geofence is None:
         return
     if not isinstance(geofence, dict) or geofence.get("type") != "FeatureCollection":
-        raise HTTPException(
-            status_code=422, detail="geofence must be a GeoJSON FeatureCollection"
-        )
+        raise HTTPException(status_code=422, detail="geofence must be a GeoJSON FeatureCollection")
     features = geofence.get("features")
     if not isinstance(features, list):
         raise HTTPException(status_code=422, detail="geofence.features must be a list")
     for feat in features:
         if not isinstance(feat, dict):
-            raise HTTPException(
-                status_code=422, detail="each geofence feature must be an object"
-            )
+            raise HTTPException(status_code=422, detail="each geofence feature must be an object")
         geom = feat.get("geometry")
-        if (
-            not isinstance(geom, dict)
-            or not geom.get("type")
-            or "coordinates" not in geom
-        ):
+        if not isinstance(geom, dict) or not geom.get("type") or "coordinates" not in geom:
             raise HTTPException(
                 status_code=422,
                 detail="each geofence feature must have a geometry with type and coordinates",
@@ -161,6 +153,23 @@ async def update_member(
         patch["role"] = patch["role"].value
     if "status" in patch and hasattr(patch["status"], "value"):
         patch["status"] = patch["status"].value
+    if "section_id" in patch:
+        if patch["section_id"] == "":
+            patch["section_id"] = None  # explicit unassign
+        else:
+            try:
+                from ..db_supabase import get_rows as _get_rows
+            except ImportError:
+                from db_supabase import get_rows as _get_rows  # type: ignore
+            _sections = await _get_rows(
+                "corporate_sections",
+                {"id": patch["section_id"], "company_id": company_id, "status": "active"},
+                limit=1,
+            )
+            if not _sections:
+                # Cross-company (or archived) section assignment is a
+                # tenancy violation, not a typo — refuse loudly.
+                raise HTTPException(status_code=404, detail="Section not found for this company")
     return await update_corporate_member(member_id, patch) or existing
 
 
@@ -218,11 +227,7 @@ async def set_allowance(
             patch[k] = patch[k].isoformat()
     for money_key in ("amount", "auto_approve_topup_amount"):
         if patch.get(money_key) is not None:
-            patch[money_key] = str(
-                Decimal(str(patch[money_key])).quantize(
-                    Decimal("0.01"), rounding=ROUND_HALF_UP
-                )
-            )
+            patch[money_key] = str(Decimal(str(patch[money_key])).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
     return await upsert_member_allowance(member_id=member_id, patch=patch)
 
 
@@ -243,11 +248,7 @@ async def patch_allowance(
         return await get_member_allowance(member_id) or {}
     for money_key in ("amount", "auto_approve_topup_amount"):
         if money_key in patch and patch[money_key] is not None:
-            patch[money_key] = str(
-                Decimal(str(patch[money_key])).quantize(
-                    Decimal("0.01"), rounding=ROUND_HALF_UP
-                )
-            )
+            patch[money_key] = str(Decimal(str(patch[money_key])).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
     return await upsert_member_allowance(member_id=member_id, patch=patch)
 
 
@@ -314,9 +315,7 @@ async def decide_allowance_request(
             raise HTTPException(status_code=409, detail="missing allowance or wallet")
         amount_raw = request.get("amount")
         if amount_raw is None:
-            raise HTTPException(
-                status_code=422, detail="allowance request amount is required"
-            )
+            raise HTTPException(status_code=422, detail="allowance request amount is required")
         await apply_grant(
             wallet_id=wallet["id"],
             allowance_id=allowance["id"],
@@ -373,8 +372,7 @@ async def replace_policy(
     # Serialise TimeWindow objects to plain dicts for JSON storage.
     if patch.get("allowed_time_windows") is not None:
         patch["allowed_time_windows"] = [
-            w.model_dump() if hasattr(w, "model_dump") else w
-            for w in patch["allowed_time_windows"]
+            w.model_dump() if hasattr(w, "model_dump") else w for w in patch["allowed_time_windows"]
         ]
 
     return await upsert_corporate_policy(company_id, patch)
@@ -395,9 +393,7 @@ async def patch_policy(
     if not patch:
         return await get_corporate_policy(company_id) or {}
 
-    if "allowed_payment_source" in patch and hasattr(
-        patch["allowed_payment_source"], "value"
-    ):
+    if "allowed_payment_source" in patch and hasattr(patch["allowed_payment_source"], "value"):
         patch["allowed_payment_source"] = patch["allowed_payment_source"].value
 
     if "allowed_geofence" in patch:
@@ -405,8 +401,7 @@ async def patch_policy(
 
     if "allowed_time_windows" in patch and patch["allowed_time_windows"] is not None:
         patch["allowed_time_windows"] = [
-            w.model_dump() if hasattr(w, "model_dump") else w
-            for w in patch["allowed_time_windows"]
+            w.model_dump() if hasattr(w, "model_dump") else w for w in patch["allowed_time_windows"]
         ]
 
     return await upsert_corporate_policy(company_id, patch)

--- a/backend/routes/corporate_company_bookings.py
+++ b/backend/routes/corporate_company_bookings.py
@@ -270,11 +270,32 @@ class SectionCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=80)
     description: Optional[str] = Field(default=None, max_length=300)
 
+    @field_validator("name")
+    @classmethod
+    def _name_not_blank(cls, v: str) -> str:
+        # min_length=1 accepts a spaces-only string; the handler strips after
+        # validation, so without this a "   " name would persist as "" and
+        # squat the company's unique empty name. Reject blank-after-trim (422).
+        v = v.strip()
+        if not v:
+            raise ValueError("Section name cannot be blank")
+        return v
+
 
 class SectionUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=80)
     description: Optional[str] = Field(default=None, max_length=300)
     status: Optional[str] = Field(default=None, pattern="^(active|archived)$")
+
+    @field_validator("name")
+    @classmethod
+    def _name_not_blank(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        v = v.strip()
+        if not v:
+            raise ValueError("Section name cannot be blank")
+        return v
 
 
 @router.get("/sections")

--- a/backend/routes/corporate_company_bookings.py
+++ b/backend/routes/corporate_company_bookings.py
@@ -17,19 +17,28 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+try:
+    from ..utils.metrics import inc as _metric_inc
+    from ..utils.rate_limiter import company_booking_limit
+except ImportError:
+    from utils.metrics import inc as _metric_inc  # type: ignore
+    from utils.rate_limiter import company_booking_limit  # type: ignore
 from pydantic import BaseModel, Field, field_validator
 
 try:
     from .. import db_supabase
-    from ..dependencies.company_guard import require_company_member
+    from ..dependencies.company_guard import require_company_admin, require_company_member
     from ..features import compute_fare_estimate
     from ..services.company_booking_service import create_company_guest_booking
+    from ..utils.error_handling import db_error_text
     from ..validators import validate_phone
 except ImportError:
     import db_supabase  # type: ignore
-    from dependencies.company_guard import require_company_member  # type: ignore
+    from dependencies.company_guard import require_company_admin, require_company_member  # type: ignore
     from features import compute_fare_estimate  # type: ignore
     from services.company_booking_service import create_company_guest_booking  # type: ignore
+    from utils.error_handling import db_error_text  # type: ignore
     from validators import validate_phone  # type: ignore
 
 router = APIRouter(prefix="/company/{company_id}", tags=["Corporate Company Bookings"])
@@ -83,13 +92,19 @@ def _booking_row(ride: Dict[str, Any], member: Optional[Dict[str, Any]], guest: 
 
 
 @router.post("/bookings")
+@company_booking_limit
 async def create_booking(
+    request: Request,
     body: CompanyGuestBookingRequest,
     ctx: dict = Depends(require_company_member),
 ):
     """Book a ride for a customer on the company's dime (booker's allowance)."""
     result = await create_company_guest_booking(ctx["company_id"], ctx["member"], body)
     ride = result["ride"]
+    _metric_inc(
+        "spinr_corporate_guest_booking_total",
+        {"scheduled": "true" if ride.get("is_scheduled") else "false"},
+    )
     return {
         "success": True,
         "booking": _booking_row(ride, ctx["member"], result.get("guest_user")),
@@ -246,6 +261,119 @@ async def booking_fare_estimate(
         vehicle_type_id=vehicle_type_id,
         surge_override=Decimal("1"),
     )
+
+
+# ── Sections (company departments — grouping + reporting, migration 206) ──
+
+
+class SectionCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=80)
+    description: Optional[str] = Field(default=None, max_length=300)
+
+
+class SectionUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=80)
+    description: Optional[str] = Field(default=None, max_length=300)
+    status: Optional[str] = Field(default=None, pattern="^(active|archived)$")
+
+
+@router.get("/sections")
+async def list_sections(ctx: dict = Depends(require_company_member)):
+    """Sections with live member counts. Member-readable — the bookings list
+    filter needs them; only owner/admin can mutate."""
+    sections = (
+        await db_supabase.get_rows(
+            "corporate_sections",
+            {"company_id": ctx["company_id"]},
+            order="created_at",
+            limit=200,
+        )
+        or []
+    )
+    members = (
+        await db_supabase.get_rows(
+            "corporate_members",
+            {"company_id": ctx["company_id"], "status": "active"},
+            columns="id,section_id",
+            limit=1000,
+        )
+        or []
+    )
+    counts: Dict[str, int] = {}
+    for m in members:
+        sid = m.get("section_id")
+        if sid:
+            counts[sid] = counts.get(sid, 0) + 1
+    return {
+        "sections": [{**s, "member_count": counts.get(s["id"], 0)} for s in sections],
+    }
+
+
+@router.post("/sections")
+async def create_section(body: SectionCreate, ctx: dict = Depends(require_company_admin)):
+    from datetime import datetime, timezone
+    from uuid import uuid4
+
+    row = {
+        "id": str(uuid4()),
+        "company_id": ctx["company_id"],
+        "name": body.name.strip(),
+        "description": (body.description or "").strip() or None,
+        "status": "active",
+        "created_by": ctx["user"]["id"],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        inserted = await db_supabase.insert_one("corporate_sections", row)
+    except Exception as e:
+        msg = db_error_text(e)
+        if "duplicate" in msg or "unique" in msg or "23505" in msg:
+            raise HTTPException(status_code=409, detail="A section with this name already exists.") from e
+        raise
+    return inserted or row
+
+
+@router.patch("/sections/{section_id}")
+async def update_section(
+    section_id: str,
+    body: SectionUpdate,
+    ctx: dict = Depends(require_company_admin),
+):
+    existing = (
+        await db_supabase.get_rows("corporate_sections", {"id": section_id, "company_id": ctx["company_id"]}, limit=1)
+        or []
+    )
+    if not existing:
+        raise HTTPException(status_code=404, detail="Section not found")
+    patch = {k: v for k, v in body.model_dump(exclude_none=True).items()}
+    if "name" in patch:
+        patch["name"] = patch["name"].strip()
+    if not patch:
+        return existing[0]
+    try:
+        updated = await db_supabase.update_one("corporate_sections", {"id": section_id}, patch)
+    except Exception as e:
+        msg = db_error_text(e)
+        if "duplicate" in msg or "unique" in msg or "23505" in msg:
+            raise HTTPException(status_code=409, detail="A section with this name already exists.") from e
+        raise
+    return updated or {**existing[0], **patch}
+
+
+@router.delete("/sections/{section_id}")
+async def archive_section(section_id: str, ctx: dict = Depends(require_company_admin)):
+    """Archive (never hard-delete): history keeps its section attribution;
+    members' section_id stays until reassigned (the FK only nulls on a true
+    row delete, which we don't do)."""
+    existing = (
+        await db_supabase.get_rows("corporate_sections", {"id": section_id, "company_id": ctx["company_id"]}, limit=1)
+        or []
+    )
+    if not existing:
+        raise HTTPException(status_code=404, detail="Section not found")
+    updated = await db_supabase.update_one("corporate_sections", {"id": section_id}, {"status": "archived"})
+    return updated or {**existing[0], "status": "archived"}
 
 
 # Re-exported for server.py mounting alongside corporate_company_router.

--- a/backend/schemas/corporate.py
+++ b/backend/schemas/corporate.py
@@ -206,6 +206,10 @@ class MemberUpdate(BaseModel):
     role: Optional[MemberRole] = None
     status: Optional[MemberStatus] = None
     policy_override: Optional[bool] = None
+    # Section assignment (migration 206). Empty string clears the section
+    # (None means "not provided" under exclude_none); the route validates
+    # the section belongs to the same company.
+    section_id: Optional[str] = None
 
 
 class AllowanceCreate(BaseModel):

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -462,6 +462,11 @@ async def auto_settle_guest_corporate(ride_id: str) -> Optional[PaymentResult]:
         # but the retry sweep must never settle an in-flight ride.
         return None
 
+    try:
+        from ..utils.metrics import inc as _metric_inc
+    except ImportError:
+        from utils.metrics import inc as _metric_inc  # type: ignore
+
     claimed = None
     for _claim_status in ("pending", "failed"):
         claimed = await db_supabase.update_one(
@@ -488,6 +493,10 @@ async def auto_settle_guest_corporate(ride_id: str) -> Optional[PaymentResult]:
             {"payment_status": "pending", "updated_at": datetime.now(timezone.utc).isoformat()},
         )
         return None
+    _metric_inc(
+        "spinr_payment_settlement_total",
+        {"outcome": "success" if result.success else "failed", "path": "corporate_guest_auto"},
+    )
     if not result.success:
         logger.error(
             "[PAYMENT] auto-settle failed for guest ride %s: %s (status %s)",

--- a/backend/tests/test_corporate_sections.py
+++ b/backend/tests/test_corporate_sections.py
@@ -40,6 +40,23 @@ async def test_create_section_scopes_to_company():
     assert row["created_by"] == "user_admin"
 
 
+def test_blank_section_name_rejected_by_schema():
+    """Codex F11: min_length=1 accepts a spaces-only name; the field_validator
+    must reject it (422 at the API) so it never persists as ''."""
+    import pydantic
+
+    from backend.routes.corporate_company_bookings import SectionCreate, SectionUpdate
+
+    for blank in ("   ", "\t", "\n "):
+        with pytest.raises(pydantic.ValidationError):
+            SectionCreate(name=blank)
+        with pytest.raises(pydantic.ValidationError):
+            SectionUpdate(name=blank)
+    # Valid names trim and pass; SectionUpdate(name=None) is allowed (no-op).
+    assert SectionCreate(name="  Showroom ").name == "Showroom"
+    assert SectionUpdate(name=None).name is None
+
+
 @pytest.mark.anyio
 async def test_create_section_duplicate_name_is_409():
     from backend.routes.corporate_company_bookings import SectionCreate, create_section

--- a/backend/tests/test_corporate_sections.py
+++ b/backend/tests/test_corporate_sections.py
@@ -1,0 +1,152 @@
+"""Sections (company departments) — CRUD authz + tenancy scoping.
+
+Handlers are called directly with an explicit ctx (what the company guards
+return), so these tests pin the tenancy rules without the HTTP layer.
+
+Run:
+    pytest backend/tests/test_corporate_sections.py -v
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_CCB = "backend.routes.corporate_company_bookings."
+_COMPANY_ID = "company_sec"
+
+_ADMIN_CTX = {
+    "user": {"id": "user_admin"},
+    "company_id": _COMPANY_ID,
+    "role": "admin",
+    "member_id": "member_admin",
+    "member": {"id": "member_admin", "company_id": _COMPANY_ID, "role": "admin"},
+}
+
+
+@pytest.mark.anyio
+async def test_create_section_scopes_to_company():
+    from backend.routes.corporate_company_bookings import SectionCreate, create_section
+
+    with patch(_CCB + "db_supabase.insert_one", AsyncMock(side_effect=lambda t, row: row)) as ins:
+        row = await create_section(SectionCreate(name="  Service Department "), _ADMIN_CTX)
+
+    assert ins.call_args.args[0] == "corporate_sections"
+    assert row["company_id"] == _COMPANY_ID
+    assert row["name"] == "Service Department"
+    assert row["status"] == "active"
+    assert row["created_by"] == "user_admin"
+
+
+@pytest.mark.anyio
+async def test_create_section_duplicate_name_is_409():
+    from backend.routes.corporate_company_bookings import SectionCreate, create_section
+
+    with patch(
+        _CCB + "db_supabase.insert_one",
+        AsyncMock(
+            side_effect=Exception('duplicate key value violates unique constraint "corp_sections_company_name_unique"')
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await create_section(SectionCreate(name="Showroom"), _ADMIN_CTX)
+    assert exc_info.value.status_code == 409
+
+
+@pytest.mark.anyio
+async def test_update_section_cross_company_is_404():
+    from backend.routes.corporate_company_bookings import SectionUpdate, update_section
+
+    # The company-scoped lookup returns nothing for another company's section.
+    with patch(_CCB + "db_supabase.get_rows", AsyncMock(return_value=[])):
+        with pytest.raises(HTTPException) as exc_info:
+            await update_section("sec_other_co", SectionUpdate(name="X"), _ADMIN_CTX)
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_archive_never_deletes():
+    from backend.routes.corporate_company_bookings import archive_section
+
+    section = {"id": "sec1", "company_id": _COMPANY_ID, "name": "Showroom", "status": "active"}
+    with (
+        patch(_CCB + "db_supabase.get_rows", AsyncMock(return_value=[section])),
+        patch(
+            _CCB + "db_supabase.update_one",
+            AsyncMock(return_value={**section, "status": "archived"}),
+        ) as upd,
+    ):
+        row = await archive_section("sec1", _ADMIN_CTX)
+
+    assert row["status"] == "archived"
+    assert upd.call_args.args[2] == {"status": "archived"}, "archive is a status flip, not a delete"
+
+
+@pytest.mark.anyio
+async def test_list_sections_reports_member_counts():
+    from backend.routes.corporate_company_bookings import list_sections
+
+    async def _rows(table, filters=None, **kwargs):
+        if table == "corporate_sections":
+            return [
+                {"id": "sec1", "company_id": _COMPANY_ID, "name": "Showroom", "status": "active"},
+                {"id": "sec2", "company_id": _COMPANY_ID, "name": "Service", "status": "active"},
+            ]
+        if table == "corporate_members":
+            return [
+                {"id": "m1", "section_id": "sec1"},
+                {"id": "m2", "section_id": "sec1"},
+                {"id": "m3", "section_id": None},
+            ]
+        return []
+
+    with patch(_CCB + "db_supabase.get_rows", AsyncMock(side_effect=_rows)):
+        result = await list_sections(_ADMIN_CTX)
+
+    counts = {s["id"]: s["member_count"] for s in result["sections"]}
+    assert counts == {"sec1": 2, "sec2": 0}
+
+
+@pytest.mark.anyio
+async def test_member_section_assignment_validates_company():
+    """PATCH /members/{id} with a section from another company must 404 —
+    tenancy violation, not a typo."""
+    from backend.routes.corporate_company import update_member
+    from backend.schemas.corporate import MemberUpdate
+
+    member = {"id": "m1", "company_id": _COMPANY_ID, "role": "member", "status": "active"}
+    with (
+        patch(
+            "backend.routes.corporate_company.get_corporate_member_by_id",
+            AsyncMock(return_value=member),
+        ),
+        patch("backend.db_supabase.get_rows", AsyncMock(return_value=[])),  # section not in company
+        patch("backend.routes.corporate_company.update_corporate_member", AsyncMock()) as upd,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await update_member(_COMPANY_ID, "m1", MemberUpdate(section_id="sec_foreign"), guard=_ADMIN_CTX)
+    assert exc_info.value.status_code == 404
+    upd.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_member_section_empty_string_clears():
+    from backend.routes.corporate_company import update_member
+    from backend.schemas.corporate import MemberUpdate
+
+    member = {"id": "m1", "company_id": _COMPANY_ID, "role": "member", "status": "active"}
+    with (
+        patch(
+            "backend.routes.corporate_company.get_corporate_member_by_id",
+            AsyncMock(return_value=member),
+        ),
+        patch(
+            "backend.routes.corporate_company.update_corporate_member",
+            AsyncMock(return_value={**member, "section_id": None}),
+        ) as upd,
+    ):
+        await update_member(_COMPANY_ID, "m1", MemberUpdate(section_id=""), guard=_ADMIN_CTX)
+
+    assert upd.call_args.args[1] == {"section_id": None}, "empty string is the explicit unassign"

--- a/backend/tests/test_csrf_middleware.py
+++ b/backend/tests/test_csrf_middleware.py
@@ -191,6 +191,37 @@ class TestValidCsrf:
         )
         assert res.status_code == 200
 
+    def test_company_namespace_cookie_allowed(self, client: TestClient, valid_csrf_token: str):
+        """The company portal uses its own csrf_token_company cookie (staff and
+        portal share the origin) — a header matching it must validate."""
+        res = client.post(
+            "/api/v1/test",
+            headers={
+                "Origin": "https://example.com",
+                "X-CSRF-Token": valid_csrf_token,
+            },
+            cookies={"csrf_token_company": valid_csrf_token},
+        )
+        assert res.status_code == 200
+
+    def test_both_namespaces_present_header_matches_company(self, client: TestClient):
+        """Both sessions active in one browser: the header must validate against
+        whichever cookie it matches (here the company one), not just csrf_token —
+        this is the collision the per-audience cookie fixes."""
+        from core.csrf import generate_csrf_token
+
+        admin_tok = generate_csrf_token()
+        company_tok = generate_csrf_token()
+        res = client.post(
+            "/api/v1/test",
+            headers={
+                "Origin": "https://example.com",
+                "X-CSRF-Token": company_tok,
+            },
+            cookies={"csrf_token": admin_tok, "csrf_token_company": company_tok},
+        )
+        assert res.status_code == 200
+
 
 # ── Invalid CSRF ──────────────────────────────────────────────────────────────
 
@@ -213,6 +244,21 @@ class TestInvalidCsrf:
             "/api/v1/test",
             headers={"Origin": "https://example.com"},
             cookies={"csrf_token": valid_csrf_token},
+        )
+        assert res.status_code == 403
+
+    def test_company_cookie_present_wrong_header_rejected(self, client: TestClient):
+        """A header matching NEITHER present cookie is still rejected — the
+        per-audience acceptance doesn't weaken the double-submit check."""
+        from core.csrf import generate_csrf_token
+
+        res = client.post(
+            "/api/v1/test",
+            headers={
+                "Origin": "https://example.com",
+                "X-CSRF-Token": generate_csrf_token(),
+            },
+            cookies={"csrf_token_company": generate_csrf_token()},
         )
         assert res.status_code == 403
 

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -216,6 +216,12 @@ cancel_ride_limit = default_limiter.limit("10/hour")
 # Ride read endpoints — generous ceiling covers 3 s polling without churn
 ride_read_limit = default_limiter.limit("120/minute")
 
+# Corporate guest bookings: each one fires 2-3 customer SMS, so this is an
+# SMS-cost/abuse bound as much as a booking bound. 30/hour comfortably covers
+# a busy showroom desk. (The /company + /api/company double-mount tracks
+# each prefix separately — accepted caveat, see server.py.)
+company_booking_limit = default_limiter.limit("30/hour")
+
 # Promo enumeration guard - max 20 per minute
 promo_available_limit = default_limiter.limit("20/minute")
 

--- a/docs/runbooks/corporate-guest-booking.md
+++ b/docs/runbooks/corporate-guest-booking.md
@@ -1,0 +1,62 @@
+# Runbook — Corporate Guest Booking (Spinr for Business)
+
+A company employee books a ride for a customer by name + phone from the
+company portal (`/company-portal` on the admin domain, own login at
+`/company-login` using rider phone-OTP). The customer needs no app: SMS
+carries the booked-by line, pickup OTP, and the public tracking link.
+
+## Moving parts
+
+| Piece | Where |
+|---|---|
+| Booking service | `backend/services/company_booking_service.py` |
+| Guest identity | `backend/services/guest_user_service.py` (`users.is_guest`, auto-claimed at first OTP login) |
+| Endpoints | `backend/routes/corporate_company_bookings.py` (`/company/{id}/bookings*`, `/sections*`; also mounted under `/api`) |
+| SMS lifecycle | `backend/services/guest_notification_service.py` (hooks: booking, driver-accept, arrived, cancels) |
+| Settlement | `payment_service.settle_corporate` (payer = `rides.corporate_member_id`) + `auto_settle_guest_corporate` on completion + sweep in `utils/payment_retry.py` |
+| Portal auth | `admin-dashboard/src/store/companyAuthStore.ts`, `/company-login`, `company_token` cookie in `src/middleware.ts` |
+
+## Metrics / alerts
+
+- `spinr_corporate_guest_booking_total{scheduled}` — booking volume.
+- `spinr_payment_settlement_total{path="corporate_guest_auto", outcome}` —
+  settlement outcomes; alert on `outcome="failed"` growth.
+- Guest SMS failures log as `guest SMS failed (<context>) ride=<id>` —
+  errors carry sanitized Twilio codes only (PIPEDA: no phone/body in logs).
+
+## Common incidents
+
+**Customer says they got no SMS** — check logs for `guest SMS failed`
+with the ride id; Twilio code 21211 = bad number (typo at booking: cancel +
+rebook), 21608/trial = Twilio account issue. Confirm `twilio_*` keys in
+app_settings.
+
+**Ride completed but company not charged** — ride stuck
+`payment_status=pending`. The payment-retry sweep re-drives guest
+settlements every ~5 min (10-min grace after completion). If it stays
+pending: check for `auto-settle failed` / `corporate_member_id ... invalid`
+logs — a mismatched/inactive booking member fails loudly by design; fix the
+membership, then the sweep settles it.
+
+**Booker can't book: 403 allowance_low** — the employee's allowance needs
+1.5× the fare headroom unless company policy allows master-wallet fallback.
+Top up the allowance or set `allowed_payment_source` to `both`.
+
+**Wrong-number booking** — blast radius is one ride: the pickup OTP only
+starts that ride, the tracking page is PII-scrubbed and expires in 24 h.
+Cancel from the portal (customer gets a cancel SMS) and rebook.
+
+**Portal login loops** — the `company_token` cookie and staff `admin_token`
+are separate; company users must use `/company-login`. A rider with no
+`corporate_members` row gets "no company memberships" by design.
+
+## Deploy notes
+
+- Migrations 206 + 207 must be applied before bookings are attempted
+  (`guest_booking` column write fails loudly otherwise). Index builds are
+  CONCURRENTLY; verify `pg_index.indisvalid` for
+  `idx_rides_corporate_account_created` and `idx_users_is_guest` post-apply.
+- Booking POST is rate-limited 30/hour per client (SMS cost bound).
+- Cancellation fees: company cancels currently ride the normal pre-trip fee
+  logic via the guest's cancel path; if fee attribution to guests proves
+  noisy, waive-on-company-cancel is the documented v1 fallback (plan risk #1).


### PR DESCRIPTION
## Spinr for Business — company portal (guest booking UI, sections, hardening)

Builds the company-facing half of the guest-booking feature on top of the backend merged in 301b3015/41680dc2.

### What's in here

**Portal auth (new surface, fully separated from staff admin auth)**
- `/company-login`: rider phone-OTP login (send/verify via the `/api/v1` catch-all proxy). Accepts `?invite_token=` so an employee invited by email can join from a desk browser — closes the app-only invite gap.
- `companyAuthStore` + `companyApi`: memory-only access token, `company_token` HttpOnly cookie for the edge middleware, silent refresh from the rider refresh cookie, 401 → `/company-login` (never the staff `/login`).
- `middleware.ts`: `/company-portal/**` gated on `company_token`.
- `lib/api.ts` `request()` delegates `/api/company/*` + `/api/rider/work-profile*` to the company session — the eight pre-existing WIP portal pages (overview/members/allowances/billing/activity/…) start working with zero page edits (their `/company/*` calls were never proxied before).
- Landing page = the caller's OWN memberships (work-profile), auto-entering single-company accounts.

**Booking UX**
- `book` page: customer name/phone (with a confirm-the-number checkbox — the pickup code texts to it), maps-proxy address autocomplete, vehicle type, now/scheduled, live surge-free fare preview, success panel with the tracking link. The pickup OTP is never shown to the booker (meter-start fraud).
- `bookings` page: 12 s polling table, status chips, fare + payment attribution, member-scoped visibility (backend-enforced), pre-trip cancel with customer SMS.

**Sections (backend + UI)**
- `/company/{id}/sections` list/create/patch/archive (archive = status flip; history keeps attribution; per-company unique name → 409).
- `MemberUpdate.section_id` with same-company validation (cross-company assignment 404s as a tenancy violation; `""` = explicit unassign) + assignment UI.

**Hardening**
- `POST /bookings` rate-limited 30/hour (SMS-cost bound), `spinr_corporate_guest_booking_total` + settlement-outcome metrics, ops runbook at `docs/runbooks/corporate-guest-booking.md`.

### Verification
- 64 backend tests green (sections tenancy/authz, guest booking, auto-settle, SMS PII-cleanliness + all untouched corporate suites); ruff clean.
- admin-dashboard `tsc --noEmit` clean; ESLint 0 errors (7 pre-existing-style a11y warnings).

### Deploy notes
- Requires migrations 206 + 207 (already on main) applied before first booking.
- No rider/driver app changes in this PR.

AI-assisted — spinr platform (Claude Code)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
