### PR TITLE
fix(rider-app): promo Done closes on iOS; keep full-size smooth vehic…

### DIFF
--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -13,7 +13,6 @@ import {
   Animated,
   TextInput,
   Keyboard,
-  LayoutAnimation,
 } from 'react-native';
 import { Image as ExpoImage } from 'expo-image';
 import BottomSheet, { BottomSheetScrollView } from '@gorhom/bottom-sheet';
@@ -129,28 +128,43 @@ function RideOptionsScreenContent() {
   // itself (softwareKeyboardLayoutMode: 'resize'), so it stays 0 there.
   const [promoKbHeight, setPromoKbHeight] = useState(0);
   const promoKbVisible = promoKbHeight > 0;
+  // iOS won't dismiss a Modal while its TextInput keyboard is still up — tapping
+  // Done then did nothing there (Android closes fine). When a close is requested
+  // with the keyboard up we set this flag, dismiss the keyboard, and perform the
+  // actual close in keyboardWillHide once the keyboard is on its way out.
+  const promoPendingCloseRef = useRef(false);
   useEffect(() => {
     if (Platform.OS !== 'ios') return;
     const show = Keyboard.addListener('keyboardWillShow', (e) => {
-      LayoutAnimation.configureNext(
-        LayoutAnimation.create(e.duration || 250, LayoutAnimation.Types.keyboard, LayoutAnimation.Properties.opacity),
-      );
       setPromoKbHeight(e.endCoordinates?.height ?? 0);
     });
-    const hide = Keyboard.addListener('keyboardWillHide', (e) => {
-      LayoutAnimation.configureNext(
-        LayoutAnimation.create(e.duration || 200, LayoutAnimation.Types.keyboard, LayoutAnimation.Properties.opacity),
-      );
+    const hide = Keyboard.addListener('keyboardWillHide', () => {
       setPromoKbHeight(0);
+      if (promoPendingCloseRef.current) {
+        promoPendingCloseRef.current = false;
+        setShowPromoSheet(false);
+      }
     });
     return () => { show.remove(); hide.remove(); };
   }, []);
-  // Belt-and-suspenders: reset the lift when the sheet opens (guards any stale
-  // value) and dismiss the keyboard when it closes.
+  // Reset the lift when the sheet opens (guards any stale value) and dismiss the
+  // keyboard when it closes.
   useEffect(() => {
     if (showPromoSheet) setPromoKbHeight(0);
     else Keyboard.dismiss();
   }, [showPromoSheet]);
+  // Single close path for the promo sheet. On iOS with the keyboard up, defer
+  // the Modal close to keyboardWillHide (see promoPendingCloseRef) so it isn't
+  // swallowed; otherwise close immediately.
+  const closePromoSheet = useCallback(() => {
+    if (Platform.OS === 'ios' && promoKbHeight > 0) {
+      promoPendingCloseRef.current = true;
+      Keyboard.dismiss();
+    } else {
+      Keyboard.dismiss();
+      setShowPromoSheet(false);
+    }
+  }, [promoKbHeight]);
   const [fareBreakdownOpen, setFareBreakdownOpen] = useState(false);
   const [confirmSheet, setConfirmSheet] = useState<{
     visible: boolean; title: string; message: string;
@@ -518,7 +532,7 @@ function RideOptionsScreenContent() {
       applyPromo(match);
       setPromoInput('');
       setPromoError('');
-      setShowPromoSheet(false);
+      closePromoSheet();
     } else {
       setPromoError('Code not found or has expired');
     }
@@ -1046,7 +1060,7 @@ function RideOptionsScreenContent() {
 
       {/* ═══ Promo selection modal ═══ */}
       <Modal visible={showPromoSheet} animationType="slide" transparent onRequestClose={() => setShowPromoSheet(false)}>
-        <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={() => setShowPromoSheet(false)}>
+        <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={closePromoSheet}>
           {/* marginBottom lifts the sheet above the keyboard while typing
               (promoKbHeight); it is 0 whenever the keyboard is hidden, so the
               sheet sits flush with the screen edge — no grey gap under Done. */}
@@ -1127,7 +1141,7 @@ function RideOptionsScreenContent() {
                         return;
                       }
                       applyPromo(promo);
-                      setShowPromoSheet(false);
+                      closePromoSheet();
                     }}
                     activeOpacity={0.75}
                   >
@@ -1171,7 +1185,7 @@ function RideOptionsScreenContent() {
             {appliedPromo && (
               <TouchableOpacity
                 style={styles.promoRemoveRow}
-                onPress={() => { applyPromo(null); setShowPromoSheet(false); }}
+                onPress={() => { applyPromo(null); closePromoSheet(); }}
               >
                 <Ionicons name="close-circle-outline" size={18} color="#EF4444" />
                 <Text style={styles.promoRemoveText}>Remove applied code</Text>
@@ -1180,7 +1194,7 @@ function RideOptionsScreenContent() {
 
             <TouchableOpacity
               style={styles.paymentDoneBtn}
-              onPress={() => { Keyboard.dismiss(); setShowPromoSheet(false); }}
+              onPress={closePromoSheet}
             >
               <Text style={styles.paymentDoneBtnText}>Done</Text>
             </TouchableOpacity>
@@ -1241,11 +1255,12 @@ function AnimatedVehicleCard({
   }, [isSelected]);
 
   const scale = scaleAnim.interpolate({ inputRange: [0, 1], outputRange: [1, 1.03] });
-  // Selected option's car art pops via a native-driver SCALE (transform only —
-  // no layout), so switching selection never changes row height and the list
-  // can't reflow. The fixed container (carImageContainer) reserves the layout
-  // box; the transform just draws bigger.
-  const imageScale = imageSizeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.9, 1.25] });
+  // Car art keeps the original sizes — selected is the full 150×98 hero,
+  // unselected the 88×58 thumbnail — but the growth is a native-driver SCALE
+  // (transform only, no layout). The container reserves the MAX (150×98) box so
+  // the row height is constant; the transform scales DOWN to 0.59 for unselected.
+  // Nothing reflows on selection switch, so it's smooth with no shake.
+  const imageScale = imageSizeAnim.interpolate({ inputRange: [0, 1], outputRange: [0.59, 1] });
 
   // Every card shows its own discounted price (not just the selected one) —
   // computed per fare because percentage promos scale with each card's ride
@@ -1517,10 +1532,11 @@ function createStyles(colors: ThemeColors, sf: (size: number) => number, insets:
     // Width/height are animated per-card (64×42 resting → 118×76 selected),
     // so the container only carries layout; the image/fallback fill it.
     carImageContainer: {
-      // Fixed layout box — the selected pop is a transform scale (no layout),
-      // so the row height is constant and the list never reflows on switch.
-      width: 96,
-      height: 64,
+      // Fixed layout box at the MAX (selected) car size — the pop is a transform
+      // scale (no layout), so the row height is constant and the list never
+      // reflows on switch. Unselected rows scale the image down to the thumbnail.
+      width: 150,
+      height: 98,
       marginRight: 12,
       justifyContent: 'center',
       alignItems: 'center',


### PR DESCRIPTION
…le pop

Done didn't close the promo sheet on iOS (worked on Android): iOS won't dismiss a Modal while its TextInput keyboard is still up, and the iOS-only LayoutAnimation from Keyboard.dismiss compounded it. Route every promo-sheet close through closePromoSheet(): when the keyboard is up on iOS it flags a pending close, dismisses the keyboard, and performs the Modal close in keyboardWillHide (once the keyboard is on its way out); otherwise it closes immediately. Android is unchanged. Removed LayoutAnimation entirely.

Vehicle-type transition: restore the original sizes (selected = full 150×98 hero, unselected = 88×58 thumbnail) — the previous smoothing shrank the selected car. Keep it smooth + reflow-free by fixing the image container at the MAX 150×98 layout box and driving the size with a native-driver SCALE transform (0.59 unselected → 1.0 selected). Transform doesn't affect layout, so row height is constant and the list never reflows/"shakes".

Co-developed with Claude Code (claude-sonnet-4-6)


Claude-Session: https://claude.ai/code/session_012zvjZTfUdquUXCxVpf6Qk2

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
