### PR TITLE
fix(db): add missing drivers destination-mode columns

### DIFF
--- a/backend/migrations/219_drivers_destination_mode.sql
+++ b/backend/migrations/219_drivers_destination_mode.sql
@@ -1,0 +1,61 @@
+-- 219_drivers_destination_mode.sql
+-- =============================================================================
+-- Purpose: Add the driver "destination mode" columns to the drivers table.
+--
+-- The destination-mode feature ships in the backend already:
+--   - routes/drivers.py    : POST/DELETE/GET /drivers/destination read & write
+--                            destination_mode / destination_address /
+--                            destination_lat / destination_lng.
+--   - services/dispatch_service.py : _ride_brings_driver_closer_to_destination
+--                            reads destination_mode + destination_lat/lng to
+--                            gate offers for drivers heading home.
+--   - routes/rides.py      : the dispatch candidate query AND the /rides/estimate
+--                            candidate query both SELECT destination_mode,
+--                            destination_lat, destination_lng in their column
+--                            projection.
+--
+-- But no migration ever added these columns, so against a real database every
+-- SELECT that lists them aborts with:
+--       column drivers.destination_mode does not exist
+-- That failure takes down the whole /rides/estimate query, which is why the
+-- rider app shows no vehicle types and surfaces a "destination_mode does not
+-- exist" error in the fare-estimate panel. This migration closes the gap.
+--
+-- Forward-compatible: all columns are additive and nullable / DEFAULT false,
+-- so existing rows are unaffected and in-flight traffic (old backend that does
+-- not reference these columns) keeps working. No table rewrite: a nullable
+-- ADD COLUMN and a boolean ADD COLUMN with a constant DEFAULT are both
+-- metadata-only in Postgres 11+.
+--
+-- RLS: the columns ride the existing drivers table-level RLS policies (service
+-- role reads/writes; a driver may read their own row). No new policy needed.
+--
+-- Rollback plan:
+--   ALTER TABLE drivers DROP COLUMN IF EXISTS destination_mode;
+--   ALTER TABLE drivers DROP COLUMN IF EXISTS destination_address;
+--   ALTER TABLE drivers DROP COLUMN IF EXISTS destination_lat;
+--   ALTER TABLE drivers DROP COLUMN IF EXISTS destination_lng;
+-- =============================================================================
+
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS destination_mode BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS destination_address TEXT;
+
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS destination_lat DOUBLE PRECISION;
+
+ALTER TABLE drivers
+  ADD COLUMN IF NOT EXISTS destination_lng DOUBLE PRECISION;
+
+COMMENT ON COLUMN drivers.destination_mode IS
+  'Driver tapped "Heading home": dispatch only offers rides whose dropoff '
+  'brings them closer to destination_lat/lng (services/dispatch_service.py).';
+COMMENT ON COLUMN drivers.destination_address IS
+  'Human-readable destination the driver set for destination mode (driver-only, '
+  'never shared with riders).';
+COMMENT ON COLUMN drivers.destination_lat IS
+  'Latitude of the driver destination-mode target; NULL when not set.';
+COMMENT ON COLUMN drivers.destination_lng IS
+  'Longitude of the driver destination-mode target; NULL when not set.';

--- a/rider-app/app/(tabs)/index.tsx
+++ b/rider-app/app/(tabs)/index.tsx
@@ -499,6 +499,7 @@ export default function HomeScreen() {
           <BottomSheetContent
             colors={colors}
             styles={styles}
+            aiMode={aiMode}
             showPromo={showPromo}
             setShowPromo={setShowPromo}
             handleSearchPress={handleSearchPress}
@@ -529,6 +530,7 @@ export default function HomeScreen() {
             <BottomSheetContent
               colors={colors}
               styles={styles}
+              aiMode={aiMode}
               showPromo={showPromo}
               setShowPromo={setShowPromo}
               handleSearchPress={handleSearchPress}
@@ -543,9 +545,10 @@ export default function HomeScreen() {
 }
 
 function BottomSheetContent({
-  colors, styles, showPromo, setShowPromo, handleSearchPress, handleAiPress, handleQuickAction,
+  colors, styles, aiMode, showPromo, setShowPromo, handleSearchPress, handleAiPress, handleQuickAction,
 }: {
   colors: ThemeColors; styles: any;
+  aiMode: 'enabled' | 'coming_soon' | 'hidden';
   showPromo: boolean; setShowPromo: (v: boolean) => void;
   handleSearchPress: () => void; handleAiPress: () => void; handleQuickAction: (type: string) => void;
 }) {


### PR DESCRIPTION
The destination-mode feature (routes/drivers.py, dispatch_service.py) and
both the dispatch and /rides/estimate candidate queries in routes/rides.py
SELECT destination_mode, destination_address, destination_lat and
destination_lng from the drivers table, but no migration ever added them.

Against a real database every projection listing those columns aborts with
"column drivers.destination_mode does not exist", which takes down the whole
/rides/estimate query — so the rider app shows no vehicle types and surfaces
the destination_mode error in the fare-estimate panel.

Add the four columns (additive, nullable / DEFAULT false, metadata-only, RLS
via existing drivers policies) to close the schema gap.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012zvjZTfUdquUXCxVpf6Qk2

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
