### PR TITLE
fix(rider-app): promo sheet sizes to content, extends (not shifts) fo…

### DIFF
--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -125,7 +125,11 @@ function RideOptionsScreenContent() {
   // instead of JS-side Keyboard events, so there's no timing race to get stuck
   // on, and behavior is consistent between iOS and Android.
   const promoSheetRef = useRef<BottomSheet>(null);
-  const promoSnapPoints = useMemo(() => ['75%'], []);
+  // Dynamic sizing (no fixed snapPoints) so the sheet is only as tall as its
+  // content — 2 offers vs. 8 shouldn't both claim a fixed 75% and leave a
+  // huge empty gap under a short list. Capped at 80% of the screen so a long
+  // offer list scrolls instead of pushing off the top.
+  const promoMaxSheetHeight = SCREEN_HEIGHT * 0.8;
   const openPromoSheet = useCallback(() => {
     setPromoError('');
     promoSheetRef.current?.expand();
@@ -1033,13 +1037,13 @@ function RideOptionsScreenContent() {
       <BottomSheet
         ref={promoSheetRef}
         index={-1}
-        snapPoints={promoSnapPoints}
+        enableDynamicSizing
+        maxDynamicContentSize={promoMaxSheetHeight}
         enablePanDownToClose
-        enableDynamicSizing={false}
         backdropComponent={renderPromoBackdrop}
         backgroundStyle={styles.sheetBackground}
         handleIndicatorStyle={styles.sheetIndicator}
-        keyboardBehavior="interactive"
+        keyboardBehavior="extend"
         keyboardBlurBehavior="restore"
         android_keyboardInputMode="adjustResize"
         onClose={() => Keyboard.dismiss()}


### PR DESCRIPTION
…r keyboard

Two bugs from the earlier Modal→BottomSheet rewrite, both traced to the fixed snapPoints={['75%']} + keyboardBehavior="interactive" combo:

- A short offer list (e.g. 2 promos) still claimed a fixed 75% of the screen, leaving a large empty white gap below the list — confirmed by screenshot. Switched to enableDynamicSizing with maxDynamicContentSize capped at 80% of screen height, so the sheet is only as tall as its content (input + offers), and only scrolls once that content actually exceeds the cap.

- "interactive" keyboard behavior offsets the whole sheet upward by the keyboard's height. With a tall sheet already open, typing in the promo input pushed the sheet's top past the screen's top edge and broke the layout. Switched to keyboardBehavior="extend", which grows the sheet's height (bounded by maxDynamicContentSize) to stay above the keyboard instead of translating the whole sheet upward.

Verified with `tsc --noEmit` — zero new errors introduced.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
