### PR TITLE
Exempt mobile bootstrap/OTP endpoints from App Check and initialize App Check provider earlier in apps

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -118,6 +118,17 @@ _APP_CHECK_EXEMPT_PREFIXES = (
     # no longer required on these two read endpoints.
     "/api/v1/vehicle-types",
     "/api/v1/maps/",
+    # Public mobile bootstrap config. It contains publishable/client config only
+    # (settings.py filters to Maps/Stripe publishable keys + tracking base URL),
+    # so startup must not deadlock behind the App Check configuration it helps
+    # the apps discover.
+    "/api/v1/settings",
+    # OTP login must stay reachable when App Check native modules are unavailable
+    # or not yet attested (Expo Go/debug builds, newly registered devices). The
+    # handlers keep their own OTP throttling/lockout and do not expose data
+    # without possession of the SMS code.
+    "/api/v1/auth/send-otp",
+    "/api/v1/auth/verify-otp",
 )
 
 

--- a/backend/tests/test_p1_cors.py
+++ b/backend/tests/test_p1_cors.py
@@ -366,3 +366,31 @@ class TestStripeAppCheckExemption:
         from backend.core.middleware import _APP_CHECK_EXEMPT_PREFIXES
 
         assert not any("/api/v1/drivers/payouts".startswith(p) for p in _APP_CHECK_EXEMPT_PREFIXES)
+
+
+class TestMobileBootstrapAppCheckExemptions:
+    """Login/bootstrap endpoints must not deadlock behind App Check.
+
+    They either return public client config or have their own OTP proof and
+    rate-limit controls. Authenticated ride/payment endpoints remain enforced.
+    """
+
+    def test_login_and_public_settings_endpoints_are_exempt(self):
+        from backend.core.middleware import _APP_CHECK_EXEMPT_PREFIXES
+
+        for path in (
+            "/api/v1/settings",
+            "/api/v1/auth/send-otp",
+            "/api/v1/auth/verify-otp",
+        ):
+            assert any(path.startswith(p) for p in _APP_CHECK_EXEMPT_PREFIXES), path
+
+    def test_authenticated_ride_endpoints_remain_enforced(self):
+        from backend.core.middleware import _APP_CHECK_EXEMPT_PREFIXES
+
+        for path in (
+            "/api/v1/rides/active",
+            "/api/v1/drivers/rides/active",
+        ):
+            assert not any(path.startswith(p) for p in _APP_CHECK_EXEMPT_PREFIXES), path
+

--- a/driver-app/app/_layout.tsx
+++ b/driver-app/app/_layout.tsx
@@ -57,6 +57,12 @@ import {
   getAppCheckToken,
 } from '@shared/services/firebase';
 import { setAppCheckTokenProvider } from '@shared/api/client';
+
+// Register App Check token retrieval at module load so early startup requests
+// (driver active-ride hydration and login OTP) wait for Firebase App Check
+// instead of racing ahead without X-Firebase-AppCheck.
+setAppCheckTokenProvider(getAppCheckToken);
+
 // Notifee — rich notifications (heads-up + full-screen intent + Accept/Decline
 // action buttons). Lazy-required because the native module isn't linked in
 // Expo Go / web; we treat the import failure the same as Expo Go: no-op.
@@ -330,7 +336,6 @@ function RootLayout() {
         // registration is deferred to a separate effect that waits for
         // an authenticated session (below).
         await initFirebaseServices();
-        setAppCheckTokenProvider(getAppCheckToken);
         await requestNotificationPermission();
 
         captureMessage('driver-app cold start', 'log');

--- a/rider-app/app/_layout.tsx
+++ b/rider-app/app/_layout.tsx
@@ -68,11 +68,17 @@ import {
   getAppCheckToken,
 } from '@shared/services/firebase';
 import { setAppCheckTokenProvider } from '@shared/api/client';
+
 import { handleScheduledRideReminderFCM } from '../hooks/useScheduledRideReminder';
 import { useRideStatusNotification } from '../hooks/useRideStatusNotification';
 import ConfirmSheet from '../components/ConfirmSheet';
 import type { ConfirmSheetButton } from '../components/ConfirmSheet';
 import Toast from '../components/Toast';
+
+// Register App Check token retrieval at module load so early startup requests
+// (public settings, active-ride hydration, and login OTP) wait for Firebase
+// App Check instead of racing ahead without X-Firebase-AppCheck.
+setAppCheckTokenProvider(getAppCheckToken);
 
 
 function routeFromNotificationData(data: Record<string, string> | undefined) {
@@ -298,7 +304,6 @@ function RootLayout() {
 
         await useRideStore.getState().hydrateActiveRide();
         await initFirebaseServices();
-        setAppCheckTokenProvider(getAppCheckToken);
         await requestNotificationPermission();
         captureMessage('rider-app cold start', 'log');
 


### PR DESCRIPTION
### Motivation

- Prevent App Check from blocking public mobile startup/config and OTP login flows that either return only publishable client config or enforce their own possession-based OTP checks.
- Ensure early startup requests from the rider and driver apps wait for Firebase App Check token availability instead of racing and sending unauthenticated requests.

### Description

- Added `"/api/v1/settings"`, `"/api/v1/auth/send-otp"`, and `"/api/v1/auth/verify-otp"` to `_APP_CHECK_EXEMPT_PREFIXES` in `backend/core/middleware.py` with explanatory comments. 
- Added `TestMobileBootstrapAppCheckExemptions` to `backend/tests/test_p1_cors.py` to assert the new exempt paths and to ensure authenticated ride endpoints remain enforced. 
- Registered the App Check token provider at module load by calling `setAppCheckTokenProvider(getAppCheckToken)` in both `driver-app/app/_layout.tsx` and `rider-app/app/_layout.tsx`, and removed the late registration inside the cold-start `useEffect` so early requests will wait for App Check.

### Testing

- Ran the new test file with `pytest backend/tests/test_p1_cors.py` and the `TestMobileBootstrapAppCheckExemptions` tests passed. 
- Ran the backend unit test suite with `pytest backend` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff7af52d083309b0e9e1adfdf9b73)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
