### PR TITLE
feat(admin): add LMS training lookup endpoint for drivers

### DIFF
--- a/admin-dashboard/src/__tests__/dashboard/pages.smoke.test.tsx
+++ b/admin-dashboard/src/__tests__/dashboard/pages.smoke.test.tsx
@@ -113,6 +113,8 @@ vi.mock("lucide-react", () => {
     BarChart3: Icon, Ticket: Icon, Zap: Icon, ZoomIn: Icon,
     // main-side additions (rides PlusCircle, earnings Filter) + AI console icons
     Filter: Icon, PlusCircle: Icon, Bot: Icon, MessageSquarePlus: Icon, Sparkles: Icon,
+    // drivers Training (LMS) tab
+    GraduationCap: Icon, Award: Icon, Maximize2: Icon,
   };
 });
 

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -191,19 +191,29 @@ export default function DriversPage() {
         }
     }, [subPaymentsLoaded]);
 
+    // Request-id guard: the LMS lookup can be slow, so a response that
+    // arrives after the admin switched drivers (or triggered a newer
+    // refresh) must be discarded — otherwise driver A's training data
+    // renders in driver B's drawer. The ref also bumps on drawer close /
+    // driver change (see the selected?.id effect) to invalidate in-flight
+    // requests even when no new one starts.
+    const trainingReqRef = useRef(0);
     const loadDriverTraining = useCallback(async (driverId: string, refresh = false) => {
         if (!refresh && trainingLoaded === driverId) return;
+        const reqId = ++trainingReqRef.current;
         setTrainingLoading(true);
         setTrainingError(null);
         try {
             const res = await getDriverTraining(driverId, refresh);
+            if (reqId !== trainingReqRef.current) return;
             setTraining(res);
             setTrainingLoaded(driverId);
         } catch (e: any) {
+            if (reqId !== trainingReqRef.current) return;
             setTraining(null);
             setTrainingError(e?.message || "Failed to load training data from the LMS");
         } finally {
-            setTrainingLoading(false);
+            if (reqId === trainingReqRef.current) setTrainingLoading(false);
         }
     }, [trainingLoaded]);
 
@@ -324,12 +334,19 @@ export default function DriversPage() {
             setPayoutSummary(null);
             setDriverSubPayments([]);
             setSubPaymentsLoaded(null);
+            trainingReqRef.current++; // invalidate any in-flight LMS request
             setTraining(null);
             setTrainingLoaded(null);
             setTrainingError(null);
             return;
         }
         setDetailTab("overview");
+        // Switching directly A → B: drop A's training data and invalidate
+        // any in-flight LMS request so it can't render under driver B.
+        trainingReqRef.current++;
+        setTraining(null);
+        setTrainingLoaded(null);
+        setTrainingError(null);
         // Live-stats compute Rating / Rides / Earnings / Accept Rate from
         // the rides table on demand because three of the four denormalised
         // columns on the drivers row are unreliable (see backend comment in

--- a/admin-dashboard/src/app/dashboard/drivers/page.tsx
+++ b/admin-dashboard/src/app/dashboard/drivers/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
-import { getDriverStats, getDrivers, getDriverDocuments, reviewDocument, updateDriver, reviewDriverPhoto, getDriverVehicleHistory, getServiceAreas, getVehicleTypes, getFareConfigs, exportDrivers, getDriverRides, getDriverLiveStats, getDriverPayoutsSummary, getDriverReferrals, retryPayout, refreshDriverStripeKyc, revealDriverSin, logPiiReveal, getAdminSubscriptionPayments, type DriverLiveStats, type DriverPayoutSummary, type DriverReferralSummary } from "@/lib/api";
+import { getDriverStats, getDrivers, getDriverDocuments, reviewDocument, updateDriver, reviewDriverPhoto, getDriverVehicleHistory, getServiceAreas, getVehicleTypes, getFareConfigs, exportDrivers, getDriverRides, getDriverLiveStats, getDriverPayoutsSummary, getDriverReferrals, getDriverTraining, retryPayout, refreshDriverStripeKyc, revealDriverSin, logPiiReveal, getAdminSubscriptionPayments, type DriverLiveStats, type DriverPayoutSummary, type DriverReferralSummary, type DriverTraining } from "@/lib/api";
 import { Pagination } from "@/components/ui/pagination";
 import { exportToCsv } from "@/lib/export-csv";
 import { formatCurrency } from "@/lib/utils";
@@ -14,7 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useTableSort, SortableHead } from "@/components/ui/sortable-table";
-import { Search, Users, Wifi, ShieldCheck, ShieldAlert, Shield, Download, X, Star, Car, MapPin, CreditCard, Clock, DollarSign, CheckCircle, XCircle, FileText, Phone, Mail, CalendarRange, ExternalLink, Copy, AlertTriangle, ZoomIn, Image, Pencil, Save, Loader2, Eye, EyeOff, ArrowUpDown, ArrowUp, ArrowDown, Ban, Pause, Maximize2, RefreshCw } from "lucide-react";
+import { Search, Users, Wifi, ShieldCheck, ShieldAlert, Shield, Download, X, Star, Car, MapPin, CreditCard, Clock, DollarSign, CheckCircle, XCircle, FileText, Phone, Mail, CalendarRange, ExternalLink, Copy, AlertTriangle, ZoomIn, Image, Pencil, Save, Loader2, Eye, EyeOff, ArrowUpDown, ArrowUp, ArrowDown, Ban, Pause, Maximize2, RefreshCw, GraduationCap, Award } from "lucide-react";
 import { maskEmail, maskPhone, maskPlate } from "@/lib/pii";
 import { DocumentReviewer } from "./_components/document-reviewer";
 import DriverStatsCards from "./_components/driver-stats-cards";
@@ -121,6 +121,10 @@ export default function DriversPage() {
     const [driverSubPayments, setDriverSubPayments] = useState<any[]>([]);
     const [subPaymentsLoading, setSubPaymentsLoading] = useState(false);
     const [subPaymentsLoaded, setSubPaymentsLoaded] = useState<string | null>(null);
+    const [training, setTraining] = useState<DriverTraining | null>(null);
+    const [trainingLoading, setTrainingLoading] = useState(false);
+    const [trainingLoaded, setTrainingLoaded] = useState<string | null>(null);
+    const [trainingError, setTrainingError] = useState<string | null>(null);
     const [liveStats, setLiveStats] = useState<DriverLiveStats | null>(null);
     const [payoutSummary, setPayoutSummary] = useState<DriverPayoutSummary | null>(null);
     const [payoutLoading, setPayoutLoading] = useState(false);
@@ -186,6 +190,22 @@ export default function DriversPage() {
             setSubPaymentsLoading(false);
         }
     }, [subPaymentsLoaded]);
