### PR TITLE
OSRM: add timestamps/bearings and polyline dedupe; Background location: persistent offline queue and replay

### DIFF
--- a/backend/tests/test_route_distance_osrm.py
+++ b/backend/tests/test_route_distance_osrm.py
@@ -53,7 +53,12 @@ def _client_factory(resp=None, exc=None, capture=None):
 
 def _trip(n=6):
     return [
-        {"lat": 50.45 - i * 0.001, "lng": -104.62 - i * 0.001, "tracking_phase": "trip_in_progress", "accuracy": 8}
+        {
+            "lat": 50.45 - i * 0.001,
+            "lng": -104.62 - i * 0.001,
+            "tracking_phase": "trip_in_progress",
+            "accuracy": 8,
+        }
         for i in range(n)
     ]
 
@@ -79,16 +84,33 @@ def test_osrm_radius_clamped_and_defaulted():
     assert rd._osrm_radius({"accuracy": "bad"}) == "20"  # non-numeric -> default
 
 
+def test_osrm_timestamp_accepts_iso_seconds_and_expo_millis():
+    assert rd._osrm_timestamp({"timestamp": "2026-07-09T12:34:56Z"}) == 1783600496
+    assert rd._osrm_timestamp({"timestamp": 1783600496}) == 1783600496
+    assert rd._osrm_timestamp({"timestamp": 1783600496000}) == 1783600496
+    assert rd._osrm_timestamp({"timestamp": "bad"}) is None
+
+
+def test_osrm_bearing_uses_heading_when_available():
+    assert rd._osrm_bearing({"heading": 361.2}) == "1,45"
+    assert rd._osrm_bearing({"bearing": 90}) == "90,45"
+    assert rd._osrm_bearing({"course": "bad"}) == ""
+
+
 # ── _compute_via_osrm (distance + geometry) ───────────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_osrm_returns_distance_and_geometry():
+    trip = _trip(6)
+    for i, p in enumerate(trip):
+        p["timestamp"] = f"2026-07-09T12:00:{i:02d}Z"
+        p["heading"] = 180 + i
     capture = {}
     with patch.object(
         rd.httpx, "AsyncClient", _client_factory(resp=_FakeResp(payload=_osrm_payload()), capture=capture)
     ):
-        result = await rd._compute_via_osrm(_trip(6), "http://osrm:5000/")
+        result = await rd._compute_via_osrm(trip, "http://osrm:5000/")
 
     assert result is not None
     distance_km, polyline = result
@@ -99,8 +121,24 @@ async def test_osrm_returns_distance_and_geometry():
     # requests geometry, and uses lng,lat order + /match/v1/driving
     assert capture["params"]["overview"] == "full"
     assert capture["params"]["geometries"] == "geojson"
+    assert capture["params"]["gaps"] == "split"
+    assert capture["params"]["timestamps"] == "1783598400;1783598401;1783598402;1783598403;1783598404;1783598405"
+    assert capture["params"]["bearings"] == "180,45;181,45;182,45;183,45;184,45;185,45"
     assert "/match/v1/driving/" in capture["url"]
     assert "-104.62,50.45" in capture["url"]
+
+
+@pytest.mark.asyncio
+async def test_osrm_omits_optional_hints_when_unavailable():
+    capture = {}
+    with patch.object(
+        rd.httpx, "AsyncClient", _client_factory(resp=_FakeResp(payload=_osrm_payload()), capture=capture)
+    ):
+        result = await rd._compute_via_osrm(_trip(6), "http://osrm:5000/")
+
+    assert result is not None
+    assert "timestamps" not in capture["params"]
+    assert "bearings" not in capture["params"]
 
 
 @pytest.mark.asyncio

--- a/backend/utils/route_distance.py
+++ b/backend/utils/route_distance.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+from datetime import datetime, timezone
 from typing import Any, List, Optional, Tuple
 
 import httpx
