### PR TITLE
Add regulatory/compliance fields, service-area defaults, and Saskatoon import tooling

### DIFF
--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -366,12 +366,73 @@ export default function DriversPage() {
     };
     const confirmReview = async () => { if (!reviewingDoc) return; await handleReviewDoc(reviewingDoc.id, reviewingDoc.action, reviewReason || undefined, reviewExpiry || undefined); setReviewingDoc(null); };
 
-    const startEditing = () => { if (!selected) return; setEditForm({ first_name: selected.first_name || "", last_name: selected.last_name || "", email: selected.email || "", phone: selected.phone || "", city: selected.city || "", service_area_id: selected.service_area_id || "", vehicle_type_id: selected.vehicle_type_id || "", vehicle_make: selected.vehicle_make || "", vehicle_model: selected.vehicle_model || "", vehicle_color: selected.vehicle_color || "", vehicle_year: selected.vehicle_year || "", license_plate: selected.license_plate || "", vehicle_vin: selected.vehicle_vin || "" }); setEditing(true); };
+    const dateInputValue = (v: any) => {
+        if (!v) return "";
+        const d = new Date(v);
+        return Number.isNaN(d.getTime()) ? String(v).slice(0, 10) : d.toISOString().slice(0, 10);
+    };
+    const datetimeLocalValue = (v: any) => {
+        if (!v) return "";
+        const d = new Date(v);
+        if (Number.isNaN(d.getTime())) return String(v).slice(0, 16);
+        const local = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
+        return local.toISOString().slice(0, 16);
+    };
+    const boolInputValue = (v: any) => (v === true ? "true" : v === false ? "false" : "");
+    const fromBoolInput = (v: any) => (v === "true" ? true : v === "false" ? false : null);
+    const startEditing = () => {
+        if (!selected) return;
+        setEditForm({
+            first_name: selected.first_name || "",
+            last_name: selected.last_name || "",
+            email: selected.email || "",
+            phone: selected.phone || "",
+            city: selected.city || "",
+            service_area_id: selected.service_area_id || "",
+            vehicle_type_id: selected.vehicle_type_id || "",
+            vehicle_make: selected.vehicle_make || "",
+            vehicle_model: selected.vehicle_model || "",
+            vehicle_color: selected.vehicle_color || "",
+            vehicle_year: selected.vehicle_year || "",
+            license_plate: selected.license_plate || "",
+            vehicle_vin: selected.vehicle_vin || "",
+            date_of_birth: dateInputValue(selected.date_of_birth),
+            license_class: selected.license_class || "",
+            regulatory_authority: selected.regulatory_authority || (selected.sgi_approved != null ? "SGI" : ""),
+            regulatory_region: selected.regulatory_region || "",
+            regulatory_authority_approved: boolInputValue(selected.regulatory_authority_approved ?? selected.sgi_approved),
+            regulatory_authority_approved_at: datetimeLocalValue(selected.regulatory_authority_approved_at || selected.sgi_approved_at),
+            work_authorization_status: selected.work_authorization_status || "",
+            is_permanent_resident: boolInputValue(selected.is_permanent_resident),
+            is_citizen: boolInputValue(selected.is_citizen),
+            decals_sent: boolInputValue(selected.decals_sent),
+            decals_sent_at: datetimeLocalValue(selected.decals_sent_at),
+        });
+        setEditing(true);
+    };
 
     const saveEdits = async () => {
         if (!selected) return;
         const changes: Record<string, any> = {};
-        for (const [k, v] of Object.entries(editForm)) { if (v !== (selected[k] || "")) changes[k] = v; }
+        const boolFields = new Set(["regulatory_authority_approved", "is_permanent_resident", "is_citizen", "decals_sent"]);
+        const dateFields = new Set(["date_of_birth"]);
+        const datetimeFields = new Set(["regulatory_authority_approved_at", "decals_sent_at"]);
+        const normalized: Record<string, any> = {};
+        for (const [k, v] of Object.entries(editForm)) {
+            if (boolFields.has(k)) normalized[k] = fromBoolInput(v);
+            else if (dateFields.has(k)) normalized[k] = v || null;
+            else normalized[k] = v === "" ? null : v;
+        }
+        for (const [k, v] of Object.entries(normalized)) {
+            const current = boolFields.has(k)
+                ? (selected[k] ?? null)
+                : dateFields.has(k)
+                    ? (dateInputValue(selected[k]) || null)
+                    : datetimeFields.has(k)
+                        ? (datetimeLocalValue(selected[k]) || null)
+                        : (selected[k] ?? null);
+            if (v !== current) changes[k] = v;
+        }
         if (Object.keys(changes).length === 0) { setEditing(false); return; }
         setSaving(true);
         try { await updateDriver(selected.id, changes); const updated = { ...selected, ...changes }; setSelected(updated); setDrivers(prev => prev.map(d => d.id === selected.id ? { ...d, ...changes } : d)); setEditing(false); } catch (e: any) { toast({ title: "Failed to save driver", description: e?.message || "Unknown error", variant: "destructive" }); } finally { setSaving(false); }
@@ -976,6 +1037,49 @@ export default function DriversPage() {
                                                     <DetailField icon={FileText} label="VIN" value={selected.vehicle_vin || "\u2014"} mono />
                                                 </div>
                                             </>
+                                        )}
+                                    </DetailSection>
+                                    <DetailSection title="Compliance & Import Data" icon={ShieldCheck}>
+                                        {editing ? (
+                                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                                <EditField label="Date of Birth" value={ef("date_of_birth")} onChange={v => setEf("date_of_birth", v)} type="date" />
+                                                <EditField label="License Class" value={ef("license_class")} onChange={v => setEf("license_class", v)} />
+                                                <EditField label="Regulatory Authority" value={ef("regulatory_authority")} onChange={v => setEf("regulatory_authority", v)} />
+                                                <EditField label="Regulatory Region" value={ef("regulatory_region")} onChange={v => setEf("regulatory_region", v)} />
+                                                <EditBooleanField label="Authority Approved" value={ef("regulatory_authority_approved")} onChange={v => setEf("regulatory_authority_approved", v)} />
+                                                <EditField label="Authority Approved At" value={ef("regulatory_authority_approved_at")} onChange={v => setEf("regulatory_authority_approved_at", v)} type="datetime-local" />
+                                                <div>
+                                                    <label className="text-[11px] text-muted-foreground mb-1 block">Work Authorization Status</label>
+                                                    <Select value={ef("work_authorization_status") || "unknown"} onValueChange={v => setEf("work_authorization_status", v === "unknown" ? "" : v)}>
+                                                        <SelectTrigger className="h-9 text-sm"><SelectValue /></SelectTrigger>
+                                                        <SelectContent>
+                                                            <SelectItem value="unknown">Unknown</SelectItem>
+                                                            <SelectItem value="expiring">Expiring</SelectItem>
+                                                            <SelectItem value="indefinite">Indefinite</SelectItem>
+                                                            <SelectItem value="permanent_resident">Permanent resident</SelectItem>
+                                                            <SelectItem value="citizen">Citizen</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                </div>
+                                                <EditBooleanField label="Permanent Resident" value={ef("is_permanent_resident")} onChange={v => setEf("is_permanent_resident", v)} />
+                                                <EditBooleanField label="Citizen" value={ef("is_citizen")} onChange={v => setEf("is_citizen", v)} />
+                                                <EditBooleanField label="Decals Sent" value={ef("decals_sent")} onChange={v => setEf("decals_sent", v)} />
+                                                <EditField label="Decals Sent At" value={ef("decals_sent_at")} onChange={v => setEf("decals_sent_at", v)} type="datetime-local" />
+                                            </div>
+                                        ) : (
+                                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                                                <DetailField icon={CalendarRange} label="Date of Birth" value={selected.date_of_birth ? fmtDate(selected.date_of_birth) : "—"} />
+                                                <DetailField icon={FileText} label="License Class" value={selected.license_class || "—"} />
+                                                <DetailField icon={ShieldCheck} label="Regulatory Authority" value={selected.regulatory_authority || (selected.sgi_approved != null ? "SGI" : "—")} />
+                                                <DetailField icon={MapPin} label="Regulatory Region" value={selected.regulatory_region || "—"} />
+                                                <DetailField icon={ShieldCheck} label="Authority Approved" value={(selected.regulatory_authority_approved ?? selected.sgi_approved) === true ? "Yes" : (selected.regulatory_authority_approved ?? selected.sgi_approved) === false ? "No" : "Unknown"} />
+                                                <DetailField icon={Clock} label="Authority Approved At" value={(selected.regulatory_authority_approved_at || selected.sgi_approved_at) ? new Date(selected.regulatory_authority_approved_at || selected.sgi_approved_at).toLocaleString("en-CA") : "—"} />
+                                                <DetailField icon={FileText} label="Work Authorization" value={selected.work_authorization_status ? selected.work_authorization_status.replace(/_/g, " ") : "Unknown"} />
+                                                <DetailField icon={Shield} label="Permanent Resident" value={selected.is_permanent_resident === true ? "Yes" : selected.is_permanent_resident === false ? "No" : "Unknown"} />
+                                                <DetailField icon={Shield} label="Citizen" value={selected.is_citizen === true ? "Yes" : selected.is_citizen === false ? "No" : "Unknown"} />
+                                                <DetailField icon={CheckCircle} label="Decals Sent" value={selected.decals_sent === true ? "Yes" : selected.decals_sent === false ? "No" : "Unknown"} />
+                                                <DetailField icon={Clock} label="Decals Sent At" value={selected.decals_sent_at ? new Date(selected.decals_sent_at).toLocaleString("en-CA") : "—"} />
+                                            </div>
                                         )}
                                     </DetailSection>
                                     <DetailSection title="Vehicle Change History" icon={FileText}>
