### PR TITLE
fix(rider-app): promo sheet keyboard float doesn't cover input or cra…

### DIFF
--- a/rider-app/app/ride-options.tsx
+++ b/rider-app/app/ride-options.tsx
@@ -117,14 +117,31 @@ function RideOptionsScreenContent() {
   const [promoInput, setPromoInput] = useState('');
   const [promoError, setPromoError] = useState('');
   // Promo sheet is a real @gorhom/bottom-sheet instance (same lib as the main
-  // vehicle sheet below), not an RN <Modal>. That fixes both iOS bugs the old
-  // Modal + manual keyboardWillShow/Hide tracking never fully solved: the sheet
-  // wouldn't reliably close while its TextInput keyboard was still up, and a
-  // stale keyboard-height value left a grey gap under the sheet. The library
-  // drives keyboard avoidance and open/close off the native keyboard frame
-  // instead of JS-side Keyboard events, so there's no timing race to get stuck
-  // on, and behavior is consistent between iOS and Android.
+  // vehicle sheet below), not an RN <Modal>. keyboardBehavior="interactive"
+  // (below) floats the sheet above the keyboard by putting it into a
+  // "temporary position" — on iOS, calling .close() while it's still in that
+  // temporary position (keyboard not yet fully dismissed) corrupts the
+  // sheet's internal layout state and crashes on the next touch/drag. Gate
+  // our own close calls behind the keyboard actually finishing its hide
+  // animation, same idea as the old Modal-era pending-close pattern, just
+  // scoped to this one race instead of also driving positioning by hand.
   const promoSheetRef = useRef<BottomSheet>(null);
+  const promoKeyboardVisibleRef = useRef(false);
+  const promoPendingCloseRef = useRef(false);
+  useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+    const show = Keyboard.addListener('keyboardWillShow', () => {
+      promoKeyboardVisibleRef.current = true;
+    });
+    const hide = Keyboard.addListener('keyboardWillHide', () => {
+      promoKeyboardVisibleRef.current = false;
+      if (promoPendingCloseRef.current) {
+        promoPendingCloseRef.current = false;
+        promoSheetRef.current?.close();
+      }
+    });
+    return () => { show.remove(); hide.remove(); };
+  }, []);
   // Dynamic sizing (no fixed snapPoints) so the sheet is only as tall as its
   // content — 2 offers vs. 8 shouldn't both claim a fixed 75% and leave a
   // huge empty gap under a short list. Capped at 80% of the screen so a long