@@ -137,27 +138,76 @@ def _osrm_radius(point: dict) -> str:
     return str(int(r))
 
 
+def _osrm_timestamp(point: dict) -> Optional[int]:
+    """Return a Unix timestamp for OSRM /match, or None when unavailable."""
+    ts = point.get("timestamp") or point.get("recorded_at") or point.get("created_at")
+    if ts is None:
+        return None
+    if isinstance(ts, (int, float)):
+        # Expo Location timestamps are milliseconds; server rows are usually seconds/ISO.
+        return int(ts / 1000) if ts > 10_000_000_000 else int(ts)
+    if isinstance(ts, str):
+        try:
+            return int(float(ts))
+        except ValueError:
+            pass
+        try:
+            parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return int(parsed.timestamp())
+        except ValueError:
+            return None
+    return None
+
+
+def _osrm_bearing(point: dict) -> str:
+    """Per-point heading constraint for OSRM /match.
+
+    Empty string means "no bearing constraint" for that coordinate. When the
+    phone provides heading/course, giving OSRM a directional hint helps avoid
+    snapping a noisy fix to the opposite carriageway on divided roads.
+    """
+    bearing = point.get("heading")
+    if bearing is None:
+        bearing = point.get("bearing")
+    if bearing is None:
+        bearing = point.get("course")
+    try:
+        return f"{int(round(float(bearing))) % 360},45"
+    except (TypeError, ValueError):
+        return ""
+
+
 async def _compute_via_osrm(trip_points: list[dict], osrm_url: str) -> Optional[RoadMatch]:
     """Map-match the trace with OSRM /match; return (distance_km, [[lat,lng],...]).
 
     OSRM expects {lng},{lat} order. We sum every matching's distance and
     concatenate their geometries because a sparse/messy trace can be split into
-    several matchings; gaps=ignore keeps a momentary signal loss from
-    fragmenting the trip and tidy=true drops outliers before matching.
+    several matchings. gaps=split keeps OSRM from force-joining questionable
+    traces across GPS dropouts, timestamps improve speed plausibility, bearings
+    help stay on the correct carriageway on divided roads, and tidy=true drops
+    outliers before matching.
     overview=full + geometries=geojson returns the snapped road geometry.
     """
     sampled = _downsample(trip_points, _OSRM_MAX_POINTS)
     coords = ";".join(f"{p['lng']},{p['lat']}" for p in sampled)
     radiuses = ";".join(_osrm_radius(p) for p in sampled)
+    timestamps = [_osrm_timestamp(p) for p in sampled]
+    bearings = [_osrm_bearing(p) for p in sampled]
     url = f"{osrm_url.rstrip('/')}/match/v1/driving/{coords}"
     params = {
         "overview": "full",  # return the snapped road geometry, not just distance
         "geometries": "geojson",  # [[lng,lat],...] — no polyline decoder needed
         "steps": "false",
         "radiuses": radiuses,
-        "gaps": "ignore",
+        "gaps": "split",
         "tidy": "true",
     }
