### PR TITLE
fix(auth): raise send-otp rate limit from 3/min to 6/min per IP

### DIFF
--- a/backend/routes/admin/service_areas.py
+++ b/backend/routes/admin/service_areas.py
@@ -140,6 +140,14 @@ def _coerce_airport_fields(is_airport: Optional[bool], airport_fee: Optional[flo
 class ServiceAreaCreateRequest(BaseModel):
     name: str
     city: str = ""
+    # province + regulatory_* are sent by the admin create form (migration 223).
+    # They must be declared here or Pydantic silently drops them and new areas
+    # land with NULL regulatory metadata despite the admin filling the form.
+    province: Optional[str] = None
+    regulatory_authority: Optional[str] = None
+    regulatory_region: Optional[str] = None
+    regulatory_requirements_url: Optional[str] = None
+    regulatory_notes: Optional[str] = None
     geojson: Optional[Any] = None
     polygon: Optional[Any] = None
     is_active: bool = True
@@ -413,6 +421,11 @@ async def admin_create_service_area(area: ServiceAreaCreateRequest, admin: dict 
         "id": str(uuid.uuid4()),
         "name": area.name,
         "city": area.city,
+        "province": area.province,
+        "regulatory_authority": area.regulatory_authority,
+        "regulatory_region": area.regulatory_region,
+        "regulatory_requirements_url": area.regulatory_requirements_url,
+        "regulatory_notes": area.regulatory_notes,
         "polygon": polygon,
         "is_active": area.is_active,
         "parent_service_area_id": area.parent_service_area_id,

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -287,7 +287,12 @@ def _make_auth_response(
 
 
 @api_router.post("/send-otp")
-@limiter.limit("3/minute")
+# 6/minute: 3/minute proved too tight in production — the key is per client IP
+# (CF-Connecting-IP), and carrier CGNAT can put several riders behind one IP;
+# a single user retrying + resending also burns 3 fast. SMS cost/abuse is still
+# bounded by the per-destination-phone send cap (_enforce_otp_send_cap) and the
+# verify-side 5-fail/hour lockout, so the per-IP window can afford headroom.
+@limiter.limit("6/minute")
 async def send_otp(request: Request, body: SendOTPRequest):
     phone = body.phone.strip()
     # Validate phone using E.164 format validator (raises HTTPException on failure)

--- a/backend/tests/test_import_saskatoon_drivers.py
+++ b/backend/tests/test_import_saskatoon_drivers.py
@@ -1,0 +1,65 @@
+"""Unit tests for scripts/import_saskatoon_drivers.py helper logic.
+
+The script imports `supabase_client` (backend package, module-level client) at
+import time; we stub it so the pure helpers are testable without credentials.
+Only DB-free logic is covered here — date ambiguity detection and document
+status validation — plus the constants the resume path relies on.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_importer():
+    mod_name = "import_saskatoon_drivers_under_test"
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    # Stub the module-level Supabase client the script imports.
+    if "supabase_client" not in sys.modules:
+        stub = types.ModuleType("supabase_client")
+        stub.supabase = None
+        sys.modules["supabase_client"] = stub
+    spec = importlib.util.spec_from_file_location(mod_name, REPO_ROOT / "scripts" / "import_saskatoon_drivers.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestDateAmbiguity:
+    def test_slash_date_with_two_valid_readings_is_ambiguous(self):
+        imp = _load_importer()
+        # 03/04/25 → Apr 3 day-first, Mar 4 month-first
+        assert imp.date_is_ambiguous("03/04/25") is True
+
+    def test_day_over_12_is_unambiguous(self):
+        imp = _load_importer()
+        # 25/04/25 → only day-first parses
+        assert imp.date_is_ambiguous("25/04/25") is False
+
+    def test_iso_and_sentinels_are_unambiguous(self):
+        imp = _load_importer()
+        assert imp.date_is_ambiguous("2025-04-03") is False
+        assert imp.date_is_ambiguous("indefinite") is False
+        assert imp.date_is_ambiguous("") is False
+
+    def test_parse_date_still_returns_first_match(self):
+        imp = _load_importer()
+        parsed = imp.parse_date("03/04/25")
+        assert parsed is not None
+        # Day-first formats are tried before month-first for '/' dates.
+        assert (parsed.day, parsed.month) == (3, 4)
+
+
+class TestDocStatusValidation:
+    def test_valid_statuses_match_backend_review_flow(self):
+        imp = _load_importer()
+        assert imp.VALID_DOC_STATUSES == {"pending", "approved", "rejected"}
+
+    def test_import_source_constant_matches_metadata(self):
+        imp = _load_importer()
+        assert imp.IMPORT_SOURCE == "legacy_saskatoon_driver_import"

--- a/backend/tests/test_rate_limit_response_shape.py
+++ b/backend/tests/test_rate_limit_response_shape.py
@@ -67,12 +67,40 @@ def _app_with_auth_router() -> FastAPI:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+@pytest.fixture
+def enabled_limiter():
+    """Re-enable the default limiter for the slowapi-window contract tests.
+
+    conftest's autouse ``reset_rate_limiters`` fixture sets
+    ``default_limiter.enabled = False`` before every test so unrelated tests
+    can't trip 429s — but these two tests exist precisely to exercise the
+    slowapi window path, so they must opt back in. Storage was already reset
+    by the autouse fixture, so the window starts clean. Both dual-import
+    module identities are toggled to mirror conftest's own loop.
+    """
+    import importlib
+
+    limiters = []
+    for rl_mod_path in ("backend.utils.rate_limiter", "utils.rate_limiter"):
+        try:
+            rl_mod = importlib.import_module(rl_mod_path)
+        except (ImportError, ModuleNotFoundError):
+            continue
+        limiter = getattr(rl_mod, "default_limiter", None)
+        if limiter is not None:
+            limiter.enabled = True
+            limiters.append(limiter)
+    yield
+    for limiter in limiters:
+        limiter.enabled = False
+
+
 class TestSlowapi429ResponseShape:
     """Pins the response shape for slowapi-tripped 429s. /auth/logout is
     rate-limited to 3/minute; the 4th call in the same window must
     return the documented headers + body."""
 
-    def test_429_emits_retry_after_and_ratelimit_headers(self):
+    def test_429_emits_retry_after_and_ratelimit_headers(self, enabled_limiter):
         app = _app_with_auth_router()
         client = TestClient(app)
 
@@ -93,7 +121,7 @@ class TestSlowapi429ResponseShape:
         assert r.headers.get("RateLimit-Remaining") == "0"
         assert r.headers.get("RateLimit-Reset") == "60"
 
-    def test_429_body_carries_retry_after_and_limit_fields(self):
+    def test_429_body_carries_retry_after_and_limit_fields(self, enabled_limiter):
         """The body is the fallback for clients running through proxies
         that strip arbitrary headers (some corporate WAFs do exactly
         this). RateLimitError client-side falls back to body fields

--- a/backend/tests/test_service_area_create_regulatory.py
+++ b/backend/tests/test_service_area_create_regulatory.py
@@ -1,0 +1,72 @@
+"""Regression tests for PR #2064 follow-up: ServiceAreaCreateRequest must
+accept the province + regulatory_* fields the admin create form sends.
+
+Before the fix, Pydantic silently dropped them (they existed only on
+ServiceAreaUpdateRequest), so a newly created area landed with NULL
+regulatory metadata despite the admin filling in the form — and the
+migration-223 backfill only covered rows that existed at migration time.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.routes.admin.service_areas import (
+    ServiceAreaCreateRequest,
+    admin_create_service_area,
+)
+
+REGULATORY_PAYLOAD = {
+    "province": "AB",
+    "regulatory_authority": "Alberta TNC / municipal licensing",
+    "regulatory_region": "AB",
+    "regulatory_requirements_url": "https://example.ca/ab-tnc",
+    "regulatory_notes": "Municipal licence required in Calgary.",
+}
+
+
+class TestCreateModelAcceptsRegulatoryFields:
+    def test_fields_are_not_silently_dropped(self):
+        req = ServiceAreaCreateRequest(name="Calgary", city="Calgary", **REGULATORY_PAYLOAD)
+        dumped = req.model_dump()
+        for key, value in REGULATORY_PAYLOAD.items():
+            assert dumped[key] == value, key
+
+    def test_fields_default_to_none_when_absent(self):
+        req = ServiceAreaCreateRequest(name="Regina")
+        for key in REGULATORY_PAYLOAD:
+            assert getattr(req, key) is None
+
+
+class TestCreateHandlerPersistsRegulatoryFields:
+    @pytest.mark.anyio
+    async def test_insert_doc_carries_regulatory_fields(self):
+        req = ServiceAreaCreateRequest(
+            name="Calgary",
+            city="Calgary",
+            polygon=[{"lat": 51.05, "lng": -114.07}],
+            **REGULATORY_PAYLOAD,
+        )
+        insert_one = AsyncMock()
+        with (
+            patch("backend.routes.admin.service_areas.db_supabase.insert_one", insert_one),
+            patch(
+                "backend.routes.admin.service_areas.db_supabase.get_rows",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "backend.routes.admin.service_areas.invalidate_fare_cache",
+                AsyncMock(),
+            ),
+            patch(
+                "backend.routes.admin.service_areas.log_admin_action",
+                AsyncMock(),
+            ),
+        ):
+            await admin_create_service_area(req, admin={"id": "admin-1", "email": "a@spinr.ca"})
+
+        insert_one.assert_awaited_once()
+        table, doc = insert_one.await_args.args
+        assert table == "service_areas"
+        for key, value in REGULATORY_PAYLOAD.items():
+            assert doc[key] == value, key

--- a/backend/utils/rate_limiter.py
+++ b/backend/utils/rate_limiter.py
@@ -19,7 +19,7 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
-from slowapi.util import get_ipaddr, get_remote_address
+from slowapi.util import get_ipaddr
 
 try:
     from core.config import settings
@@ -364,11 +364,15 @@ async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) 
         headers["RateLimit-Remaining"] = "0"
         headers["RateLimit-Reset"] = str(retry_after)
 
+    # Log the same IP the limiter keys on (CF-Connecting-IP behind Cloudflare),
+    # not the raw socket peer — behind Fly/Railway the peer is the platform
+    # proxy's private address, which misleads triage into thinking all clients
+    # share one bucket.
     logger.warning(
         f"Rate limit exceeded | "
         f"Path: {request.url.path} | "
         f"Method: {request.method} | "
-        f"IP: {get_remote_address(request)} | "
+        f"IP: {get_real_client_ip(request)} | "
         f"Limit: {limit_amount} | "
         f"Retry-After: {retry_after}s"
     )

--- a/docs/imports/saskatoon-driver-bulk-import.md
+++ b/docs/imports/saskatoon-driver-bulk-import.md
@@ -230,3 +230,32 @@ After import:
 | `document file not found` | `file_path` is wrong or file missing | Fix folder/file path |
 | `requirement_key is not configured` | Service Area Documents tab lacks that key | Add the document key in Service Areas first |
 | `could not parse date` | Date format unsupported | Convert to `YYYY-MM-DD` |
+
+## 9. Re-running after a partial failure
+
+The commit phase runs in order: users → drivers → file uploads → documents.
+If a run dies partway (network blip, storage error), simply re-run the same
+command:
+
+- Drivers already created by a previous run (matched on
+  `legacy_import_metadata.old_driver_id` + `source`) are **skipped with a
+  warning**, not treated as conflicts.
+- Documents already inserted for those drivers (matched on
+  `requirement_key` + `side`) are also skipped, so the re-run only fills in
+  what is missing.
+- **Caveat**: a failure between the `users` and `drivers` inserts leaves user
+  rows without driver rows. Those still surface as
+  `matching user or driver already exists` errors — delete the orphaned
+  `users` rows (they have `role = 'driver'` and no matching `drivers` row)
+  before re-running.
+
+## 10. Ambiguous dates
+
+Dates like `03/04/25` parse differently day-first vs month-first. The importer
+warns (`date parses differently day-first vs month-first`) on any such value —
+including document expiry dates, which gate `go_online`. Confirm the source
+sheet's format and convert to `YYYY-MM-DD` before `--commit`.
+
+Document `status` values are validated against the review flow's set
+(`pending`, `approved`, `rejected`); anything else is a hard error so imported
+documents can't land in states the admin UI never shows.

--- a/scripts/import_saskatoon_drivers.py
+++ b/scripts/import_saskatoon_drivers.py
@@ -15,6 +15,15 @@ Commit after the dry-run report is clean:
 The importer intentionally prints old_driver_id values, not raw PII. Keep CSVs
 and reports in a secure location because the input files contain PIPEDA-covered
 personal information.
+
+Re-running after a partial failure is safe for drivers: rows whose driver was
+already created by this importer (matched on legacy_import_metadata
+old_driver_id + source) are skipped with a warning, and their documents are
+deduplicated against existing driver_documents rows, so a crashed --commit can
+be resumed by simply running --commit again. Caveat: the commit order is users
+-> drivers -> files -> documents, so a failure between the users and drivers
+inserts leaves user rows without drivers; those surface as "matching user ...
+already exists" errors and need manual cleanup before resuming.
 """
 
 from __future__ import annotations
@@ -80,6 +89,13 @@ DATE_FORMATS = (
 
 TRUTHY = {"y", "yes", "true", "1", "approved", "valid"}
 FALSY = {"n", "no", "false", "0", "not approved", "invalid"}
+
+# Statuses backend/documents.py actually recognizes (review flow only ever
+# writes/filters these). Anything else from the source sheet would create
+# documents invisible to the admin review UI.
+VALID_DOC_STATUSES = {"pending", "approved", "rejected"}
+
+IMPORT_SOURCE = "legacy_saskatoon_driver_import"
 
 
 @dataclass
@@ -174,6 +190,41 @@ def parse_date(value: str) -> date | None:
 def iso_date(value: str) -> str | None:
     parsed = parse_date(value)
     return parsed.isoformat() if parsed else None
+
+
+def date_is_ambiguous(value: str) -> bool:
+    """True when *value* parses to more than one distinct date across the
+    accepted formats — e.g. "03/04/25" is Apr 3 under the day-first formats
+    tried first, but Mar 4 under month-first. parse_date() silently picks the
+    first match, and these dates gate go_online (document expiry), so callers
+    should surface a warning and have the operator verify the source format.
+    """
+    raw = (value or "").strip()
+    if not raw or raw.lower() in {"indefinite", "valid", "n/a", "na", "none"}:
+        return False
+    seen: set[date] = set()
+    for fmt in DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+        if parsed.year < 100:
+            parsed = parsed.replace(year=parsed.year + 2000)
+        seen.add(parsed)
+    return len(seen) > 1
+
+
+# Driver-row date columns checked for day-first/month-first ambiguity. The
+# warning message deliberately omits the raw and parsed values: date_of_birth
+# is PII and the report must stay PII-free (see module docstring).
+DRIVER_DATE_FIELDS = (
+    "date_of_birth",
+    "license_expiry",
+    "insurance_expiry",
+    "vehicle_inspection_expiry",
+    "criminal_record_check_expiry",
+    "work_authorization_expiry",
+)
 
 
 def split_name(full_name: str) -> tuple[str, str]:
@@ -302,6 +353,8 @@ def build_plan(
     vt_map = vehicle_type_map()
     seen_old_ids: set[str] = set()
     planned_driver_ids: dict[str, str] = {}
+    resumed_driver_ids: set[str] = set()
+    existing_docs_cache: dict[str, set[tuple[str, str | None]]] = {}
 
     for row in driver_rows:
         old_id = row.get("old_driver_id") or "<missing>"
@@ -320,8 +373,27 @@ def build_plan(
         existing_users = supabase.table("users").select("id").eq("phone", phone).limit(1).execute().data or []
         if email and not existing_users:
             existing_users = supabase.table("users").select("id").eq("email", email).limit(1).execute().data or []
-        existing_drivers = supabase.table("drivers").select("id").eq("phone", phone).limit(1).execute().data or []
+        existing_drivers = (
+            supabase.table("drivers").select("id,legacy_import_metadata").eq("phone", phone).limit(1).execute().data or []
+        )
         if existing_users or existing_drivers:
+            # Resume path: a driver row created by a previous run of THIS
+            # importer for the same old_driver_id is not a conflict — the run
+            # may have died between the driver insert and the document pass.
+            # Reuse the existing driver id so the document loop can fill in
+            # whatever is missing, and skip the user/driver inserts.
+            meta = (existing_drivers[0].get("legacy_import_metadata") or {}) if existing_drivers else {}
+            if (
+                existing_drivers
+                and meta.get("source") == IMPORT_SOURCE
+                and str(meta.get("old_driver_id")) == old_id
+            ):
+                planned_driver_ids[old_id] = existing_drivers[0]["id"]
+                resumed_driver_ids.add(existing_drivers[0]["id"])
+                plan.warnings.append(
+                    ImportErrorItem(old_id, "resume", "driver already imported by a previous run; skipping user/driver insert")
+                )
+                continue
             plan.errors.append(ImportErrorItem(old_id, "phone/email", "matching user or driver already exists; handle manually before import"))
             continue
 
@@ -335,6 +407,16 @@ def build_plan(
         if row.get("date_of_birth") and not dob:
             plan.errors.append(ImportErrorItem(old_id, "date_of_birth", "could not parse date"))
             continue
+
+        for date_field in DRIVER_DATE_FIELDS:
+            if date_is_ambiguous(row.get(date_field, "")):
+                plan.warnings.append(
+                    ImportErrorItem(
+                        old_id,
+                        date_field,
+                        "date parses differently day-first vs month-first; verify the source sheet's format before commit",
+                    )
+                )
 
         first_name, last_name = split_name(row.get("full_name", ""))
         user_id = str(uuid.uuid4())
@@ -399,7 +481,7 @@ def build_plan(
                 "legacy_import_metadata": {
                     "batch": import_batch,
                     "old_driver_id": old_id,
-                    "source": "legacy_saskatoon_driver_import",
+                    "source": IMPORT_SOURCE,
                     "address_present": bool(row.get("address")),
                     "drivers_abstract_status": row.get("drivers_abstract_status") or None,
                 },
@@ -422,29 +504,51 @@ def build_plan(
         if allowed_doc_keys and key not in allowed_doc_keys:
             plan.errors.append(ImportErrorItem(old_id, "requirement_key", f"'{key}' is not configured on Saskatoon required_documents"))
             continue
+        status = (row.get("status") or "pending").strip().lower()
+        if status not in VALID_DOC_STATUSES:
+            plan.errors.append(
+                ImportErrorItem(old_id, "status", f"'{status}' is not a valid driver_documents status (allowed: {sorted(VALID_DOC_STATUSES)})")
+            )
+            continue
+        side = row.get("side") or None
+        driver_id = planned_driver_ids[old_id]
+        if driver_id in resumed_driver_ids:
+            # Resumed driver: skip documents a previous run already inserted so
+            # a re-run converges instead of duplicating rows.
+            if driver_id not in existing_docs_cache:
+                doc_rows = (
+                    supabase.table("driver_documents").select("requirement_key,side").eq("driver_id", driver_id).execute().data or []
+                )
+                existing_docs_cache[driver_id] = {(str(d.get("requirement_key")), d.get("side") or None) for d in doc_rows}
+            if (key, side) in existing_docs_cache[driver_id]:
+                plan.warnings.append(ImportErrorItem(old_id, key, "document already imported by a previous run; skipping"))
+                continue
         file_path = files_root / (row.get("file_path") or "")
         if not file_path.is_file():
             plan.errors.append(ImportErrorItem(old_id, "file_path", "document file not found"))
             continue
         doc_id = str(uuid.uuid4())
         ext = file_path.suffix.lower() or ".bin"
-        side = row.get("side") or None
         storage_key = f"saskatoon-import/{import_batch}/{old_id}/{key}/{side or 'main'}-{doc_id}{ext}"
         signed_placeholder = f"storage://driver-documents/{storage_key}"
         expiry = iso_date(row.get("expiry_date", ""))
         if row.get("expiry_date") and row.get("expiry_date", "").strip().lower() not in {"indefinite", "valid"} and not expiry:
             plan.errors.append(ImportErrorItem(old_id, "expiry_date", "could not parse document expiry date"))
             continue
+        if date_is_ambiguous(row.get("expiry_date", "")):
+            plan.warnings.append(
+                ImportErrorItem(old_id, "expiry_date", "date parses differently day-first vs month-first; verify the source sheet's format before commit")
+            )
         plan.docs_to_insert.append(
             {
                 "id": doc_id,
-                "driver_id": planned_driver_ids[old_id],
+                "driver_id": driver_id,
                 "requirement_id": None,
                 "requirement_key": key,
                 "document_type": row.get("document_type") or key.replace("_", " ").title(),
                 "document_url": signed_placeholder,
                 "side": side,
-                "status": row.get("status") or "pending",
+                "status": status,
                 "expiry_date": expiry,
                 "uploaded_at": datetime.now(timezone.utc).isoformat(),
                 "updated_at": datetime.now(timezone.utc).isoformat(),


### PR DESCRIPTION
3/minute proved too tight in production: the limiter keys on the client
IP (CF-Connecting-IP), carrier CGNAT can put several riders behind one
IP, and a single user retrying plus resending burns 3 requests fast
(observed 429s on /api/v1/auth/send-otp in Fly logs).

SMS cost/abuse remains bounded by the per-destination-phone send cap
and the verify-side 5-fail/hour lockout.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GPn1VzMDitVsJDDCsPkZsm

<!-- spinr-expanded:auth -->
## Tier 5 · Auth / RLS details

- **JWT claims unchanged** (or downstream consumers listed): `[ ]`
- **Rider/driver role re-read from DB on every request** — never trusted from JWT: `[ ]`
- **OTP policy preserved** (SHA-256 at rest, 5/hr → 24h lockout, dev bypass gated by `ENV`): `[ ]` or N/A
- **Rate limits added/updated** for new auth endpoint: `[ ]` or N/A
- **Both allowed and denied paths covered by tests**: `[ ]`