@@ -135,10 +152,22 @@ function RideOptionsScreenContent() {
     promoSheetRef.current?.expand();
   }, []);
   const closePromoSheet = useCallback(() => {
-    promoSheetRef.current?.close();
+    if (Platform.OS === 'ios' && promoKeyboardVisibleRef.current) {
+      promoPendingCloseRef.current = true;
+      Keyboard.dismiss();
+    } else {
+      promoSheetRef.current?.close();
+    }
   }, []);
   const renderPromoBackdrop = useCallback((props: any) => (
-    <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} pressBehavior="close" opacity={0.4} />
+    <BottomSheetBackdrop
+      {...props}
+      appearsOnIndex={0}
+      disappearsOnIndex={-1}
+      pressBehavior="close"
+      opacity={0.4}
+      onPress={() => Keyboard.dismiss()}
+    />
   ), []);
   const [fareBreakdownOpen, setFareBreakdownOpen] = useState(false);
   const [confirmSheet, setConfirmSheet] = useState<{
@@ -1040,10 +1069,17 @@ function RideOptionsScreenContent() {
         enableDynamicSizing
         maxDynamicContentSize={promoMaxSheetHeight}
         enablePanDownToClose
+        enableBlurKeyboardOnGesture
         backdropComponent={renderPromoBackdrop}
         backgroundStyle={styles.sheetBackground}
         handleIndicatorStyle={styles.sheetIndicator}
-        keyboardBehavior="extend"
+        // "interactive" floats the whole sheet up above the keyboard (same
+        // height, repositioned) instead of growing it — "extend" was a no-op
+        // here since dynamic sizing only ever produces a single detent, so it
+        // left the keyboard covering the input. Now that the sheet is
+        // content-sized (not a fixed 75%), floating it up no longer risks
+        // pushing it past the top of the screen.
+        keyboardBehavior="interactive"
         keyboardBlurBehavior="restore"
         android_keyboardInputMode="adjustResize"
         onClose={() => Keyboard.dismiss()}


### PR DESCRIPTION
…sh on iOS

Two more bugs from the keyboard-handling tuning, both on iOS only (matches the user's report that Android never crashed):

- keyboardBehavior="extend" turned out to be a no-op with dynamic sizing: extend snaps the sheet to its "highest detent", but a dynamically-sized sheet only ever has one detent (its content height), so nothing grew and the keyboard just sat on top of the promo input, hiding it while typing. Switched to keyboardBehavior="interactive", which floats the whole sheet (same height, repositioned higher) above the keyboard instead of trying to grow it. That's safe now that the sheet is content-sized rather than a fixed 75% — there's no risk of the float pushing it past the top of the screen the way there was before the dynamic-sizing fix.

- "interactive" puts the sheet into a "temporary position" while the keyboard is up. Calling promoSheetRef.close() while still in that temporary position (e.g. right after Apply succeeds, before the keyboard has actually finished hiding) corrupted the sheet's internal layout state on iOS — sheet rendered mostly empty with the input pinned near the top, and any further tap/drag crashed the app. Gated our own close() calls behind the keyboard's actual hide event on iOS (mirrors the old Modal-era pending-close pattern, but only for this one race, not for positioning). Also added enableBlurKeyboardOnGesture so dragging the sheet blurs the keyboard first instead of racing it, and dismiss the keyboard on backdrop tap before its built-in close() runs.

Verified with `tsc --noEmit` — zero new errors introduced.

<!--
Spinr PR template. Required fields are marked [required]. Replace every
<angle-bracketed placeholder> with a real value. CI will fail the PR if any
required field still contains a placeholder.

If this is a `trivial` PR (formatting, typo, comment-only, lockfile-only) you
may delete every section below Tier 1 and mark type=trivial.

Conditional sections (migration, money, UI, auth, background-job, bug-fix,
risk:high) are auto-appended by the pr-checks workflow when the diff warrants
them — you don't need to add them manually.
-->

## Tier 1 — Summary

- **Summary** [required]: <one line — what changed>
- **Type** [required]: `feat` | `fix` | `chore` | `refactor` | `perf` | `security` | `docs` | `trivial`
- **Linked issue** [required]: Fixes #<n>  (use `Refs #<n>` if not a direct fix, or `none` with reason)
- **Risk** [required]: `low` | `medium` | `high` — <one-line justification if medium/high>
- **User-visible change** [required]: `none` | `riders` | `drivers` | `admins` | `corporate` — <one line if not none>
- **Scope contract** [required]: `[ ]` This PR matches its stated type — no unrelated refactors, renames, or cleanups bundled in.

<!-- trivial-stop: if type=trivial you may delete everything below this line -->

## Tier 2 — Impact

- **Surfaces touched** [required]: `[ ]` backend  `[ ]` rider-app  `[ ]` driver-app  `[ ]` admin  `[ ]` shared  `[ ]` migrations  `[ ]` infra  `[ ]` CI
- **Blast radius** [required]: `isolated` | `single-surface` | `multi-surface` | `cross-cutting`
- **Data schema change** [required]: `none` | `additive` | `breaking` | `coordinated-deploy`
- **API contract change** [required]: `none` | `additive` | `breaking` | `versioned`
- **Background job change** [required]: `none` | `new-loop` | `modified` | `deleted`
- **Feature flag** [required]: `none` | `behind-new-flag` | `removes-existing-flag`
- **Config / secret change** [required]: `none` | `new-env-var` | `app_settings-row` | `rotation-required`
- **Rollback plan** [required]: `git-revert-safe` | `revert-plus-data-cleanup` | `coordinated` | `not-revertible` — <one line; include whether old backend talks to new DB if schema changed>
- **Dependencies / coordination** [required]: `none` | <list: PRs that must merge first, mobile release required before backend deploy, secret rotation, etc.>
- **Assumptions** [required]: <one line — what this PR assumes about the rest of the system; write `none` if truly none>
- **Not changing but considered** (optional): <one line — deliberate non-action, if any>

## Tier 3 — Compliance flags

Tick any that apply and fill the elaboration line. At least one reviewer from the flagged area must approve.

- `[ ]` **Money-touching** (fares, wallets, Stripe, corporate billing, payouts, tips, refunds) — <one line>
- `[ ]` **PIPEDA-relevant** (PII fields, logs/analytics payloads, data export/deletion, consent) — <one line>
- `[ ]` **SK Transportation Act** (driver eligibility, trip retention, tax line items, accessibility, surge cap) — <one line>
- `[ ]` **Auth / RLS** (JWT claims, RLS policies, OTP, role checks) — <one line>
- `[ ]` **Safety** (SOS, insurance periods, emergency contacts, night-ride rules) — <one line>
- `[ ]` **Third-party SDK added** — <name + privacy/legal justification>
- `[ ]` **Breaking change to `shared/`** — <one line; list downstream surfaces that need coordinated release>

## Tier 4 — Verification

- **Unit tests** [required]: `added` | `updated` | `not-applicable` — <count or reason>
- **Integration tests** [required]: `added` | `updated` | `not-applicable` — <one line>
- **Metrics / logs introduced** [required]: `none` | <list; confirm naming follows `spinr.<domain>.<metric>.<unit>`>
- **Screenshots / video** [required if UI files touched]: <attach or link>
- **Perf numbers** [required if SLA-critical path touched — dispatch, fare calc, settlement, WS fan-out, driver location, token refresh, Stripe webhook]: <before/after P95>

**Pre-merge checklist** [required]:

- [ ] Ran the changed code against real Supabase dev (not just mocks) — if backend change
- [ ] Tested with rider + driver + admin accounts — if multi-surface
- [ ] Verified the rollback command actually works (not just exists) — if `risk:high`
- [ ] Updated `CLAUDE.md` / `.claude/context/*.md` if a convention changed
- [ ] No PII (raw lat/lng, full phone, email, name, card numbers, gov IDs) added to logs, Sentry payloads, or analytics

<!--
Tiers 5–7 (Conflict & Debug Log, Bug-fix notes, Stop condition, Unmerge
trigger) are appended below by the pr-checks workflow when the diff or branch
history warrants them. Do not fill these until the bot adds the sections —
they are conditional on detected state.
-->

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