+    if all(ts is not None for ts in timestamps):
+        params["timestamps"] = ";".join(str(ts) for ts in timestamps)
+    if any(bearings):
+        params["bearings"] = ";".join(bearings)
 
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
@@ -183,7 +233,9 @@ async def _compute_via_osrm(trip_points: list[dict], osrm_url: str) -> Optional[
             total_m += float(d)
         # geometry.coordinates is [[lng, lat], ...] for geojson.
         for lng, lat in (m.get("geometry") or {}).get("coordinates") or []:
-            polyline.append([round(float(lat), 6), round(float(lng), 6)])
+            point = [round(float(lat), 6), round(float(lng), 6)]
+            if not polyline or polyline[-1] != point:
+                polyline.append(point)
 
     if total_m <= 0:
         return None

--- a/driver-app/utils/__tests__/backgroundLocation.test.ts
+++ b/driver-app/utils/__tests__/backgroundLocation.test.ts
@@ -11,6 +11,7 @@
 const mockStartUpdates = jest.fn((..._args: any[]) => Promise.resolve());
 let mockTaskRegistered = true;
 let mockBgPermission = 'granted';
+const mockAsyncStorage: Record<string, string> = {};
 
 jest.mock('expo-location', () => ({
   startLocationUpdatesAsync: (...args: any[]) => mockStartUpdates(...args),
@@ -31,20 +32,57 @@ jest.mock('expo-task-manager', () => ({
 }));
 
 jest.mock('expo-secure-store', () => ({
-  getItemAsync: jest.fn(() => Promise.resolve(null)),
+  getItemAsync: jest.fn((key: string) => {
+    if (key === 'bg_access_token') return Promise.resolve('access-token');
+    if (key === 'bg_access_token_expires') return Promise.resolve(String(Date.now() + 120_000));
+    return Promise.resolve(null);
+  }),
   setItemAsync: jest.fn(() => Promise.resolve()),
   deleteItemAsync: jest.fn(() => Promise.resolve()),
 }));
 
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn((key: string) => Promise.resolve(mockAsyncStorage[key] ?? null)),
+  setItem: jest.fn((key: string, value: string) => {
+    mockAsyncStorage[key] = value;
+    return Promise.resolve();
+  }),
+  removeItem: jest.fn((key: string) => {
+    delete mockAsyncStorage[key];
+    return Promise.resolve();
+  }),
+}));
+
 jest.mock('@shared/config', () => ({ API_URL: 'https://example.test' }), { virtual: true });
+jest.mock('@shared/config/spinr.config', () => ({
+  __esModule: true,
+  default: { backendUrl: 'https://example.test' },
+}));
+jest.mock('@shared/services/firebase', () => ({
+  initFirebaseServices: jest.fn(() => Promise.resolve()),
+  getAppCheckToken: jest.fn(() => Promise.resolve('app-check')),
+}));
 
 import {
   updateBackgroundLocationCadence,
   setBackgroundTripActive,
+  handleBackgroundLocationTask,
   TRIP_CADENCE,
   IDLE_CADENCE,
 } from '../backgroundLocation';
 import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const makeLocation = (i: number) => ({
+  coords: {
+    latitude: 52.1 + i * 0.001,
+    longitude: -106.6 - i * 0.001,
+    speed: 12,
+    heading: 90 + i,
+    accuracy: 8,
+  },
+  timestamp: Date.UTC(2026, 6, 9, 12, 0, i),
+});
 
 describe('setBackgroundTripActive (killed-app recovery cadence)', () => {
   beforeEach(() => {
@@ -60,6 +98,56 @@ describe('setBackgroundTripActive (killed-app recovery cadence)', () => {
   it('clears the trip flag when idle', async () => {
     await setBackgroundTripActive(false);
     expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('spinr_bg_trip_active');
+  });
+});
+
+describe('background location offline queue', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(mockAsyncStorage)) delete mockAsyncStorage[key];
+    (global as any).fetch = jest.fn(() => Promise.resolve({ ok: true, status: 200 }));
+    (AsyncStorage.getItem as jest.Mock).mockClear();
+    (AsyncStorage.setItem as jest.Mock).mockClear();
+    (AsyncStorage.removeItem as jest.Mock).mockClear();
+  });
+
+  it('persists background points when upload fails', async () => {
+    (global as any).fetch = jest.fn(() => Promise.reject(new Error('offline')));
+
+    await handleBackgroundLocationTask({ data: { locations: [makeLocation(0), makeLocation(1)] } as any });
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      'spinr_bg_location_queue',
+      expect.stringContaining('"tracking_phase":"background"')
+    );
+    const queued = JSON.parse(mockAsyncStorage.spinr_bg_location_queue);
+    expect(queued).toHaveLength(2);
+  });
+
+  it('replays queued background points before new points and clears queue on success', async () => {
+    mockAsyncStorage.spinr_bg_location_queue = JSON.stringify([
+      {
+        lat: 52,
+        lng: -106,
+        speed: 10,
+        heading: 45,
+        accuracy: 9,
+        timestamp: '2026-07-09T11:59:00.000Z',
+        tracking_phase: 'background',
+      },
+    ]);
+
+    await handleBackgroundLocationTask({ data: { locations: [makeLocation(0)] } as any });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://example.test/api/v1/drivers/location-batch',
+      expect.objectContaining({
+        body: expect.any(String),
+      })
+    );
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.points).toHaveLength(2);
+    expect(body.points[0].timestamp).toBe('2026-07-09T11:59:00.000Z');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('spinr_bg_location_queue');
   });
 });
 