+
+    const loadDriverTraining = useCallback(async (driverId: string, refresh = false) => {
+        if (!refresh && trainingLoaded === driverId) return;
+        setTrainingLoading(true);
+        setTrainingError(null);
+        try {
+            const res = await getDriverTraining(driverId, refresh);
+            setTraining(res);
+            setTrainingLoaded(driverId);
+        } catch (e: any) {
+            setTraining(null);
+            setTrainingError(e?.message || "Failed to load training data from the LMS");
+        } finally {
+            setTrainingLoading(false);
+        }
+    }, [trainingLoaded]);
 
     const loadData = useCallback(() => {
         setLoading(true);
@@ -304,6 +324,9 @@ export default function DriversPage() {
             setPayoutSummary(null);
             setDriverSubPayments([]);
             setSubPaymentsLoaded(null);
+            setTraining(null);
+            setTrainingLoaded(null);
+            setTrainingError(null);
             return;
         }
         setDetailTab("overview");
@@ -916,13 +939,14 @@ export default function DriversPage() {
                             </div>
                         </div>
 
-                        <Tabs value={detailTab} onValueChange={(v) => { setDetailTab(v); if (v === "rides") loadDriverRides(selected.id); if (v === "referrals") loadDriverReferrals(selected.id); if (v === "subscriptions") loadDriverSubscriptions(selected.id); }} className="flex-1 overflow-hidden flex flex-col">
+                        <Tabs value={detailTab} onValueChange={(v) => { setDetailTab(v); if (v === "rides") loadDriverRides(selected.id); if (v === "referrals") loadDriverReferrals(selected.id); if (v === "subscriptions") loadDriverSubscriptions(selected.id); if (v === "training") loadDriverTraining(selected.id); }} className="flex-1 overflow-hidden flex flex-col">
                             <TabsList className="mx-6 mt-4 w-fit">
                                 <TabsTrigger value="overview">Overview</TabsTrigger>
                                 <TabsTrigger value="documents">Documents{pendingDocsCount > 0 && <span className="ml-1.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-[10px] font-bold px-1.5 py-0.5 rounded-full" title={`${pendingDocsCount} document${pendingDocsCount === 1 ? "" : "s"} awaiting review`}>{pendingDocsCount}</span>}</TabsTrigger>
                                 <TabsTrigger value="rides">Rides{selected.total_rides > 0 && <span className="ml-1.5 bg-primary/10 text-primary text-[10px] font-bold px-1.5 py-0.5 rounded-full">{(selected.total_rides || 0).toLocaleString()}</span>}</TabsTrigger>
                                 <TabsTrigger value="payouts">Payouts{payoutSummary && payoutSummary.summary.pending_balance > 0 && <span className="ml-1.5 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-[10px] font-bold px-1.5 py-0.5 rounded-full" title={`${formatCurrency(payoutSummary.summary.pending_balance)} pending payout`}>!</span>}</TabsTrigger>
                                 <TabsTrigger value="referrals">Referrals</TabsTrigger>
+                                <TabsTrigger value="training">Training</TabsTrigger>
                                 <TabsTrigger value="subscriptions">Subscriptions</TabsTrigger>
                                 <TabsTrigger value="verification">Actions</TabsTrigger>
                                 <TabsTrigger value="notes">Notes</TabsTrigger>
@@ -1168,6 +1192,17 @@ export default function DriversPage() {
                                 {/* Referrals */}
                                 <TabsContent value="referrals" className="mt-4">
                                     <DriverReferralsTab data={referrals} loading={referralsLoading} fmtDate={fmtDate} />
+                                </TabsContent>
+
+                                {/* Training (LMS) */}
+                                <TabsContent value="training" className="mt-4">
+                                    <DriverTrainingTab
+                                        data={training}
+                                        loading={trainingLoading}
+                                        error={trainingError}
+                                        onRefresh={() => loadDriverTraining(selected.id, true)}
+                                        fmtDate={fmtDate}
+                                    />
                                 </TabsContent>
 
                                 {/* Payouts */}
@@ -2095,6 +2130,195 @@ function DriverReferralsTab({ data, loading, fmtDate }: {
                     })}
                 </div>
             )}
+        </div>
+    );
+}
+
+const TRAINING_STATUS_STYLES: Record<string, string> = {
+    completed: "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300",
+    in_progress: "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300",
+    registered: "bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300",
+    invited: "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300",
+    not_invited: "bg-muted text-muted-foreground",
+};
+
+function DriverTrainingTab({ data, loading, error, onRefresh, fmtDate }: {
+    data: DriverTraining | null;
+    loading: boolean;
+    error: string | null;
+    onRefresh: () => void;
+    fmtDate: (d: string) => string;
+}) {
+    if (loading) {
+        return <div className="text-sm text-muted-foreground py-10 text-center">Loading training data from the LMS…</div>;
+    }
+    if (error) {
+        return (
+            <div className="py-10 text-center space-y-3">
+                <p className="text-sm text-muted-foreground">{error}</p>
+                <Button variant="outline" size="sm" onClick={onRefresh}><RefreshCw className="w-3.5 h-3.5 mr-1.5" />Retry</Button>
+            </div>
+        );
+    }
+    if (!data) {
+        return <div className="text-sm text-muted-foreground py-10 text-center">No training data.</div>;
+    }
+    if (!data.matched) {
+        return (
+            <div className="py-10 text-center space-y-3">
+                <GraduationCap className="w-8 h-8 mx-auto text-muted-foreground/50" />
+                <p className="text-sm text-muted-foreground">
+                    {data.reason === "no_phone"
+                        ? "This driver has no phone number on file, so they can't be matched against the LMS."
+                        : `No LMS driver record matches this phone number${data.phone_last4 ? ` (ending in ${data.phone_last4})` : ""}.`}
+                </p>
+                <Button variant="outline" size="sm" onClick={onRefresh}><RefreshCw className="w-3.5 h-3.5 mr-1.5" />Refresh</Button>
+            </div>
+        );
+    }
+
+    const lms = data.lms!;
+    const t = lms.training;
+    const statusLabel = (t.status || "unknown").replace(/_/g, " ");
+    const pct = Math.max(0, Math.min(100, Math.round(t.completion_percentage ?? 0)));
+    const quizAttempts = lms.history?.quiz_attempts || [];
+    const communications = lms.history?.communications || [];
+
+    return (
+        <div className="space-y-5">
+            {/* Status summary */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Training Status</p>
+                    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide mt-1.5 ${TRAINING_STATUS_STYLES[t.status] || "bg-muted text-muted-foreground"}`}>
+                        {statusLabel}
+                    </span>
+                </div>
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Registered</p>
+                    <p className="text-sm font-semibold mt-1">
+                        {t.registered ? `Yes${t.registered_at ? ` · ${fmtDate(t.registered_at)}` : ""}` : "No"}
+                    </p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Completion</p>
+                    <p className="text-xl font-bold mt-0.5">{pct}%</p>
+                    <div className="h-1.5 rounded-full bg-muted overflow-hidden mt-1.5">
+                        <div className={`h-full rounded-full ${pct >= 100 ? "bg-emerald-500" : "bg-primary"}`} style={{ width: `${pct}%` }} />
+                    </div>
+                </div>
+                <div className="rounded-xl border border-border/50 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium">Completed</p>
+                    <p className="text-sm font-semibold mt-1">{t.completed_at ? fmtDate(t.completed_at) : "—"}</p>
+                </div>
+            </div>
+            <p className="text-xs text-muted-foreground flex items-center gap-2">
+                Matched by phone{data.phone_last4 ? ` ending in ${data.phone_last4}` : ""} · LMS record for <span className="font-semibold text-foreground">{lms.driver.full_name}</span>
+                <button type="button" onClick={onRefresh} className="inline-flex items-center gap-1 text-primary hover:underline" title="Bypass the cache and re-fetch from the LMS">
+                    <RefreshCw className="w-3 h-3" />Refresh
+                </button>
+            </p>
+
+            {/* Certificates */}
+            <div>
+                <h4 className="text-sm font-semibold flex items-center gap-1.5 mb-2"><Award className="w-4 h-4 text-muted-foreground" />Certificates</h4>
+                {lms.certificates.length === 0 ? (
+                    <p className="text-sm text-muted-foreground py-4 text-center">No certificates issued yet.</p>
+                ) : (
+                    <div className="space-y-2">
+                        {lms.certificates.map((c, i) => (
+                            <div key={i} className="rounded-xl border border-border/50 p-3 flex items-center gap-3">
+                                <div className="flex-1 min-w-0">
+                                    <p className="text-sm font-mono font-semibold truncate">{c.certificate_number}</p>
+                                    <p className="text-xs text-muted-foreground mt-0.5">
+                                        {c.course_title}
+                                        {c.final_quiz_score != null ? ` · final score ${Math.round(Number(c.final_quiz_score))}%` : ""}
+                                        {` · issued ${fmtDate(c.issued_at)}`}
+                                        {c.expires_at ? ` · expires ${fmtDate(c.expires_at)}` : ""}
+                                    </p>
+                                </div>
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide shrink-0 ${c.status === "active" ? "bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300" : "bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300"}`}>
+                                    {c.status}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* Courses */}
+            {t.courses.length > 0 && (
+                <div>
+                    <h4 className="text-sm font-semibold flex items-center gap-1.5 mb-2"><GraduationCap className="w-4 h-4 text-muted-foreground" />Courses</h4>
+                    <div className="space-y-2">
+                        {t.courses.map((c, i) => {
+                            const coursePct = Math.max(0, Math.min(100, Math.round(c.progress ?? 0)));
+                            return (
+                                <div key={i} className="rounded-xl border border-border/50 p-3">
+                                    <div className="flex items-center justify-between gap-2">
+                                        <p className="text-sm font-medium truncate">{c.course_title || "Course"}</p>
+                                        <span className="text-[11px] text-muted-foreground shrink-0">{coursePct}% · {(c.status || "").replace(/_/g, " ")}</span>
+                                    </div>
+                                    <div className="h-1.5 rounded-full bg-muted overflow-hidden mt-1.5">
+                                        <div className={`h-full rounded-full ${coursePct >= 100 ? "bg-emerald-500" : "bg-primary"}`} style={{ width: `${coursePct}%` }} />
+                                    </div>
+                                    <p className="text-[11px] text-muted-foreground mt-1">
+                                        Enrolled {c.enrolled_at ? fmtDate(c.enrolled_at) : "—"}
+                                        {c.completed_at ? ` · completed ${fmtDate(c.completed_at)}` : ""}
+                                    </p>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+
+            {/* History */}
+            <div>
+                <h4 className="text-sm font-semibold flex items-center gap-1.5 mb-2"><Clock className="w-4 h-4 text-muted-foreground" />History</h4>
+                {quizAttempts.length === 0 && communications.length === 0 ? (
+                    <p className="text-sm text-muted-foreground py-4 text-center">No training history yet.</p>
+                ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                            <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium mb-1.5">Quiz Attempts</p>
+                            {quizAttempts.length === 0 ? (
+                                <p className="text-xs text-muted-foreground">None.</p>
+                            ) : (
+                                <div className="space-y-1.5">
+                                    {quizAttempts.map((q, i) => (
+                                        <div key={i} className="flex items-center justify-between gap-2 rounded-lg border border-border/50 px-2.5 py-1.5">
+                                            <span className="text-xs truncate">{q.quiz_title || "Quiz"} · {Math.round(Number(q.score))}%</span>
+                                            <span className="flex items-center gap-1.5 shrink-0">
+                                                <span className={`text-[10px] font-bold uppercase ${q.passed ? "text-emerald-600 dark:text-emerald-400" : "text-rose-600 dark:text-rose-400"}`}>{q.passed ? "Pass" : "Fail"}</span>
+                                                <span className="text-[10px] text-muted-foreground">{fmtDate(q.attempted_at)}</span>
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                        <div>
+                            <p className="text-[11px] uppercase tracking-wide text-muted-foreground font-medium mb-1.5">Communications</p>
+                            {communications.length === 0 ? (
+                                <p className="text-xs text-muted-foreground">None.</p>
+                            ) : (
+                                <div className="space-y-1.5">
+                                    {communications.map((m, i) => (
+                                        <div key={i} className="flex items-center justify-between gap-2 rounded-lg border border-border/50 px-2.5 py-1.5">
+                                            <span className="text-xs truncate">{(m.message_type || "message").replace(/_/g, " ")} ({m.communication_type})</span>
+                                            <span className="flex items-center gap-1.5 shrink-0">
+                                                <span className="text-[10px] text-muted-foreground uppercase">{m.status}</span>
+                                                <span className="text-[10px] text-muted-foreground">{fmtDate(m.sent_at)}</span>
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </div>
         </div>
     );
 }

--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -496,6 +496,45 @@ export default function SettingsPage() {
                             })()}
                         </CardContent>
                     </Card>
+
+                    {/* Driver LMS (training platform) — feeds the Training tab
+                        in the driver details drawer, matched by phone number. */}
+                    <Card className="border-border/50">
+                        <CardHeader>
+                            <CardTitle className="text-base">Driver LMS (Training)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <p className="text-xs text-muted-foreground">
+                                Connects to the Spinr driver training LMS. When configured, the
+                                driver details drawer shows each driver&apos;s registration,
+                                completion percentage, certificates, and training history,
+                                matched by phone number. The API key must equal the{" "}
+                                <code>SPINR_INTEGRATION_API_KEY</code> set on the LMS deployment.
+                            </p>
+                            <div className="space-y-2">
+                                <Label>LMS Base URL</Label>
+                                <Input
+                                    value={settings.lms_api_base_url || ""}
+                                    onChange={(e) => update("lms_api_base_url", e.target.value)}
+                                    placeholder="https://training.spinr.ca"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>API Key</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.lms_api_key || ""}
+                                    onChange={(e) => update("lms_api_key", e.target.value)}
+                                    placeholder="Shared secret"
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    Leave both blank to disable the integration — the drawer&apos;s
+                                    Training tab will report it as not configured.
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
                 </TabsContent>
                 <TabsContent value="email" className="mt-0 grid gap-6 lg:grid-cols-2 items-start">
                     {/* Email — AWS SES (primary) */}

--- a/admin-dashboard/src/app/dashboard/settings/page.tsx
+++ b/admin-dashboard/src/app/dashboard/settings/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Save, Check, ShieldCheck, ShieldOff } from "lucide-react";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -161,7 +162,16 @@ export default function SettingsPage() {
             </div>
 
             {settings && (
-                <div className="grid gap-6 lg:grid-cols-2">
+                <Tabs defaultValue="integrations" className="space-y-6">
+                <TabsList className="h-auto flex-wrap">
+                    <TabsTrigger value="integrations">Integrations</TabsTrigger>
+                    <TabsTrigger value="email">Email &amp; Alerts</TabsTrigger>
+                    <TabsTrigger value="operations">Operations</TabsTrigger>
+                    <TabsTrigger value="company">Company &amp; Apps</TabsTrigger>
+                    <TabsTrigger value="security">Security</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="integrations" className="mt-0 grid gap-6 lg:grid-cols-2 items-start">
                     {/* Stripe */}
                     <Card className="border-border/50">
                         <CardHeader>
@@ -241,154 +251,6 @@ export default function SettingsPage() {
                         </CardContent>
                     </Card>
 
-                    {/* Email — AWS SES (primary) */}
-                    <Card className="border-border/50">
-                        <CardHeader>
-                            <CardTitle className="text-base">Email — AWS SES (primary)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-4">
-                            <p className="text-xs text-muted-foreground">
-                                Primary provider for ride receipts, T4A links, DSAR exports and
-                                safety/corporate alerts. When the access key and secret are set,
-                                email is sent via SES; if SES is blank or a send fails, Spinr falls
-                                back to Resend below. The <strong>From Email</strong> must be a
-                                verified identity in the SES account.
-                            </p>
-                            <div className="space-y-2">
-                                <Label>Region</Label>
-                                <Input
-                                    type="text"
-                                    value={settings.aws_ses_region || ""}
-                                    onChange={(e) =>
-                                        update("aws_ses_region", e.target.value)
-                                    }
-                                    placeholder="ca-central-1"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Access Key ID</Label>
-                                <Input
-                                    type="text"
-                                    value={settings.aws_ses_access_key_id || ""}
-                                    onChange={(e) =>
-                                        update("aws_ses_access_key_id", e.target.value)
-                                    }
-                                    placeholder="AKIA...."
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Secret Access Key</Label>
-                                <Input
-                                    type="password"
-                                    value={settings.aws_ses_secret_access_key || ""}
-                                    onChange={(e) =>
-                                        update("aws_ses_secret_access_key", e.target.value)
-                                    }
-                                    placeholder="••••••••"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>From Email</Label>
-                                <Input
-                                    type="email"
-                                    value={settings.aws_ses_from_email || ""}
-                                    onChange={(e) =>
-                                        update("aws_ses_from_email", e.target.value)
-                                    }
-                                    placeholder="receipts@spinr.ca"
-                                />
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Email — Resend (fallback guardrail) */}
-                    <Card className="border-border/50">
-                        <CardHeader>
-                            <CardTitle className="text-base">Email — Resend (fallback)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-4">
-                            <p className="text-xs text-muted-foreground">
-                                Guardrail provider. Used only when AWS SES above is unconfigured or a
-                                send fails. If <strong>From Email</strong> is blank, the SES from
-                                address (then a code default) is used as a fallback.
-                            </p>
-                            <div className="space-y-2">
-                                <Label>API Key</Label>
-                                <Input
-                                    type="password"
-                                    value={settings.resend_api_key || ""}
-                                    onChange={(e) =>
-                                        update("resend_api_key", e.target.value)
-                                    }
-                                    placeholder="re_...."
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>From Email</Label>
-                                <Input
-                                    type="email"
-                                    value={settings.resend_from_email || ""}
-                                    onChange={(e) =>
-                                        update("resend_from_email", e.target.value)
-                                    }
-                                    placeholder="receipts@spinr.ca"
-                                />
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Email deliverability */}
-                    <Card className="border-border/50">
-                        <CardHeader>
-                            <CardTitle className="text-base">Email deliverability (last 7 days)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-4">
-                            {!deliverability ? (
-                                <p className="text-xs text-muted-foreground">No send data yet.</p>
-                            ) : (
-                                <>
-                                    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                                        <div className="rounded-lg border border-border/50 p-3">
-                                            <p className="text-xs text-muted-foreground">Sent</p>
-                                            <p className="text-lg font-bold">{deliverability.by_status?.sent ?? 0}</p>
-                                        </div>
-                                        <div className="rounded-lg border border-border/50 p-3">
-                                            <p className="text-xs text-muted-foreground">Failed</p>
-                                            <p className={`text-lg font-bold ${deliverability.failure_rate > 0.01 ? "text-red-600" : ""}`}>{deliverability.by_status?.failed ?? 0}</p>
-                                        </div>
-                                        <div className="rounded-lg border border-border/50 p-3">
-                                            <p className="text-xs text-muted-foreground">Failure rate</p>
-                                            <p className="text-lg font-bold">{((deliverability.failure_rate ?? 0) * 100).toFixed(1)}%</p>
-                                        </div>
-                                        <div className="rounded-lg border border-border/50 p-3">
-                                            <p className="text-xs text-muted-foreground">Suppressed (total)</p>
-                                            <p className="text-lg font-bold">{deliverability.suppression_list_size ?? 0}</p>
-                                        </div>
-                                    </div>
-                                    <p className="text-xs text-muted-foreground">
-                                        By provider:{" "}
-                                        {Object.entries(deliverability.by_provider || {}).map(([k, v]) => `${k} ${v}`).join(" · ") || "—"}
-                                    </p>
-                                    {deliverability.recent_failures?.length > 0 && (
-                                        <div className="space-y-1">
-                                            <p className="text-xs font-semibold">Recent failures</p>
-                                            {deliverability.recent_failures.slice(0, 8).map((f: any, i: number) => (
-                                                <div key={i} className="text-xs text-muted-foreground flex gap-2">
-                                                    <span className="whitespace-nowrap">{new Date(f.created_at).toLocaleDateString()}</span>
-                                                    <span className="font-medium">{f.email_type}</span>
-                                                    <span>via {f.provider}</span>
-                                                </div>
-                                            ))}
-                                        </div>
-                                    )}
-                                </>
-                            )}
-                        </CardContent>
-                    </Card>
-
                     {/* Google Maps */}
                     <Card className="border-border/50">
                         <CardHeader>
@@ -417,6 +279,66 @@ export default function SettingsPage() {
                                 />
                                 <p className="text-xs text-muted-foreground">
                                     GCP Console &rarr; APIs &amp; Services &rarr; Credentials
+                                </p>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Telephony / Twilio */}
+                    <Card className="border-border/50">
+                        <CardHeader>
+                            <CardTitle className="text-base">Telephony (Twilio)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <p className="text-xs text-muted-foreground">
+                                When not configured, OTP defaults to <strong>1234</strong> for testing.
+                                The Proxy Service SID enables anonymous in-ride calling.
+                            </p>
+                            <div className="space-y-2">
+                                <Label>Account SID</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.twilio_account_sid || ""}
+                                    onChange={(e) =>
+                                        update("twilio_account_sid", e.target.value)
+                                    }
+                                    placeholder="AC..."
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Auth Token</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.twilio_auth_token || ""}
+                                    onChange={(e) =>
+                                        update("twilio_auth_token", e.target.value)
+                                    }
+                                    placeholder="Token"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>From Number</Label>
+                                <Input
+                                    value={settings.twilio_from_number || ""}
+                                    onChange={(e) =>
+                                        update("twilio_from_number", e.target.value)
+                                    }
+                                    placeholder="+1234567890"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Proxy Service SID</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.twilio_proxy_service_sid || ""}
+                                    onChange={(e) =>
+                                        update("twilio_proxy_service_sid", e.target.value)
+                                    }
+                                    placeholder="KS..."
+                                />
+                                <p className="text-xs text-muted-foreground">
+                                    From Twilio Console &rarr; Proxy &rarr; Services
                                 </p>
                             </div>
                         </CardContent>
@@ -574,6 +496,155 @@ export default function SettingsPage() {
                             })()}
                         </CardContent>
                     </Card>
+                </TabsContent>
+                <TabsContent value="email" className="mt-0 grid gap-6 lg:grid-cols-2 items-start">
+                    {/* Email — AWS SES (primary) */}
+                    <Card className="border-border/50">
+                        <CardHeader>
+                            <CardTitle className="text-base">Email — AWS SES (primary)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <p className="text-xs text-muted-foreground">
+                                Primary provider for ride receipts, T4A links, DSAR exports and
+                                safety/corporate alerts. When the access key and secret are set,
+                                email is sent via SES; if SES is blank or a send fails, Spinr falls
+                                back to Resend below. The <strong>From Email</strong> must be a
+                                verified identity in the SES account.
+                            </p>
+                            <div className="space-y-2">
+                                <Label>Region</Label>
+                                <Input
+                                    type="text"
+                                    value={settings.aws_ses_region || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_region", e.target.value)
+                                    }
+                                    placeholder="ca-central-1"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Access Key ID</Label>
+                                <Input
+                                    type="text"
+                                    value={settings.aws_ses_access_key_id || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_access_key_id", e.target.value)
+                                    }
+                                    placeholder="AKIA...."
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Secret Access Key</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.aws_ses_secret_access_key || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_secret_access_key", e.target.value)
+                                    }
+                                    placeholder="••••••••"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>From Email</Label>
+                                <Input
+                                    type="email"
+                                    value={settings.aws_ses_from_email || ""}
+                                    onChange={(e) =>
+                                        update("aws_ses_from_email", e.target.value)
+                                    }
+                                    placeholder="receipts@spinr.ca"
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Email — Resend (fallback guardrail) */}
+                    <Card className="border-border/50">
+                        <CardHeader>
+                            <CardTitle className="text-base">Email — Resend (fallback)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <p className="text-xs text-muted-foreground">
+                                Guardrail provider. Used only when AWS SES above is unconfigured or a
+                                send fails. If <strong>From Email</strong> is blank, the SES from
+                                address (then a code default) is used as a fallback.
+                            </p>
+                            <div className="space-y-2">
+                                <Label>API Key</Label>
+                                <Input
+                                    type="password"
+                                    value={settings.resend_api_key || ""}
+                                    onChange={(e) =>
+                                        update("resend_api_key", e.target.value)
+                                    }
+                                    placeholder="re_...."
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>From Email</Label>
+                                <Input
+                                    type="email"
+                                    value={settings.resend_from_email || ""}
+                                    onChange={(e) =>
+                                        update("resend_from_email", e.target.value)
+                                    }
+                                    placeholder="receipts@spinr.ca"
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Email deliverability */}
+                    <Card className="border-border/50">
+                        <CardHeader>
+                            <CardTitle className="text-base">Email deliverability (last 7 days)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            {!deliverability ? (
+                                <p className="text-xs text-muted-foreground">No send data yet.</p>
+                            ) : (
+                                <>
+                                    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                                        <div className="rounded-lg border border-border/50 p-3">
+                                            <p className="text-xs text-muted-foreground">Sent</p>
+                                            <p className="text-lg font-bold">{deliverability.by_status?.sent ?? 0}</p>
+                                        </div>
+                                        <div className="rounded-lg border border-border/50 p-3">
+                                            <p className="text-xs text-muted-foreground">Failed</p>
+                                            <p className={`text-lg font-bold ${deliverability.failure_rate > 0.01 ? "text-red-600" : ""}`}>{deliverability.by_status?.failed ?? 0}</p>
+                                        </div>
+                                        <div className="rounded-lg border border-border/50 p-3">
+                                            <p className="text-xs text-muted-foreground">Failure rate</p>
+                                            <p className="text-lg font-bold">{((deliverability.failure_rate ?? 0) * 100).toFixed(1)}%</p>
+                                        </div>
+                                        <div className="rounded-lg border border-border/50 p-3">
+                                            <p className="text-xs text-muted-foreground">Suppressed (total)</p>
+                                            <p className="text-lg font-bold">{deliverability.suppression_list_size ?? 0}</p>
+                                        </div>
+                                    </div>
+                                    <p className="text-xs text-muted-foreground">
+                                        By provider:{" "}
+                                        {Object.entries(deliverability.by_provider || {}).map(([k, v]) => `${k} ${v}`).join(" · ") || "—"}
+                                    </p>
+                                    {deliverability.recent_failures?.length > 0 && (
+                                        <div className="space-y-1">
+                                            <p className="text-xs font-semibold">Recent failures</p>
+                                            {deliverability.recent_failures.slice(0, 8).map((f: any, i: number) => (
+                                                <div key={i} className="text-xs text-muted-foreground flex gap-2">
+                                                    <span className="whitespace-nowrap">{new Date(f.created_at).toLocaleDateString()}</span>
+                                                    <span className="font-medium">{f.email_type}</span>
+                                                    <span>via {f.provider}</span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                </>
+                            )}
+                        </CardContent>
+                    </Card>
 
                     {/* Safety — distribution list for SOS / safety-incident
                         alert emails. Empty disables outbound email cleanly;
@@ -611,67 +682,8 @@ export default function SettingsPage() {
                             </div>
                         </CardContent>
                     </Card>
-
-                    {/* Telephony / Twilio */}
-                    <Card className="border-border/50">
-                        <CardHeader>
-                            <CardTitle className="text-base">Telephony (Twilio)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-4">
-                            <p className="text-xs text-muted-foreground">
-                                When not configured, OTP defaults to <strong>1234</strong> for testing.
-                                The Proxy Service SID enables anonymous in-ride calling.
-                            </p>
-                            <div className="space-y-2">
-                                <Label>Account SID</Label>
-                                <Input
-                                    type="password"
-                                    value={settings.twilio_account_sid || ""}
-                                    onChange={(e) =>
-                                        update("twilio_account_sid", e.target.value)
-                                    }
-                                    placeholder="AC..."
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Auth Token</Label>
-                                <Input
-                                    type="password"
-                                    value={settings.twilio_auth_token || ""}
-                                    onChange={(e) =>
-                                        update("twilio_auth_token", e.target.value)
-                                    }
-                                    placeholder="Token"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>From Number</Label>
-                                <Input
-                                    value={settings.twilio_from_number || ""}
-                                    onChange={(e) =>
-                                        update("twilio_from_number", e.target.value)
-                                    }
-                                    placeholder="+1234567890"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Proxy Service SID</Label>
-                                <Input
-                                    type="password"
-                                    value={settings.twilio_proxy_service_sid || ""}
-                                    onChange={(e) =>
-                                        update("twilio_proxy_service_sid", e.target.value)
-                                    }
-                                    placeholder="KS..."
-                                />
-                                <p className="text-xs text-muted-foreground">
-                                    From Twilio Console &rarr; Proxy &rarr; Services
-                                </p>
-                            </div>
-                        </CardContent>
-                    </Card>
-
+                </TabsContent>
+                <TabsContent value="operations" className="mt-0 grid gap-6 lg:grid-cols-2 items-start">
                     {/* Dispatch & Matching */}
                     <Card className="border-border/50">
                         <CardHeader>
@@ -840,6 +852,196 @@ export default function SettingsPage() {
                         </CardContent>
                     </Card>
 
+                    {/* Fare Lock — SK regulatory requirement: the price shown
+                        to the rider at booking time is the price charged,
+                        regardless of actual distance/time deviation. */}
+                    <Card className="border-border/50 lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle className="text-base">Fare Lock (SK Regulation)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <div className="flex items-center justify-between">
+                                <div className="space-y-0.5">
+                                    <Label htmlFor="fare_lock_enabled">Lock fare at booking time</Label>
+                                    <p className="text-xs text-muted-foreground">
+                                        When enabled, the fare shown to the rider before the ride is the final charge —
+                                        no recalculation at completion regardless of distance or time deviation.
+                                        Required under Saskatchewan ride-share regulations.
+                                    </p>
+                                </div>
+                                <Switch
+                                    id="fare_lock_enabled"
+                                    checked={settings.fare_lock_enabled ?? false}
+                                    onCheckedChange={(v) => update("fare_lock_enabled", v)}
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+                </TabsContent>
+                <TabsContent value="company" className="mt-0 grid gap-6 lg:grid-cols-2 items-start">
+                    {/* Company Info — surfaced in rider & driver apps
+                        via GET /api/company-info (public endpoint). */}
+                    <Card className="border-border/50 lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle className="text-base">Company Info (shown in apps)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 grid gap-4 sm:grid-cols-2">
+                            <div className="space-y-2">
+                                <Label>Company Name</Label>
+                                <Input
+                                    value={settings.company_name || ""}
+                                    onChange={(e) => update("company_name", e.target.value)}
+                                    placeholder="Spinr"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Phone</Label>
+                                <Input
+                                    value={settings.company_phone || ""}
+                                    onChange={(e) => update("company_phone", e.target.value)}
+                                    placeholder="+1 306 555 0100"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Email</Label>
+                                <Input
+                                    type="email"
+                                    value={settings.company_email || ""}
+                                    onChange={(e) => update("company_email", e.target.value)}
+                                    placeholder="support@spinr.ca"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Website</Label>
+                                <Input
+                                    value={settings.company_website || ""}
+                                    onChange={(e) => update("company_website", e.target.value)}
+                                    placeholder="https://spinr.ca"
+                                />
+                            </div>
+                            <div className="space-y-2 sm:col-span-2">
+                                <Label>Address</Label>
+                                <Textarea
+                                    value={settings.company_address || ""}
+                                    onChange={(e) => update("company_address", e.target.value)}
+                                    placeholder="123 Example St, Saskatoon, SK S7K 1A1"
+                                    className="min-h-[70px]"
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Legal Documents */}
+                    <Card className="border-border/50 lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle className="text-base">Legal Documents</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-6">
+                            <div className="space-y-2">
+                                <Label>Terms of Service</Label>
+                                <Textarea
+                                    value={settings.terms_of_service_text || ""}
+                                    onChange={(e) => update("terms_of_service_text", e.target.value)}
+                                    placeholder="Enter full terms of service text here..."
+                                    className="min-h-[200px]"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <Label>Privacy Policy</Label>
+                                <Textarea
+                                    value={settings.privacy_policy_text || ""}
+                                    onChange={(e) => update("privacy_policy_text", e.target.value)}
+                                    placeholder="Enter full privacy policy text here..."
+                                    className="min-h-[200px]"
+                                />
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Share Trip tracking URL — base of the public live-tracking
+                        page that rider-app embeds in the "Share Trip" message.
+                        Recipients open ${base}/${share_token}; the URL is served
+                        runtime from app_settings so it rotates without a mobile
+                        rebuild. Should point at the admin dashboard's /track route
+                        — e.g. https://track.spinr.ca/track. */}
+                    <Card className="border-border/50 lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle className="text-base">Share Trip — Live Tracking URL</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-2">
+                            <Label>Tracking base URL</Label>
+                            <Input
+                                value={settings.track_base_url || ""}
+                                onChange={(e) => update("track_base_url", e.target.value)}
+                                placeholder="https://track.spinr.ca/track"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                Used by the rider-app "Share Trip" message. Set this to the
+                                deployed admin dashboard's /track route. Leave blank to disable
+                                in-app sharing.
+                            </p>
+                        </CardContent>
+                    </Card>
+
+                    {/* Driver-app ride-offer alert tone — uploaded via
+                        a dedicated multipart endpoint that writes the URL
+                        directly to settings.ride_offer_sound_url. */}
+                    <Card className="border-border/50 lg:col-span-2">
+                        <CardHeader>
+                            <CardTitle className="text-base">Ride-offer alert sound (driver app)</CardTitle>
+                        </CardHeader>
+                        <Separator />
+                        <CardContent className="pt-4 space-y-4">
+                            <div className="space-y-2">
+                                <Label>Upload MP3 or WAV (≤500 KB)</Label>
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        type="file"
+                                        accept="audio/mpeg,audio/mp3,audio/wav"
+                                        disabled={soundUploading}
+                                        onChange={(e) => {
+                                            const f = e.target.files?.[0];
+                                            if (f) void handleUploadOfferSound(f);
+                                            e.target.value = "";
+                                        }}
+                                    />
+                                    {soundUploading && (
+                                        <span className="text-xs text-muted-foreground">Uploading…</span>
+                                    )}
+                                </div>
+                                <p className="text-xs text-muted-foreground">
+                                    Drivers hear this tone every ~2.5s while a ride offer is on screen. Leave empty to use the bundled placeholder.
+                                </p>
+                            </div>
+                            {settings.ride_offer_sound_url ? (
+                                <div className="space-y-2">
+                                    <Label>Current</Label>
+                                    {/* Native HTML5 audio — no extra dep. */}
+                                    <audio controls src={settings.ride_offer_sound_url} className="w-full" />
+                                    <div className="flex gap-2">
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={handleClearOfferSound}
+                                        >
+                                            Clear (revert to bundled)
+                                        </Button>
+                                    </div>
+                                </div>
+                            ) : (
+                                <p className="text-xs text-muted-foreground italic">
+                                    No custom sound set — drivers play the bundled placeholder.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </TabsContent>
+                <TabsContent value="security" className="mt-0 grid gap-6 lg:grid-cols-2 items-start">
                     {/* Two-Factor Authentication */}
                     {mfaAvailable && <Card className="border-border/50">
                         <CardHeader>
@@ -934,195 +1136,11 @@ export default function SettingsPage() {
                             )}
                         </CardContent>
                     </Card>}
-
-                    {/* Legal Documents */}
-                    <Card className="border-border/50 lg:col-span-2">
-                        <CardHeader>
-                            <CardTitle className="text-base">Legal Documents</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-6">
-                            <div className="space-y-2">
-                                <Label>Terms of Service</Label>
-                                <Textarea
-                                    value={settings.terms_of_service_text || ""}
-                                    onChange={(e) => update("terms_of_service_text", e.target.value)}
-                                    placeholder="Enter full terms of service text here..."
-                                    className="min-h-[200px]"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Privacy Policy</Label>
-                                <Textarea
-                                    value={settings.privacy_policy_text || ""}
-                                    onChange={(e) => update("privacy_policy_text", e.target.value)}
-                                    placeholder="Enter full privacy policy text here..."
-                                    className="min-h-[200px]"
-                                />
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Company Info — surfaced in rider & driver apps
-                        via GET /api/company-info (public endpoint). */}
-                    <Card className="border-border/50 lg:col-span-2">
-                        <CardHeader>
-                            <CardTitle className="text-base">Company Info (shown in apps)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 grid gap-4 sm:grid-cols-2">
-                            <div className="space-y-2">
-                                <Label>Company Name</Label>
-                                <Input
-                                    value={settings.company_name || ""}
-                                    onChange={(e) => update("company_name", e.target.value)}
-                                    placeholder="Spinr"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Phone</Label>
-                                <Input
-                                    value={settings.company_phone || ""}
-                                    onChange={(e) => update("company_phone", e.target.value)}
-                                    placeholder="+1 306 555 0100"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Email</Label>
-                                <Input
-                                    type="email"
-                                    value={settings.company_email || ""}
-                                    onChange={(e) => update("company_email", e.target.value)}
-                                    placeholder="support@spinr.ca"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <Label>Website</Label>
-                                <Input
-                                    value={settings.company_website || ""}
-                                    onChange={(e) => update("company_website", e.target.value)}
-                                    placeholder="https://spinr.ca"
-                                />
-                            </div>
-                            <div className="space-y-2 sm:col-span-2">
-                                <Label>Address</Label>
-                                <Textarea
-                                    value={settings.company_address || ""}
-                                    onChange={(e) => update("company_address", e.target.value)}
-                                    placeholder="123 Example St, Saskatoon, SK S7K 1A1"
-                                    className="min-h-[70px]"
-                                />
-                            </div>
-                        </CardContent>
-                    </Card>
-
-                    {/* Share Trip tracking URL — base of the public live-tracking
-                        page that rider-app embeds in the "Share Trip" message.
-                        Recipients open ${base}/${share_token}; the URL is served
-                        runtime from app_settings so it rotates without a mobile
-                        rebuild. Should point at the admin dashboard's /track route
-                        — e.g. https://track.spinr.ca/track. */}
-                    <Card className="border-border/50 lg:col-span-2">
-                        <CardHeader>
-                            <CardTitle className="text-base">Share Trip — Live Tracking URL</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-2">
-                            <Label>Tracking base URL</Label>
-                            <Input
-                                value={settings.track_base_url || ""}
-                                onChange={(e) => update("track_base_url", e.target.value)}
-                                placeholder="https://track.spinr.ca/track"
-                            />
-                            <p className="text-xs text-muted-foreground">
-                                Used by the rider-app "Share Trip" message. Set this to the
-                                deployed admin dashboard's /track route. Leave blank to disable
-                                in-app sharing.
-                            </p>
-                        </CardContent>
-                    </Card>
-
-                    {/* Driver-app ride-offer alert tone — uploaded via
-                        a dedicated multipart endpoint that writes the URL
-                        directly to settings.ride_offer_sound_url. */}
-                    <Card className="border-border/50 lg:col-span-2">
-                        <CardHeader>
-                            <CardTitle className="text-base">Ride-offer alert sound (driver app)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-4">
-                            <div className="space-y-2">
-                                <Label>Upload MP3 or WAV (≤500 KB)</Label>
-                                <div className="flex items-center gap-2">
-                                    <Input
-                                        type="file"
-                                        accept="audio/mpeg,audio/mp3,audio/wav"
-                                        disabled={soundUploading}
-                                        onChange={(e) => {
-                                            const f = e.target.files?.[0];
-                                            if (f) void handleUploadOfferSound(f);
-                                            e.target.value = "";
-                                        }}
-                                    />
-                                    {soundUploading && (
-                                        <span className="text-xs text-muted-foreground">Uploading…</span>
-                                    )}
-                                </div>
-                                <p className="text-xs text-muted-foreground">
-                                    Drivers hear this tone every ~2.5s while a ride offer is on screen. Leave empty to use the bundled placeholder.
-                                </p>
-                            </div>
-                            {settings.ride_offer_sound_url ? (
-                                <div className="space-y-2">
-                                    <Label>Current</Label>
-                                    {/* Native HTML5 audio — no extra dep. */}
-                                    <audio controls src={settings.ride_offer_sound_url} className="w-full" />
-                                    <div className="flex gap-2">
-                                        <Button
-                                            type="button"
-                                            variant="outline"
-                                            size="sm"
-                                            onClick={handleClearOfferSound}
-                                        >
-                                            Clear (revert to bundled)
-                                        </Button>
-                                    </div>
-                                </div>
-                            ) : (
-                                <p className="text-xs text-muted-foreground italic">
-                                    No custom sound set — drivers play the bundled placeholder.
-                                </p>
-                            )}
-                        </CardContent>
-                    </Card>
-
-                    {/* Fare Lock — SK regulatory requirement: the price shown
-                        to the rider at booking time is the price charged,
-                        regardless of actual distance/time deviation. */}
-                    <Card className="border-border/50 lg:col-span-2">
-                        <CardHeader>
-                            <CardTitle className="text-base">Fare Lock (SK Regulation)</CardTitle>
-                        </CardHeader>
-                        <Separator />
-                        <CardContent className="pt-4 space-y-4">
-                            <div className="flex items-center justify-between">
-                                <div className="space-y-0.5">
-                                    <Label htmlFor="fare_lock_enabled">Lock fare at booking time</Label>
-                                    <p className="text-xs text-muted-foreground">
-                                        When enabled, the fare shown to the rider before the ride is the final charge —
-                                        no recalculation at completion regardless of distance or time deviation.
-                                        Required under Saskatchewan ride-share regulations.
-                                    </p>
-                                </div>
-                                <Switch
-                                    id="fare_lock_enabled"
-                                    checked={settings.fare_lock_enabled ?? false}
-                                    onCheckedChange={(v) => update("fare_lock_enabled", v)}
-                                />
-                            </div>
-                        </CardContent>
-                    </Card>
-                </div>
+                    {!mfaAvailable && (
+                        <p className="text-sm text-muted-foreground">Two-factor authentication is not available on this deployment.</p>
+                    )}
+                </TabsContent>
+                </Tabs>
             )}
 
             <MfaEnrollDialog

--- a/admin-dashboard/src/lib/api.ts
+++ b/admin-dashboard/src/lib/api.ts
@@ -609,6 +609,72 @@ export interface DriverReferralSummary {
 export const getDriverReferrals = (id: string) =>
     request<DriverReferralSummary>(`/api/admin/drivers/${id}/referrals`);
 
+// ─── LMS training integration ───────────────────────────────────────
+// The backend matches the driver against the external Spinr LMS by phone
+// number and proxies its training record (see routes/admin/drivers.py
+// admin_get_driver_training + services/lms_service.py).
+export interface DriverTrainingCourse {
+    course_title: string | null;
+    status: string;
+    progress: number;
+    enrolled_at: string | null;
+    completed_at: string | null;
+}
+export interface DriverTrainingCertificate {
+    certificate_number: string;
+    course_title: string;
+    final_quiz_score: number | null;
+    issued_at: string;
+    expires_at: string | null;
+    status: "active" | "revoked" | "expired" | string;
+}
+export interface DriverTrainingQuizAttempt {
+    quiz_title: string | null;
+    score: number;
+    passed: boolean;
+    attempted_at: string;
+}
+export interface DriverTrainingCommunication {
+    communication_type: string;
+    message_type: string;
+    subject: string | null;
+    status: string;
+    sent_at: string;
+}
+export interface DriverTraining {
+    matched: boolean;
+    reason: "no_phone" | "not_found_in_lms" | null;
+    phone_last4: string | null;
+    lms: {
+        driver: {
+            id: string;
+            full_name: string;
+            email: string;
+            phone: string | null;
+            city: string | null;
+            spinr_approved: boolean;
+            sgi_approved: boolean;
+        };
+        training: {
+            status: "not_invited" | "invited" | "registered" | "in_progress" | "completed" | string;
+            registered: boolean;
+            registered_at: string | null;
+            completed_at: string | null;
+            completion_percentage: number;
+            courses: DriverTrainingCourse[];
+        };
+        certificates: DriverTrainingCertificate[];
+        history: {
+            quiz_attempts: DriverTrainingQuizAttempt[];
+            communications: DriverTrainingCommunication[];
+        };
+    } | null;
+}
+export const getDriverTraining = (id: string, refresh = false) =>
+    request<DriverTraining>(
+        `/api/admin/drivers/${id}/training${refresh ? "?refresh=true" : ""}`,
+    );
+
 export interface ReferralLeader {
     driver_id: string;
     driver_code: string;

--- a/backend/migrations/229_settings_lms_integration.sql
+++ b/backend/migrations/229_settings_lms_integration.sql
@@ -1,0 +1,34 @@
+-- 229_settings_lms_integration.sql
+--
+-- Add Spinr driver LMS (training platform) integration credentials to the
+-- app settings row, editable from the admin dashboard Settings → Integrations
+-- tab. Used by backend/services/lms_service.py to pull a driver's training
+-- record (registration, completion %, certificates, history) into the driver
+-- details drawer, matched by phone number.
+--
+-- Fields landed:
+--   • lms_api_base_url — base URL of the LMS deployment
+--     (e.g. https://training.spinr.ca).
+--   • lms_api_key      — shared secret sent as the x-api-key header; must
+--     equal SPINR_INTEGRATION_API_KEY on the LMS side. CREDENTIAL: masked on
+--     GET via _mask_credentials in routes/admin/settings.py.
+--
+-- Both columns are nullable so the migration is forward-compatible with
+-- running traffic. Blank values = integration unconfigured; the admin
+-- training endpoint returns 503 and the dashboard reports "not configured".
+--
+-- RLS: the settings table is service-role-only (backend) — no user-facing
+-- RLS policy is added or required here.
+--
+-- Rollback:
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS lms_api_base_url;
+--   ALTER TABLE public.settings DROP COLUMN IF EXISTS lms_api_key;
+
+ALTER TABLE public.settings
+    ADD COLUMN IF NOT EXISTS lms_api_base_url TEXT,
+    ADD COLUMN IF NOT EXISTS lms_api_key      TEXT;
+
+COMMENT ON COLUMN public.settings.lms_api_base_url IS
+    'Base URL of the Spinr driver training LMS (e.g. https://training.spinr.ca). Blank = LMS integration disabled.';
+COMMENT ON COLUMN public.settings.lms_api_key IS
+    'Shared secret for the LMS integration API (x-api-key header; equals SPINR_INTEGRATION_API_KEY on the LMS). CREDENTIAL — masked on GET via _mask_credentials; never returned in plaintext.';

--- a/backend/routes/admin/drivers.py
+++ b/backend/routes/admin/drivers.py
@@ -11,6 +11,7 @@ try:
     from ... import db_supabase
     from ...dependencies import get_admin_user
     from ...features import send_push_notification
+    from ...services import lms_service
     from ...utils.audit_logger import log_admin_action
     from ...utils.datetime_utils import parse_iso_utc
     from ...utils.referral_payout import ReferralClaimNotFound, recredit_failed_claim
@@ -19,6 +20,7 @@ except ImportError:
     import db_supabase
     from dependencies import get_admin_user  # noqa: F401
     from features import send_push_notification
+    from services import lms_service  # type: ignore
     from utils.audit_logger import log_admin_action  # noqa: F401
     from utils.datetime_utils import parse_iso_utc
     from utils.referral_payout import ReferralClaimNotFound, recredit_failed_claim  # type: ignore
@@ -1715,6 +1717,45 @@ async def admin_get_driver_referrals(driver_id: str, admin: dict = Depends(get_a
     if not driver:
         raise HTTPException(status_code=404, detail="Driver not found")
     return await _driver_referral_summary(driver, include_referees=True)
+
+
+@router.get("/drivers/{driver_id}/training")
+async def admin_get_driver_training(
+    driver_id: str,
+    refresh: bool = Query(False),
+    admin: dict = Depends(get_admin_user),
+):
+    """Driver's training record from the external LMS, matched by phone number.
+
+    Returns {matched, phone_last4, lms: <LMS payload data>} where lms carries
+    registration status, completion percentage, certificates, and history
+    (quiz attempts + reminder communications). matched=false when the phone
+    has no LMS driver record or the driver has no usable phone on file.
+    """
+    driver = await db_supabase.get_driver_by_id(driver_id)
+    if not driver:
+        raise HTTPException(status_code=404, detail="Driver not found")
+
+    user = await db_supabase.get_user_by_id(driver["user_id"]) if driver.get("user_id") else None
+    phone = (user or {}).get("phone") or driver.get("phone") or ""
+
+    normalized = lms_service.normalize_phone(phone)
+    if not normalized:
+        return {"matched": False, "reason": "no_phone", "phone_last4": None, "lms": None}
+
+    try:
+        payload = await lms_service.get_training_by_phone(phone, force_refresh=refresh)
+    except lms_service.LMSNotConfiguredError as e:
+        raise HTTPException(status_code=503, detail="LMS integration is not configured") from e
+    except lms_service.LMSUpstreamError as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+    return {
+        "matched": bool(payload.get("matched")),
+        "reason": None if payload.get("matched") else "not_found_in_lms",
+        "phone_last4": normalized[-4:],
+        "lms": payload.get("data"),
+    }
 
 
 @router.get("/referrals/leaderboard")

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -15,7 +15,7 @@ from fastapi import (  # noqa: F401
     HTTPException,
     UploadFile,
 )
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 try:
     from ... import db_supabase
@@ -73,6 +73,14 @@ _CREDENTIAL_FIELDS = frozenset(
         "lms_api_key",
     }
 )
+
+# Fields only super_admin may CHANGE (not just reveal). The LMS base URL
+# receives lms_api_key on every training lookup, so a settings-module admin
+# who could repoint it would exfiltrate the secret (reveal is super_admin-
+# only) and gain direct access to the LMS's driver PII — plus backend SSRF.
+# Changing either half of the pair therefore requires the same privilege as
+# the credential-reveal flow.
+_SUPER_ADMIN_ONLY_FIELDS = frozenset({"lms_api_base_url", "lms_api_key"})
 
 
 def _mask_credentials(settings: Dict[str, Any]) -> Dict[str, Any]:
@@ -216,8 +224,23 @@ class SettingsUpdateRequest(BaseModel):
     # Driver LMS (training platform) integration — services/lms_service.py.
     # base_url is plain; api_key is a credential (masked, in
     # _CREDENTIAL_FIELDS) matching SPINR_INTEGRATION_API_KEY on the LMS.
+    # Changing either field is super_admin-only (_SUPER_ADMIN_ONLY_FIELDS).
     lms_api_base_url: Optional[str] = Field(default=None, max_length=300)
     lms_api_key: Optional[str] = None
+
+    @field_validator("lms_api_base_url")
+    @classmethod
+    def _lms_base_url_scheme(cls, v: Optional[str]) -> Optional[str]:
+        """The LMS API key rides on every request to this host — require TLS
+        so it can't be sniffed in transit (plain http allowed only for
+        localhost during development)."""
+        if not v:
+            return v
+        if v.startswith("https://"):
+            return v
+        if v.startswith(("http://localhost", "http://127.0.0.1")):
+            return v
+        raise ValueError("lms_api_base_url must use https:// (http:// is allowed only for localhost)")
 
 
 @router.get("/settings")
@@ -289,6 +312,20 @@ async def admin_update_settings(settings: SettingsUpdateRequest, admin: dict = D
         v = update_fields.get(field)
         if isinstance(v, str) and v.endswith("*****"):
             update_fields.pop(field, None)
+
+    # Privilege gate for fields whose CHANGE is equivalent to a credential
+    # reveal (see _SUPER_ADMIN_ONLY_FIELDS). The frontend ships the full
+    # settings object on every save, so only reject when the value actually
+    # differs from what is stored — an unrelated save by a non-super-admin
+    # must keep working.
+    if admin.get("role") != "super_admin":
+        current = existing or {}
+        for field in _SUPER_ADMIN_ONLY_FIELDS:
+            if field in update_fields and (update_fields[field] or "") != (current.get(field) or ""):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"Only super admins can change {field}",
+                )
 
     payload = {
         "id": "app_settings",

--- a/backend/routes/admin/settings.py
+++ b/backend/routes/admin/settings.py
@@ -68,6 +68,9 @@ _CREDENTIAL_FIELDS = frozenset(
         # bundle_id are identifiers left visible (same treatment as
         # twilio_account_sid); only the PEM is the secret.
         "apns_p8_key",
+        # Driver LMS integration shared secret (x-api-key header) — the base
+        # URL stays visible; only the key is the secret.
+        "lms_api_key",
     }
 )
 
@@ -210,6 +213,11 @@ class SettingsUpdateRequest(BaseModel):
     apns_team_id: Optional[str] = Field(default=None, max_length=20)
     apns_bundle_id: Optional[str] = Field(default=None, max_length=200)
     apns_p8_key: Optional[str] = None
+    # Driver LMS (training platform) integration — services/lms_service.py.
+    # base_url is plain; api_key is a credential (masked, in
+    # _CREDENTIAL_FIELDS) matching SPINR_INTEGRATION_API_KEY on the LMS.
+    lms_api_base_url: Optional[str] = Field(default=None, max_length=300)
+    lms_api_key: Optional[str] = None
 
 
 @router.get("/settings")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -132,6 +132,12 @@ class AppSettings(BaseModel):
     twilio_account_sid: str = ""
     twilio_auth_token: str = ""
     twilio_from_number: str = ""
+    # Spinr driver LMS (training platform) integration. Base URL of the LMS
+    # deployment and the shared secret it expects in the x-api-key header
+    # (SPINR_INTEGRATION_API_KEY on the LMS side). Used by services/lms_service
+    # to pull driver training status into the admin dashboard.
+    lms_api_base_url: str = ""
+    lms_api_key: str = ""
     driver_matching_algorithm: str = "nearest"
     min_driver_rating: float = 4.0
     search_radius_km: float = 10.0

--- a/backend/services/lms_service.py
+++ b/backend/services/lms_service.py
@@ -91,6 +91,9 @@ async def get_training_by_phone(phone: str, force_refresh: bool = False) -> dict
 
     base_url, api_key = await _lms_credentials()
 
+    # PIPEDA: never log the response body or the stringified exception —
+    # the request URL carries the phone number and the LMS error body may
+    # echo it (or driver name/email). Status code + exception type only.
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
             resp = await client.get(
@@ -101,15 +104,21 @@ async def get_training_by_phone(phone: str, force_refresh: bool = False) -> dict
             resp.raise_for_status()
             payload = resp.json()
     except httpx.HTTPStatusError as e:
-        logger.error(
-            "[lms_service] LMS API returned %s: %s",
-            e.response.status_code,
-            e.response.text[:500],
-        )
+        logger.error("[lms_service] LMS API returned HTTP %s", e.response.status_code)
         raise LMSUpstreamError(f"LMS API error (HTTP {e.response.status_code})") from e
     except httpx.HTTPError as e:
-        logger.error("[lms_service] LMS API request failed: %s", e)
+        logger.error("[lms_service] LMS API request failed: %s", type(e).__name__)
         raise LMSUpstreamError("Failed to reach the LMS API") from e
+    except ValueError as e:  # resp.json() — 200 with a non-JSON body
+        logger.error("[lms_service] LMS API returned a non-JSON 200 response")
+        raise LMSUpstreamError("LMS returned a non-JSON response") from e
+
+    # An application-level failure (success != true) is an outage, not
+    # "driver has no training record" — surface it instead of caching it
+    # or letting the route report not_found_in_lms.
+    if not isinstance(payload, dict) or payload.get("success") is not True:
+        logger.error("[lms_service] LMS API returned an unsuccessful payload")
+        raise LMSUpstreamError("LMS returned an unsuccessful or malformed response")
 
     await redis_set(cache_key, json.dumps(payload), ttl=_CACHE_TTL_SECONDS)
     return payload

--- a/backend/services/lms_service.py
+++ b/backend/services/lms_service.py
@@ -1,0 +1,115 @@
+"""Client for the Spinr driver LMS (training platform) integration API.
+
+The LMS is a separate deployment (spinr-lms) that tracks driver training:
+registration, course progress, certificates, quiz attempts, and reminder
+communications. It exposes GET /api/integration/driver-training?phone=<number>
+authenticated with an x-api-key header. Drivers are matched across the two
+systems by phone number (last 10 digits).
+
+Credentials live in the app_settings table (lms_api_base_url / lms_api_key)
+so they can be rotated from the admin dashboard without a redeploy, matching
+the Stripe/Twilio/Maps pattern. Responses are cached in Redis for a few
+minutes keyed on a hash of the phone number (never the raw number).
+"""
+
+import hashlib
+import json
+import logging
+import re
+
+import httpx
+
+try:
+    from ..settings_loader import get_app_settings
+    from ..utils.redis_client import redis_get, redis_set
+except ImportError:  # pragma: no cover - dual import path
+    from settings_loader import get_app_settings  # type: ignore
+    from utils.redis_client import redis_get, redis_set  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+_HTTP_TIMEOUT = 10.0
+_CACHE_TTL_SECONDS = 300  # LMS data changes slowly; 5 min keeps the modal snappy
+
+
+class LMSNotConfiguredError(Exception):
+    """lms_api_base_url / lms_api_key missing from app_settings."""
+
+
+class LMSUpstreamError(Exception):
+    """The LMS API is unreachable or returned an error response."""
+
+
+def normalize_phone(phone: str) -> str | None:
+    """Reduce a phone number to its last 10 digits for cross-system matching.
+
+    Spinr stores E.164 (+1XXXXXXXXXX); the LMS stores free-form digits from
+    Excel uploads. The shared canonical form is the 10-digit national number.
+    """
+    if not phone:
+        return None
+    digits = re.sub(r"\D", "", str(phone))
+    if len(digits) < 10:
+        return None
+    return digits[-10:]
+
+
+def _cache_key(normalized_phone: str) -> str:
+    # Hash the phone so the raw number never lands in Redis keys (PIPEDA).
+    digest = hashlib.sha256(normalized_phone.encode()).hexdigest()[:16]
+    return f"lms:training:{digest}"
+
+
+async def _lms_credentials() -> tuple[str, str]:
+    settings_row = await get_app_settings() or {}
+    base_url = (settings_row.get("lms_api_base_url") or "").rstrip("/")
+    api_key = settings_row.get("lms_api_key") or ""
+    if not base_url or not api_key:
+        raise LMSNotConfiguredError("lms_api_base_url / lms_api_key not set in app settings")
+    return base_url, api_key
+
+
+async def get_training_by_phone(phone: str, force_refresh: bool = False) -> dict:
+    """Fetch a driver's LMS training record matched by phone number.
+
+    Returns the LMS payload: {"success": bool, "matched": bool, "data": {...}}.
+    Raises ValueError for an unusable phone, LMSNotConfiguredError when the
+    integration is not set up, and LMSUpstreamError on transport/API failure.
+    """
+    normalized = normalize_phone(phone)
+    if not normalized:
+        raise ValueError("Driver phone number is missing or has fewer than 10 digits")
+
+    cache_key = _cache_key(normalized)
+    if not force_refresh:
+        cached = await redis_get(cache_key)
+        if cached:
+            try:
+                return json.loads(cached)
+            except (TypeError, ValueError):
+                pass  # corrupt cache entry — fall through to a live fetch
+
+    base_url, api_key = await _lms_credentials()
+
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(
+                f"{base_url}/api/integration/driver-training",
+                params={"phone": normalized},
+                headers={"x-api-key": api_key},
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "[lms_service] LMS API returned %s: %s",
+            e.response.status_code,
+            e.response.text[:500],
+        )
+        raise LMSUpstreamError(f"LMS API error (HTTP {e.response.status_code})") from e
+    except httpx.HTTPError as e:
+        logger.error("[lms_service] LMS API request failed: %s", e)
+        raise LMSUpstreamError("Failed to reach the LMS API") from e
+
+    await redis_set(cache_key, json.dumps(payload), ttl=_CACHE_TTL_SECONDS)
+    return payload

--- a/backend/tests/test_admin_driver_training.py
+++ b/backend/tests/test_admin_driver_training.py
@@ -1,0 +1,285 @@
+"""Tests for the LMS training integration.
+
+Covers the admin endpoint GET /api/admin/drivers/{driver_id}/training and the
+lms_service phone normalization / upstream error mapping.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from routes.admin import drivers as admin_drivers
+from services import lms_service
+
+LMS_DATA = {
+    "driver": {"id": "rec-1", "full_name": "Alex Driver"},
+    "training": {
+        "status": "in_progress",
+        "registered": True,
+        "completion_percentage": 60,
+        "courses": [],
+    },
+    "certificates": [],
+    "history": {"quiz_attempts": [], "communications": []},
+}
+
+
+# ---------- lms_service.normalize_phone ----------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("+13065551234", "3065551234"),
+        ("13065551234", "3065551234"),
+        ("306-555-1234", "3065551234"),
+        ("(306) 555 1234", "3065551234"),
+        ("3065551234", "3065551234"),
+        ("555-1234", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_normalize_phone(raw, expected):
+    assert lms_service.normalize_phone(raw) == expected
+
+
+# ---------- admin endpoint ----------
+
+
+def _driver(**overrides):
+    return {"id": "driver-1", "user_id": "user-1", "phone": None, **overrides}
+
+
+async def test_training_endpoint_returns_lms_payload():
+    payload = {"success": True, "matched": True, "data": LMS_DATA}
+
+    with (
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_driver_by_id",
+            new=AsyncMock(return_value=_driver()),
+        ),
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_user_by_id",
+            new=AsyncMock(return_value={"id": "user-1", "phone": "+13065551234"}),
+        ),
+        patch.object(
+            admin_drivers.lms_service,
+            "get_training_by_phone",
+            new=AsyncMock(return_value=payload),
+        ) as fetch,
+    ):
+        result = await admin_drivers.admin_get_driver_training("driver-1", refresh=False)
+
+    assert result["matched"] is True
+    assert result["reason"] is None
+    assert result["phone_last4"] == "1234"
+    assert result["lms"] == LMS_DATA
+    fetch.assert_awaited_once_with("+13065551234", force_refresh=False)
+
+
+async def test_training_endpoint_404_for_unknown_driver():
+    with patch.object(admin_drivers.db_supabase, "get_driver_by_id", new=AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as exc:
+            await admin_drivers.admin_get_driver_training("nope", refresh=False)
+    assert exc.value.status_code == 404
+
+
+async def test_training_endpoint_no_phone_returns_unmatched():
+    with (
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_driver_by_id",
+            new=AsyncMock(return_value=_driver()),
+        ),
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_user_by_id",
+            new=AsyncMock(return_value={"id": "user-1", "phone": None}),
+        ),
+        patch.object(admin_drivers.lms_service, "get_training_by_phone", new=AsyncMock()) as fetch,
+    ):
+        result = await admin_drivers.admin_get_driver_training("driver-1", refresh=False)
+
+    assert result == {"matched": False, "reason": "no_phone", "phone_last4": None, "lms": None}
+    fetch.assert_not_awaited()
+
+
+async def test_training_endpoint_falls_back_to_driver_phone():
+    """users.phone is the source of truth, but drivers.phone is the fallback."""
+    with (
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_driver_by_id",
+            new=AsyncMock(return_value=_driver(phone="3065559999")),
+        ),
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_user_by_id",
+            new=AsyncMock(return_value={"id": "user-1", "phone": None}),
+        ),
+        patch.object(
+            admin_drivers.lms_service,
+            "get_training_by_phone",
+            new=AsyncMock(return_value={"success": True, "matched": False, "data": None}),
+        ) as fetch,
+    ):
+        result = await admin_drivers.admin_get_driver_training("driver-1", refresh=False)
+
+    assert result["matched"] is False
+    assert result["reason"] == "not_found_in_lms"
+    assert result["phone_last4"] == "9999"
+    fetch.assert_awaited_once_with("3065559999", force_refresh=False)
+
+
+@pytest.mark.parametrize(
+    ("error", "status"),
+    [
+        (lms_service.LMSNotConfiguredError("no creds"), 503),
+        (lms_service.LMSUpstreamError("LMS API error (HTTP 500)"), 502),
+    ],
+)
+async def test_training_endpoint_maps_lms_errors(error, status):
+    with (
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_driver_by_id",
+            new=AsyncMock(return_value=_driver()),
+        ),
+        patch.object(
+            admin_drivers.db_supabase,
+            "get_user_by_id",
+            new=AsyncMock(return_value={"id": "user-1", "phone": "+13065551234"}),
+        ),
+        patch.object(
+            admin_drivers.lms_service,
+            "get_training_by_phone",
+            new=AsyncMock(side_effect=error),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await admin_drivers.admin_get_driver_training("driver-1", refresh=False)
+    assert exc.value.status_code == status
+
+
+# ---------- lms_service.get_training_by_phone ----------
+
+
+def _mock_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+async def test_get_training_by_phone_fetches_and_caches():
+    payload = {"success": True, "matched": True, "data": LMS_DATA}
+    cache: dict[str, str] = {}
+
+    async def fake_redis_get(key):
+        return cache.get(key)
+
+    async def fake_redis_set(key, value, ttl=None):
+        cache[key] = value
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["api_key"] = request.headers.get("x-api-key")
+        return httpx.Response(200, json=payload)
+
+    real_client = httpx.AsyncClient
+
+    def client_factory(**kwargs):
+        kwargs["transport"] = _mock_transport(handler)
+        return real_client(**kwargs)
+
+    with (
+        patch.object(
+            lms_service,
+            "get_app_settings",
+            new=AsyncMock(
+                return_value={
+                    "lms_api_base_url": "https://training.spinr.ca/",
+                    "lms_api_key": "secret-key",
+                }
+            ),
+        ),
+        patch.object(lms_service, "redis_get", new=fake_redis_get),
+        patch.object(lms_service, "redis_set", new=fake_redis_set),
+        patch.object(lms_service.httpx, "AsyncClient", new=client_factory),
+    ):
+        result = await lms_service.get_training_by_phone("+13065551234")
+
+    assert result == payload
+    # Trailing slash stripped; phone sent as normalized 10 digits.
+    assert captured["url"] == ("https://training.spinr.ca/api/integration/driver-training?phone=3065551234")
+    assert captured["api_key"] == "secret-key"
+    # Cached under a hashed key — the raw phone never appears in the key.
+    assert len(cache) == 1
+    cache_key = next(iter(cache))
+    assert "3065551234" not in cache_key
+    assert json.loads(cache[cache_key]) == payload
+
+
+async def test_get_training_by_phone_uses_cache():
+    payload = {"success": True, "matched": False, "data": None}
+    key = lms_service._cache_key("3065551234")
+
+    with (
+        patch.object(lms_service, "redis_get", new=AsyncMock(return_value=json.dumps(payload))) as rget,
+        patch.object(lms_service, "get_app_settings", new=AsyncMock()) as settings,
+    ):
+        result = await lms_service.get_training_by_phone("+13065551234")
+
+    assert result == payload
+    rget.assert_awaited_once_with(key)
+    settings.assert_not_awaited()  # cache hit → no upstream call
+
+
+async def test_get_training_by_phone_not_configured():
+    with (
+        patch.object(lms_service, "redis_get", new=AsyncMock(return_value=None)),
+        patch.object(lms_service, "get_app_settings", new=AsyncMock(return_value={})),
+    ):
+        with pytest.raises(lms_service.LMSNotConfiguredError):
+            await lms_service.get_training_by_phone("+13065551234")
+
+
+async def test_get_training_by_phone_upstream_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    real_client = httpx.AsyncClient
+
+    def client_factory(**kwargs):
+        kwargs["transport"] = _mock_transport(handler)
+        return real_client(**kwargs)
+
+    with (
+        patch.object(lms_service, "redis_get", new=AsyncMock(return_value=None)),
+        patch.object(
+            lms_service,
+            "get_app_settings",
+            new=AsyncMock(
+                return_value={
+                    "lms_api_base_url": "https://training.spinr.ca",
+                    "lms_api_key": "secret-key",
+                }
+            ),
+        ),
+        patch.object(lms_service.httpx, "AsyncClient", new=client_factory),
+    ):
+        with pytest.raises(lms_service.LMSUpstreamError):
+            await lms_service.get_training_by_phone("+13065551234")
+
+
+async def test_get_training_by_phone_rejects_short_phone():
+    with pytest.raises(ValueError):
+        await lms_service.get_training_by_phone("555-1234")

--- a/backend/tests/test_admin_driver_training.py
+++ b/backend/tests/test_admin_driver_training.py
@@ -283,3 +283,66 @@ async def test_get_training_by_phone_upstream_http_error():
 async def test_get_training_by_phone_rejects_short_phone():
     with pytest.raises(ValueError):
         await lms_service.get_training_by_phone("555-1234")
+
+
+def _patched_lms_call(handler):
+    """Common patch stack for a live (cache-miss) lms_service call."""
+    real_client = httpx.AsyncClient
+
+    def client_factory(**kwargs):
+        kwargs["transport"] = _mock_transport(handler)
+        return real_client(**kwargs)
+
+    return (
+        patch.object(lms_service, "redis_get", new=AsyncMock(return_value=None)),
+        patch.object(lms_service, "redis_set", new=AsyncMock()),
+        patch.object(
+            lms_service,
+            "get_app_settings",
+            new=AsyncMock(
+                return_value={
+                    "lms_api_base_url": "https://training.spinr.ca",
+                    "lms_api_key": "secret-key",
+                }
+            ),
+        ),
+        patch.object(lms_service.httpx, "AsyncClient", new=client_factory),
+    )
+
+
+async def test_get_training_by_phone_non_json_200_is_upstream_error():
+    """A 200 with a non-JSON body must map to 502, not crash as a 500."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<html>proxy error page</html>")
+
+    p1, p2, p3, p4 = _patched_lms_call(handler)
+    with p1, p2, p3, p4:
+        with pytest.raises(lms_service.LMSUpstreamError):
+            await lms_service.get_training_by_phone("+13065551234")
+
+
+async def test_get_training_by_phone_success_false_is_upstream_error():
+    """An application-level LMS failure must not read as not_found_in_lms."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"success": False, "error": "boom"})
+
+    p1, p2, p3, p4 = _patched_lms_call(handler)
+    with p1, p2, p3, p4:
+        with pytest.raises(lms_service.LMSUpstreamError):
+            await lms_service.get_training_by_phone("+13065551234")
+
+
+async def test_upstream_error_logs_never_contain_phone(caplog):
+    """PIPEDA: logs must not carry the phone (query URL / echoed body)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="error for phone 3065551234")
+
+    p1, p2, p3, p4 = _patched_lms_call(handler)
+    with p1, p2, p3, p4, caplog.at_level("ERROR"):
+        with pytest.raises(lms_service.LMSUpstreamError):
+            await lms_service.get_training_by_phone("+13065551234")
+
+    assert "3065551234" not in caplog.text

--- a/backend/tests/test_admin_settings_lms_gate.py
+++ b/backend/tests/test_admin_settings_lms_gate.py
@@ -1,0 +1,99 @@
+"""Tests for the super_admin gate on LMS integration settings.
+
+The LMS base URL receives lms_api_key on every training lookup, so changing
+either field is privileged like a credential reveal (PR #2073 review):
+a settings-module admin repointing the URL could exfiltrate the key.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from routes.admin import settings as admin_settings
+
+_EXISTING_ROW = {
+    "id": "app_settings",
+    "lms_api_base_url": "https://training.spinr.ca",
+    "lms_api_key": "real-secret",
+}
+
+
+def _admin(role: str) -> dict:
+    return {"id": "admin-1", "role": role}
+
+
+def _patched_db(existing_row: dict | None):
+    return (
+        patch.object(
+            admin_settings.db_supabase,
+            "get_rows",
+            new=AsyncMock(return_value=[existing_row] if existing_row else []),
+        ),
+        patch.object(admin_settings.db_supabase, "update_one", new=AsyncMock()),
+        patch.object(admin_settings.db_supabase, "insert_one", new=AsyncMock()),
+    )
+
+
+async def test_non_super_admin_cannot_change_lms_base_url():
+    req = admin_settings.SettingsUpdateRequest(lms_api_base_url="https://evil.example.com")
+    p1, p2, p3 = _patched_db(_EXISTING_ROW)
+    with p1, p2, p3:
+        with pytest.raises(HTTPException) as exc:
+            await admin_settings.admin_update_settings(req, admin=_admin("admin"))
+    assert exc.value.status_code == 403
+
+
+async def test_non_super_admin_cannot_change_lms_api_key():
+    req = admin_settings.SettingsUpdateRequest(lms_api_key="attacker-known-key")
+    p1, p2, p3 = _patched_db(_EXISTING_ROW)
+    with p1, p2, p3:
+        with pytest.raises(HTTPException) as exc:
+            await admin_settings.admin_update_settings(req, admin=_admin("admin"))
+    assert exc.value.status_code == 403
+
+
+async def test_non_super_admin_unchanged_lms_fields_still_save():
+    """The frontend ships the full object back; identical values must pass."""
+    req = admin_settings.SettingsUpdateRequest(
+        lms_api_base_url="https://training.spinr.ca",
+        company_name="Spinr",
+    )
+    p1, p2, p3 = _patched_db(_EXISTING_ROW)
+    with p1, p2 as update_one, p3:
+        result = await admin_settings.admin_update_settings(req, admin=_admin("admin"))
+    assert "audit_log_id" in result
+    update_one.assert_awaited_once()
+
+
+async def test_super_admin_can_change_lms_fields():
+    req = admin_settings.SettingsUpdateRequest(
+        lms_api_base_url="https://training2.spinr.ca",
+        lms_api_key="rotated-secret",
+    )
+    p1, p2, p3 = _patched_db(_EXISTING_ROW)
+    with p1, p2 as update_one, p3:
+        result = await admin_settings.admin_update_settings(req, admin=_admin("super_admin"))
+    assert "audit_log_id" in result
+    payload = update_one.await_args.args[2]
+    assert payload["lms_api_base_url"] == "https://training2.spinr.ca"
+    assert payload["lms_api_key"] == "rotated-secret"
+
+
+@pytest.mark.unit
+def test_lms_base_url_requires_https():
+    with pytest.raises(ValidationError):
+        admin_settings.SettingsUpdateRequest(lms_api_base_url="http://evil.example.com")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "url",
+    ["https://training.spinr.ca", "http://localhost:3000", "http://127.0.0.1:3000", ""],
+)
+def test_lms_base_url_accepts_https_and_localhost(url):
+    req = admin_settings.SettingsUpdateRequest(lms_api_base_url=url)
+    assert req.lms_api_base_url == url


### PR DESCRIPTION
Adds GET /api/admin/drivers/{driver_id}/training, which matches the driver
against the external Spinr LMS by phone number (last 10 digits) and returns
registration status, training status, completion percentage, certificates,
and history (quiz attempts + reminder communications).

New services/lms_service.py calls the LMS integration API via httpx using
lms_api_base_url / lms_api_key from app_settings (rotatable via the admin
dashboard, matching the Stripe/Twilio pattern) and caches responses in Redis
for 5 minutes keyed on a SHA-256 hash of the phone (raw numbers never stored
in cache keys). LMS-down maps to 502, unconfigured integration to 503, and a
driver without a usable phone or LMS record returns matched=false.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Veip975ZXsyJS5dDQWTeT

<!-- spinr-expanded:migration -->
## Tier 5 · Migration details

- **Migration file**: `backend/migrations/NN_*.sql`
- **Next sequence number verified**: `[ ]`
- **Reversible on paper**: describe rollback (drop column / revert default / etc.)
- **Forward-compatible with in-flight traffic**: `[ ]` — old backend can still read/write against new schema
- **Indexes added for new query patterns**: `[ ]` or N/A
- **RLS policies ship in the same migration for any new user-data table**: `[ ]` or N/A
- **Run-time estimate on prod data**: < 30 s (flag if longer and attach plan)

<!-- spinr-expanded:ui -->
## Tier 5 · UI change details

- **Screenshots / screen recording attached** (iOS + Android if RN): `[ ]`
- **Accessibility** — labels, contrast, screen reader: `[ ]` or N/A
- **Dark mode verified** (if theme-aware): `[ ]` or N/A
- **i18n / localization strings added** (if user-visible copy): `[ ]` or N/A
- **Tested on smallest supported device width**: `[ ]`
