### PR TITLE
Fix rider App Check startup race

### DIFF
--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -68,11 +68,17 @@ import {
   getAppCheckToken,
 } from '@shared/services/firebase';
 import { setAppCheckTokenProvider } from '@shared/api/client';
+
 import { handleScheduledRideReminderFCM } from '../hooks/useScheduledRideReminder';
 import { useRideStatusNotification } from '../hooks/useRideStatusNotification';
 import ConfirmSheet from '../components/ConfirmSheet';
 import type { ConfirmSheetButton } from '../components/ConfirmSheet';
 import Toast from '../components/Toast';
+
+// Register App Check token retrieval at module load so early startup requests
+// (public settings, active-ride hydration, and login OTP) wait for Firebase
+// App Check instead of racing ahead without X-Firebase-AppCheck.
+setAppCheckTokenProvider(getAppCheckToken);
 
 
 function routeFromNotificationData(data: Record<string, string> | undefined) {
@@ -298,7 +304,6 @@ function RootLayout() {
 
         await useRideStore.getState().hydrateActiveRide();
         await initFirebaseServices();
-        setAppCheckTokenProvider(getAppCheckToken);
         await requestNotificationPermission();
         captureMessage('rider-app cold start', 'log');
 


### PR DESCRIPTION
### Motivation
- Prevent early cold-start requests (e.g. `GET /settings`, `GET /rides/active`, `POST /auth/send-otp`) from being rejected with 401 when Firebase App Check has not yet minted a token by ensuring the API client can obtain an App Check token before those requests fire.

### Description
- Register the App Check token provider at module load by calling `setAppCheckTokenProvider(getAppCheckToken)` in `rider-app/app/_layout.tsx`, and remove the later/too-late provider registration after `initFirebaseServices()` so early startup requests and OTP login use `X-Firebase-AppCheck` when available.

### Testing
- Ran `cd rider-app && yarn lint` which could not complete due to an environment/ESLint package export error (`Package subpath './config' is not defined by "exports"`), and attempted the codegraph rebuild command per repo guidance but it could not run because the environment lacks `pip`/`graphify` so automated checks were not fully executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff7af52d083309b0e9e1adfdf9b73)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