--- a/driver-app/utils/backgroundLocation.ts
+++ b/driver-app/utils/backgroundLocation.ts
@@ -1,6 +1,7 @@
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
 import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import SpinrConfig from '@shared/config/spinr.config';
 import { getAppCheckToken, initFirebaseServices } from '@shared/services/firebase';
@@ -13,6 +14,8 @@ import { getAppCheckToken, initFirebaseServices } from '@shared/services/firebas
 const API_URL = SpinrConfig.backendUrl;
 
 const TASK_NAME = 'spinr-background-location';
+const BG_LOCATION_QUEUE_KEY = 'spinr_bg_location_queue';
+const BG_LOCATION_QUEUE_MAX_POINTS = 1000;
 
 // ── Geofence-based killed-app recovery ─────────────────────────────────
 // When the user force-swipes the app, Expo's foreground service is killed
@@ -31,6 +34,40 @@ const TRIP_ACTIVE_KEY = 'spinr_bg_trip_active';
 type LocationTaskData = {
   locations: Location.LocationObject[];
 };
+
+type BackgroundLocationPoint = {
+  lat: number;
+  lng: number;
+  speed: number | null;
+  heading: number | null;
+  accuracy: number | null;
+  timestamp: string;
+  tracking_phase: 'background';
+};
+
+async function loadQueuedBackgroundPoints(): Promise<BackgroundLocationPoint[]> {
+  try {
+    const raw = await AsyncStorage.getItem(BG_LOCATION_QUEUE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+async function saveQueuedBackgroundPoints(points: BackgroundLocationPoint[]): Promise<void> {
+  const capped = points.slice(-BG_LOCATION_QUEUE_MAX_POINTS);
+  try {
+    if (capped.length === 0) {
+      await AsyncStorage.removeItem(BG_LOCATION_QUEUE_KEY);
+    } else {
+      await AsyncStorage.setItem(BG_LOCATION_QUEUE_KEY, JSON.stringify(capped));
+    }
+  } catch (e) {
+    console.warn('[BgLocation] Failed to persist offline queue:', e);
+  }
+}
 
 /**
  * Get a valid access token for the background task.
@@ -105,15 +142,12 @@ export async function getBackgroundAuthToken(): Promise<string | null> {
   }
 }
 
-TaskManager.defineTask<LocationTaskData>(TASK_NAME, async ({ data, error }) => {
+export async function handleBackgroundLocationTask({ data, error }: { data?: LocationTaskData; error?: { message?: string } | null }): Promise<void> {
   if (error) {
     console.error('[BgLocation] Task error:', error.message);
     return;
   }
   if (!data?.locations?.length) return;
-
-  const token = await getBackgroundAuthToken();
-  if (!token || !API_URL) return;
 
   // Filter out spoofed/mock locations
   const trusted = data.locations.filter((loc) => {
@@ -124,15 +158,23 @@ TaskManager.defineTask<LocationTaskData>(TASK_NAME, async ({ data, error }) => {
   });
   if (!trusted.length) return;
 
-  const points = trusted.map((loc) => ({
+  const points: BackgroundLocationPoint[] = trusted.map((loc) => ({
     lat: loc.coords.latitude,
     lng: loc.coords.longitude,
-    speed: loc.coords.speed,
-    heading: loc.coords.heading,
-    accuracy: loc.coords.accuracy,
+    speed: loc.coords.speed ?? null,
+    heading: loc.coords.heading ?? null,
+    accuracy: loc.coords.accuracy ?? null,
     timestamp: new Date(loc.timestamp).toISOString(),
     tracking_phase: 'background',
   }));
+  const queued = await loadQueuedBackgroundPoints();
+  const pointsToUpload = [...queued, ...points].slice(-BG_LOCATION_QUEUE_MAX_POINTS);
+
+  const token = await getBackgroundAuthToken();
+  if (!token || !API_URL) {
+    await saveQueuedBackgroundPoints(pointsToUpload);
+    return;
+  }
 
   try {
     // App Check is enforced on /api/* in production. Initialize it (idempotent;
@@ -141,20 +183,27 @@ TaskManager.defineTask<LocationTaskData>(TASK_NAME, async ({ data, error }) => {
     // go stale while the task logs the points as sent.
     await initFirebaseServices();
     const appCheckToken = await getAppCheckToken();
-    await fetch(`${API_URL}/api/v1/drivers/location-batch`, {
+    const resp = await fetch(`${API_URL}/api/v1/drivers/location-batch`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
         ...(appCheckToken ? { 'X-Firebase-AppCheck': appCheckToken } : {}),
       },
-      body: JSON.stringify({ points }),
+      body: JSON.stringify({ points: pointsToUpload }),
     });
-    console.log(`[BgLocation] Sent ${points.length} points`);
+    if (!resp.ok) {
+      throw new Error(`location-batch ${resp.status}`);
+    }
+    await saveQueuedBackgroundPoints([]);
+    console.log(`[BgLocation] Sent ${pointsToUpload.length} points`);
   } catch (e) {
     console.warn('[BgLocation] Upload failed:', e);
+    await saveQueuedBackgroundPoints(pointsToUpload);
   }
-});
+}
+
+TaskManager.defineTask<LocationTaskData>(TASK_NAME, handleBackgroundLocationTask);
 
 export interface BgLocationConfig {
   timeInterval?: number;


### PR DESCRIPTION
### Motivation
- Improve OSRM /match reliability and speed by supplying per-point timestamps and bearing hints and avoid noisy geometry and snapping errors. 
- Make headless background location more robust to network failures by persisting points to AsyncStorage and replaying them on the next successful upload. 

### Description
- Add `_osrm_timestamp` and `_osrm_bearing` helpers and include `timestamps` and `bearings` parameters to OSRM `/match` requests when available, change `gaps` to `split`, and keep `tidy=true`. 
- Normalize OSRM geometry by deduplicating consecutive points before capping via `_cap_polyline`, and keep the distance summation logic unchanged. 
- Add `datetime` import and defensive parsing of various timestamp formats (ISO seconds, expo millis, numeric strings) in `_osrm_timestamp`. 
- Add AsyncStorage-backed offline queue in the background location task with `loadQueuedBackgroundPoints` and `saveQueuedBackgroundPoints`, cap queue size, prepend queued points to new points before upload, and clear the queue on success. 
- Export a standalone `handleBackgroundLocationTask` function and register it with `TaskManager.defineTask`, and make background upload attach App Check and background access tokens with retry/queue behavior. 
- Update tests and mocks to cover new OSRM timestamp/bearing behavior, param capture, polyline handling, and background-location queuing/replay logic; adjust SecureStore and AsyncStorage mocks for headless task flows. 

### Testing
- Ran the backend unit tests for OSRM behavior with `pytest backend/tests/test_route_distance_osrm.py`, which exercised `_osrm_timestamp`, `_osrm_bearing`, and `_compute_via_osrm` and passed. 
- Ran the driver app unit tests for background location with Jest for `driver-app/utils/__tests__/backgroundLocation.test.ts`, which validated queue persistence, replay, and cadence behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd66def3883308b08f9397b5b004f)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
