### PR TITLE
fix(faqs): rename colliding 215/216 FAQ migrations to free slots 229/230

### DIFF
--- a/backend/migrations/229_faqs_service_area.sql
+++ b/backend/migrations/229_faqs_service_area.sql
@@ -1,4 +1,4 @@
--- 215_faqs_service_area.sql
+-- 229_faqs_service_area.sql
 --
 -- Adds an optional, multi-valued service-area scope to faqs so a single FAQ can
 -- be location-specific to one OR MORE service areas (e.g. one SGI /

--- a/backend/migrations/230_seed_rider_faqs.sql
+++ b/backend/migrations/230_seed_rider_faqs.sql
@@ -1,4 +1,4 @@
--- 216_seed_rider_faqs.sql
+-- 230_seed_rider_faqs.sql
 --
 -- Seeds rider-audience FAQ content (booking, fares/surge, payments/refunds,
 -- wallet, promos, safety, accessibility, receipts, support). The driver app


### PR DESCRIPTION
The admin FAQ page returned 503 ("Failed to load FAQ"): GET /api/admin/faqs
failed with 'column faqs.service_area_ids does not exist'. The migration that
adds that column, plus the rider-FAQ seed, were committed under prefixes 215
and 216 that already belonged to earlier-merged migrations
(215_profile_photos_public_bucket, 216_deletion_hard_delete_no_anonymize).

Per the migration convention (and the ci-guardrails duplicate-prefix guard),
the second-comer must take the next free slot. These were never applied to
production (the column is absent), so re-keying is safe and idempotent:
  215_faqs_service_area.sql  -> 229_faqs_service_area.sql   (ADD COLUMN IF NOT EXISTS)
  216_seed_rider_faqs.sql    -> 230_seed_rider_faqs.sql     (insert-if-not-exists)

229 (add column) still sorts before 230 (seed), preserving the dependency.
On the next migration run the column is created and the admin/public/AI FAQ
paths that select service_area_ids resolve cleanly.

Co-developed with Claude Code (claude-sonnet-4-6)

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013x7org2nmRG24H4BAkux96

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)
