### PR TITLE
fix: money / dispatch / security + perf audit remediation

### DIFF
--- a/admin-dashboard/src/app/api/company-auth/logout/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/logout/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: NextRequest) {
     try {
       // Backend /auth/logout requires the bearer (get_current_user) and
       // revokes the refresh token from the body.
-      await fetch(`${BACKEND_URL}/api/v1/auth/logout`, {
+      await fetch(`${BACKEND_URL}/api/portal/auth/logout`, {
         method: "POST",
         headers: {
           ...forwardedHeaders(req),

--- a/admin-dashboard/src/app/api/company-auth/refresh/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/refresh/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
 
   let upstream: Response;
   try {
-    upstream = await fetch(`${BACKEND_URL}/api/v1/auth/refresh`, {
+    upstream = await fetch(`${BACKEND_URL}/api/portal/auth/refresh`, {
       method: "POST",
       headers: forwardedHeaders(req),
       // Backend reads the refresh token from cookie OR body; we hold it in a

--- a/admin-dashboard/src/app/api/company-auth/verify-otp/route.ts
+++ b/admin-dashboard/src/app/api/company-auth/verify-otp/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: NextRequest) {
 
   let upstream: Response;
   try {
-    upstream = await fetch(`${BACKEND_URL}/api/v1/auth/verify-otp`, {
+    upstream = await fetch(`${BACKEND_URL}/api/portal/auth/verify-otp`, {
       method: "POST",
       headers: forwardedHeaders(req),
       body: JSON.stringify(body),

--- a/admin-dashboard/src/lib/companyApi.ts
+++ b/admin-dashboard/src/lib/companyApi.ts
@@ -91,7 +91,9 @@ export async function companyRequest<T>(path: string, options: RequestInit = {})
 /* ── Portal auth (phone OTP — rider identity) ── */
 
 export const sendCompanyOtp = async (phone: string): Promise<void> => {
-    const res = await fetch("/api/v1/auth/send-otp", {
+    // Portal auth namespace (App-Check-exempt on the backend; mobile keeps
+    // /api/v1/auth/* enforced). Routed via the catch-all /api proxy → backend.
+    const res = await fetch("/api/portal/auth/send-otp", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ phone }),

--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -35,6 +35,10 @@ _CSRF_EXEMPT_EXACT = frozenset(
         "/openapi.json",
         "/api/v1/auth/send-otp",
         "/api/v1/auth/verify-otp",
+        # Company-portal auth namespace mirrors the /api/v1/auth pre-auth
+        # exemptions (send-otp is a browser-Origin POST with no csrf cookie yet).
+        "/api/portal/auth/send-otp",
+        "/api/portal/auth/verify-otp",
         "/api/v1/auth/firebase",
         "/api/admin/auth/login",
         "/api/v1/stripe/webhook",
@@ -94,6 +98,24 @@ _APP_CHECK_EXEMPT_PREFIXES = (
     # and /stripe-account-session still requires the driver's JWT Bearer token.
     "/api/v1/drivers/stripe-embedded",
     "/api/v1/drivers/stripe-account-session",
+    # Company portal (Spinr for Business) is a browser Next.js app — like the
+    # admin dashboard it cannot attach an X-Firebase-AppCheck header. These are
+    # its surfaces, gated instead by the rider JWT + corporate membership:
+    #   /api/company/*           corporate data (require_company_admin/member)
+    #   /api/rider/work-profile  the caller's own memberships (rider JWT)
+    #   /api/portal/*            the portal's dedicated auth namespace (OTP /
+    #                            refresh / logout). Mobile keeps /api/v1/auth/*
+    #                            App-Check-enforced — only the browser portal
+    #                            uses /api/portal/auth/*.
+    "/api/company/",
+    "/api/rider/work-profile",
+    "/api/portal/",
+    # Low-sensitivity shared reads the portal's booking page needs (public
+    # vehicle list; JWT-gated Google Maps proxy). Exempted rather than
+    # duplicated under /api/portal — mobile still sends App Check, it is simply
+    # no longer required on these two read endpoints.
+    "/api/v1/vehicle-types",
+    "/api/v1/maps/",
 )
 
 

--- a/backend/features.py
+++ b/backend/features.py
@@ -898,19 +898,22 @@ async def compute_fare_estimate(
     pins the multiplier — corporate-paid rides are always 1.0x (surge never
     applies to company-billed trips; see routes.rides._is_corporate_paid).
     """
-    fare_config = (lambda _r: _r[0] if _r else None)(
-        await db_supabase.get_rows("fare_configs", {"vehicle_type_id": vehicle_type_id}, limit=1)
+    # P5: the fare_config and service_areas reads are independent — gather them
+    # instead of two serial round-trips on the <300ms estimate path.
+    fare_config_rows, all_areas = await asyncio.gather(
+        db_supabase.get_rows("fare_configs", {"vehicle_type_id": vehicle_type_id}, limit=1),
+        db_supabase.get_rows("service_areas", {"is_active": True}, limit=100),
     )
+    fare_config = fare_config_rows[0] if fare_config_rows else None
     fare_info = fare_config if fare_config else dict(DEFAULT_FARE)
 
     # Resolve surge from the service area covering the pickup point
-    all_areas = await db_supabase.get_rows("service_areas", {"is_active": True}, limit=100)
     surge = Decimal("1")
-    matched_area_id = None
+    matched_area = None
     for area in all_areas:
         poly = get_service_area_polygon(area)
         if poly and point_in_polygon(pickup_lat, pickup_lng, poly):
-            matched_area_id = area.get("id")
+            matched_area = area
             # Gate on the per-area surge master toggle, same as the main fare
             # builders (fare_service / routes.fares). Without this, a stale
             # surge_active flag or parked multiplier on a disabled area would
@@ -919,6 +922,7 @@ async def compute_fare_estimate(
             if area.get("surge_enabled") and area.get("surge_active") and area.get("surge_multiplier", 1.0) > 1.0:
                 surge = min(_fare_d(area["surge_multiplier"]), _fare_d(SURGE_CAP))
             break
+    matched_area_id = matched_area.get("id") if matched_area else None
     if surge_override is not None:
         surge = surge_override
 
@@ -934,6 +938,9 @@ async def compute_fare_estimate(
         distance_km,
         subtotal,
         _all_areas=all_areas,
+        # P5: reuse the pickup area we already resolved above — avoids
+        # calculate_all_fees re-running point-in-polygon over every area.
+        _matched_area=matched_area,
     )
 
     grand_total = round(subtotal + fees_result["fees_total"] + fees_result["tax_amount"], 2)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -112,6 +112,51 @@ api_router = APIRouter(prefix="/auth", tags=["Authentication"])
 _FAIL_KEY = "otp_fail:{}"
 _LOCK_KEY = "otp_lock:{}"
 
+# ── Per-destination-phone SMS SEND cap (C5) ─────────────────────────────
+# Distinct from the failure lockout above (which counts VERIFY failures). The
+# IP limiter is XFF-spoofable and there was no per-number send throttle, so one
+# spoofed header could SMS-bomb any victim number and burn Twilio spend. Keyed
+# on the phone so it survives IP rotation.
+_SEND_COUNT_KEY = "otp_sendc:{}"
+_SEND_INTERVAL_KEY = "otp_sendi:{}"
+_OTP_SEND_MAX_PER_HOUR = 5
+_OTP_SEND_WINDOW_SECONDS = 3600
+_OTP_SEND_MIN_INTERVAL_SECONDS = 30
+
+
+async def _enforce_otp_send_cap(phone: str) -> None:
+    """Throttle real OTP SMS per destination phone (a 30s min-interval + an
+    hourly cap). Fail-CLOSED on Redis errors per the OTP security policy:
+    briefly refusing a send beats allowing unbounded SMS during an outage."""
+    interval_key = _SEND_INTERVAL_KEY.format(phone)
+    count_key = _SEND_COUNT_KEY.format(phone)
+    try:
+        if await redis_get(interval_key):
+            raise HTTPException(
+                status_code=429,
+                detail="A code was just sent — please wait a moment before requesting another",
+                headers={"Retry-After": str(_OTP_SEND_MIN_INTERVAL_SECONDS)},
+            )
+        count = await redis_incr(count_key)
+        if count == 1:
+            await redis_expire(count_key, _OTP_SEND_WINDOW_SECONDS)
+        if count > _OTP_SEND_MAX_PER_HOUR:
+            logger.warning("OTP_SEND_CAP phone=...%s count=%s", phone[-4:], count)
+            raise HTTPException(
+                status_code=429,
+                detail="Too many code requests for this number — try again later",
+                headers={"Retry-After": str(_OTP_SEND_WINDOW_SECONDS)},
+            )
+        await redis_set(interval_key, "1", _OTP_SEND_MIN_INTERVAL_SECONDS)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Redis unavailable in OTP send cap: %s", e)
+        raise HTTPException(
+            status_code=503,
+            detail="Auth service temporarily unavailable, please try again",
+        ) from e
+
 
 async def _check_otp_lockout(phone: str) -> None:
     """Raise 429 if phone is currently locked out. Raises 503 on Redis errors (fail closed).
@@ -314,6 +359,12 @@ async def send_otp(request: Request, body: SendOTPRequest):
             status_code=503,
             message_key=ErrorKeys.SYSTEM_DATABASE,
         ) from e
+
+    # Per-destination-phone SMS send cap (C5) — only for real Twilio sends, so
+    # dev-bypass and reviewer accounts are unaffected. Enforced before the send
+    # so a bombing attempt costs no SMS.
+    if deliver_via_sms and twilio_configured:
+        await _enforce_otp_send_cap(phone)
 
     # Send OTP via SMS (Twilio when configured, console log otherwise).
     # Reviewer accounts skip SMS entirely — the code is pre-shared out of band.

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -339,6 +339,14 @@ async def send_otp(request: Request, body: SendOTPRequest):
             message_key=ErrorKeys.SYSTEM_SERVICE_UNAVAILABLE,
         )
 
+    # Per-destination-phone SMS send cap (C5) — enforced BEFORE the stored OTP
+    # is replaced, so a throttled resend (429) doesn't wipe the still-valid code
+    # already on the user's phone (which would lock them out until the cap
+    # resets). Only real Twilio sends are capped; dev-bypass and reviewer
+    # accounts skip SMS and so skip the cap.
+    if deliver_via_sms and twilio_configured:
+        await _enforce_otp_send_cap(phone)
+
     otp_record = OTPRecord(
         phone=phone,
         code=hash_otp(otp_code),  # stored as SHA-256 hash (SEC-016)
@@ -360,14 +368,9 @@ async def send_otp(request: Request, body: SendOTPRequest):
             message_key=ErrorKeys.SYSTEM_DATABASE,
         ) from e
 
-    # Per-destination-phone SMS send cap (C5) — only for real Twilio sends, so
-    # dev-bypass and reviewer accounts are unaffected. Enforced before the send
-    # so a bombing attempt costs no SMS.
-    if deliver_via_sms and twilio_configured:
-        await _enforce_otp_send_cap(phone)
-
     # Send OTP via SMS (Twilio when configured, console log otherwise).
     # Reviewer accounts skip SMS entirely — the code is pre-shared out of band.
+    # (The per-phone send cap already ran above, before the OTP row was stored.)
     if deliver_via_sms:
         sms_result = await send_otp_sms(
             phone,

--- a/backend/routes/drivers.py
+++ b/backend/routes/drivers.py
@@ -4228,7 +4228,10 @@ async def accept_ride(ride_id: str, current_user: dict = Depends(get_current_use
                     .execute()
                 )
             )
-            for lid in loser_ids:
+
+            # P2: each loser is an independent driver — release + notify them
+            # concurrently instead of one serial chain of DB/WS round-trips.
+            async def _release_loser(lid: str) -> None:
                 await db_supabase.set_driver_available(lid, True)
                 await record_period_transition(lid, 1)
                 try:
@@ -4241,6 +4244,8 @@ async def accept_ride(ride_id: str, current_user: dict = Depends(get_current_use
                         )
                 except Exception as e:
                     logger.warning(f"Failed to send ride_taken WS to loser driver {lid}: {e}")
+
+            await asyncio.gather(*(_release_loser(lid) for lid in loser_ids))
     except Exception as e:
         logger.error(f"[ACCEPT] batch offer cleanup failed for ride {ride_id}: {e}", exc_info=True)
 

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -505,17 +505,37 @@ def _build_fare_breakdown(ride: dict) -> list[dict]:
     line-item structure.
     """
     lines: list[dict] = []
-    ride_fare = float(_d(ride.get("base_fare", 0)) + _d(ride.get("distance_fare", 0)) + _d(ride.get("time_fare", 0)))
-    if ride_fare > 0:
+    base = _d(ride.get("base_fare", 0))
+    dist_surged = _d(ride.get("distance_fare", 0))
+    time_surged = _d(ride.get("time_fare", 0))
+    booking = _d(ride.get("booking_fee", 0) or 0)
+    airport = _d(ride.get("airport_fee", 0) or 0)
+    surge = _d(ride.get("surge_multiplier") or 1)
+
+    # C4: disclose surge as a real dollar line on the actual bill surfaces
+    # (receipt / history / admin), matching the estimate — it was amount:None
+    # here. surge multiplies only distance+time; the pre-surge ride fare + the
+    # surge delta sum to the same total. Cap the delta at what surge actually
+    # added: if the minimum fare clamped the surged fare, surge contributed $0.
+    surge_delta = Decimal("0")
+    if surge > Decimal("1"):
+        surged_dt = dist_surged + time_surged
+        unsurged_dt = _round(surged_dt / surge)
+        surged_subtotal = base + surged_dt + booking + airport
+        total_fare = _d(ride.get("total_fare") or surged_subtotal)
+        min_clamped = (total_fare - surged_subtotal) > Decimal("0.005")
+        surge_delta = Decimal("0") if min_clamped else _round(surged_dt - unsurged_dt)
+
+    ride_fare_d = base + dist_surged + time_surged - surge_delta
+    if ride_fare_d > 0:
         dist_km = round(float(ride.get("distance_km") or 0), 1)
-        lines.append({"label": f"Ride fare ({dist_km} km)", "amount": _f(Decimal(str(ride_fare))), "type": "ride"})
-    if ride.get("airport_fee") and float(ride["airport_fee"]) > 0:
+        lines.append({"label": f"Ride fare ({dist_km} km)", "amount": _f(_round(ride_fare_d)), "type": "ride"})
+    if airport > 0:
         lines.append({"label": "Airport surcharge", "amount": ride["airport_fee"], "type": "fee"})
-    if ride.get("booking_fee") and float(ride["booking_fee"]) > 0:
+    if booking > 0:
         lines.append({"label": "Booking fee", "amount": ride["booking_fee"], "type": "fee"})
-    surge = float(ride.get("surge_multiplier") or 1)
-    if surge > 1:
-        lines.append({"label": f"Surge ({surge}×)", "amount": None, "type": "modifier"})
+    if surge > Decimal("1"):
+        lines.append({"label": f"Surge ({float(surge)}×)", "amount": _f(_round(surge_delta)), "type": "modifier"})
     for af in ride.get("area_fees_breakdown") or []:
         afv = af.get("calculated_value", 0)
         if float(afv) > 0:
@@ -531,6 +551,9 @@ def _build_fare_breakdown(ride: dict) -> list[dict]:
         # taxes. Cap the displayed discount at ride_fare so legacy rides with
         # an uncapped discount_amount still render a sane breakdown.
         raw_discount = float(ride["discount_amount"])
+        # Cap against the full (surged) ride fare — the driver's 100%-share base,
+        # which the promo discounts — not the pre-surge line shown above.
+        ride_fare = float(base + dist_surged + time_surged)
         capped_discount = min(raw_discount, ride_fare) if ride_fare > 0 else raw_discount
         lines.append({"label": promo_label, "amount": -capped_discount, "type": "discount"})
     if ride.get("tip_amount") and float(ride["tip_amount"]) > 0:

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -706,6 +706,23 @@ async def _match_driver_to_ride_attempt(ride_id: str, *, ride: Optional[dict] = 
         logger.error(f"[DISPATCH] match_driver_to_ride: ride {ride_id} not found")
         return
 
+    # C2: never dispatch a ride that is no longer searching. The offer-timeout
+    # re-dispatch path runs ~15 awaits after its own status check, so a driver
+    # accept can land in that window and flip the ride to driver_accepted;
+    # without this guard we would claim fresh drivers and emit phantom offers on
+    # an already-live ride (ride-state invariant violation) and needlessly pull
+    # available drivers offline. Every caller either passes a fresh searching
+    # ride (booking) or re-fetches after ensuring searching (scheduled flips
+    # scheduled→searching first; offer-timeout / decline re-dispatch re-fetch),
+    # so this only ever skips a genuinely stale (already-accepted) ride.
+    if ride.get("status") != RideStatus.SEARCHING:
+        logger.info(
+            "[DISPATCH] skipping dispatch for ride %s — status is %s, not searching",
+            ride_id,
+            ride.get("status"),
+        )
+        return
+
     # Refuse to dispatch a ride with missing coordinates — the driver-app
     # cannot render the map polyline and would either drop the offer or
     # plot (0,0) (Gulf of Guinea). Surfacing loudly per CLAUDE.md ("Do not

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -1687,7 +1687,11 @@ async def _batch_offer_timeout_handler(
         except Exception:
             miss_threshold = 3
 
-        for did in pending_ids:
+        # P2: each pending driver's release is independent (distinct driver,
+        # no cross-driver ordering), so run them concurrently instead of one
+        # serial chain of DB/WS round-trips. Sub-steps within a driver stay
+        # sequential (they have their own ordering).
+        async def _release_pending_driver(did: str) -> None:
             miss_count = await increment_miss_streak(did)
             await update_acceptance_rate(did, accepted=False)
 
@@ -1728,6 +1732,8 @@ async def _batch_offer_timeout_handler(
                     )
             except Exception as e:
                 logger.warning(f"Failed to send offer_expired WS to driver {did}: {e}")
+
+        await asyncio.gather(*(_release_pending_driver(did) for did in pending_ids))
 
         if rider_id:
             await manager.send_personal_message(

--- a/backend/routes/rides.py
+++ b/backend/routes/rides.py
@@ -812,6 +812,11 @@ async def _match_driver_to_ride_attempt(ride_id: str, *, ride: Optional[dict] = 
     all_drivers = await db_supabase.get_rows(
         "drivers",
         _dispatch_filter,
+        # P1: project only what ranking/filtering reads — NOT "*". The full row
+        # carries encrypted PII (address, licence, vehicle details) that this hot
+        # path (up to 500 rows every dispatch + retry, every replica) never needs;
+        # the offer payload is built from the post-claim get_driver_by_id re-read.
+        columns="id,user_id,lat,lng,rating,is_wav,acceptance_rate,destination_mode,destination_lat,destination_lng,vehicle_type_id",
         limit=500,
     )
 
@@ -1035,7 +1040,12 @@ async def _match_driver_to_ride_attempt(ride_id: str, *, ride: Optional[dict] = 
                 }
                 if ride.get("requires_wav"):
                     _casc_filter["is_wav"] = True
-                _casc_pool = await db_supabase.get_rows("drivers", _casc_filter, limit=500)
+                _casc_pool = await db_supabase.get_rows(
+                    "drivers",
+                    _casc_filter,
+                    columns="id,user_id,lat,lng,rating,is_wav,acceptance_rate,destination_mode,destination_lat,destination_lng,vehicle_type_id",
+                    limit=500,
+                )
                 # Fix 4: Presence filter using _checked variant so a Redis outage
                 # (configured-but-unavailable) cannot silently empty the cascade pool.
                 # present_driver_ids_checked returns (set, reachable=False) on failure;
@@ -1144,12 +1154,19 @@ async def _match_driver_to_ride_attempt(ride_id: str, *, ride: Optional[dict] = 
     if use_eta:
         try:
             maps_key = app_settings.get("google_maps_api_key", "")
-            eta_map = await batch_get_etas(
-                [d for d, _ in pre_filtered],
-                # ETA to the road-snapped pickup the driver actually drives to.
-                ride["pickup_nav_lat"] if ride.get("pickup_nav_lat") is not None else ride["pickup_lat"],
-                ride["pickup_nav_lng"] if ride.get("pickup_nav_lng") is not None else ride["pickup_lng"],
-                maps_key,
+            eta_map = await asyncio.wait_for(
+                batch_get_etas(
+                    [d for d, _ in pre_filtered],
+                    # ETA to the road-snapped pickup the driver actually drives to.
+                    ride["pickup_nav_lat"] if ride.get("pickup_nav_lat") is not None else ride["pickup_lat"],
+                    ride["pickup_nav_lng"] if ride.get("pickup_nav_lng") is not None else ride["pickup_lng"],
+                    maps_key,
+                ),
+                # P3: bound the external Distance-Matrix call to the dispatch
+                # budget — its own _MAPS_TIMEOUT is 3s, too long for the <2s
+                # offer clock. A TimeoutError is caught below → haversine
+                # ranking, so a slow Maps API can't blow the dispatch SLA.
+                timeout=1.2,
             )
             ranked = rank_by_eta_with_acceptance([(d, eta_map.get(d["id"], 9999)) for d, _ in pre_filtered])
         except Exception as e:
@@ -1924,6 +1941,9 @@ async def compute_ride_estimates(
             # 10 km matches the exact haversine gate in the loop below.
             "$and": dispatch_geo_bounds(body.pickup_lat, body.pickup_lng, 10.0),
         },
+        # P1: same projection as the dispatch pool — the estimate badge only
+        # needs id/user_id/lat/lng/vehicle_type_id/is_wav, never encrypted PII.
+        columns="id,user_id,lat,lng,rating,is_wav,acceptance_rate,destination_mode,destination_lat,destination_lng,vehicle_type_id",
         order="went_online_at",
         desc=True,
         limit=200,

--- a/backend/routes/webhooks.py
+++ b/backend/routes/webhooks.py
@@ -317,7 +317,7 @@ def _invoice_period_end_iso(invoice: dict) -> str | None:
             end = period.get("end")
             if end:
                 return datetime.fromtimestamp(int(end), tz=timezone.utc).isoformat()
-    except Exception:
+    except Exception:  # noqa: S110 — best-effort period parse, fall through to None
         pass
     return None
 
@@ -368,7 +368,7 @@ def _event_to_plain_dict(event):
     if callable(fn):
         try:
             return fn()
-        except Exception:  # pragma: no cover — fall through to JSON
+        except Exception:  # noqa: S110  # pragma: no cover — fall through to JSON
             pass
     try:
         return json.loads(str(event))
@@ -614,14 +614,39 @@ async def stripe_webhook(request: Request):
                 await mark_stripe_event_processed(event_id)
                 return {"received": True, "underpaid": True, "event_id": event_id}
 
-            updated = await db_supabase.update_ride(
-                ride_id,
-                {
-                    "payment_status": "paid",
-                    "payment_intent_id": payment_intent_id,
-                    "paid_at": datetime.now(timezone.utc).isoformat(),
-                },
-            )
+            # C1: PaymentSheet / Google-Pay rides settle ONLY via this webhook —
+            # process_payment (settle_card) never runs — so they must get the
+            # SAME GST receipt + financial_events ledger row + driver tip credit
+            # here, mirroring _handle_ride_invoice_paid. Idempotent: do the
+            # bookkeeping only when the ride was NOT already settled in-app
+            # (payment_status paid/waived_admin/processing), so a process_payment
+            # ride that also emits this webhook isn't double-written.
+            _already_settled = ride.get("payment_status") in ("paid", "waived_admin", "processing")
+            _tip = Decimal(str(ride.get("tip_amount") or 0))
+            try:
+                from ..services.payment_service import (
+                    _tip_ride_update,
+                    record_payment_event,
+                    send_ride_receipt,
+                )
+            except ImportError:
+                from services.payment_service import (  # type: ignore
+                    _tip_ride_update,
+                    record_payment_event,
+                    send_ride_receipt,
+                )
+
+            _paid_fields: dict = {
+                "payment_status": "paid",
+                "payment_intent_id": payment_intent_id,
+                "paid_at": datetime.now(timezone.utc).isoformat(),
+            }
+            if not _already_settled:
+                # Credit the stored tip to the driver exactly once — the delta
+                # model is idempotent with the /rate path that may also apply it.
+                _paid_fields.update(_tip_ride_update(ride, _tip))
+
+            updated = await db_supabase.update_ride(ride_id, _paid_fields)
             if updated is None:
                 logger.error(
                     f"Webhook payment_intent.succeeded: ride {ride_id} not found or 0 rows "
@@ -633,8 +658,31 @@ async def stripe_webhook(request: Request):
                     },
                 )
                 raise HTTPException(status_code=500, detail="Ride update failed — Stripe will retry")
-            else:
-                logger.info(f"Payment confirmed via webhook for ride {ride_id}")
+
+            logger.info(f"Payment confirmed via webhook for ride {ride_id}")
+            if not _already_settled:
+                await record_payment_event(
+                    ride_id=ride_id,
+                    user_id=ride.get("rider_id") or user_id or "",
+                    amount_cents=received_cents,
+                    payment_intent_id=payment_intent_id,
+                    ride=ride,
+                    tip_amount=_tip,
+                )
+                _rcpt_rider = ride.get("rider_id")
+                if _rcpt_rider:
+                    try:
+                        await send_ride_receipt(
+                            dict(updated) if isinstance(updated, dict) else dict(ride),
+                            _rcpt_rider,
+                            _tip,
+                        )
+                    except Exception:
+                        logger.error(
+                            "[webhook] GST receipt send failed for ride %s (payment recorded)",
+                            ride_id,
+                            exc_info=True,
+                        )
 
         if user_id:
             # Wrap push notification so a Firebase outage does not cause Stripe
@@ -797,7 +845,8 @@ async def stripe_webhook(request: Request):
             if rides:
                 ride = rides[0]
                 ride_id = ride["id"]
-                refunded_amount = Decimal(str(charge.get("amount_refunded", 0))) / Decimal("100")
+                refunded_cents = int(charge.get("amount_refunded", 0))
+                refunded_amount = Decimal(str(refunded_cents)) / Decimal("100")
                 refunded_amount = refunded_amount.quantize(_TWO_PLACES, rounding=ROUND_HALF_UP)
                 await db_supabase.update_one(
                     "rides",
@@ -808,8 +857,26 @@ async def stripe_webhook(request: Request):
                         "updated_at": datetime.now(timezone.utc).isoformat(),
                     },
                 )
+                # C3: write a compensating ledger row so the 7-year tax/audit
+                # ledger nets the refund out (it previously recorded none). Per
+                # policy the driver KEEPS their pay — driver_earnings is NOT
+                # clawed back — but the reversed rider-side GST/PST is captured
+                # here for remittance. Idempotent-ish: a duplicate charge.refunded
+                # delivery is deduped upstream by claim_stripe_event(event_id).
+                try:
+                    from ..services.payment_service import record_refund_event
+                except ImportError:
+                    from services.payment_service import record_refund_event  # type: ignore
+                await record_refund_event(
+                    ride_id=ride_id,
+                    user_id=ride.get("rider_id") or "",
+                    refund_cents=refunded_cents,
+                    payment_intent_id=payment_intent_id,
+                    ride=ride,
+                )
                 logger.info(
-                    f"Stripe refund: ride {ride_id} marked refunded (${refunded_amount:.2f})",
+                    f"Stripe refund: ride {ride_id} marked refunded (${refunded_amount:.2f}); "
+                    f"driver pay retained, ledger + GST reversal recorded",
                     extra={
                         "domain": "payments",
                         "ride_id": ride_id,

--- a/backend/routes/websocket.py
+++ b/backend/routes/websocket.py
@@ -1238,6 +1238,9 @@ async def websocket_endpoint(
         # the tail of a trail. Best-effort — cleanup must not mask the
         # original disconnect, and the on-device buffer re-uploads via REST.
         if current_driver_id:
+            # P7: release the admin-location throttle slot so _admin_loc_last
+            # doesn't grow one entry per driver ever seen.
+            manager.forget_driver_location_throttle(current_driver_id)
             try:
                 await flush_driver_breadcrumbs(current_driver_id)
             except Exception:

--- a/backend/server.py
+++ b/backend/server.py
@@ -337,6 +337,11 @@ v1_api_router.include_router(maps_router)
 app.include_router(v1_api_router, prefix="/api/v1")
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(auth_router, prefix="/api")
+# Company-portal auth namespace: the SAME auth handlers under an
+# App-Check-exempt path (see _APP_CHECK_EXEMPT_PREFIXES) so the browser portal —
+# which can't attach an X-Firebase-AppCheck header — can send OTP / verify /
+# refresh / logout, while mobile keeps /api/v1/auth/* App-Check-enforced.
+app.include_router(auth_router, prefix="/api/portal")
 
 # WebSocket routes — mounted at root so the path /ws/{client_type}/{client_id} is served directly
 app.include_router(websocket_router)

--- a/backend/services/fare_service.py
+++ b/backend/services/fare_service.py
@@ -57,9 +57,7 @@ def _fd(v: Any) -> float:
     return float(_round(_d(v)))
 
 
-def build_default_fares(
-    vehicle_types: List[Dict[str, Any]], surge: Any = _d(1)
-) -> List[Dict[str, Any]]:
+def build_default_fares(vehicle_types: List[Dict[str, Any]], surge: Any = _d(1)) -> List[Dict[str, Any]]:
     """
     Build a default fare entry per vehicle type.
 
@@ -83,9 +81,7 @@ def build_default_fares(
     ]
 
 
-def find_service_area_for_point(
-    areas: List[Dict[str, Any]], lat: float, lng: float
-) -> Optional[Dict[str, Any]]:
+def find_service_area_for_point(areas: List[Dict[str, Any]], lat: float, lng: float) -> Optional[Dict[str, Any]]:
     """
     Return the first service area whose polygon contains (lat, lng), or None.
 
@@ -113,9 +109,7 @@ def merge_vehicle_pricing_with_vehicle_types(
         return []
 
     pricing_by_name = {
-        row.get("vehicle_type"): row
-        for row in vehicle_pricing
-        if isinstance(row, dict) and row.get("vehicle_type")
+        row.get("vehicle_type"): row for row in vehicle_pricing if isinstance(row, dict) and row.get("vehicle_type")
     }
     result = []
     for vt in vehicle_types:
@@ -180,6 +174,12 @@ class FareBreakdown:
     surge_multiplier: Decimal
     driver_earnings: Decimal
     admin_earnings: Decimal
+    # Pre-surge distance/time fares (C4). surge multiplies ONLY distance+time,
+    # so these let the receipt itemise the surge delta as a real dollar figure
+    # instead of baking it into "Ride fare" behind an amount-less "Surge" line.
+    # Default 0 so existing FareBreakdown constructors are unaffected.
+    distance_fare_base: Decimal = Decimal("0")
+    time_fare_base: Decimal = Decimal("0")
 
 
 def calculate_fare(
@@ -201,6 +201,8 @@ def calculate_fare(
     minimum = _d(fare_info.get("minimum_fare", DEFAULT_FARE["minimum_fare"]))
     ap_fee = _d(airport_fee)
 
+    distance_fare_base = _round(per_km * _d(distance_km))
+    time_fare_base = _round(per_min * _d(duration_minutes))
     distance_fare = _round(per_km * _d(distance_km) * surge)
     time_fare = _round(per_min * _d(duration_minutes) * surge)
 
@@ -221,6 +223,8 @@ def calculate_fare(
         surge_multiplier=surge,
         driver_earnings=driver_earnings,
         admin_earnings=admin_earnings,
+        distance_fare_base=distance_fare_base,
+        time_fare_base=time_fare_base,
     )
 
 
@@ -239,8 +243,21 @@ def build_fare_breakdown_lines(
     """
     lines: List[Dict[str, Any]] = []
 
-    # Consolidated ride line — driver earns 100% of this amount (0% commission model)
-    ride_subtotal = _f(fb.base_fare + fb.distance_fare + fb.time_fare)
+    # C4: surge multiplies only distance+time, so split it out as a real dollar
+    # line rather than baking it into "Ride fare" behind an amount-less "Surge"
+    # line. The pre-surge ride fare + the surge delta sum back to the exact same
+    # total (base + surged distance + surged time), so the grand total is
+    # unchanged — only the disclosure improves.
+    surged_dt = fb.distance_fare + fb.time_fare
+    base_dt = fb.distance_fare_base + fb.time_fare_base
+    if fb.surge_multiplier > Decimal("1") and base_dt <= Decimal("0"):
+        # Older FareBreakdown without the pre-surge fields — derive from the
+        # multiplier (keeps totals exact via the subtraction below).
+        base_dt = _round(surged_dt / fb.surge_multiplier)
+    surge_delta = _round(surged_dt - base_dt) if fb.surge_multiplier > Decimal("1") else Decimal("0")
+
+    # Consolidated ride line (pre-surge) — driver earns 100% (0% commission model)
+    ride_subtotal = _f(fb.base_fare + surged_dt - surge_delta)
     lines.append(
         {
             "label": f"Ride fare ({round(distance_km, 1)} km)",
@@ -250,20 +267,16 @@ def build_fare_breakdown_lines(
     )
 
     if fb.airport_fee > Decimal("0"):
-        lines.append(
-            {"label": "Airport surcharge", "amount": _f(fb.airport_fee), "type": "fee"}
-        )
+        lines.append({"label": "Airport surcharge", "amount": _f(fb.airport_fee), "type": "fee"})
 
     if fb.booking_fee > Decimal("0"):
-        lines.append(
-            {"label": "Booking fee", "amount": _f(fb.booking_fee), "type": "fee"}
-        )
+        lines.append({"label": "Booking fee", "amount": _f(fb.booking_fee), "type": "fee"})
 
     if fb.surge_multiplier > Decimal("1"):
         lines.append(
             {
                 "label": f"Surge ({float(fb.surge_multiplier)}×)",
-                "amount": None,
+                "amount": _f(surge_delta),
                 "type": "modifier",
             }
         )
@@ -271,9 +284,7 @@ def build_fare_breakdown_lines(
     for fee in area_fees or []:
         val = fee.get("calculated_value", 0)
         if float(val) > 0:
-            lines.append(
-                {"label": fee.get("name", "Fee"), "amount": float(val), "type": "fee"}
-            )
+            lines.append({"label": fee.get("name", "Fee"), "amount": float(val), "type": "fee"})
 
     if tax_breakdown:
         for tax_name, info in tax_breakdown.items():
@@ -317,13 +328,11 @@ def recalculate_fare_for_distance(
         + _d(ride.get("booking_fee", 0))
         + _d(ride.get("airport_fee") or 0)
     )
-    new_driver_earnings = _round(
-        _d(ride.get("base_fare", 0)) + new_distance_fare + _d(ride.get("time_fare", 0))
-    )
+    new_driver_earnings = _round(_d(ride.get("base_fare", 0)) + new_distance_fare + _d(ride.get("time_fare", 0)))
 
     area_fees_total = _d(ride.get("area_fees_total", 0))
     if area_fees_total == 0:
-        for af in (ride.get("area_fees_breakdown") or []):
+        for af in ride.get("area_fees_breakdown") or []:
             if isinstance(af, dict):
                 area_fees_total += _d(af.get("calculated_value", 0))
     tax_amount = _d(ride.get("tax_amount", 0))
@@ -370,9 +379,7 @@ class FareService:
         if not vehicle_types:
             return []
 
-        all_areas = await self.db.get_rows(
-            "service_areas", {"is_active": True}, limit=100
-        )
+        all_areas = await self.db.get_rows("service_areas", {"is_active": True}, limit=100)
         matching_area = find_service_area_for_point(all_areas, lat, lng)
 
         if not matching_area:
@@ -386,9 +393,7 @@ class FareService:
             else _d(1)
         )
         vehicle_pricing = matching_area.get("vehicle_pricing") or []
-        vehicle_pricing_fares = merge_vehicle_pricing_with_vehicle_types(
-            vehicle_pricing, vehicle_types, surge
-        )
+        vehicle_pricing_fares = merge_vehicle_pricing_with_vehicle_types(vehicle_pricing, vehicle_types, surge)
         if vehicle_pricing_fares:
             return vehicle_pricing_fares
 
@@ -401,6 +406,4 @@ class FareService:
         if not fare_configs:
             return []
 
-        return merge_fare_configs_with_vehicle_types(
-            fare_configs, vehicle_types, surge
-        )
+        return merge_fare_configs_with_vehicle_types(fare_configs, vehicle_types, surge)

--- a/backend/services/fare_service.py
+++ b/backend/services/fare_service.py
@@ -251,13 +251,21 @@ def build_fare_breakdown_lines(
     surged_dt = fb.distance_fare + fb.time_fare
     base_dt = fb.distance_fare_base + fb.time_fare_base
     if fb.surge_multiplier > Decimal("1") and base_dt <= Decimal("0"):
-        # Older FareBreakdown without the pre-surge fields — derive from the
-        # multiplier (keeps totals exact via the subtraction below).
+        # Older FareBreakdown without the pre-surge fields — derive from the multiplier.
         base_dt = _round(surged_dt / fb.surge_multiplier)
-    surge_delta = _round(surged_dt - base_dt) if fb.surge_multiplier > Decimal("1") else Decimal("0")
+    if fb.surge_multiplier > Decimal("1"):
+        # Show what surge ACTUALLY added to the price, not the raw distance/time
+        # delta: on a short ride the minimum fare can absorb some or all of the
+        # surge, so the real contribution is (surged total − unsurged total),
+        # both minimum-clamped. Prevents overstating surge on minimum-fare rides.
+        unsurged_total = max(fb.base_fare + base_dt + fb.booking_fee + fb.airport_fee, fb.minimum_fare)
+        surge_delta = max(Decimal("0"), _round(fb.total_fare - unsurged_total))
+    else:
+        surge_delta = Decimal("0")
 
-    # Consolidated ride line (pre-surge) — driver earns 100% (0% commission model)
-    ride_subtotal = _f(fb.base_fare + surged_dt - surge_delta)
+    # Consolidated ride line — absorbs the minimum-fare adjustment so ride +
+    # surge + booking + airport == total_fare exactly. Driver earns 100%.
+    ride_subtotal = _f(fb.total_fare - surge_delta - fb.booking_fee - fb.airport_fee)
     lines.append(
         {
             "label": f"Ride fare ({round(distance_km, 1)} km)",

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -95,8 +95,13 @@ def _tip_ride_update(ride: dict, tip_amount: Decimal) -> dict:
     existing_tip = _round(_d(ride.get("tip_amount") or 0))
     tip_delta = tip_d - existing_tip
     fields: dict = {"tip_amount": _f(tip_d)}
-    if tip_delta > 0:
-        fields["driver_earnings"] = _f(_round(_d(ride.get("driver_earnings") or 0) + tip_delta))
+    # Apply the delta in BOTH directions (C3): a downward tip correction must
+    # claw the over-credit back out of driver_earnings, not just an increase —
+    # otherwise a reduced/removed tip leaves the driver overpaid. Clamp at 0 so
+    # a correction can never drive earnings negative.
+    if tip_delta != 0:
+        new_earnings = _round(_d(ride.get("driver_earnings") or 0) + tip_delta)
+        fields["driver_earnings"] = _f(max(new_earnings, _round(Decimal("0"))))
     return fields
 
 

--- a/backend/services/payment_service.py
+++ b/backend/services/payment_service.py
@@ -180,6 +180,65 @@ async def record_payment_event(
         )
 
 
+async def record_refund_event(
+    ride_id: str,
+    user_id: str,
+    refund_cents: int,
+    payment_intent_id: str | None = None,
+    *,
+    ride: dict | None = None,
+) -> None:
+    """Append a stripe_refund row to the financial_events ledger (C3).
+
+    A refund previously left NO ledger entry, so the 7-year tax/audit ledger
+    over-stated collected revenue + GST. This records the rider refund so
+    remittance nets out. Per policy the driver KEEPS their pay on a refund
+    (Spinr absorbs the payout), so ``driver_earnings`` is deliberately untouched
+    — but we capture the reversed rider-side tax (proportional to the refund
+    fraction) and note the retained driver amount for reconciliation.
+    ``delta_cents`` is NEGATIVE (money leaving). Never raises.
+    """
+    meta: Dict[str, Any] = {"source": "charge.refunded", "driver_pay_absorbed_by_platform": True}
+    if ride:
+        total = _round(_d(ride.get("grand_total") or ride.get("total_fare") or 0))
+        tax_total = _round(_d(ride.get("tax_amount") or 0))
+        refund_d = _round(_d(refund_cents) / Decimal("100"))
+        frac = min(refund_d / total, Decimal("1")) if total > Decimal("0") else Decimal("1")
+        meta.update(
+            {
+                "refund_amount": str(refund_d),
+                # Rider-side GST/PST reversed by this refund (remittance nets it out).
+                "tax_reversed": str(_round(tax_total * frac)),
+                "tax_breakdown": ride.get("tax_breakdown") or {},
+                "driver_id": ride.get("driver_id") or "",
+                # Driver keeps this — recorded so T4A/reconciliation can see the
+                # platform absorbed it rather than clawing it back.
+                "driver_earnings_retained": str(_round(_d(ride.get("driver_earnings") or 0))),
+            }
+        )
+    try:
+        await db_supabase.insert_one(
+            "financial_events",
+            {
+                "event_type": "stripe_refund",
+                "user_id": user_id,
+                "ride_id": ride_id,
+                "delta_cents": -abs(int(refund_cents)),
+                "ref": payment_intent_id,
+                "metadata": meta,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+    except Exception as ledger_err:
+        logger.error(
+            "[PAYMENT] refund financial_events write failed for ride %s pi=%s: %s",
+            ride_id,
+            payment_intent_id,
+            ledger_err,
+            exc_info=True,
+        )
+
+
 # ── Wallet settlement ───────────────────────────────────────────────
 
 

--- a/backend/socket_manager.py
+++ b/backend/socket_manager.py
@@ -391,6 +391,13 @@ class ConnectionManager:
         self._admin_loc_last[driver_id] = now
         await self.broadcast_to_admins(message)
 
+    def forget_driver_location_throttle(self, driver_id: str) -> None:
+        """Drop a driver's admin-location throttle entry (P7). Called on driver
+        disconnect so _admin_loc_last doesn't retain one float per driver ever
+        seen (an unbounded, if slow, leak). Location pings for a driver land on
+        one replica, so this local eviction is sufficient."""
+        self._admin_loc_last.pop(driver_id, None)
+
     async def broadcast_ride_status(
         self,
         ride_id: str,

--- a/backend/tests/test_appcheck_portal_exempt.py
+++ b/backend/tests/test_appcheck_portal_exempt.py
@@ -1,0 +1,36 @@
+"""H2: the browser company portal (which can't attach an X-Firebase-AppCheck
+header) must be App-Check-exempt on its own surfaces, while the MOBILE
+/api/v1/auth/* endpoints stay enforced."""
+
+from backend.core.middleware import _APP_CHECK_EXEMPT_PREFIXES, _CSRF_EXEMPT_EXACT
+
+
+def _appcheck_exempt(path: str) -> bool:
+    return any(path.startswith(p) for p in _APP_CHECK_EXEMPT_PREFIXES)
+
+
+def test_portal_surfaces_are_appcheck_exempt():
+    assert _appcheck_exempt("/api/portal/auth/send-otp")
+    assert _appcheck_exempt("/api/portal/auth/verify-otp")
+    assert _appcheck_exempt("/api/portal/auth/refresh")
+    assert _appcheck_exempt("/api/portal/auth/logout")
+    assert _appcheck_exempt("/api/company/abc123/bookings")
+    assert _appcheck_exempt("/api/rider/work-profile")
+    assert _appcheck_exempt("/api/rider/work-profile/accept-invite")
+    assert _appcheck_exempt("/api/v1/vehicle-types")
+    assert _appcheck_exempt("/api/v1/maps/places/autocomplete")
+
+
+def test_mobile_auth_stays_appcheck_enforced():
+    # The hybrid keeps mobile's own auth namespace enforced — only the browser
+    # portal's /api/portal/auth/* is exempt.
+    assert not _appcheck_exempt("/api/v1/auth/verify-otp")
+    assert not _appcheck_exempt("/api/v1/auth/refresh")
+    assert not _appcheck_exempt("/api/v1/auth/logout")
+    assert not _appcheck_exempt("/api/v1/rides")
+
+
+def test_portal_preauth_is_csrf_exempt():
+    # send-otp is a browser-Origin POST with no csrf cookie yet.
+    assert "/api/portal/auth/send-otp" in _CSRF_EXEMPT_EXACT
+    assert "/api/portal/auth/verify-otp" in _CSRF_EXEMPT_EXACT

--- a/backend/tests/test_refund_ledger.py
+++ b/backend/tests/test_refund_ledger.py
@@ -1,0 +1,73 @@
+"""C3: a refund must leave a compensating financial_events row (previously
+none), reverse the rider-side tax for remittance, and — per policy — retain the
+driver's pay (Spinr absorbs it) rather than clawing driver_earnings back."""
+
+from decimal import Decimal  # noqa: F401 — kept for parity with money modules
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_refund_event_writes_negative_row_and_retains_driver_pay():
+    from backend.services.payment_service import record_refund_event
+
+    ride = {
+        "id": "r1",
+        "rider_id": "u1",
+        "driver_id": "d1",
+        "grand_total": "20.00",
+        "tax_amount": "2.20",
+        "driver_earnings": "15.00",
+        "tax_breakdown": {"GST": {"amount": 1.0}, "PST": {"amount": 1.2}},
+    }
+    with patch(
+        "backend.services.payment_service.db_supabase.insert_one",
+        AsyncMock(return_value={}),
+    ) as ins:
+        await record_refund_event("r1", "u1", refund_cents=2000, payment_intent_id="pi_1", ride=ride)
+
+    assert ins.call_args.args[0] == "financial_events"
+    row = ins.call_args.args[1]
+    assert row["event_type"] == "stripe_refund"
+    assert row["delta_cents"] == -2000, "refund must be a negative ledger delta"
+    assert row["ref"] == "pi_1"
+    meta = row["metadata"]
+    assert meta["driver_pay_absorbed_by_platform"] is True
+    assert meta["driver_earnings_retained"] == "15.00", "driver keeps pay (policy)"
+    assert meta["tax_reversed"] == "2.20", "full refund reverses all rider-side tax"
+    assert meta["refund_amount"] == "20.00"
+
+
+@pytest.mark.anyio
+async def test_refund_event_prorates_tax_on_partial_refund():
+    from backend.services.payment_service import record_refund_event
+
+    ride = {
+        "id": "r2",
+        "rider_id": "u2",
+        "grand_total": "20.00",
+        "tax_amount": "2.00",
+        "driver_earnings": "15.00",
+    }
+    with patch(
+        "backend.services.payment_service.db_supabase.insert_one",
+        AsyncMock(return_value={}),
+    ) as ins:
+        await record_refund_event("r2", "u2", refund_cents=1000, ride=ride)  # 50% refund
+
+    meta = ins.call_args.args[1]["metadata"]
+    assert meta["tax_reversed"] == "1.00", "partial refund reverses tax proportionally"
+    assert meta["driver_earnings_retained"] == "15.00"
+
+
+@pytest.mark.anyio
+async def test_refund_event_never_raises_on_ledger_error():
+    """Best-effort — a ledger write failure must not break the refund webhook."""
+    from backend.services.payment_service import record_refund_event
+
+    with patch(
+        "backend.services.payment_service.db_supabase.insert_one",
+        AsyncMock(side_effect=Exception("db down")),
+    ):
+        await record_refund_event("r3", "u3", refund_cents=500, ride=None)  # no raise

--- a/backend/tests/test_surge_line_item.py
+++ b/backend/tests/test_surge_line_item.py
@@ -1,0 +1,45 @@
+"""C4: surge must be itemised as a real dollar amount, not amount=None, and the
+line-item total must be unchanged by the split."""
+
+from decimal import Decimal
+
+from backend.services.fare_service import build_fare_breakdown_lines, calculate_fare
+
+_FARE_INFO = {
+    "base_fare": 3.0,
+    "per_km_rate": 1.5,
+    "per_minute_rate": 0.3,
+    "booking_fee": 1.0,
+    "minimum_fare": 5.0,
+}
+
+
+def _lines_total(lines):
+    return sum(Decimal(str(line["amount"])) for line in lines if line.get("amount") is not None)
+
+
+def test_surge_line_carries_real_dollar_amount():
+    fb = calculate_fare(_FARE_INFO, distance_km=10.0, duration_minutes=15.0, surge=Decimal("1.5"))
+    lines = build_fare_breakdown_lines(fb, distance_km=10.0, duration_minutes=15)
+
+    surge_lines = [x for x in lines if x["type"] == "modifier" and x["label"].startswith("Surge")]
+    assert surge_lines, "expected a Surge line when surge > 1"
+    amount = surge_lines[0]["amount"]
+    assert amount is not None, "C4: surge line must show a dollar amount, not None"
+
+    # Surge delta = surged(distance+time) - unsurged(distance+time).
+    expected = float((fb.distance_fare + fb.time_fare) - (fb.distance_fare_base + fb.time_fare_base))
+    assert abs(float(amount) - expected) < 0.011
+
+    # The split preserves the grand total: base(pre-surge ride) + surge + booking.
+    total = _lines_total(lines)
+    assert abs(float(total) - float(fb.base_fare + fb.distance_fare + fb.time_fare + fb.booking_fee)) < 0.011
+
+
+def test_no_surge_line_when_multiplier_is_one():
+    fb = calculate_fare(_FARE_INFO, distance_km=10.0, duration_minutes=15.0, surge=Decimal("1"))
+    lines = build_fare_breakdown_lines(fb, distance_km=10.0, duration_minutes=15)
+    assert not [x for x in lines if x["type"] == "modifier" and x["label"].startswith("Surge")]
+    # Ride line still equals base + distance + time when unsurged.
+    ride = next(x for x in lines if x["type"] == "ride")
+    assert abs(float(ride["amount"]) - float(fb.base_fare + fb.distance_fare + fb.time_fare)) < 0.011

--- a/backend/tests/test_surge_line_item.py
+++ b/backend/tests/test_surge_line_item.py
@@ -36,6 +36,28 @@ def test_surge_line_carries_real_dollar_amount():
     assert abs(float(total) - float(fb.base_fare + fb.distance_fare + fb.time_fare + fb.booking_fee)) < 0.011
 
 
+def test_surge_not_overstated_on_minimum_fare_ride():
+    """Codex-3: a short ride whose surged fare is still under the minimum must
+    NOT show the full raw surge delta — surge added only what pushed the bill
+    above the no-surge total (here: nothing)."""
+    tiny = {
+        "base_fare": 1.0,
+        "per_km_rate": 0.5,
+        "per_minute_rate": 0.1,
+        "booking_fee": 0.0,
+        "minimum_fare": 20.0,  # floor well above even the surged fare
+    }
+    fb = calculate_fare(tiny, distance_km=1.0, duration_minutes=2.0, surge=Decimal("2.0"))
+    # Surged subtotal (1 + 1.0 + 0.4 = 2.4) is far below the 20.0 minimum, so
+    # surge is fully absorbed by the floor.
+    assert float(fb.total_fare) == 20.0
+    lines = build_fare_breakdown_lines(fb, distance_km=1.0, duration_minutes=2)
+    surge_lines = [x for x in lines if x["type"] == "modifier" and x["label"].startswith("Surge")]
+    assert surge_lines and float(surge_lines[0]["amount"]) == 0.0, "surge under the floor added $0"
+    # Lines still sum to the (minimum) total.
+    assert abs(float(_lines_total(lines)) - 20.0) < 0.011
+
+
 def test_no_surge_line_when_multiplier_is_one():
     fb = calculate_fare(_FARE_INFO, distance_km=10.0, duration_minutes=15.0, surge=Decimal("1"))
     lines = build_fare_breakdown_lines(fb, distance_km=10.0, duration_minutes=15)

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -96,10 +96,33 @@ def _is_otp_key(key: str) -> bool:
     return any(fragment in lower for fragment in _OTP_KEY_FRAGMENTS)
 
 
-# Default limiter — reads the real client IP from X-Forwarded-For when the
-# app sits behind a load balancer or CDN (Cloudflare, Fly.io, Railway). (P2-7)
+def get_real_client_ip(request: Request) -> str:
+    """Resolve the true client IP behind the CDN/proxy chain (C5).
+
+    slowapi's ``get_ipaddr`` trusts the LEFTMOST ``X-Forwarded-For`` entry,
+    which is fully client-supplied and therefore spoofable — a forged header
+    lets an attacker rotate the rate-limit key at will. Spinr sits behind
+    Cloudflare, which OVERWRITES ``CF-Connecting-IP`` with the real connecting
+    IP and ignores any client-supplied value, so it is authoritative. Prefer it,
+    then ``X-Real-IP`` (set by the platform edge), then fall back to
+    ``get_ipaddr`` for local dev / non-Cloudflare paths.
+
+    (Origin hosts must only accept traffic from Cloudflare for this to be
+    airtight against a direct-to-origin bypass — an infra/network control.)
+    """
+    cf_ip = request.headers.get("cf-connecting-ip")
+    if cf_ip:
+        return cf_ip.strip()
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        return real_ip.strip()
+    return get_ipaddr(request)
+
+
+# Default limiter — keyed on the authoritative client IP (CF-Connecting-IP when
+# behind Cloudflare) instead of the spoofable leftmost X-Forwarded-For. (P2-7, C5)
 default_limiter = Limiter(
-    key_func=get_ipaddr,
+    key_func=get_real_client_ip,
     default_limits=["100/minute", "1000/hour"],
     storage_uri=_rate_limit_storage_uri,
 )
@@ -132,8 +155,8 @@ def get_client_identifier(request: Request) -> str:
     except Exception:  # noqa: S110
         logger.warning("rate_limiter: get_rate_limit_key: body parse failed; falling back to IP", exc_info=True)
 
-    # Fallback to real IP (respects X-Forwarded-For behind proxies)
-    return f"ip:{get_ipaddr(request)}"
+    # Fallback to the authoritative client IP (CF-Connecting-IP when present).
+    return f"ip:{get_real_client_ip(request)}"
 
 
 def get_phone_based_key(request: Request) -> str:
@@ -145,8 +168,8 @@ def get_phone_based_key(request: Request) -> str:
         phone_hash = hashlib.sha256(phone.encode()).hexdigest()[:16]
         return f"phone:{phone_hash}"
 
-    # Fallback to real IP (respects X-Forwarded-For behind proxies)
-    return f"ip:{get_ipaddr(request)}"
+    # Fallback to the authoritative client IP (CF-Connecting-IP when present).
+    return f"ip:{get_real_client_ip(request)}"
 
 
 # ============================================================================

--- a/backend/utils/stripe_charge.py
+++ b/backend/utils/stripe_charge.py
@@ -53,6 +53,7 @@ CAD, hardcoded. See P0-5 scoping doc §9 for the multi-currency question.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from decimal import ROUND_HALF_UP, Decimal
@@ -214,16 +215,20 @@ async def charge_ride(
             # requires_action, or a PI created at booking time).
             # Idempotency key guards against two replicas both confirming and
             # both charging when they simultaneously pass the DB claim race.
-            intent = stripe.PaymentIntent.confirm(
-                payment_intent_id,
-                api_key=stripe_secret,
-                idempotency_key=f"ride-confirm-{ride_id}-{amount_cents}",
+            intent = await asyncio.to_thread(
+                lambda: stripe.PaymentIntent.confirm(
+                    payment_intent_id,
+                    api_key=stripe_secret,
+                    idempotency_key=f"ride-confirm-{ride_id}-{amount_cents}",
+                )
             )
         else:
-            intent = stripe.PaymentIntent.create(
-                **params,
-                api_key=stripe_secret,
-                idempotency_key=idempotency_key,
+            intent = await asyncio.to_thread(
+                lambda: stripe.PaymentIntent.create(
+                    **params,
+                    api_key=stripe_secret,
+                    idempotency_key=idempotency_key,
+                )
             )
     except _StripeCardError as e:
         # Card explicitly declined (insufficient_funds, card_declined, etc.).
@@ -380,10 +385,12 @@ async def charge_ancillary_fee(
     }
 
     try:
-        intent = stripe.PaymentIntent.create(
-            **params,
-            api_key=stripe_secret,
-            idempotency_key=idempotency_key,
+        intent = await asyncio.to_thread(
+            lambda: stripe.PaymentIntent.create(
+                **params,
+                api_key=stripe_secret,
+                idempotency_key=idempotency_key,
+            )
         )
     except _StripeCardError as e:
         err = getattr(e, "error", None)
@@ -529,10 +536,12 @@ async def authorize_ride(
     }
 
     try:
-        intent = stripe.PaymentIntent.create(
-            **params,
-            api_key=secret,
-            idempotency_key=idempotency_key,
+        intent = await asyncio.to_thread(
+            lambda: stripe.PaymentIntent.create(
+                **params,
+                api_key=secret,
+                idempotency_key=idempotency_key,
+            )
         )
     except _StripeCardError as e:
         err = getattr(e, "error", None)
@@ -616,7 +625,7 @@ async def verify_authorization(
         return ChargeOutcome(status="unconfigured", error_message="Payment processing is not configured")
 
     try:
-        intent = stripe.PaymentIntent.retrieve(payment_intent_id, api_key=secret)
+        intent = await asyncio.to_thread(lambda: stripe.PaymentIntent.retrieve(payment_intent_id, api_key=secret))
     except _StripeBaseError as e:
         logger.error("Stripe error verifying auth ride=%s pi=%s: %s", ride_id, payment_intent_id, e)
         return ChargeOutcome(status="failed", payment_intent_id=payment_intent_id, error_message=str(e))
@@ -724,13 +733,15 @@ async def capture_ride(
 
     amount_cents = dollars_to_cents(amount)
     try:
-        intent = stripe.PaymentIntent.capture(
-            payment_intent_id,
-            amount_to_capture=amount_cents,
-            api_key=secret,
-            # Same PI + same captured amount must not double-capture if two
-            # replicas race past the DB claim; Stripe dedupes the identical key.
-            idempotency_key=f"ride-capture-{ride_id}-{amount_cents}",
+        intent = await asyncio.to_thread(
+            lambda: stripe.PaymentIntent.capture(
+                payment_intent_id,
+                amount_to_capture=amount_cents,
+                api_key=secret,
+                # Same PI + same captured amount must not double-capture if two
+                # replicas race past the DB claim; Stripe dedupes the identical key.
+                idempotency_key=f"ride-capture-{ride_id}-{amount_cents}",
+            )
         )
     except _StripeCardError as e:
         err = getattr(e, "error", None)
@@ -788,10 +799,12 @@ async def cancel_authorization(*, ride_id: str, payment_intent_id: str) -> bool:
     # Call Stripe directly (same pattern as capture_ride / authorize_ride in this
     # module) — there is no run_sync helper here.
     try:
-        stripe.PaymentIntent.cancel(
-            payment_intent_id,
-            api_key=secret,
-            idempotency_key=f"ride-cancelauth-{ride_id}-{payment_intent_id}",
+        await asyncio.to_thread(
+            lambda: stripe.PaymentIntent.cancel(
+                payment_intent_id,
+                api_key=secret,
+                idempotency_key=f"ride-cancelauth-{ride_id}-{payment_intent_id}",
+            )
         )
         return True
     except _StripeBaseError as e:

--- a/backend/utils/ws_pubsub.py
+++ b/backend/utils/ws_pubsub.py
@@ -178,21 +178,19 @@ class _WSPubSub:
         if not self.active:
             return False
 
-        # Sequence and buffer for reconnect replays (2 round-trips:
-        # one INCR to get the seq, then a 3-op pipeline for the outbox).
+        # Durable path is 2 Redis round-trips (was 3): one INCR for the seq
+        # (its result builds seq_message, so it can't fold into a
+        # non-transactional pipeline), then ONE pipeline that both buffers the
+        # outbox AND publishes.
         seq_message: Any = message
+        buffered = False
         if durable:
             try:
                 seq = await self._redis.incr(f"spinr:ws:seq:{client_id}")
                 seq_message = {"seq": seq, "data": message}
-                outbox_key = f"spinr:ws:outbox:{client_id}"
-                pipe = self._redis.pipeline(transaction=False)
-                pipe.rpush(outbox_key, json.dumps(seq_message))
-                pipe.ltrim(outbox_key, -50, -1)
-                pipe.expire(outbox_key, 300)
-                await pipe.execute()
+                buffered = True
             except Exception as e:
-                logger.error(f"WS pub/sub: outbox sequence failed for {client_id}: {e}")
+                logger.error(f"WS pub/sub: seq incr failed for {client_id}: {e}")
                 seq_message = message
 
         try:
@@ -202,6 +200,23 @@ class _WSPubSub:
             # to fail silently if we swallowed this; log loudly.
             logger.error(f"WS pub/sub: could not serialise message for {client_id}: {e}")
             return False
+
+        if buffered:
+            # Outbox writes + PUBLISH in a single round-trip.
+            try:
+                outbox_key = f"spinr:ws:outbox:{client_id}"
+                pipe = self._redis.pipeline(transaction=False)
+                pipe.rpush(outbox_key, json.dumps(seq_message))
+                pipe.ltrim(outbox_key, -50, -1)
+                pipe.expire(outbox_key, 300)
+                pipe.publish(CHANNEL, body)
+                await pipe.execute()
+                return True
+            except Exception as e:
+                # Durability bookkeeping failed — still deliver via a bare
+                # publish below rather than dropping the event.
+                logger.error(f"WS pub/sub: durable pipeline failed for {client_id}, bare-publishing: {e}")
+
         try:
             await self._redis.publish(CHANNEL, body)
             return True


### PR DESCRIPTION
## Money / dispatch / security + performance audit fixes

Verified each finding from two audit passes against the current code (fan-out verification workflows), then fixed the confirmed ones. Owner decisions taken up front: **refund → driver keeps pay**, **surge stays distance+time**, **App Check → hybrid**.

### All 14 findings addressed
| # | Sev | Fix |
|---|---|---|
| C1 | P1 | PaymentSheet/`payment_intent.succeeded` path now does full idempotent bookkeeping (GST receipt + `financial_events` ledger + tip credit) |
| C2 | P1 | `match_driver_to_ride` refuses non-`searching` rides → phantom-offer TOCTOU closed |
| C3 | P0 | `charge.refunded` writes a compensating `stripe_refund` ledger row + reverses rider-side GST; driver keeps pay (T4A-recorded); tip delta applied both directions |
| C4 | P2 | Surge itemised as a real dollar line (estimate **and** receipt/history/admin), minimum-fare-aware; total unchanged |
| C5 | P1 | Per-phone OTP send cap (fail-closed, enforced before the OTP row is replaced) + Cloudflare `CF-Connecting-IP` authoritative client IP |
| C6 | P1 | 7 Stripe SDK calls threaded off the event loop |
| H2 | P1 | App Check hybrid: `/api/portal/auth/*` exempt namespace for the browser portal; `/api/company/*`, `/api/rider/work-profile`, vehicle-types + maps exempt — mobile `/api/v1/auth/*` stays enforced |
| P1 | P1 | Dispatch/estimate candidate queries project columns, not `*` |
| P2 | P2 | Batch-timeout + loser-cleanup per-driver releases parallelised (`asyncio.gather`) |
| P3 | P2 | Inline batch ETA bounded to the dispatch SLA (haversine fallback) |
| P4 | P3 | Durable WS publish: 3 Redis round-trips → 2 |
| P5 | P2 | Fare-estimate reads gathered + service-area resolved once |
| P7 | P2 | `_admin_loc_last` throttle evicted on disconnect |

Verification corrected two findings: **C1's "driver never paid" was wrong** (earnings key on `status=completed`) — the real gap was the missing receipt/ledger row (P0→P1); **C6 was not** already fixed by the earlier Stripe work.

### Codex review (3 rounds) — all resolved
Codex found 3 real defects in the fixes themselves: C5 cap ran after the OTP row was replaced (locked users out); C4 wasn't applied to the receipt/snapshot builder; C4 overstated surge on minimum-fare rides. All fixed + regression-tested.

### One sub-item deliberately deferred (noted in the P2 commit)
Changing `claim_driver_atomic`'s return type (bool → row) to drop the post-claim `get_driver_by_id` re-read — saves one read per claimed driver but changes a repository contract mocked by 6 tests and needs the offer-notification path re-verified. Low payoff, not worth bundling here.

### Follow-ups needing ops input, not code
- Pin origin-accepts-Cloudflare-only so C5's IP resolution can't be bypassed direct-to-origin.
- Finance process for the refund→GST reconciliation the C3 ledger rows now feed.
- Legacy `POST /payments/confirm` (unused, skips bookkeeping) — separate cleanup.

Backend `ruff` clean; targeted suites green (CSRF 22, appcheck-exempt 3, WS 18, fare 37, refund-ledger 3, sections). The handful of red payment/dispatch tests are pre-existing local-env noise (confirmed identical with changes stashed). Dashboard `tsc` + production build pass.

AI-assisted — spinr platform (Claude Code)

<!-- spinr-expanded:money -->
## Tier 5 · Money-touching details

- **Decimal-only arithmetic** — no floats touch fare/wallet/surge math: `[ ]`
- **Stripe idempotency**: `claim_stripe_event` called before processing webhook (N/A if not webhook): `[ ]`
- **Surge cap 2.5× respected** (or manual override with documented justification): `[ ]`
- **Corporate billing priority preserved** (rider wallet → card → allowance → master fallback): `[ ]`
- **Receipt line-items remain transparent** — no hidden "service fee": `[ ]`
- **PST/GST line items correct** (if receipt-facing): `[ ]` or N/A
- **Before/after fare on a sample trip** (attach): 

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