@@ -2325,6 +2429,22 @@ function EditField({ label, value, onChange, type = "text" }: { label: string; v
     return <div><label className="text-[11px] text-muted-foreground mb-1 block">{label}</label><Input type={type} value={value} onChange={e => onChange(e.target.value)} className="h-9 text-sm" /></div>;
 }
 
+function EditBooleanField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+    return (
+        <div>
+            <label className="text-[11px] text-muted-foreground mb-1 block">{label}</label>
+            <Select value={value || "unknown"} onValueChange={v => onChange(v === "unknown" ? "" : v)}>
+                <SelectTrigger className="h-9 text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="unknown">Unknown</SelectItem>
+                    <SelectItem value="true">Yes</SelectItem>
+                    <SelectItem value="false">No</SelectItem>
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}
+
 type DocSummary = {
     expiry?: string;
     docStatus: "approved" | "pending" | "rejected" | "missing";
@@ -2427,4 +2547,3 @@ function DocCard({ d, docBusy, onPreview, onReview }: { d: any; docBusy: string 
         </div>
     );
 }
-

--- a/admin-dashboard/src/app/dashboard/service-areas/page.tsx
+++ b/admin-dashboard/src/app/dashboard/service-areas/page.tsx
@@ -14,6 +14,13 @@ import { useRequireModule } from "@/hooks/useRequireModule";
 
 const GeofenceMap = lazy(() => import("@/components/geofence-map"));
 
+const regulatoryDefaultsForProvince = (province: string) => {
+  if (province === "SK") return { authority: "SGI", region: "SK" };
+  if (province === "AB") return { authority: "Alberta TNC / municipal licensing", region: "AB" };
+  if (province === "ON") return { authority: "Municipal vehicle-for-hire / PTC licensing", region: "ON" };
+  return { authority: "Provincial / municipal authority", region: province || "" };
+};
+
 const CITY_PRESETS: Record<string, { city: string; province: string; center: { lat: number; lng: number }; polygon: { lat: number; lng: number }[] }> = {
   saskatoon: { city: "Saskatoon", province: "SK", center: { lat: 52.13, lng: -106.67 }, polygon: [{ lat: 52.19, lng: -106.75 }, { lat: 52.19, lng: -106.55 }, { lat: 52.08, lng: -106.55 }, { lat: 52.08, lng: -106.75 }] },
   regina: { city: "Regina", province: "SK", center: { lat: 50.45, lng: -104.62 }, polygon: [{ lat: 50.50, lng: -104.72 }, { lat: 50.50, lng: -104.52 }, { lat: 50.40, lng: -104.52 }, { lat: 50.40, lng: -104.72 }] },
@@ -84,6 +91,8 @@ export default function ServiceAreasPage() {
   // Create form
   const [createForm, setCreateForm] = useState({
     name: "", city: "", province: "SK", preset: "",
+    regulatory_authority: regulatoryDefaultsForProvince("SK").authority, regulatory_region: regulatoryDefaultsForProvince("SK").region,
+    regulatory_requirements_url: "", regulatory_notes: "",
     polygon: [] as any[], polygonText: "",
     is_active: true, is_airport: false,
   });
@@ -122,6 +131,8 @@ export default function ServiceAreasPage() {
       setCreateForm({
         ...createForm, preset: key, name: createForm.name || p.city,
         city: p.city, province: p.province,
+        regulatory_authority: regulatoryDefaultsForProvince(p.province).authority,
+        regulatory_region: regulatoryDefaultsForProvince(p.province).region,
         polygon: p.polygon, polygonText: polygonToText(p.polygon),
       });
       setMapKey(k => k + 1);
@@ -133,6 +144,10 @@ export default function ServiceAreasPage() {
     try {
       await createServiceArea({
         name: createForm.name, city: createForm.city, province: createForm.province,
+        regulatory_authority: createForm.regulatory_authority || regulatoryDefaultsForProvince(createForm.province).authority,
+        regulatory_region: createForm.regulatory_region || regulatoryDefaultsForProvince(createForm.province).region,
+        regulatory_requirements_url: createForm.regulatory_requirements_url || "",
+        regulatory_notes: createForm.regulatory_notes || "",
         geojson: { type: "Polygon", coordinates: [createForm.polygon.map(p => [p.lng, p.lat])] },
         is_active: createForm.is_active, is_airport: createForm.is_airport,
         // Defaults
@@ -143,7 +158,7 @@ export default function ServiceAreasPage() {
         max_pickup_radius_km: 5.0, currency: 'CAD',
       });
       setShowCreate(false);
-      setCreateForm({ name: "", city: "", province: "SK", preset: "", polygon: [], polygonText: "", is_active: true, is_airport: false });
+      setCreateForm({ name: "", city: "", province: "SK", preset: "", regulatory_authority: regulatoryDefaultsForProvince("SK").authority, regulatory_region: regulatoryDefaultsForProvince("SK").region, regulatory_requirements_url: "", regulatory_notes: "", polygon: [], polygonText: "", is_active: true, is_airport: false });
       crudToast.created("Service area");
       load();
     } catch (e) { crudToast.error("create service area", e); }
@@ -239,7 +254,7 @@ export default function ServiceAreasPage() {
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-600 mb-1">Province</label>
-              <select className="w-full border rounded-xl px-4 py-2.5 text-sm" value={createForm.province} onChange={e => setCreateForm({...createForm, province: e.target.value})}>
+              <select className="w-full border rounded-xl px-4 py-2.5 text-sm" value={createForm.province} onChange={e => { const province = e.target.value; const defaults = regulatoryDefaultsForProvince(province); setCreateForm({...createForm, province, regulatory_authority: defaults.authority, regulatory_region: defaults.region}); }}>
                 {['SK','AB','MB','ON','BC','QC','NS','NB','PE','NL','NT','YT','NU'].map(p => <option key={p} value={p}>{p}</option>)}
               </select>
             </div>
@@ -562,6 +577,10 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
     name: area.name || "",
     city: area.city || "",
     province: area.province || "SK",
+    regulatory_authority: area.regulatory_authority || regulatoryDefaultsForProvince(area.province || "SK").authority,
+    regulatory_region: area.regulatory_region || area.province || "SK",
+    regulatory_requirements_url: area.regulatory_requirements_url || "",
+    regulatory_notes: area.regulatory_notes || "",
     max_pickup_radius_km: area.max_pickup_radius_km || 5,
     is_active: area.is_active !== false,
     driver_matching_algorithm: area.driver_matching_algorithm || "nearest",
@@ -605,6 +624,10 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
       name: form.name,
       city: form.city,
       province: form.province,
+      regulatory_authority: form.regulatory_authority,
+      regulatory_region: form.regulatory_region || form.province,
+      regulatory_requirements_url: form.regulatory_requirements_url,
+      regulatory_notes: form.regulatory_notes,
       max_pickup_radius_km: parseFloat(String(form.max_pickup_radius_km)) || 5,
       is_active: form.is_active,
       driver_matching_algorithm: form.driver_matching_algorithm,
@@ -657,9 +680,29 @@ function GeneralTabForm({ area, onSave, onDelete }: { area: any; onSave: (update
         </div>
         <div>
           <label className="block text-xs font-semibold text-gray-500 mb-1">Province</label>
-          <select className="w-full border rounded-lg px-3 py-2 text-sm" value={form.province} onChange={e => setForm({ ...form, province: e.target.value })}>
+          <select className="w-full border rounded-lg px-3 py-2 text-sm" value={form.province} onChange={e => {
+            const province = e.target.value;
+            const defaults = regulatoryDefaultsForProvince(province);
+            setForm({ ...form, province, regulatory_authority: form.regulatory_authority || defaults.authority, regulatory_region: form.regulatory_region || defaults.region });
+          }}>
             {['SK','AB','MB','ON','BC','QC','NS','NB','PE','NL','NT','YT','NU'].map(p => <option key={p} value={p}>{p}</option>)}
           </select>
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 mb-1">Regulatory Authority</label>
+          <input className="w-full border rounded-lg px-3 py-2 text-sm" value={form.regulatory_authority} onChange={e => setForm({ ...form, regulatory_authority: e.target.value })} placeholder="e.g. SGI, Calgary Livery, Toronto PTC" />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 mb-1">Regulatory Region</label>
+          <input className="w-full border rounded-lg px-3 py-2 text-sm" value={form.regulatory_region} onChange={e => setForm({ ...form, regulatory_region: e.target.value })} placeholder="e.g. SK, AB, Calgary, Toronto" />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-gray-500 mb-1">Requirements URL</label>
+          <input className="w-full border rounded-lg px-3 py-2 text-sm" value={form.regulatory_requirements_url} onChange={e => setForm({ ...form, regulatory_requirements_url: e.target.value })} placeholder="Official local requirements link" />
+        </div>
+        <div className="md:col-span-3">
+          <label className="block text-xs font-semibold text-gray-500 mb-1">Regulatory Notes</label>
+          <textarea className="w-full border rounded-lg px-3 py-2 text-sm min-h-[80px]" value={form.regulatory_notes} onChange={e => setForm({ ...form, regulatory_notes: e.target.value })} placeholder="Summarize local driver approval/licensing rules for this service area" />
         </div>
         <div>
           <label className="block text-xs font-semibold text-gray-500 mb-1">Pickup Radius (km)</label>

--- a/backend/migrations/221_drivers_bulk_import_fields.sql
+++ b/backend/migrations/221_drivers_bulk_import_fields.sql
@@ -1,0 +1,62 @@
+-- 221_drivers_bulk_import_fields.sql
+-- Purpose: Add optional metadata fields needed for legacy Saskatoon driver imports.
+-- Rollback:
+--   ALTER TABLE public.drivers
+--     DROP COLUMN IF EXISTS date_of_birth,
+--     DROP COLUMN IF EXISTS license_class,
+--     DROP COLUMN IF EXISTS sgi_approved,
+--     DROP COLUMN IF EXISTS sgi_approved_at,
+--     DROP COLUMN IF EXISTS work_authorization_status,
+--     DROP COLUMN IF EXISTS is_permanent_resident,
+--     DROP COLUMN IF EXISTS is_citizen,
+--     DROP COLUMN IF EXISTS decals_sent,
+--     DROP COLUMN IF EXISTS decals_sent_at,
+--     DROP COLUMN IF EXISTS legacy_import_metadata;
+--
+-- Notes:
+-- - All columns are nullable/additive so this is safe with production traffic.
+-- - Full driver addresses are intentionally kept out of first-class plain-text
+--   columns. Importers should keep them in legacy_import_metadata only if a
+--   secure operational process has approved that data flow, or migrate them to
+--   a vault-backed field in a follow-up.
+
+ALTER TABLE public.drivers
+  ADD COLUMN IF NOT EXISTS date_of_birth DATE,
+  ADD COLUMN IF NOT EXISTS license_class TEXT,
+  ADD COLUMN IF NOT EXISTS sgi_approved BOOLEAN,
+  ADD COLUMN IF NOT EXISTS sgi_approved_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS work_authorization_status TEXT,
+  ADD COLUMN IF NOT EXISTS is_permanent_resident BOOLEAN,
+  ADD COLUMN IF NOT EXISTS is_citizen BOOLEAN,
+  ADD COLUMN IF NOT EXISTS decals_sent BOOLEAN,
+  ADD COLUMN IF NOT EXISTS decals_sent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS legacy_import_metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_drivers_sgi_approved
+  ON public.drivers (sgi_approved)
+  WHERE sgi_approved IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drivers_license_class
+  ON public.drivers (license_class)
+  WHERE license_class IS NOT NULL;
+
+COMMENT ON COLUMN public.drivers.date_of_birth IS
+  'Driver date of birth imported from legacy onboarding data. PII: never log or expose outside admin/compliance flows.';
+COMMENT ON COLUMN public.drivers.license_class IS
+  'Saskatchewan driver licence class from onboarding/import data, e.g. 4 or 5.';
+COMMENT ON COLUMN public.drivers.sgi_approved IS
+  'Whether imported records indicate SGI approval for passenger-for-hire/rideshare operation.';
+COMMENT ON COLUMN public.drivers.sgi_approved_at IS
+  'Timestamp when SGI approval was verified/imported, if known.';
+COMMENT ON COLUMN public.drivers.work_authorization_status IS
+  'Normalized work authorization status such as expiring, indefinite, permanent_resident, citizen, unknown.';
+COMMENT ON COLUMN public.drivers.is_permanent_resident IS
+  'Imported immigration/work-eligibility flag. Sensitive admin/compliance data.';
+COMMENT ON COLUMN public.drivers.is_citizen IS
+  'Imported citizenship/work-eligibility flag. Sensitive admin/compliance data.';
+COMMENT ON COLUMN public.drivers.decals_sent IS
+  'Operations flag indicating whether Spinr decals were sent to the driver.';
+COMMENT ON COLUMN public.drivers.decals_sent_at IS
+  'Timestamp when decals were sent, if known.';
+COMMENT ON COLUMN public.drivers.legacy_import_metadata IS
+  'JSON metadata from legacy imports, scoped to admin/compliance use only. Avoid storing raw PII unless explicitly approved.';

--- a/backend/migrations/222_drivers_general_regulatory_approval.sql
+++ b/backend/migrations/222_drivers_general_regulatory_approval.sql
@@ -1,0 +1,51 @@
+-- 222_drivers_general_regulatory_approval.sql
+-- Purpose: Generalize Saskatchewan-only SGI approval import fields so future
+-- Alberta/Ontario/other-province launches can track the applicable regulator
+-- or municipal licensing authority without adding province-specific columns.
+--
+-- Rollback:
+--   ALTER TABLE public.drivers
+--     DROP COLUMN IF EXISTS regulatory_authority,
+--     DROP COLUMN IF EXISTS regulatory_region,
+--     DROP COLUMN IF EXISTS regulatory_authority_approved,
+--     DROP COLUMN IF EXISTS regulatory_authority_approved_at;
+--   DROP INDEX IF EXISTS idx_drivers_regulatory_authority_approved;
+--   DROP INDEX IF EXISTS idx_drivers_regulatory_region;
+--
+-- Notes:
+-- - Nullable/additive for production safety.
+-- - Existing sgi_approved values are copied forward for Saskatchewan imports.
+-- - Keep the old SGI columns for backward compatibility with any in-flight PRs
+--   or exports; new code should read/write the generalized columns.
+
+ALTER TABLE public.drivers
+  ADD COLUMN IF NOT EXISTS regulatory_authority TEXT,
+  ADD COLUMN IF NOT EXISTS regulatory_region TEXT,
+  ADD COLUMN IF NOT EXISTS regulatory_authority_approved BOOLEAN,
+  ADD COLUMN IF NOT EXISTS regulatory_authority_approved_at TIMESTAMPTZ;
+
+UPDATE public.drivers
+SET
+  regulatory_authority = COALESCE(regulatory_authority, 'SGI'),
+  regulatory_region = COALESCE(regulatory_region, 'SK'),
+  regulatory_authority_approved = COALESCE(regulatory_authority_approved, sgi_approved),
+  regulatory_authority_approved_at = COALESCE(regulatory_authority_approved_at, sgi_approved_at)
+WHERE sgi_approved IS NOT NULL
+   OR sgi_approved_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drivers_regulatory_authority_approved
+  ON public.drivers (regulatory_authority_approved)
+  WHERE regulatory_authority_approved IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_drivers_regulatory_region
+  ON public.drivers (regulatory_region)
+  WHERE regulatory_region IS NOT NULL;
+
+COMMENT ON COLUMN public.drivers.regulatory_authority IS
+  'Province/municipal regulator or licensing authority label for imported approval data, e.g. SGI, Alberta TNC/municipal licence, Toronto PTC.';
+COMMENT ON COLUMN public.drivers.regulatory_region IS
+  'Regulatory region for approval metadata, e.g. SK, AB, ON, Toronto, Calgary.';
+COMMENT ON COLUMN public.drivers.regulatory_authority_approved IS
+  'Whether the relevant provincial/municipal authority approval or eligibility check is recorded as approved.';
+COMMENT ON COLUMN public.drivers.regulatory_authority_approved_at IS
+  'Timestamp when the regulatory approval was verified/imported, if known.';

--- a/backend/migrations/223_service_areas_regulatory_authority.sql
+++ b/backend/migrations/223_service_areas_regulatory_authority.sql
@@ -1,0 +1,38 @@
+-- 223_service_areas_regulatory_authority.sql
+-- Purpose: Store per-service-area regulatory authority defaults so imports and
+-- admin driver edits can use the correct provincial/municipal regulator instead
+-- of hardcoding Saskatchewan SGI.
+--
+-- Rollback:
+--   ALTER TABLE public.service_areas
+--     DROP COLUMN IF EXISTS regulatory_authority,
+--     DROP COLUMN IF EXISTS regulatory_region,
+--     DROP COLUMN IF EXISTS regulatory_requirements_url,
+--     DROP COLUMN IF EXISTS regulatory_notes;
+--   DROP INDEX IF EXISTS idx_service_areas_regulatory_region;
+
+ALTER TABLE public.service_areas
+  ADD COLUMN IF NOT EXISTS regulatory_authority TEXT,
+  ADD COLUMN IF NOT EXISTS regulatory_region TEXT,
+  ADD COLUMN IF NOT EXISTS regulatory_requirements_url TEXT,
+  ADD COLUMN IF NOT EXISTS regulatory_notes TEXT;
+
+UPDATE public.service_areas
+SET
+  regulatory_authority = COALESCE(regulatory_authority, CASE WHEN province = 'SK' THEN 'SGI' ELSE NULL END),
+  regulatory_region = COALESCE(regulatory_region, province)
+WHERE regulatory_authority IS NULL
+   OR regulatory_region IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_service_areas_regulatory_region
+  ON public.service_areas (regulatory_region)
+  WHERE regulatory_region IS NOT NULL;
+
+COMMENT ON COLUMN public.service_areas.regulatory_authority IS
+  'Default regulator/licensing authority for drivers in this service area, e.g. SGI, Calgary Livery Transport Services, Toronto PTC.';
+COMMENT ON COLUMN public.service_areas.regulatory_region IS
+  'Province/municipality code or name for driver regulatory rules, e.g. SK, AB, ON, Calgary, Toronto.';
+COMMENT ON COLUMN public.service_areas.regulatory_requirements_url IS
+  'Admin-maintained source URL for local driver eligibility/licensing requirements.';
+COMMENT ON COLUMN public.service_areas.regulatory_notes IS
+  'Admin-maintained notes summarizing local regulatory requirements for this service area.';

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -1006,6 +1006,19 @@ async def admin_update_driver(driver_id: str, updates: Dict[str, Any], admin: di
         "vehicle_inspection_expiry_date",
         "background_check_expiry_date",
         "work_eligibility_expiry_date",
+        "date_of_birth",
+        "license_class",
+        "sgi_approved",
+        "sgi_approved_at",
+        "regulatory_authority",
+        "regulatory_region",
+        "regulatory_authority_approved",
+        "regulatory_authority_approved_at",
+        "work_authorization_status",
+        "is_permanent_resident",
+        "is_citizen",
+        "decals_sent",
+        "decals_sent_at",
     }
     allowed = user_fields | driver_fields
     filtered = {k: v for k, v in updates.items() if k in allowed}

--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -212,6 +212,10 @@ class ServiceAreaUpdateRequest(BaseModel):
     show_demand_heatmap: Optional[bool] = None
     vehicle_pricing: Optional[List[Dict[str, Any]]] = None
     province: Optional[str] = None
+    regulatory_authority: Optional[str] = None
+    regulatory_region: Optional[str] = None
+    regulatory_requirements_url: Optional[str] = None
+    regulatory_notes: Optional[str] = None
     max_pickup_radius_km: Optional[float] = Field(default=None, ge=0.1, le=200)
     surge_source: Optional[str] = None
     insurance_fee_percent: Optional[float] = Field(default=None, ge=0, le=100)
@@ -541,6 +545,10 @@ async def admin_update_service_area(
         "name",
         "city",
         "province",
+        "regulatory_authority",
+        "regulatory_region",
+        "regulatory_requirements_url",
+        "regulatory_notes",
         "is_active",
         "parent_service_area_id",
         "is_airport",

--- a/docs/imports/saskatoon-driver-bulk-import.md
+++ b/docs/imports/saskatoon-driver-bulk-import.md
@@ -1,0 +1,232 @@
+# Saskatoon Driver Bulk Import Runbook
+
+This runbook explains how to prepare legacy driver data and document files for
+` scripts/import_saskatoon_drivers.py `. The same format can be reused for other
+service areas once their Service Area regulatory settings are configured in the
+admin dashboard.
+
+## 1. Configure the service area first
+
+In Admin Dashboard → Service Areas → open the target area → General tab, set:
+
+| Field | Saskatoon value | Future examples |
+|---|---|---|
+| Province | `SK` | `AB`, `ON` |
+| Regulatory Authority | `SGI` | `Alberta TNC / municipal licensing`, `Toronto PTC` |
+| Regulatory Region | `SK` | `AB`, `Calgary`, `Toronto` |
+| Requirements URL | Official regulator/local requirements page | Official municipal/provincial page |
+| Regulatory Notes | Short local rule summary | Short local rule summary |
+
+Then confirm the Service Area → Documents tab has the document keys you will use
+in `documents.csv`, for example:
+
+```text
+drivers_license
+insurance
+vehicle_registration
+vehicle_inspection
+background_check
+drivers_abstract
+work_authorization
+```
+
+The importer rejects document rows whose `requirement_key` does not exist on the
+selected service area's `required_documents` list.
+
+## 2. Folder layout
+
+Create one import folder per batch. Do not mix service areas in one batch.
+
+```text
+bulk-import-saskatoon/
+  drivers.csv
+  documents.csv
+  files/
+    OLD_DRIVER_001/
+      drivers_license_front.jpg
+      drivers_license_back.jpg
+      insurance.pdf
+      vehicle_registration.jpg
+      vehicle_inspection.jpg
+      background_check.pdf
+      drivers_abstract.pdf
+      work_authorization.pdf
+    OLD_DRIVER_002/
+      drivers_license_front.jpg
+      drivers_license_back.jpg
+      insurance.pdf
+      vehicle_registration.jpg
+      vehicle_inspection.jpg
+      background_check.pdf
+      drivers_abstract.pdf
+      work_authorization.pdf
+```
+
+Rules:
+
+- `old_driver_id` is the stable join key between `drivers.csv`, `documents.csv`,
+  and each driver's file folder.
+- Use old-app IDs if available. If not, create stable IDs like `OLD_DRIVER_001`.
+- Do not use driver names as folder names.
+- Keep source CSVs and files in a secure location because they contain PII.
+- Do not commit real import CSVs or document files to git.
+
+## 3. Required `drivers.csv` format
+
+Minimum required columns:
+
+```csv
+old_driver_id,full_name,phone,email,vehicle_plate,vehicle_type,vehicle_year,vehicle_make,vehicle_model
+```
+
+Recommended full format for your legacy sheet:
+
+```csv
+old_driver_id,full_name,date_of_birth,phone,email,license_number,license_class,address,regulatory_authority,regulatory_region,regulatory_authority_approved,spinr_approved,vehicle_plate,vin,vehicle_type,vehicle_year,vehicle_make,vehicle_model,criminal_record_check_expiry,insurance_expiry,vehicle_inspection_expiry,drivers_abstract_status,work_authorization_expiry,permanent_resident,citizen,decals_sent,service_area
+```
+
+Example with fake data:
+
+```csv
+old_driver_id,full_name,date_of_birth,phone,email,license_number,license_class,address,regulatory_authority,regulatory_region,regulatory_authority_approved,spinr_approved,vehicle_plate,vin,vehicle_type,vehicle_year,vehicle_make,vehicle_model,criminal_record_check_expiry,insurance_expiry,vehicle_inspection_expiry,drivers_abstract_status,work_authorization_expiry,permanent_resident,citizen,decals_sent,service_area
+OLD_DRIVER_001,Test Driver One,1988-05-26,+13065550111,test1@example.com,LIC12345,5,"123 Test St, Saskatoon, SK",SGI,SK,Y,Y,ABC123,1HGCM82633A004352,SUV,2021,Toyota,RAV4,2026-10-23,2026-10-17,2026-10-31,Valid,2027-12-05,Yes,No,Y,saskatoon
+OLD_DRIVER_002,Test Driver Two,1979-07-15,+13065550222,test2@example.com,LIC67890,4,"456 Test Ave, Saskatoon, SK",SGI,SK,Y,N,XYZ789,2HGFB2F59DH000000,XL,2017,Dodge,Caravan,2026-10-13,2026-06-18,2026-10-31,Valid,Indefinite,No,Yes,Y,saskatoon
+```
+
+### Driver CSV notes
+
+- `phone`: prefer E.164 format like `+13065550111`; 10-digit numbers are
+  normalized to `+1...`.
+- `vehicle_type`: must match an existing `vehicle_types` name/display name/id,
+  for example `SUV`, `XL`, or `Sedan`.
+- `regulatory_authority` and `regulatory_region`: optional. If blank, the
+  importer uses the selected Service Area defaults.
+- `approved_from_sgi` is still accepted as a legacy alias for
+  `regulatory_authority_approved`, but new CSVs should use the generalized name.
+- `spinr_approved` controls whether the imported driver can be marked active
+  together with regulatory approval. If either regulatory approval or Spinr
+  approval is not true, the driver imports as `needs_review`.
+- `address` is treated as source metadata only and is not inserted into a
+  first-class plain-text driver column.
+
+## 4. Required `documents.csv` format
+
+Required columns:
+
+```csv
+old_driver_id,requirement_key,side,file_path,expiry_date,status,document_type
+```
+
+Example:
+
+```csv
+old_driver_id,requirement_key,side,file_path,expiry_date,status,document_type
+OLD_DRIVER_001,drivers_license,front,files/OLD_DRIVER_001/drivers_license_front.jpg,2028-05-26,pending,Driver's License
+OLD_DRIVER_001,drivers_license,back,files/OLD_DRIVER_001/drivers_license_back.jpg,2028-05-26,pending,Driver's License
+OLD_DRIVER_001,insurance,,files/OLD_DRIVER_001/insurance.pdf,2026-10-17,pending,Vehicle Insurance
+OLD_DRIVER_001,vehicle_registration,,files/OLD_DRIVER_001/vehicle_registration.jpg,2026-10-17,pending,Vehicle Registration
+OLD_DRIVER_001,vehicle_inspection,,files/OLD_DRIVER_001/vehicle_inspection.jpg,2026-10-31,pending,Vehicle Inspection
+OLD_DRIVER_001,background_check,,files/OLD_DRIVER_001/background_check.pdf,2026-10-23,pending,Background Check
+OLD_DRIVER_001,drivers_abstract,,files/OLD_DRIVER_001/drivers_abstract.pdf,,pending,Driver Abstract
+OLD_DRIVER_001,work_authorization,,files/OLD_DRIVER_001/work_authorization.pdf,2027-12-05,pending,Work Authorization
+```
+
+### Document CSV notes
+
+- `file_path` is relative to `--files-root`.
+- `requirement_key` must exist in the target service area's required documents.
+- `side` is usually blank, `front`, or `back`.
+- Use `status=pending` for normal imports so admins can review documents.
+- Use `status=approved` only if the old-app verification is trusted and audit-ready.
+- Supported date inputs include ISO dates like `2026-10-23` and legacy dates like
+  `23-Oct-26`. Use `Indefinite` only for work authorization style fields.
+
+## 5. Dry run first
+
+From the repo root:
+
+```bash
+python3 scripts/import_saskatoon_drivers.py \
+  --drivers-csv bulk-import-saskatoon/drivers.csv \
+  --documents-csv bulk-import-saskatoon/documents.csv \
+  --files-root bulk-import-saskatoon \
+  --service-area-name Saskatoon \
+  --dry-run
+```
+
+If more than one service area matches, pass the exact ID:
+
+```bash
+python3 scripts/import_saskatoon_drivers.py \
+  --drivers-csv bulk-import-saskatoon/drivers.csv \
+  --documents-csv bulk-import-saskatoon/documents.csv \
+  --files-root bulk-import-saskatoon \
+  --service-area-id <saskatoon-service-area-id> \
+  --dry-run
+```
+
+Expected clean report shape:
+
+```text
+DRY RUN report
+  users planned: 200
+  drivers planned: 200
+  documents planned: 1200
+  files planned: 1200
+  warnings: 0
+  errors: 0
+```
+
+Do not run `--commit` until `errors: 0`.
+
+## 6. Commit import
+
+After a clean dry run:
+
+```bash
+python3 scripts/import_saskatoon_drivers.py \
+  --drivers-csv bulk-import-saskatoon/drivers.csv \
+  --documents-csv bulk-import-saskatoon/documents.csv \
+  --files-root bulk-import-saskatoon \
+  --service-area-id <saskatoon-service-area-id> \
+  --batch saskatoon-legacy-2026-07 \
+  --commit
+```
+
+The importer will:
+
+1. Insert `users` rows.
+2. Insert `drivers` rows scoped to the target service area.
+3. Encrypt license number and VIN through the backend PII encryption RPC before
+   inserting those driver fields.
+4. Upload document files to Supabase Storage under:
+
+```text
+saskatoon-import/<batch>/<old_driver_id>/<requirement_key>/<side-or-main>-<document_id>.<ext>
+```
+
+5. Insert `driver_documents` rows pointing at the uploaded storage objects.
+
+## 7. Post-import admin review
+
+After import:
+
+1. Go to Admin Dashboard → Drivers.
+2. Filter to the Saskatoon service area.
+3. Open each imported driver.
+4. Review **Compliance & Import Data**.
+5. Review the **Documents** tab and approve/reject uploaded documents.
+6. Use the **Actions** tab to approve/activate drivers only after compliance
+   review is complete.
+
+## 8. Common validation errors
+
+| Error | Meaning | Fix |
+|---|---|---|
+| `drivers CSV is missing required column` | Header is missing | Add the required column exactly or use a supported alias |
+| `row is not scoped to Saskatoon` | `service_area`/`service_area_id` does not match target | Fix the row or import in the correct batch |
+| `matching user or driver already exists` | Duplicate phone/email/driver found | Resolve manually before import |
+| `no vehicle_types row matched` | `vehicle_type` does not match catalogue | Update vehicle type label or create the vehicle type |
+| `document file not found` | `file_path` is wrong or file missing | Fix folder/file path |
+| `requirement_key is not configured` | Service Area Documents tab lacks that key | Add the document key in Service Areas first |
+| `could not parse date` | Date format unsupported | Convert to `YYYY-MM-DD` |

--- a/scripts/import_saskatoon_drivers.py
+++ b/scripts/import_saskatoon_drivers.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""Bulk-import legacy Saskatoon drivers and document files.
+
+Dry-run first:
+  python3 scripts/import_saskatoon_drivers.py \
+    --drivers-csv bulk-import-saskatoon/drivers.csv \
+    --documents-csv bulk-import-saskatoon/documents.csv \
+    --files-root bulk-import-saskatoon \
+    --service-area-name Saskatoon \
+    --dry-run
+
+Commit after the dry-run report is clean:
+  python3 scripts/import_saskatoon_drivers.py ... --commit
+
+The importer intentionally prints old_driver_id values, not raw PII. Keep CSVs
+and reports in a secure location because the input files contain PIPEDA-covered
+personal information.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import mimetypes
+import re
+import sys
+import uuid
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT / "backend") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+from supabase_client import supabase  # noqa: E402
+from utils.driver_code import generate_driver_code  # noqa: E402
+
+REQUIRED_DRIVER_COLUMNS = {
+    "old_driver_id",
+    "full_name",
+    "phone",
+    "email",
+    "vehicle_plate",
+    "vehicle_type",
+    "vehicle_year",
+    "vehicle_make",
+    "vehicle_model",
+}
+
+DOCUMENT_REQUIREMENT_ALIASES = {
+    "criminal_record_check": "background_check",
+    "crimininal_record_check": "background_check",  # common typo from source sheet
+    "criminal record check": "background_check",
+    "car_insurance": "insurance",
+    "car insurance": "insurance",
+    "vehicle_inspection": "vehicle_inspection",
+    "vehicle inspection": "vehicle_inspection",
+    "drivers_abstract": "drivers_abstract",
+    "drivers abstract": "drivers_abstract",
+    "work_authorization": "work_authorization",
+    "work authorization": "work_authorization",
+    "driving_license": "drivers_license",
+    "driving license": "drivers_license",
+    "drivers_license": "drivers_license",
+}
+
+DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%d-%b-%y",
+    "%d-%b-%Y",
+    "%d-%m-%y",
+    "%d-%m-%Y",
+    "%d/%m/%y",
+    "%d/%m/%Y",
+    "%m/%d/%y",
+    "%m/%d/%Y",
+)
+
+TRUTHY = {"y", "yes", "true", "1", "approved", "valid"}
+FALSY = {"n", "no", "false", "0", "not approved", "invalid"}
+
+
+@dataclass
+class ImportErrorItem:
+    old_driver_id: str
+    field: str
+    message: str
+
+
+@dataclass
+class ImportPlan:
+    users_to_insert: list[dict[str, Any]] = field(default_factory=list)
+    drivers_to_insert: list[dict[str, Any]] = field(default_factory=list)
+    docs_to_insert: list[dict[str, Any]] = field(default_factory=list)
+    files_to_upload: list[tuple[Path, str, str]] = field(default_factory=list)  # path, storage_key, doc_id
+    warnings: list[ImportErrorItem] = field(default_factory=list)
+    errors: list[ImportErrorItem] = field(default_factory=list)
+
+
+def normalize_header(value: str) -> str:
+    value = value.strip().lower().replace("?", "")
+    value = re.sub(r"[^a-z0-9]+", "_", value).strip("_")
+    aliases = {
+        "name": "full_name",
+        "date_of_birth": "date_of_birth",
+        "dob": "date_of_birth",
+        "driving_license_number": "license_number",
+        "driving_licence_number": "license_number",
+        "license_no": "license_number",
+        "licence_no": "license_number",
+        "license_class": "license_class",
+        "approved_from_sgi": "regulatory_authority_approved",
+        "sgi_approved": "regulatory_authority_approved",
+        "regulatory_approved": "regulatory_authority_approved",
+        "regulatory_authority_approved": "regulatory_authority_approved",
+        "regulatory_authority": "regulatory_authority",
+        "regulatory_region": "regulatory_region",
+        "spinr_approved": "spinr_approved",
+        "vehicle_plate": "vehicle_plate",
+        "plate": "vehicle_plate",
+        "vin": "vin",
+        "car_year": "vehicle_year",
+        "car_make": "vehicle_make",
+        "car_model": "vehicle_model",
+        "crimininal_record_check": "criminal_record_check_expiry",
+        "criminal_record_check": "criminal_record_check_expiry",
+        "car_insurance": "insurance_expiry",
+        "vehicle_inspection": "vehicle_inspection_expiry",
+        "drivers_abstract": "drivers_abstract_status",
+        "pr": "permanent_resident",
+        "citizen": "citizen",
+        "decals_sent": "decals_sent",
+    }
+    return aliases.get(value, value)
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        if not reader.fieldnames:
+            raise ValueError(f"{path} has no header row")
+        reader.fieldnames = [normalize_header(h or "") for h in reader.fieldnames]
+        return [{k: (v or "").strip() for k, v in row.items()} for row in reader]
+
+
+def parse_bool(value: str) -> bool | None:
+    raw = (value or "").strip().lower()
+    if not raw:
+        return None
+    if raw in TRUTHY:
+        return True
+    if raw in FALSY:
+        return False
+    return None
+
+
+def parse_date(value: str) -> date | None:
+    raw = (value or "").strip()
+    if not raw or raw.lower() in {"indefinite", "valid", "n/a", "na", "none"}:
+        return None
+    for fmt in DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(raw, fmt).date()
+            if parsed.year < 100:
+                parsed = parsed.replace(year=parsed.year + 2000)
+            return parsed
+        except ValueError:
+            continue
+    return None
+
+
+def iso_date(value: str) -> str | None:
+    parsed = parse_date(value)
+    return parsed.isoformat() if parsed else None
+
+
+def split_name(full_name: str) -> tuple[str, str]:
+    cleaned = re.sub(r"\s*\([^)]*\)", "", full_name).strip()
+    parts = cleaned.split()
+    if not parts:
+        return "", ""
+    if len(parts) == 1:
+        return parts[0], ""
+    return parts[0], " ".join(parts[1:])
+
+
+def normalize_phone(phone: str) -> str:
+    digits = re.sub(r"\D+", "", phone or "")
+    if len(digits) == 10:
+        return f"+1{digits}"
+    if len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    return phone.strip()
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", (value or "").strip().lower()).strip("_")
+
+
+def canonical_requirement_key(value: str) -> str:
+    key = slug(value)
+    return DOCUMENT_REQUIREMENT_ALIASES.get(key, DOCUMENT_REQUIREMENT_ALIASES.get(value.strip().lower(), key))
+
+
+def storage_signed_url(storage_key: str) -> str:
+    res = supabase.storage.from_("driver-documents").create_signed_url(storage_key, 3600)
+    data = getattr(res, "data", None)
+    if isinstance(data, dict):
+        url = data.get("signedURL") or data.get("signedUrl") or data.get("signed_url")
+        if url:
+            return url
+    url = getattr(data, "signed_url", None) or getattr(data, "signedURL", None)
+    if not url:
+        raise RuntimeError(f"create_signed_url returned no URL for {storage_key}")
+    return url
+
+
+def encrypt_pii(value: str | None) -> str | None:
+    if not value:
+        return None
+    res = supabase.rpc("encrypt_driver_pii", {"plaintext": value}).execute()
+    return getattr(res, "data", None)
+
+
+def get_service_area(service_area_id: str | None, service_area_name: str) -> dict[str, Any]:
+    if service_area_id:
+        rows = supabase.table("service_areas").select("id,name,province,required_documents,regulatory_authority,regulatory_region").eq("id", service_area_id).limit(1).execute().data or []
+    else:
+        rows = supabase.table("service_areas").select("id,name,province,required_documents,regulatory_authority,regulatory_region").ilike("name", f"%{service_area_name}%").limit(5).execute().data or []
+    if not rows:
+        raise RuntimeError("Saskatoon service area was not found; pass --service-area-id explicitly")
+    if len(rows) > 1 and not service_area_id:
+        names = ", ".join(f"{r.get('name')} ({r.get('id')})" for r in rows)
+        raise RuntimeError(f"Multiple service areas matched; pass --service-area-id. Matches: {names}")
+    return rows[0]
+
+
+def vehicle_type_map() -> dict[str, str]:
+    rows = supabase.table("vehicle_types").select("id,name,display_name").execute().data or []
+    out: dict[str, str] = {}
+    for row in rows:
+        vid = row.get("id")
+        if not vid:
+            continue
+        for val in (row.get("name"), row.get("display_name"), vid):
+            if val:
+                out[slug(str(val))] = vid
+    return out
+
+
+def validate_required_columns(rows: list[dict[str, str]], plan: ImportPlan) -> None:
+    if not rows:
+        plan.errors.append(ImportErrorItem("<file>", "drivers_csv", "drivers CSV is empty"))
+        return
+    missing = REQUIRED_DRIVER_COLUMNS - set(rows[0].keys())
+    for col in sorted(missing):
+        plan.errors.append(ImportErrorItem("<file>", col, "drivers CSV is missing required column"))
+
+
+def work_auth_status(row: dict[str, str]) -> str:
+    if parse_bool(row.get("citizen", "")):
+        return "citizen"
+    if parse_bool(row.get("permanent_resident", "")):
+        return "permanent_resident"
+    raw = (row.get("work_authorization_expiry") or "").strip().lower()
+    if raw == "indefinite":
+        return "indefinite"
+    if raw:
+        return "expiring"
+    return "unknown"
+
+
+def regulatory_authority_defaults(row: dict[str, str], service_area: dict[str, Any]) -> tuple[str, str]:
+    authority = (row.get("regulatory_authority") or "").strip()
+    region = (row.get("regulatory_region") or row.get("province") or service_area.get("regulatory_region") or service_area.get("province") or "").strip().upper()
+    area_name = str(service_area.get("name") or "").lower()
+    if not region:
+        region = "SK" if "saskatoon" in area_name or "saskatchewan" in area_name else ""
+    if not authority:
+        authority = (service_area.get("regulatory_authority") or "").strip()
+    if not authority:
+        authority = "SGI" if region == "SK" else "Provincial / municipal authority"
+    return authority, region
+
+
+def build_plan(
+    driver_rows: list[dict[str, str]],
+    document_rows: list[dict[str, str]],
+    files_root: Path,
+    service_area: dict[str, Any],
+    import_batch: str,
+) -> ImportPlan:
+    plan = ImportPlan()
+    validate_required_columns(driver_rows, plan)
+    if plan.errors:
+        return plan
+
+    required_docs = service_area.get("required_documents") or []
+    allowed_doc_keys = {str(d.get("key")) for d in required_docs if d.get("key")}
+    vt_map = vehicle_type_map()
+    seen_old_ids: set[str] = set()
+    planned_driver_ids: dict[str, str] = {}
+
+    for row in driver_rows:
+        old_id = row.get("old_driver_id") or "<missing>"
+        if old_id in seen_old_ids:
+            plan.errors.append(ImportErrorItem(old_id, "old_driver_id", "duplicate old_driver_id"))
+            continue
+        seen_old_ids.add(old_id)
+
+        service_scope = (row.get("service_area_id") or row.get("service_area_slug") or row.get("service_area") or "saskatoon").lower()
+        if service_scope not in {"saskatoon", str(service_area.get("id", "")).lower(), str(service_area.get("name", "")).lower()}:
+            plan.errors.append(ImportErrorItem(old_id, "service_area", "row is not scoped to Saskatoon"))
+            continue
+
+        phone = normalize_phone(row.get("phone", ""))
+        email = (row.get("email") or "").strip().lower()
+        existing_users = supabase.table("users").select("id").eq("phone", phone).limit(1).execute().data or []
+        if email and not existing_users:
+            existing_users = supabase.table("users").select("id").eq("email", email).limit(1).execute().data or []
+        existing_drivers = supabase.table("drivers").select("id").eq("phone", phone).limit(1).execute().data or []
+        if existing_users or existing_drivers:
+            plan.errors.append(ImportErrorItem(old_id, "phone/email", "matching user or driver already exists; handle manually before import"))
+            continue
+
+        vt_key = slug(row.get("vehicle_type", ""))
+        vehicle_type_id = vt_map.get(vt_key)
+        if not vehicle_type_id:
+            plan.errors.append(ImportErrorItem(old_id, "vehicle_type", f"no vehicle_types row matched '{vt_key}'"))
+            continue
+
+        dob = iso_date(row.get("date_of_birth", ""))
+        if row.get("date_of_birth") and not dob:
+            plan.errors.append(ImportErrorItem(old_id, "date_of_birth", "could not parse date"))
+            continue
+
+        first_name, last_name = split_name(row.get("full_name", ""))
+        user_id = str(uuid.uuid4())
+        driver_id = str(uuid.uuid4())
+        planned_driver_ids[old_id] = driver_id
+
+        regulatory_approved = parse_bool(row.get("regulatory_authority_approved", ""))
+        regulatory_authority, regulatory_region = regulatory_authority_defaults(row, service_area)
+        is_approved = parse_bool(row.get("spinr_approved", "")) is True and regulatory_approved is True
+        driver_status = "needs_review" if not is_approved else "active"
+
+        plan.users_to_insert.append(
+            {
+                "id": user_id,
+                "phone": phone,
+                "first_name": first_name,
+                "last_name": last_name,
+                "email": email or None,
+                "role": "driver",
+                "is_driver": True,
+                "profile_complete": True,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        plan.drivers_to_insert.append(
+            {
+                "id": driver_id,
+                "user_id": user_id,
+                "driver_code": generate_driver_code(),
+                "name": row.get("full_name"),
+                "first_name": first_name,
+                "last_name": last_name,
+                "phone": phone,
+                "vehicle_type_id": vehicle_type_id,
+                "vehicle_make": row.get("vehicle_make", ""),
+                "vehicle_model": row.get("vehicle_model", ""),
+                "vehicle_color": row.get("vehicle_color", ""),
+                "vehicle_year": int(row["vehicle_year"]) if row.get("vehicle_year", "").isdigit() else None,
+                "license_plate": row.get("vehicle_plate", ""),
+                "vehicle_vin": None,
+                "license_number": None,
+                "_plain_vehicle_vin": row.get("vin") or None,
+                "_plain_license_number": row.get("license_number") or None,
+                "license_class": row.get("license_class") or None,
+                "date_of_birth": dob,
+                "service_area_id": service_area["id"],
+                "city": "Saskatoon",
+                "status": driver_status,
+                "is_verified": is_approved,
+                "is_online": False,
+                "is_available": False,
+                "sgi_approved": regulatory_approved if regulatory_authority == "SGI" else None,
+                "sgi_approved_at": datetime.now(timezone.utc).isoformat() if regulatory_authority == "SGI" and regulatory_approved else None,
+                "regulatory_authority": regulatory_authority,
+                "regulatory_region": regulatory_region or None,
+                "regulatory_authority_approved": regulatory_approved,
+                "regulatory_authority_approved_at": datetime.now(timezone.utc).isoformat() if regulatory_approved else None,
+                "work_authorization_status": work_auth_status(row),
+                "is_permanent_resident": parse_bool(row.get("permanent_resident", "")),
+                "is_citizen": parse_bool(row.get("citizen", "")),
+                "decals_sent": parse_bool(row.get("decals_sent", "")),
+                "legacy_import_metadata": {
+                    "batch": import_batch,
+                    "old_driver_id": old_id,
+                    "source": "legacy_saskatoon_driver_import",
+                    "address_present": bool(row.get("address")),
+                    "drivers_abstract_status": row.get("drivers_abstract_status") or None,
+                },
+                "license_expiry_date": iso_date(row.get("license_expiry", "")),
+                "insurance_expiry_date": iso_date(row.get("insurance_expiry", "")),
+                "vehicle_inspection_expiry_date": iso_date(row.get("vehicle_inspection_expiry", "")),
+                "background_check_expiry_date": iso_date(row.get("criminal_record_check_expiry", "")),
+                "work_eligibility_expiry_date": iso_date(row.get("work_authorization_expiry", "")),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+    for row in document_rows:
+        old_id = row.get("old_driver_id") or "<missing>"
+        if old_id not in planned_driver_ids:
+            plan.errors.append(ImportErrorItem(old_id, "old_driver_id", "document row has no importable driver row"))
+            continue
+        key = canonical_requirement_key(row.get("requirement_key") or row.get("document_type") or "")
+        if allowed_doc_keys and key not in allowed_doc_keys:
+            plan.errors.append(ImportErrorItem(old_id, "requirement_key", f"'{key}' is not configured on Saskatoon required_documents"))
+            continue
+        file_path = files_root / (row.get("file_path") or "")
+        if not file_path.is_file():
+            plan.errors.append(ImportErrorItem(old_id, "file_path", "document file not found"))
+            continue
+        doc_id = str(uuid.uuid4())
+        ext = file_path.suffix.lower() or ".bin"
+        side = row.get("side") or None
+        storage_key = f"saskatoon-import/{import_batch}/{old_id}/{key}/{side or 'main'}-{doc_id}{ext}"
+        signed_placeholder = f"storage://driver-documents/{storage_key}"
+        expiry = iso_date(row.get("expiry_date", ""))
+        if row.get("expiry_date") and row.get("expiry_date", "").strip().lower() not in {"indefinite", "valid"} and not expiry:
+            plan.errors.append(ImportErrorItem(old_id, "expiry_date", "could not parse document expiry date"))
+            continue
+        plan.docs_to_insert.append(
+            {
+                "id": doc_id,
+                "driver_id": planned_driver_ids[old_id],
+                "requirement_id": None,
+                "requirement_key": key,
+                "document_type": row.get("document_type") or key.replace("_", " ").title(),
+                "document_url": signed_placeholder,
+                "side": side,
+                "status": row.get("status") or "pending",
+                "expiry_date": expiry,
+                "uploaded_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        plan.files_to_upload.append((file_path, storage_key, doc_id))
+
+    return plan
+
+
+def commit_plan(plan: ImportPlan) -> None:
+    if plan.errors:
+        raise RuntimeError("refusing to commit with validation errors")
+    supabase.table("users").insert(plan.users_to_insert).execute()
+    drivers = []
+    for driver in plan.drivers_to_insert:
+        copied = dict(driver)
+        copied["vehicle_vin"] = encrypt_pii(copied.pop("_plain_vehicle_vin", None))
+        copied["license_number"] = encrypt_pii(copied.pop("_plain_license_number", None))
+        drivers.append(copied)
+    supabase.table("drivers").insert(drivers).execute()
+
+    signed_by_doc: dict[str, str] = {}
+    for file_path, storage_key, doc_id in plan.files_to_upload:
+        content_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+        supabase.storage.from_("driver-documents").upload(
+            path=storage_key,
+            file=file_path.read_bytes(),
+            file_options={"content-type": content_type},
+        )
+        signed_by_doc[doc_id] = storage_signed_url(storage_key)
+
+    docs = []
+    for doc in plan.docs_to_insert:
+        copied = dict(doc)
+        copied["document_url"] = signed_by_doc[copied["id"]]
+        docs.append(copied)
+    if docs:
+        supabase.table("driver_documents").insert(docs).execute()
+
+
+def print_report(plan: ImportPlan, *, dry_run: bool) -> None:
+    mode = "DRY RUN" if dry_run else "COMMIT"
+    print(f"{mode} report")
+    print(f"  users planned: {len(plan.users_to_insert)}")
+    print(f"  drivers planned: {len(plan.drivers_to_insert)}")
+    print(f"  documents planned: {len(plan.docs_to_insert)}")
+    print(f"  files planned: {len(plan.files_to_upload)}")
+    print(f"  warnings: {len(plan.warnings)}")
+    print(f"  errors: {len(plan.errors)}")
+    for item in plan.warnings[:50]:
+        print(f"WARNING old_driver_id={item.old_driver_id} field={item.field}: {item.message}")
+    for item in plan.errors[:100]:
+        print(f"ERROR old_driver_id={item.old_driver_id} field={item.field}: {item.message}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bulk import legacy Saskatoon drivers and document files")
+    parser.add_argument("--drivers-csv", type=Path, required=True)
+    parser.add_argument("--documents-csv", type=Path, required=True)
+    parser.add_argument("--files-root", type=Path, required=True)
+    parser.add_argument("--service-area-id")
+    parser.add_argument("--service-area-name", default="Saskatoon")
+    parser.add_argument("--batch", default=datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S"))
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--dry-run", action="store_true")
+    group.add_argument("--commit", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if supabase is None:
+        raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be configured")
+    drivers = read_csv(args.drivers_csv)
+    docs = read_csv(args.documents_csv)
+    service_area = get_service_area(args.service_area_id, args.service_area_name)
+    plan = build_plan(drivers, docs, args.files_root, service_area, args.batch)
+    print_report(plan, dry_run=args.dry_run)
+    if plan.errors:
+        return 2
+    if args.commit:
+        commit_plan(plan)
+        print("Committed Saskatoon driver import successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Enable ingestion of legacy Saskatoon driver data and associated documents while preserving PII handling and regulatory metadata.
- Generalize SGI-specific approval fields into province/municipal `regulatory_*` columns for multi-province support.
- Surface regulatory defaults and editable compliance metadata in the admin UI so operators can review and correct imported values.

### Description
- Frontend (admin-dashboard): add helpers `dateInputValue`, `datetimeLocalValue`, `boolInputValue`, `fromBoolInput`; extend driver edit form with new fields (`date_of_birth`, `license_class`, `regulatory_authority`, `regulatory_region`, `regulatory_authority_approved`, `regulatory_authority_approved_at`, `work_authorization_status`, `is_permanent_resident`, `is_citizen`, `decals_sent`, `decals_sent_at`), add `EditBooleanField` component and a new "Compliance & Import Data" `DetailSection` for view/edit modes.
- Frontend (service-areas): add `regulatoryDefaultsForProvince` helper and wire regulatory fields into the create/edit flows (defaults on preset/province selection and new inputs: `regulatory_authority`, `regulatory_region`, `regulatory_requirements_url`, `regulatory_notes`).
- Backend schema: add three migrations `221_drivers_bulk_import_fields.sql`, `222_drivers_general_regulatory_approval.sql`, and `223_service_areas_regulatory_authority.sql` to add nullable columns, indexes, and column comments for drivers and service_areas to support legacy import and generalized regulatory approval.
- Backend API: allow the new driver fields in admin update (`admin_update_driver`) and accept the new service-area regulatory fields in `ServiceAreaUpdateRequest` and area update handlers.
- Import tooling: add `scripts/import_saskatoon_drivers.py`, a dry-run/commit importer that validates CSVs, maps vehicle types, normalizes dates/booleans, encrypts PII via `encrypt_driver_pii` RPC, uploads document files to Supabase storage, and inserts `users`, `drivers`, `driver_documents` and records `legacy_import_metadata` per driver.

### Testing
- Ran frontend TypeScript compile/build for the `admin-dashboard` changes (`yarn build`), which completed successfully.
- Performed static checks on backend code and validated the migration SQL files for syntax and presence of the new columns and indexes.
- No automated unit tests were added for the new importer; the import script supports a `--dry-run` mode for validation before `--commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff432ce90833096d991bb4ff3064a)

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
